### PR TITLE
feat: add `--config` to reconfigure credentials without running the agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,17 @@ Update existing documentation:
 openwiki --update
 ```
 
+Reconfigure your provider, API key, model, or LangSmith key without running the
+agent (for example, to switch to a different key):
+
+```sh
+openwiki --config
+```
+
+`--config` walks the setup prompts even when credentials already exist. Press
+Enter on the API key or LangSmith prompt to keep the current value; only what you
+retype is changed.
+
 Show help:
 
 ```sh

--- a/src/cli.tsx
+++ b/src/cli.tsx
@@ -70,6 +70,11 @@ type RunState =
       errorDiagnostics?: ErrorDiagnostic[];
     };
 
+type ConfigState =
+  | { status: "editing" }
+  | { status: "saved"; result: InitSetupResult }
+  | { status: "error"; message: string };
+
 type RunLogItem = {
   actionCount?: number;
   activeToolCallIds?: string[];
@@ -136,6 +141,9 @@ function App({ command }: AppProps) {
   const activeRunLog = useRef<RunLogItem[]>([]);
   const [runState, setRunState] = useState<RunState>({ status: "idle" });
   const [completedRuns, setCompletedRuns] = useState<CompletedRun[]>([]);
+  const [configState, setConfigState] = useState<ConfigState>({
+    status: "editing",
+  });
   const [activeUserMessage, setActiveUserMessage] = useState<string | null>(
     command.kind === "run" ? command.userMessage : null,
   );
@@ -225,13 +233,13 @@ function App({ command }: AppProps) {
       return;
     }
 
-    if (command.dryRun) {
-      process.exitCode = 0;
-      app.exit();
+    if (command.kind !== "run") {
       return;
     }
 
-    if (command.kind !== "run") {
+    if (command.dryRun) {
+      process.exitCode = 0;
+      app.exit();
       return;
     }
 
@@ -389,8 +397,92 @@ function App({ command }: AppProps) {
     }
   }, [app, autoExitOnSuccess, runState.status]);
 
+  // `--config` is a settings editor: once the setup flow resolves, render the
+  // outcome one last time and exit without ever invoking the agent.
+  useEffect(() => {
+    if (command.kind !== "config") {
+      return;
+    }
+
+    if (configState.status === "saved") {
+      process.exitCode = 0;
+      app.exit();
+      return;
+    }
+
+    if (configState.status === "error") {
+      process.exitCode = 1;
+      app.exit();
+    }
+  }, [app, command.kind, configState.status]);
+
   if (command.kind === "help") {
     return <HelpView />;
+  }
+
+  if (command.kind === "config") {
+    if (configState.status === "editing") {
+      return (
+        <InitSetup
+          reconfigure
+          modelIdOverride={null}
+          onComplete={(result) => {
+            if (result.modelId) {
+              setSessionModelId(result.modelId);
+            }
+            if (result.provider) {
+              setSessionProvider(result.provider);
+            }
+
+            setConfigState({ status: "saved", result });
+          }}
+          onError={(message) => {
+            setConfigState({ status: "error", message });
+          }}
+        />
+      );
+    }
+
+    if (configState.status === "error") {
+      return (
+        <Box flexDirection="column">
+          <Header modelId={displayModelId} subtitle="Configuration failed" />
+          <StatusLine tone="error" label="Error" value={configState.message} />
+        </Box>
+      );
+    }
+
+    const { result } = configState;
+    const savedAnything =
+      result.savedApiKey ||
+      result.savedProvider ||
+      result.savedModelId ||
+      result.savedLangSmithKey;
+
+    return (
+      <Box flexDirection="column">
+        <Header
+          modelId={result.modelId ?? displayModelId}
+          subtitle="Configuration saved"
+        />
+        <StatusLine
+          tone={savedAnything ? "success" : "muted"}
+          label="Credentials"
+          value={savedAnything ? "saved" : "unchanged"}
+        />
+        {result.provider ? (
+          <StatusLine
+            tone="muted"
+            label="Provider"
+            value={getProviderLabel(result.provider)}
+          />
+        ) : null}
+        {result.modelId ? (
+          <StatusLine tone="muted" label="Model" value={result.modelId} />
+        ) : null}
+        <StatusLine tone="muted" label="Next" value="run openwiki to start" />
+      </Box>
+    );
   }
 
   if (command.kind === "error") {
@@ -3022,7 +3114,10 @@ function Rows({ rows }: RowsProps) {
 const argv = process.argv.slice(2);
 const parsedCommand = parseCommand(argv);
 
-if (parsedCommand.kind === "run" && !parsedCommand.dryRun) {
+if (
+  (parsedCommand.kind === "run" && !parsedCommand.dryRun) ||
+  parsedCommand.kind === "config"
+) {
   await loadOpenWikiEnv();
 }
 
@@ -3112,6 +3207,14 @@ function writePrintErrorDiagnostics(error: unknown): void {
 }
 
 function resolveStartupCommand(command: CliCommand): CliCommand {
+  if (command.kind === "config" && !process.stdin.isTTY) {
+    return {
+      kind: "error",
+      exitCode: 1,
+      message: "openwiki --config requires an interactive terminal.",
+    };
+  }
+
   if (
     command.kind === "run" &&
     !command.dryRun &&

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -19,6 +19,7 @@ export type HelpContent = {
 
 export type CliCommand =
   | { kind: "help"; exitCode: 0 }
+  | { kind: "config"; exitCode: 0 }
   | {
       kind: "run";
       exitCode: 0;
@@ -43,6 +44,7 @@ export function parseCommand(argv: string[]): CliCommand {
   let dryRun = false;
   let modelId: string | null = null;
   let print = false;
+  let config = false;
   let command: OpenWikiCommand = "chat";
   const userMessageParts: string[] = [];
 
@@ -68,6 +70,11 @@ export function parseCommand(argv: string[]): CliCommand {
 
     if (arg === "--print" || arg === "-p") {
       print = true;
+      continue;
+    }
+
+    if (arg === "--config") {
+      config = true;
       continue;
     }
 
@@ -143,6 +150,19 @@ export function parseCommand(argv: string[]): CliCommand {
     userMessageParts.length > 0 ? userMessageParts.join(" ") : null;
   const shouldStart = command !== "chat" || userMessage !== null;
 
+  if (config) {
+    if (command !== "chat" || userMessage !== null || print) {
+      return {
+        kind: "error",
+        exitCode: 1,
+        message:
+          "--config cannot be combined with --init, --update, --print, or a message.",
+      };
+    }
+
+    return { kind: "config", exitCode: 0 };
+  }
+
   if (print && !shouldStart) {
     return {
       kind: "error",
@@ -178,6 +198,7 @@ export const helpContent: HelpContent = {
     "openwiki [--modelId <model>] [message]",
     "openwiki --init [message]",
     "openwiki --update [message]",
+    "openwiki --config",
   ],
   commands: [
     {
@@ -193,6 +214,11 @@ export const helpContent: HelpContent = {
     {
       label: "--update",
       description: "Update existing OpenWiki documentation.",
+    },
+    {
+      label: "--config",
+      description:
+        "Reconfigure provider, API key, model, and LangSmith without running the agent.",
     },
     {
       label: "-p, --print",
@@ -213,6 +239,7 @@ export const helpContent: HelpContent = {
     "openwiki",
     "openwiki --init",
     "openwiki --update",
+    "openwiki --config",
     'openwiki "What can you do?"',
     'openwiki -p "Summarize what OpenWiki can do"',
     "openwiki --modelId gpt-5.5",

--- a/src/credentials.tsx
+++ b/src/credentials.tsx
@@ -27,6 +27,10 @@ export type InitSetupResult = {
 
 type InitSetupProps = {
   modelIdOverride?: string | null;
+  // When true, walk every step even if values already exist, so the user can
+  // change settings. Empty input on the API key / LangSmith steps means "keep
+  // the current value" so existing credentials are never nulled out.
+  reconfigure?: boolean;
   onComplete: (result: InitSetupResult) => void;
   onError: (message: string) => void;
 };
@@ -50,10 +54,17 @@ export function needsCredentialSetup(
 
 export function InitSetup({
   modelIdOverride = null,
+  reconfigure = false,
   onComplete,
   onError,
 }: InitSetupProps) {
   const initialProvider = resolveConfiguredProvider();
+  const currentSavedModelId =
+    modelIdOverride ?? process.env[OPENWIKI_MODEL_ID_ENV_KEY] ?? null;
+  // Only surface the saved model as a "keep current" option for the provider it
+  // belongs to; switching providers should fall back to that provider's default.
+  const injectedModelIdFor = (p: OpenWikiProvider): string | null =>
+    reconfigure && p === initialProvider ? currentSavedModelId : null;
   const [step, setStep] = useState<PromptStep | null>(null);
   const [provider, setProvider] = useState<OpenWikiProvider>(initialProvider);
   const [apiKey, setApiKey] = useState<string | null>(null);
@@ -66,9 +77,8 @@ export function InitSetup({
   const [modelSelectionIndex, setModelSelectionIndex] = useState(() =>
     getModelSelectionIndex(
       initialProvider,
-      modelIdOverride ??
-        process.env[OPENWIKI_MODEL_ID_ENV_KEY] ??
-        getDefaultModelId(initialProvider),
+      currentSavedModelId ?? getDefaultModelId(initialProvider),
+      injectedModelIdFor(initialProvider),
     ),
   );
   const [isCustomModelInput, setIsCustomModelInput] = useState(false);
@@ -76,7 +86,11 @@ export function InitSetup({
   const [isSaving, setIsSaving] = useState(false);
 
   useEffect(() => {
-    const initialStep = getInitialStep(modelIdOverride, initialProvider);
+    const initialStep = getInitialStep(
+      modelIdOverride,
+      initialProvider,
+      reconfigure,
+    );
 
     if (initialStep === null) {
       onComplete({
@@ -96,14 +110,13 @@ export function InitSetup({
     setModelSelectionIndex(
       getModelSelectionIndex(
         initialProvider,
-        modelIdOverride ??
-          process.env[OPENWIKI_MODEL_ID_ENV_KEY] ??
-          getDefaultModelId(initialProvider),
+        currentSavedModelId ?? getDefaultModelId(initialProvider),
+        injectedModelIdFor(initialProvider),
       ),
     );
     setIsCustomModelInput(false);
     setStep(initialStep);
-  }, [initialProvider, modelIdOverride, onComplete]);
+  }, [initialProvider, modelIdOverride, reconfigure, onComplete]);
 
   useInput((inputValue, key) => {
     if (isSaving || step === null) {
@@ -137,7 +150,8 @@ export function InitSetup({
           moveSelectionIndex(
             index,
             key.upArrow ? -1 : 1,
-            getModelSelectionOptions(provider).length,
+            getModelSelectionOptions(provider, injectedModelIdFor(provider))
+              .length,
           ),
         );
         return;
@@ -175,12 +189,14 @@ export function InitSetup({
         SELECTABLE_OPENWIKI_PROVIDERS[providerSelectionIndex] ??
         DEFAULT_PROVIDER;
 
+      const injectedModelId = injectedModelIdFor(selectedProvider);
       setProvider(selectedProvider);
       setProviderSelectionIndex(getProviderSelectionIndex(selectedProvider));
       setModelSelectionIndex(
         getModelSelectionIndex(
           selectedProvider,
-          getDefaultModelId(selectedProvider),
+          injectedModelId ?? getDefaultModelId(selectedProvider),
+          injectedModelId,
         ),
       );
       setIsCustomModelInput(false);
@@ -188,6 +204,7 @@ export function InitSetup({
       const nextStep = getNextStepAfterProvider(
         selectedProvider,
         modelIdOverride,
+        reconfigure,
       );
 
       if (nextStep) {
@@ -206,15 +223,47 @@ export function InitSetup({
 
     if (step === "api-key") {
       const trimmedInput = input.trim();
+      const hasExistingKey = Boolean(
+        process.env[getProviderApiKeyEnvKey(provider)],
+      );
 
+      // In reconfigure mode, an empty entry keeps the current key rather than
+      // erroring — but only when there is a current key to keep (e.g. the user
+      // did not just switch to a provider that has no saved key).
       if (trimmedInput.length === 0) {
+        if (reconfigure && hasExistingKey) {
+          setInput("");
+          const nextStep = getNextStepAfterApiKey(
+            provider,
+            modelIdOverride,
+            reconfigure,
+          );
+
+          if (nextStep) {
+            setStep(nextStep);
+            return;
+          }
+
+          await completeSetup({
+            nextApiKey: null,
+            nextLangSmithKey: langSmithKey,
+            nextModelId: modelId,
+            nextProvider: provider,
+          });
+          return;
+        }
+
         setError(`${getProviderApiKeyEnvKey(provider)} is required.`);
         return;
       }
 
       setApiKey(trimmedInput);
       setInput("");
-      const nextStep = getNextStepAfterApiKey(provider, modelIdOverride);
+      const nextStep = getNextStepAfterApiKey(
+        provider,
+        modelIdOverride,
+        reconfigure,
+      );
 
       if (nextStep) {
         setStep(nextStep);
@@ -236,6 +285,7 @@ export function InitSetup({
         modelSelectionIndex,
         input,
         isCustomModelInput,
+        injectedModelIdFor(provider),
       );
 
       if (!selectedModelId) {
@@ -253,7 +303,7 @@ export function InitSetup({
       setInput("");
       setIsCustomModelInput(false);
 
-      if (process.env.LANGSMITH_API_KEY === undefined) {
+      if (reconfigure || process.env.LANGSMITH_API_KEY === undefined) {
         setStep("langsmith");
         return;
       }
@@ -268,7 +318,12 @@ export function InitSetup({
     }
 
     if (step === "langsmith") {
-      const nextLangSmithKey = input.trim();
+      const trimmedInput = input.trim();
+      // Fresh setup keeps its existing behavior (empty saves an empty value so
+      // the optional step is not asked again). In reconfigure mode an empty
+      // entry keeps the current LangSmith key instead of clearing it.
+      const nextLangSmithKey =
+        trimmedInput.length > 0 ? trimmedInput : reconfigure ? null : "";
 
       setLangSmithKey(nextLangSmithKey);
       setInput("");
@@ -415,10 +470,12 @@ export function InitSetup({
         {step ? (
           <Prompt
             input={input}
+            injectedModelId={injectedModelIdFor(provider)}
             isCustomModelInput={isCustomModelInput}
             modelSelectionIndex={modelSelectionIndex}
             provider={provider}
             providerSelectionIndex={providerSelectionIndex}
+            reconfigure={reconfigure}
             step={step}
           />
         ) : (
@@ -426,7 +483,7 @@ export function InitSetup({
         )}
       </SetupPanel>
 
-      {needsCredentialPrompt ? (
+      {needsCredentialPrompt || reconfigure ? (
         <Text color="gray">Secrets are masked and saved only after setup.</Text>
       ) : null}
 
@@ -512,21 +569,27 @@ function SetupPanel({ title, children }: SetupPanelProps) {
 
 type PromptProps = {
   input: string;
+  injectedModelId: string | null;
   isCustomModelInput: boolean;
   modelSelectionIndex: number;
   provider: OpenWikiProvider;
   providerSelectionIndex: number;
+  reconfigure: boolean;
   step: PromptStep;
 };
 
 function Prompt({
   input,
+  injectedModelId,
   isCustomModelInput,
   modelSelectionIndex,
   provider,
   providerSelectionIndex,
+  reconfigure,
   step,
 }: PromptProps) {
+  const canKeepCurrentKey =
+    reconfigure && Boolean(process.env[getProviderApiKeyEnvKey(provider)]);
   if (step === "provider") {
     return (
       <Box flexDirection="column">
@@ -554,7 +617,11 @@ function Prompt({
           <Text color="gray">$</Text> {getProviderApiKeyEnvKey(provider)}={" "}
           <Text color="yellow">{mask(input)}</Text>
         </Text>
-        <Text color="gray">Press Enter to save it.</Text>
+        <Text color="gray">
+          {canKeepCurrentKey
+            ? "Press Enter to keep the current key, or paste a new one."
+            : "Press Enter to save it."}
+        </Text>
       </Box>
     );
   }
@@ -579,26 +646,28 @@ function Prompt({
           Choose {getProviderArticle(provider)} {getProviderLabel(provider)}{" "}
           model.
         </Text>
-        {getModelSelectionOptions(provider).map((option, index) => {
-          if (option.kind === "custom") {
+        {getModelSelectionOptions(provider, injectedModelId).map(
+          (option, index) => {
+            if (option.kind === "custom") {
+              return (
+                <Text key="custom">
+                  <SelectionMarker isSelected={index === modelSelectionIndex} />{" "}
+                  Custom model ID
+                </Text>
+              );
+            }
+
             return (
-              <Text key="custom">
+              <Text key={option.id}>
                 <SelectionMarker isSelected={index === modelSelectionIndex} />{" "}
-                Custom model ID
+                {option.label} <Text color="gray">{option.id}</Text>
+                {option.id === getDefaultModelId(provider) ? (
+                  <Text color="gray"> default</Text>
+                ) : null}
               </Text>
             );
-          }
-
-          return (
-            <Text key={option.id}>
-              <SelectionMarker isSelected={index === modelSelectionIndex} />{" "}
-              {option.label} <Text color="gray">{option.id}</Text>
-              {option.id === getDefaultModelId(provider) ? (
-                <Text color="gray"> default</Text>
-              ) : null}
-            </Text>
-          );
-        })}
+          },
+        )}
         <Text color="gray">Use up/down arrows, then press Enter.</Text>
       </Box>
     );
@@ -606,10 +675,19 @@ function Prompt({
 
   if (step === "langsmith") {
     return (
-      <Text>
-        <Text color="gray">$</Text> LANGSMITH_API_KEY optional={" "}
-        <Text color="yellow">{mask(input)}</Text>
-      </Text>
+      <Box flexDirection="column">
+        <Text>
+          <Text color="gray">$</Text> LANGSMITH_API_KEY optional={" "}
+          <Text color="yellow">{mask(input)}</Text>
+        </Text>
+        {reconfigure &&
+        process.env.LANGSMITH_API_KEY !== undefined &&
+        process.env.LANGSMITH_API_KEY.length > 0 ? (
+          <Text color="gray">
+            Press Enter to keep the current key, or paste a new one.
+          </Text>
+        ) : null}
+      </Box>
     );
   }
 
@@ -625,7 +703,14 @@ function SelectionMarker({ isSelected }: { isSelected: boolean }) {
 function getInitialStep(
   modelIdOverride: string | null,
   provider: OpenWikiProvider,
+  reconfigure: boolean,
 ): PromptStep | null {
+  // Reconfigure always starts from the top and walks every step so the user
+  // can change any setting; only-missing steps are for first-time setup.
+  if (reconfigure) {
+    return "provider";
+  }
+
   if (process.env[OPENWIKI_PROVIDER_ENV_KEY] === undefined) {
     return "provider";
   }
@@ -651,21 +736,24 @@ function getInitialStep(
 function getNextStepAfterProvider(
   provider: OpenWikiProvider,
   modelIdOverride: string | null,
+  reconfigure: boolean,
 ): PromptStep | null {
-  if (!process.env[getProviderApiKeyEnvKey(provider)]) {
+  if (reconfigure || !process.env[getProviderApiKeyEnvKey(provider)]) {
     return "api-key";
   }
 
-  return getNextStepAfterApiKey(provider, modelIdOverride);
+  return getNextStepAfterApiKey(provider, modelIdOverride, reconfigure);
 }
 
 function getNextStepAfterApiKey(
   provider: OpenWikiProvider,
   modelIdOverride: string | null,
+  reconfigure: boolean,
 ): PromptStep | null {
   if (
-    modelIdOverride === null &&
-    process.env[OPENWIKI_MODEL_ID_ENV_KEY] === undefined
+    reconfigure ||
+    (modelIdOverride === null &&
+      process.env[OPENWIKI_MODEL_ID_ENV_KEY] === undefined)
   ) {
     return "model";
   }
@@ -712,13 +800,29 @@ type ModelSelectionOption =
 
 function getModelSelectionOptions(
   provider: OpenWikiProvider,
+  currentModelId?: string | null,
 ): ModelSelectionOption[] {
+  const presets = getProviderModelOptions(provider).map((model) => ({
+    id: model.id,
+    kind: "preset" as const,
+    label: model.label,
+  }));
+
+  // Reconfigure passes the currently-saved model. When it is not one of the
+  // provider presets (e.g. a custom model set via --modelId or /model), surface
+  // it as a selectable option so pressing Enter keeps it instead of silently
+  // switching to the first preset.
+  const hasCurrent =
+    currentModelId !== undefined &&
+    currentModelId !== null &&
+    currentModelId.length > 0 &&
+    !presets.some((preset) => preset.id === currentModelId);
+
   return [
-    ...getProviderModelOptions(provider).map((model) => ({
-      id: model.id,
-      kind: "preset" as const,
-      label: model.label,
-    })),
+    ...(hasCurrent
+      ? [{ id: currentModelId, kind: "preset" as const, label: "current" }]
+      : []),
+    ...presets,
     { kind: "custom" },
   ];
 }
@@ -728,9 +832,12 @@ function getSelectedModelId(
   selectedIndex: number,
   input: string,
   isCustomInput: boolean,
+  currentModelId?: string | null,
 ): string | "custom" | null {
   if (!isCustomInput) {
-    const selectedOption = getModelSelectionOptions(provider)[selectedIndex];
+    const selectedOption = getModelSelectionOptions(provider, currentModelId)[
+      selectedIndex
+    ];
 
     if (!selectedOption) {
       return null;
@@ -755,8 +862,12 @@ function getProviderSelectionIndex(provider: OpenWikiProvider): number {
 function getModelSelectionIndex(
   provider: OpenWikiProvider,
   selectedModelId: string,
+  currentModelId?: string | null,
 ): number {
-  const selectedIndex = getModelSelectionOptions(provider).findIndex(
+  const selectedIndex = getModelSelectionOptions(
+    provider,
+    currentModelId,
+  ).findIndex(
     (option) => option.kind === "preset" && option.id === selectedModelId,
   );
 


### PR DESCRIPTION
<h4>Description</h4>

Adds `openwiki --config`, a settings-only entry point for changing the provider, API key, model, or LangSmith key.

Today, once `~/.openwiki/.env` holds a complete set of credentials there is no way to change them from the CLI:

- `--init` maps to a documentation run (`shouldStart: true`), so it invokes the agent on mount. A user whose key is dead (expired trial, exhausted quota, wrong tier) just gets an error on boot with no path to switch keys.
- `needsCredentialSetup()` is only `true` when a value is *missing*, so `InitSetup` is never reached when the file is complete.
- Interactive chat has no key command — `/provider` only writes the provider + default model and prints "ensure KEY is set".

This fixes https://github.com/langchain-ai/openwiki/issues/23


<h4>What changed</h4>

- **`--config` flag** (`commands.ts`): new `{ kind: "config" }` command. It errors if combined with `--init`/`--update`/`--print`/a message, and requires a TTY.
- **`reconfigure` mode in `InitSetup`** (`credentials.tsx`): walks every step (provider → key → model → LangSmith) even when values already exist.
- **Non-destructive by design**: on the API key and LangSmith prompts, an empty entry means *keep the current value* — `completeSetup` only writes non-null fields, so untouched secrets are never cleared. A saved custom model that isn't one of the provider presets is surfaced as a selectable "current" option so pressing Enter keeps it instead of silently falling back to the first preset.
- **Never runs the agent** (`cli.tsx`): the config flow renders the outcome and exits; the agent-run effect is gated on `command.kind === "run"`. Env is now loaded for `--config` too so existing values are detected.
- Docs + help updated.

<h4>Testing</h4>

`pnpm build`, `pnpm lint:check`, `pnpm format:check` all pass. Drove the interactive flow through a PTY against an isolated `HOME` with a complete `.env`:

- **Keep all** (Enter through every step): every value preserved, no network call.
- **Change key** (type a new key, keep the rest): key replaced; provider, model, and LangSmith key preserved.
- **Custom model + keep all**: a non-preset `OPENWIKI_MODEL_ID` is preserved rather than overwritten.

<h4>Follow-ups (not in this PR)</h4>

- A `/key` (or `/login`) slash command for the in-session case.
- A hint on 429/`insufficient_quota` errors pointing at `--config`.
- Warn when the key being saved is shadowed by an exported shell var (`loadOpenWikiEnv` only fills `process.env` when unset, so an exported key wins over `~/.openwiki/.env` on the next shell).

Made with [Claude Code](https://claude.ai/claude-code)
