### PR TITLE
ci: add npm pack smoke test

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -51,3 +51,27 @@ jobs:
 
       - name: Check lint
         run: pnpm run lint:check
+
+  pack:
+    name: Pack
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          run_install: false
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build and pack
+        run: pnpm run pack:check

--- a/package.json
+++ b/package.json
@@ -33,6 +33,8 @@
     "format:check": "prettier --check .",
     "lint": "eslint . --fix",
     "lint:check": "eslint .",
+    "pack": "pnpm run build && pnpm pack",
+    "pack:check": "pnpm run build && pnpm pack --dry-run",
     "prebuild": "pnpm run clean",
     "prepack": "pnpm run build",
     "start": "node dist/cli.js"


### PR DESCRIPTION
Adds `pnpm pack` scripts (`pack`, `pack:check`) and a CI job that dry-runs the package build/pack on every pull request. This catches packaging regressions (missing files, broken bin paths, build failures) before release.\n\n- `package.json`: new `pack` and `pack:check` scripts\n- `.github/workflows/checks.yml`: new `Pack` job running `pnpm run pack:check`\n\nVerified locally with `pnpm run pack:check` — tarball lists expected dist, README, LICENSE, and package.json.