### PR TITLE
feat: add Ollama provider and --init CLI flags

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -51,3 +51,27 @@ jobs:
 
       - name: Check lint
         run: pnpm run lint:check
+
+  pack:
+    name: Pack
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          run_install: false
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build and pack
+        run: pnpm run pack:check

--- a/README.md
+++ b/README.md
@@ -70,6 +70,6 @@ These configuration options and secrets will be saved to `~/.openwiki/.env` on y
 
 ## Customizing
 
-OpenWiki supports OpenRouter, Fireworks, Baseten, OpenAI and Anthropic out of the box. By default, there are a few models pre-defined (GLM 5.2, Kimi K2.6, Sonnet 5, etc) but for each inference provider, OpenWiki will allow you to specify your own custom model ID.
+OpenWiki supports OpenRouter, Fireworks, Baseten, OpenAI, Anthropic and Ollama out of the box. By default, there are a few models pre-defined (GLM 5.2, Kimi K2.6, Sonnet 5, etc) but for each inference provider, OpenWiki will allow you to specify your own custom model ID.
 
 If there's an inference provider or model you'd like to see added, please open a PR!

--- a/README.md
+++ b/README.md
@@ -48,6 +48,13 @@ Initialize OpenWiki:
 openwiki --init
 ```
 
+Initialize and skip interactive prompts by providing the provider, base URL, and model up front:
+
+```sh
+openwiki --init --provider openai --model gpt-5.5
+openwiki --init --provider ollama --base-url http://localhost:11434 --model llama3.1
+```
+
 Update existing documentation:
 
 ```sh

--- a/openwiki/cli/usage.md
+++ b/openwiki/cli/usage.md
@@ -9,13 +9,14 @@ From `src/commands.ts` and `README.md`, the supported entry patterns are:
 - `openwiki` — open the interactive chat UI.
 - `openwiki "message"` — send a chat message immediately, then stay open.
 - `openwiki --init [message]` — generate initial OpenWiki documentation.
+- `openwiki --init --provider <id> --base-url <url> --model <id>` — generate documentation with credentials pre-selected (interactive prompts are skipped for supplied values).
 - `openwiki --update [message]` — refresh existing OpenWiki documentation.
 - `openwiki -p, --print` — run once and print the final assistant output (non-interactive).
 - `openwiki --modelId <id>` / `--model-id <id>` — choose a model ID for the run.
 - `openwiki --help` / `-h` — print usage, options, and examples.
 - `openwiki --dry-run` — development-only option that avoids invoking the agent.
 
-The parser rejects incompatible combinations such as `--init` and `--update` together, and it requires a message or command when `--print` is used.
+The parser rejects incompatible combinations such as `--init` and `--update` together, and it requires a message or command when `--print` is used. `--base-url` accepts either `--base-url` or `--baseurl`.
 
 ### Auto-exit for init/update
 

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "@langchain/anthropic": "^1.5.1",
     "@langchain/core": "^1.2.1",
     "@langchain/langgraph-checkpoint-sqlite": "^1.0.3",
+    "@langchain/ollama": "^1.3.0",
     "@langchain/openai": "^1.5.3",
     "@langchain/openrouter": "^0.4.3",
     "deepagents": "^1.10.5",

--- a/package.json
+++ b/package.json
@@ -33,6 +33,8 @@
     "format:check": "prettier --check .",
     "lint": "eslint . --fix",
     "lint:check": "eslint .",
+    "pack": "pnpm run build && pnpm pack",
+    "pack:check": "pnpm run build && pnpm pack --dry-run",
     "prebuild": "pnpm run clean",
     "prepack": "pnpm run build",
     "start": "node dist/cli.js"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,6 +17,9 @@ importers:
       '@langchain/langgraph-checkpoint-sqlite':
         specifier: ^1.0.3
         version: 1.0.3(@langchain/core@1.2.1(openai@6.44.0(ws@8.21.0)(zod@4.4.3))(ws@8.21.0))(@langchain/langgraph-checkpoint@1.1.2(@langchain/core@1.2.1(openai@6.44.0(ws@8.21.0)(zod@4.4.3))(ws@8.21.0)))
+      '@langchain/ollama':
+        specifier: ^1.3.0
+        version: 1.3.0(@langchain/core@1.2.1(openai@6.44.0(ws@8.21.0)(zod@4.4.3))(ws@8.21.0))
       '@langchain/openai':
         specifier: ^1.5.3
         version: 1.5.3(@langchain/core@1.2.1(openai@6.44.0(ws@8.21.0)(zod@4.4.3))(ws@8.21.0))(ws@8.21.0)
@@ -352,6 +355,12 @@ packages:
     peerDependenciesMeta:
       zod-to-json-schema:
         optional: true
+
+  '@langchain/ollama@1.3.0':
+    resolution: {integrity: sha512-uzLkZVTXN0SI5zAoJbJzL4y/QN7gbmJ1txBgFfqJ5M0Qf+Yu2Zu8q98L3jIrfM+akWMaNmRU4R4APhcfQmeIsw==}
+    engines: {node: '>=20'}
+    peerDependencies:
+      '@langchain/core': ^1.0.0
 
   '@langchain/openai@1.5.3':
     resolution: {integrity: sha512-OStS2AUvy9oe/hEf/3ndBOFztUDOfuJYLNXh89m3iiJAI2Cp5Dp0n/pvpO27MO0b+VgENd+xSHVyQZ7fe+ulxg==}
@@ -916,6 +925,9 @@ packages:
     resolution: {integrity: sha512-KdHvFWZjEKDf0cakgFjebl371GPsISX2oZHcuyKqM7DtogIsHrqKeLTo8wBHxaXRAQlY2PsPlZmfo+9ZCxEREQ==}
     engines: {node: '>=10'}
 
+  ollama@0.6.3:
+    resolution: {integrity: sha512-KEWEhIqE5wtfzEIZbDCLH51VFZ6Z3ZSa6sIOg/E/tBV8S51flyqBOXi+bRxlOYKDf8i327zG9eSTb8IJxvm3Zg==}
+
   once@1.4.0:
     resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
 
@@ -1162,6 +1174,9 @@ packages:
 
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
+
+  whatwg-fetch@3.6.20:
+    resolution: {integrity: sha512-EqhiFU6daOA8kpjOWTL0olhVOF3i7OrFzSYiGsEMB8GcXS+RrzauAERX65xMeNWVqxA6HXH2m69Z9LaKKdisfg==}
 
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
@@ -1411,6 +1426,11 @@ snapshots:
       - react-dom
       - svelte
       - vue
+
+  '@langchain/ollama@1.3.0(@langchain/core@1.2.1(openai@6.44.0(ws@8.21.0)(zod@4.4.3))(ws@8.21.0))':
+    dependencies:
+      '@langchain/core': 1.2.1(openai@6.44.0(ws@8.21.0)(zod@4.4.3))(ws@8.21.0)
+      ollama: 0.6.3
 
   '@langchain/openai@1.5.3(@langchain/core@1.2.1(openai@6.44.0(ws@8.21.0)(zod@4.4.3))(ws@8.21.0))(ws@8.21.0)':
     dependencies:
@@ -2016,6 +2036,10 @@ snapshots:
     dependencies:
       semver: 7.8.5
 
+  ollama@0.6.3:
+    dependencies:
+      whatwg-fetch: 3.6.20
+
   once@1.4.0:
     dependencies:
       wrappy: 1.0.2
@@ -2265,6 +2289,8 @@ snapshots:
       punycode: 2.3.1
 
   util-deprecate@1.0.2: {}
+
+  whatwg-fetch@3.6.20: {}
 
   which@2.0.2:
     dependencies:

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -3,10 +3,17 @@ import { chmod, mkdir } from "node:fs/promises";
 import path from "node:path";
 import { ChatAnthropic } from "@langchain/anthropic";
 import { ChatOllama } from "@langchain/ollama";
+import { BaseMessage, ToolMessage } from "@langchain/core/messages";
+import type { CallbackManagerForLLMRun } from "@langchain/core/callbacks/manager";
 import { SqliteSaver } from "@langchain/langgraph-checkpoint-sqlite";
 import { ChatOpenAI } from "@langchain/openai";
 import { ChatOpenRouter } from "@langchain/openrouter";
-import { createDeepAgent, LocalShellBackend } from "deepagents";
+import {
+  createDeepAgent,
+  GENERAL_PURPOSE_SUBAGENT,
+  LocalShellBackend,
+} from "deepagents";
+import type { SubAgent } from "deepagents";
 import { loadOpenWikiEnv, openWikiEnvDir } from "../env.js";
 import { createSystemPrompt, createUserPrompt } from "./prompt.js";
 import type {
@@ -184,6 +191,7 @@ async function runOpenWikiAgentCore(
   const agent = createDeepAgent({
     model,
     tools: [],
+    subagents: createSubagentTypeAliases(),
     checkpointer,
     backend: new LocalShellBackend({
       maxOutputBytes: 100_000,
@@ -251,6 +259,16 @@ async function runOpenWikiAgentCore(
     command,
     model: modelId,
   };
+}
+
+function createSubagentTypeAliases(): SubAgent[] {
+  return [
+    {
+      ...GENERAL_PURPOSE_SUBAGENT,
+      name: "general-pattern",
+      description: `${GENERAL_PURPOSE_SUBAGENT.description} (alias for general-purpose)`,
+    },
+  ];
 }
 
 function createAttemptOptions(
@@ -391,7 +409,7 @@ async function createModel(provider: OpenWikiProvider, modelId: string) {
   if (provider === "ollama") {
     const providerConfig = getProviderConfig(provider);
 
-    return new ChatOllama({
+    return new SafeChatOllama({
       baseUrl:
         process.env[OLLAMA_BASE_URL_ENV_KEY] ??
         providerConfig.baseURL ??
@@ -425,6 +443,68 @@ async function createModel(provider: OpenWikiProvider, modelId: string) {
         }
       : undefined,
     model: modelId,
+  });
+}
+
+class SafeChatOllama extends ChatOllama {
+  async _generate(
+    messages: BaseMessage[],
+    options: this["ParsedCallOptions"],
+    runManager?: CallbackManagerForLLMRun,
+  ) {
+    return super._generate(
+      normalizeOllamaToolMessages(messages),
+      options,
+      runManager,
+    );
+  }
+
+  async *_streamResponseChunks(
+    messages: BaseMessage[],
+    options: this["ParsedCallOptions"],
+    runManager?: CallbackManagerForLLMRun,
+  ) {
+    yield* super._streamResponseChunks(
+      normalizeOllamaToolMessages(messages),
+      options,
+      runManager,
+    );
+  }
+}
+
+function normalizeOllamaToolMessages(messages: BaseMessage[]): BaseMessage[] {
+  return messages.map((message) => {
+    if (
+      !(message instanceof ToolMessage) ||
+      typeof message.content === "string"
+    ) {
+      return message;
+    }
+
+    const content = Array.isArray(message.content)
+      ? message.content
+          .map((block) => {
+            if (typeof block === "string") {
+              return block;
+            }
+
+            if (isRecord(block) && typeof block.text === "string") {
+              return block.text;
+            }
+
+            return JSON.stringify(block);
+          })
+          .join("\n")
+      : JSON.stringify(message.content);
+
+    return new ToolMessage({
+      content,
+      name: message.name,
+      tool_call_id: message.tool_call_id,
+      additional_kwargs: message.additional_kwargs,
+      response_metadata: message.response_metadata,
+      id: message.id,
+    });
   });
 }
 

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -2,6 +2,7 @@ import { createHash } from "node:crypto";
 import { chmod, mkdir } from "node:fs/promises";
 import path from "node:path";
 import { ChatAnthropic } from "@langchain/anthropic";
+import { ChatOllama } from "@langchain/ollama";
 import { SqliteSaver } from "@langchain/langgraph-checkpoint-sqlite";
 import { ChatOpenAI } from "@langchain/openai";
 import { ChatOpenRouter } from "@langchain/openrouter";
@@ -22,9 +23,12 @@ import {
   getProviderApiKeyEnvKey,
   getProviderConfig,
   getProviderLabel,
+  hasOptionalApiKey,
   isValidModelId,
   normalizeModelId,
+  OLLAMA_BASE_URL_ENV_KEY,
   OPENAI_API_KEY_ENV_KEY,
+  OPENAI_BASE_URL_ENV_KEY,
   OPENROUTER_API_KEY_ENV_KEY,
   OPENROUTER_BASE_URL,
   OPENROUTER_FALLBACK_MODEL_IDS,
@@ -351,7 +355,7 @@ function isFileNotFoundError(error: unknown): boolean {
 function ensureProviderKey(provider: OpenWikiProvider): void {
   const apiKeyEnvKey = getProviderApiKeyEnvKey(provider);
 
-  if (!process.env[apiKeyEnvKey]) {
+  if (!process.env[apiKeyEnvKey] && !hasOptionalApiKey(provider)) {
     throw new Error(
       `${apiKeyEnvKey} is required to run OpenWiki with ${getProviderLabel(provider)}.`,
     );
@@ -384,6 +388,18 @@ async function createModel(provider: OpenWikiProvider, modelId: string) {
     });
   }
 
+  if (provider === "ollama") {
+    const providerConfig = getProviderConfig(provider);
+
+    return new ChatOllama({
+      baseUrl:
+        process.env[OLLAMA_BASE_URL_ENV_KEY] ??
+        providerConfig.baseURL ??
+        "http://localhost:11434",
+      model: modelId,
+    });
+  }
+
   if (provider === "openrouter") {
     const models = createModelRoute(provider, modelId);
 
@@ -398,12 +414,14 @@ async function createModel(provider: OpenWikiProvider, modelId: string) {
   }
 
   const providerConfig = getProviderConfig(provider);
+  const baseURL =
+    process.env[OPENAI_BASE_URL_ENV_KEY] ?? providerConfig.baseURL;
 
   return new ChatOpenAI({
     apiKey: process.env[getProviderApiKeyEnvKey(provider)],
-    configuration: providerConfig.baseURL
+    configuration: baseURL
       ? {
-          baseURL: providerConfig.baseURL,
+          baseURL,
         }
       : undefined,
     model: modelId,

--- a/src/agent/prompt.ts
+++ b/src/agent/prompt.ts
@@ -30,6 +30,7 @@ Run discipline:
 
 Subagent discipline:
 - You may use the task tool to parallelize read-only research during init and update runs when the repository has multiple substantial domains.
+- When calling the task tool, set subagent_type to exactly 'general-purpose'. No other values are valid.
 - Default to 1-2 subagents for large or unfamiliar repositories. Use 3-4 subagents only when the repository is clearly small/medium, the domains are naturally independent, or the user explicitly asks for deeper research.
 - Subagents must only inspect and summarize. They must not create, edit, delete, or move files, and they must not write to ${OPEN_WIKI_DIR}/.
 - Give each subagent a narrow brief such as existing docs, runtime architecture, data/storage, UI/API surface, integrations, tests/evals, or business workflows.

--- a/src/cli.tsx
+++ b/src/cli.tsx
@@ -417,7 +417,8 @@ function App({ command }: AppProps) {
   if (shouldRunInteractiveCredentialSetup) {
     return (
       <InitSetup
-        modelIdOverride={command.modelId}
+        baseUrlOverride={command.kind === "run" ? command.baseUrl : null}
+        modelIdOverride={command.kind === "run" ? command.modelId : null}
         onComplete={(result) => {
           if (result.modelId) {
             setSessionModelId(result.modelId);
@@ -431,6 +432,7 @@ function App({ command }: AppProps) {
         onError={(message) => {
           setRunState({ status: "error", message });
         }}
+        providerOverride={command.kind === "run" ? command.provider : null}
       />
     );
   }

--- a/src/cli.tsx
+++ b/src/cli.tsx
@@ -3035,6 +3035,7 @@ const parsedCommand = parseCommand(argv);
 
 if (parsedCommand.kind === "run" && !parsedCommand.dryRun) {
   await loadOpenWikiEnv();
+  applyCommandEnvOverrides(parsedCommand);
 }
 
 const command = resolveStartupCommand(parsedCommand);
@@ -3206,6 +3207,29 @@ function writePrintErrorDiagnostics(error: unknown): void {
 
   for (const diagnostic of diagnostics) {
     process.stderr.write(`${diagnostic.label}: ${diagnostic.value}\n`);
+  }
+}
+
+function applyCommandEnvOverrides(command: CliCommand): void {
+  if (command.kind !== "run" || command.dryRun) {
+    return;
+  }
+
+  if (command.provider) {
+    process.env[OPENWIKI_PROVIDER_ENV_KEY] = command.provider;
+  }
+
+  if (command.modelId) {
+    process.env[OPENWIKI_MODEL_ID_ENV_KEY] = command.modelId;
+  }
+
+  if (command.baseUrl) {
+    const provider = command.provider ?? resolveConfiguredProvider();
+    const baseUrlEnvKey = getProviderBaseUrlEnvKey(provider);
+
+    if (baseUrlEnvKey) {
+      process.env[baseUrlEnvKey] = command.baseUrl;
+    }
   }
 }
 

--- a/src/cli.tsx
+++ b/src/cli.tsx
@@ -443,6 +443,7 @@ function App({ command }: AppProps) {
           subtitle="Credential setup"
         />
         {runState.result.savedApiKey ||
+        runState.result.savedBaseURL ||
         runState.result.savedProvider ||
         runState.result.savedModelId ||
         runState.result.savedLangSmithKey ? (

--- a/src/cli.tsx
+++ b/src/cli.tsx
@@ -10,6 +10,7 @@ import {
   type HelpRow,
 } from "./commands.js";
 import {
+  completeCredentialSetup,
   InitSetup,
   needsCredentialSetup,
   type InitSetupResult,
@@ -31,8 +32,11 @@ import {
   FIREWORKS_API_KEY_ENV_KEY,
   getDefaultModelId,
   getProviderApiKeyEnvKey,
+  getProviderBaseUrlEnvKey,
+  getProviderConfig,
   getProviderLabel,
   getProviderModelOptions,
+  hasOptionalApiKey,
   isValidModelId,
   normalizeModelId,
   normalizeProvider,
@@ -152,7 +156,11 @@ function App({ command }: AppProps) {
     !command.dryRun &&
     process.stdin.isTTY &&
     runState.status === "idle" &&
-    needsCredentialSetup(sessionModelId);
+    needsCredentialSetup(
+      sessionModelId,
+      command.kind === "run" ? command.provider : null,
+      command.kind === "run" ? command.baseUrl : null,
+    );
   const displayModelId = sessionModelId ?? startupModelId;
 
   function submitChatMessage(message: string) {
@@ -3034,6 +3042,13 @@ const command = resolveStartupCommand(parsedCommand);
 if (shouldPrintStartupError(argv, parsedCommand, command)) {
   process.stderr.write(`${command.message}\n`);
   process.exitCode = command.exitCode;
+} else if (
+  command.kind === "run" &&
+  command.command === "init" &&
+  !command.dryRun &&
+  !process.stdin.isTTY
+) {
+  await runNonInteractiveInit(command);
 } else if (command.kind === "run" && command.print && !command.dryRun) {
   await runPrintCommand(command);
 } else {
@@ -3055,6 +3070,86 @@ function shouldPrintStartupError(
       !process.stdin.isTTY ||
       (parsedCommand.kind === "run" && parsedCommand.shouldStart))
   );
+}
+
+async function runNonInteractiveInit(
+  command: Extract<CliCommand, { kind: "run" }>,
+): Promise<void> {
+  try {
+    const provider = command.provider ?? resolveConfiguredProvider();
+    const modelId =
+      command.modelId ??
+      process.env[OPENWIKI_MODEL_ID_ENV_KEY] ??
+      getDefaultModelId(provider);
+    const apiKeyEnvKey = getProviderApiKeyEnvKey(provider);
+    const baseUrlEnvKey = getProviderBaseUrlEnvKey(provider);
+    const providerConfig = getProviderConfig(provider);
+
+    if (!command.provider && !command.modelId && !command.baseUrl) {
+      process.stderr.write(
+        "Non-interactive init requires --provider, --model, and/or --base-url.\n",
+      );
+      process.exitCode = 1;
+      return;
+    }
+
+    if (baseUrlEnvKey !== undefined) {
+      const configuredBaseUrl =
+        command.baseUrl ?? process.env[baseUrlEnvKey] ?? providerConfig.baseURL;
+
+      if (!configuredBaseUrl) {
+        process.stderr.write(
+          `Non-interactive init requires --base-url for ${getProviderLabel(provider)}.\n`,
+        );
+        process.exitCode = 1;
+        return;
+      }
+    }
+
+    const apiKey = hasOptionalApiKey(provider)
+      ? (process.env[apiKeyEnvKey] ?? "ollama")
+      : process.env[apiKeyEnvKey];
+
+    if (!apiKey && !hasOptionalApiKey(provider)) {
+      process.stderr.write(
+        `${apiKeyEnvKey} is required for non-interactive ${getProviderLabel(provider)} init.\n`,
+      );
+      process.exitCode = 1;
+      return;
+    }
+
+    const result = await completeCredentialSetup({
+      nextApiKey: apiKey ?? null,
+      nextBaseURL:
+        command.baseUrl ??
+        process.env[baseUrlEnvKey ?? ""] ??
+        providerConfig.baseURL ??
+        null,
+      nextLangSmithKey: process.env.LANGSMITH_API_KEY ?? "",
+      nextModelId: modelId,
+      nextProvider: provider,
+    });
+
+    process.stdout.write(
+      [
+        "OpenWiki credentials saved.",
+        result.savedProvider ? `provider: ${getProviderLabel(provider)}` : "",
+        result.savedModelId ? `model: ${modelId}` : "",
+        result.savedBaseURL && baseUrlEnvKey
+          ? `${baseUrlEnvKey}: ${process.env[baseUrlEnvKey]}`
+          : "",
+      ]
+        .filter(Boolean)
+        .join("\n") + "\n",
+    );
+
+    process.exitCode = 0;
+  } catch (error) {
+    process.stderr.write(
+      `Failed to save OpenWiki credentials: ${getErrorMessage(error)}\n`,
+    );
+    process.exitCode = 1;
+  }
 }
 
 function shouldAutoExitStartupRun(command: CliCommand): boolean {
@@ -3119,6 +3214,7 @@ function resolveStartupCommand(command: CliCommand): CliCommand {
     command.kind === "run" &&
     !command.dryRun &&
     command.shouldStart &&
+    command.command !== "init" &&
     (command.print || !process.stdin.isTTY)
   ) {
     const provider = resolveConfiguredProvider();

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -1,4 +1,10 @@
-import { isValidModelId, normalizeModelId } from "./constants.js";
+import {
+  isValidModelId,
+  isValidProvider,
+  normalizeModelId,
+  normalizeProvider,
+  type OpenWikiProvider,
+} from "./constants.js";
 import type { OpenWikiCommand } from "./agent/types.js";
 
 export type HelpRow = {
@@ -22,10 +28,12 @@ export type CliCommand =
   | {
       kind: "run";
       exitCode: 0;
+      baseUrl: string | null;
       command: OpenWikiCommand;
       dryRun: boolean;
       modelId: string | null;
       print: boolean;
+      provider: OpenWikiProvider | null;
       shouldStart: boolean;
       userMessage: string | null;
     }
@@ -40,9 +48,11 @@ export function parseCommand(argv: string[]): CliCommand {
     return { kind: "help", exitCode: 0 };
   }
 
+  let baseUrl: string | null = null;
   let dryRun = false;
   let modelId: string | null = null;
   let print = false;
+  let provider: OpenWikiProvider | null = null;
   let command: OpenWikiCommand = "chat";
   const userMessageParts: string[] = [];
 
@@ -86,7 +96,7 @@ export function parseCommand(argv: string[]): CliCommand {
       continue;
     }
 
-    if (arg === "--modelId" || arg === "--model-id") {
+    if (arg === "--modelId" || arg === "--model-id" || arg === "--model") {
       const nextArg = argv[index + 1];
 
       if (!nextArg || nextArg.startsWith("-")) {
@@ -112,7 +122,11 @@ export function parseCommand(argv: string[]): CliCommand {
       continue;
     }
 
-    if (arg.startsWith("--modelId=") || arg.startsWith("--model-id=")) {
+    if (
+      arg.startsWith("--modelId=") ||
+      arg.startsWith("--model-id=") ||
+      arg.startsWith("--model=")
+    ) {
       const [, rawModelId = ""] = arg.split("=", 2);
       const parsedModelId = normalizeModelId(rawModelId);
 
@@ -125,6 +139,87 @@ export function parseCommand(argv: string[]): CliCommand {
       }
 
       modelId = parsedModelId;
+      continue;
+    }
+
+    if (arg === "--provider") {
+      const nextArg = argv[index + 1];
+
+      if (!nextArg || nextArg.startsWith("-")) {
+        return {
+          kind: "error",
+          exitCode: 1,
+          message: `${arg} requires a provider ID.`,
+        };
+      }
+
+      const parsedProvider = normalizeProvider(nextArg);
+
+      if (!parsedProvider || !isValidProvider(parsedProvider)) {
+        return {
+          kind: "error",
+          exitCode: 1,
+          message: `Invalid provider ID: ${nextArg}`,
+        };
+      }
+
+      provider = parsedProvider;
+      index += 1;
+      continue;
+    }
+
+    if (arg.startsWith("--provider=")) {
+      const [, rawProvider = ""] = arg.split("=", 2);
+      const parsedProvider = normalizeProvider(rawProvider);
+
+      if (!parsedProvider || !isValidProvider(parsedProvider)) {
+        return {
+          kind: "error",
+          exitCode: 1,
+          message: `Invalid provider ID: ${rawProvider}`,
+        };
+      }
+
+      provider = parsedProvider;
+      continue;
+    }
+
+    if (arg === "--base-url" || arg === "--baseurl") {
+      const nextArg = argv[index + 1];
+
+      if (!nextArg || nextArg.startsWith("-")) {
+        return {
+          kind: "error",
+          exitCode: 1,
+          message: `${arg} requires a URL.`,
+        };
+      }
+
+      if (!isValidBaseUrl(nextArg)) {
+        return {
+          kind: "error",
+          exitCode: 1,
+          message: `Invalid base URL: ${nextArg}`,
+        };
+      }
+
+      baseUrl = nextArg;
+      index += 1;
+      continue;
+    }
+
+    if (arg.startsWith("--base-url=") || arg.startsWith("--baseurl=")) {
+      const [, rawBaseUrl = ""] = arg.split("=", 2);
+
+      if (!isValidBaseUrl(rawBaseUrl)) {
+        return {
+          kind: "error",
+          exitCode: 1,
+          message: `Invalid base URL: ${rawBaseUrl}`,
+        };
+      }
+
+      baseUrl = rawBaseUrl;
       continue;
     }
 
@@ -151,16 +246,30 @@ export function parseCommand(argv: string[]): CliCommand {
     };
   }
 
+  if (baseUrl !== null && command !== "init") {
+    return {
+      kind: "error",
+      exitCode: 1,
+      message: "--base-url is only valid with --init.",
+    };
+  }
+
   return {
     kind: "run",
     exitCode: 0,
+    baseUrl,
     command,
     dryRun,
     modelId,
     print,
+    provider,
     shouldStart,
     userMessage,
   };
+}
+
+function isValidBaseUrl(value: string): boolean {
+  return value.trim().length > 0 && /^https?:\/\//iu.test(value);
 }
 
 export function isDevelopmentMode(): boolean {
@@ -174,9 +283,9 @@ export const helpContent: HelpContent = {
   description:
     "Run a documentation agent that generates and maintains a project wiki.",
   usage: [
-    "openwiki [--modelId <model>]",
-    "openwiki [--modelId <model>] [message]",
-    "openwiki --init [message]",
+    "openwiki [--model <model>]",
+    "openwiki [--model <model>] [message]",
+    "openwiki --init [--provider <id>] [--base-url <url>] [--model <model>] [message]",
     "openwiki --update [message]",
   ],
   commands: [
@@ -199,8 +308,16 @@ export const helpContent: HelpContent = {
       description: "Run once and print the final assistant output.",
     },
     {
-      label: "--modelId <id>",
-      description: "Use a model ID for this run.",
+      label: "--provider <id>",
+      description: "Provider for --init (skips provider prompt).",
+    },
+    {
+      label: "--base-url <url> / --baseurl <url>",
+      description: "Base URL for --init (skips base URL prompt).",
+    },
+    {
+      label: "--model <id>",
+      description: "Use a model ID for this run (also --modelId, --model-id).",
     },
   ],
   developmentOptions: [
@@ -212,11 +329,13 @@ export const helpContent: HelpContent = {
   examples: [
     "openwiki",
     "openwiki --init",
+    "openwiki --init --provider openai --model gpt-5.5",
+    "openwiki --init --provider ollama --base-url http://localhost:11434 --model llama3.1",
     "openwiki --update",
     'openwiki "What can you do?"',
     'openwiki -p "Summarize what OpenWiki can do"',
-    "openwiki --modelId gpt-5.5",
-    'openwiki --update --modelId gpt-5.5 "Please document the API routes first"',
+    "openwiki --model gpt-5.5",
+    'openwiki --update --model gpt-5.5 "Please document the API routes first"',
   ],
   developmentExamples: ["openwiki --dry-run"],
 };

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -5,6 +5,9 @@ export const FIREWORKS_API_KEY_ENV_KEY = "FIREWORKS_API_KEY";
 export const OPENAI_API_KEY_ENV_KEY = "OPENAI_API_KEY";
 export const ANTHROPIC_API_KEY_ENV_KEY = "ANTHROPIC_API_KEY";
 export const OPENROUTER_API_KEY_ENV_KEY = "OPENROUTER_API_KEY";
+export const OLLAMA_API_KEY_ENV_KEY = "OLLAMA_API_KEY";
+export const OLLAMA_BASE_URL_ENV_KEY = "OLLAMA_BASE_URL";
+export const OPENAI_BASE_URL_ENV_KEY = "OPENAI_BASE_URL";
 export const OPENWIKI_PROVIDER_ENV_KEY = "OPENWIKI_PROVIDER";
 export const OPENWIKI_MODEL_ID_ENV_KEY = "OPENWIKI_MODEL_ID";
 export const DEFAULT_PROVIDER = "openrouter";
@@ -14,6 +17,7 @@ export type OpenWikiProvider =
   | "anthropic"
   | "baseten"
   | "fireworks"
+  | "ollama"
   | "openai"
   | "openrouter";
 
@@ -27,6 +31,7 @@ export type ProviderModelOption = {
 type ProviderConfig = {
   apiKeyEnvKey: string;
   baseURL?: string;
+  baseURLEnvKey?: string;
   label: string;
   modelOptions: ProviderModelOption[];
 };
@@ -35,6 +40,7 @@ export const SELECTABLE_OPENWIKI_PROVIDERS = [
   "openrouter",
   "baseten",
   "fireworks",
+  "ollama",
   "openai",
   "anthropic",
 ] as const satisfies readonly SelectableOpenWikiProvider[];
@@ -63,10 +69,23 @@ export const PROVIDER_CONFIGS: Record<OpenWikiProvider, ProviderConfig> = {
   },
   openai: {
     apiKeyEnvKey: OPENAI_API_KEY_ENV_KEY,
+    baseURLEnvKey: OPENAI_BASE_URL_ENV_KEY,
     label: "OpenAI",
     modelOptions: [
       { id: "gpt-5.4-mini", label: "5.4 mini" },
       { id: "gpt-5.5", label: "5.5" },
+    ],
+  },
+  ollama: {
+    apiKeyEnvKey: OLLAMA_API_KEY_ENV_KEY,
+    baseURL: "http://localhost:11434",
+    baseURLEnvKey: OLLAMA_BASE_URL_ENV_KEY,
+    label: "Ollama",
+    modelOptions: [
+      { id: "llama3.1", label: "Llama 3.1" },
+      { id: "llama3", label: "Llama 3" },
+      { id: "mistral", label: "Mistral" },
+      { id: "qwen2.5", label: "Qwen 2.5" },
     ],
   },
   anthropic: {
@@ -116,6 +135,23 @@ export function getProviderLabel(provider: OpenWikiProvider): string {
 
 export function getProviderApiKeyEnvKey(provider: OpenWikiProvider): string {
   return getProviderConfig(provider).apiKeyEnvKey;
+}
+
+export function getProviderBaseUrlEnvKey(
+  provider: OpenWikiProvider,
+): string | undefined {
+  return getProviderConfig(provider).baseURLEnvKey;
+}
+
+export function hasOptionalApiKey(provider: OpenWikiProvider): boolean {
+  return provider === "ollama";
+}
+
+export function hasConfigurableBaseUrl(provider: OpenWikiProvider): boolean {
+  return (
+    getProviderConfig(provider).baseURLEnvKey !== undefined ||
+    getProviderConfig(provider).baseURL !== undefined
+  );
 }
 
 export function getProviderModelOptions(

--- a/src/credentials.tsx
+++ b/src/credentials.tsx
@@ -4,8 +4,12 @@ import {
   DEFAULT_PROVIDER,
   getDefaultModelId,
   getProviderApiKeyEnvKey,
+  getProviderBaseUrlEnvKey,
+  getProviderConfig,
   getProviderLabel,
   getProviderModelOptions,
+  hasOptionalApiKey,
+  hasConfigurableBaseUrl,
   isValidModelId,
   normalizeModelId,
   OPENWIKI_MODEL_ID_ENV_KEY,
@@ -20,6 +24,7 @@ export type InitSetupResult = {
   modelId: string | null;
   provider: OpenWikiProvider | null;
   savedApiKey: boolean;
+  savedBaseURL: boolean;
   savedLangSmithKey: boolean;
   savedModelId: boolean;
   savedProvider: boolean;
@@ -31,17 +36,21 @@ type InitSetupProps = {
   onError: (message: string) => void;
 };
 
-type PromptStep = "api-key" | "langsmith" | "model" | "provider";
+type PromptStep = "api-key" | "base-url" | "langsmith" | "model" | "provider";
 
 export function needsCredentialSetup(
   modelIdOverride: string | null = null,
 ): boolean {
   const provider = resolveConfiguredProvider();
   const apiKeyEnvKey = getProviderApiKeyEnvKey(provider);
+  const baseUrlEnvKey = getProviderBaseUrlEnvKey(provider);
 
   return (
     process.env[OPENWIKI_PROVIDER_ENV_KEY] === undefined ||
-    !process.env[apiKeyEnvKey] ||
+    (!hasOptionalApiKey(provider) && !process.env[apiKeyEnvKey]) ||
+    (baseUrlEnvKey !== undefined &&
+      process.env[baseUrlEnvKey] === undefined &&
+      getProviderConfig(provider).baseURL === undefined) ||
     (modelIdOverride === null &&
       process.env[OPENWIKI_MODEL_ID_ENV_KEY] === undefined) ||
     process.env.LANGSMITH_API_KEY === undefined
@@ -57,6 +66,7 @@ export function InitSetup({
   const [step, setStep] = useState<PromptStep | null>(null);
   const [provider, setProvider] = useState<OpenWikiProvider>(initialProvider);
   const [apiKey, setApiKey] = useState<string | null>(null);
+  const [baseURL, setBaseURL] = useState<string | null>(null);
   const [modelId, setModelId] = useState<string | null>(null);
   const [langSmithKey, setLangSmithKey] = useState<string | null>(null);
   const [input, setInput] = useState("");
@@ -84,6 +94,7 @@ export function InitSetup({
           modelIdOverride ?? process.env[OPENWIKI_MODEL_ID_ENV_KEY] ?? null,
         provider: initialProvider,
         savedApiKey: false,
+        savedBaseURL: false,
         savedLangSmithKey: false,
         savedModelId: false,
         savedProvider: false,
@@ -197,6 +208,7 @@ export function InitSetup({
 
       await completeSetup({
         nextApiKey: apiKey,
+        nextBaseURL: baseURL,
         nextLangSmithKey: langSmithKey,
         nextModelId: modelId,
         nextProvider: selectedProvider,
@@ -207,12 +219,24 @@ export function InitSetup({
     if (step === "api-key") {
       const trimmedInput = input.trim();
 
-      if (trimmedInput.length === 0) {
+      if (trimmedInput.length === 0 && !hasOptionalApiKey(provider)) {
         setError(`${getProviderApiKeyEnvKey(provider)} is required.`);
         return;
       }
 
-      setApiKey(trimmedInput);
+      const nextApiKey =
+        trimmedInput.length > 0
+          ? trimmedInput
+          : hasOptionalApiKey(provider)
+            ? "ollama"
+            : null;
+
+      if (nextApiKey === null) {
+        setError(`${getProviderApiKeyEnvKey(provider)} is required.`);
+        return;
+      }
+
+      setApiKey(nextApiKey);
       setInput("");
       const nextStep = getNextStepAfterApiKey(provider, modelIdOverride);
 
@@ -222,7 +246,33 @@ export function InitSetup({
       }
 
       await completeSetup({
-        nextApiKey: trimmedInput,
+        nextApiKey,
+        nextBaseURL: baseURL,
+        nextLangSmithKey: langSmithKey,
+        nextModelId: modelId,
+        nextProvider: provider,
+      });
+      return;
+    }
+
+    if (step === "base-url") {
+      const trimmedInput = input.trim();
+      const defaultBaseURL = getProviderConfig(provider).baseURL;
+      const nextBaseURL =
+        trimmedInput.length > 0 ? trimmedInput : (defaultBaseURL ?? null);
+
+      setBaseURL(nextBaseURL);
+      setInput("");
+      const nextStep = getNextStepAfterBaseURL(provider, modelIdOverride);
+
+      if (nextStep) {
+        setStep(nextStep);
+        return;
+      }
+
+      await completeSetup({
+        nextApiKey: apiKey,
+        nextBaseURL,
         nextLangSmithKey: langSmithKey,
         nextModelId: modelId,
         nextProvider: provider,
@@ -260,6 +310,7 @@ export function InitSetup({
 
       await completeSetup({
         nextApiKey: apiKey,
+        nextBaseURL: baseURL,
         nextLangSmithKey: langSmithKey,
         nextModelId: selectedModelId,
         nextProvider: provider,
@@ -275,6 +326,7 @@ export function InitSetup({
 
       await completeSetup({
         nextApiKey: apiKey,
+        nextBaseURL: baseURL,
         nextLangSmithKey,
         nextModelId: modelId,
         nextProvider: provider,
@@ -284,6 +336,7 @@ export function InitSetup({
 
   type CompleteSetupOptions = {
     nextApiKey: string | null;
+    nextBaseURL: string | null;
     nextLangSmithKey: string | null;
     nextModelId: string | null;
     nextProvider: OpenWikiProvider;
@@ -291,6 +344,7 @@ export function InitSetup({
 
   async function completeSetup({
     nextApiKey,
+    nextBaseURL,
     nextLangSmithKey,
     nextModelId,
     nextProvider,
@@ -308,6 +362,12 @@ export function InitSetup({
 
       if (nextApiKey !== null) {
         updates[getProviderApiKeyEnvKey(nextProvider)] = nextApiKey;
+      }
+
+      const baseUrlEnvKey = getProviderBaseUrlEnvKey(nextProvider);
+
+      if (baseUrlEnvKey !== undefined && nextBaseURL !== null) {
+        updates[baseUrlEnvKey] = nextBaseURL;
       }
 
       if (nextModelId !== null) {
@@ -335,6 +395,7 @@ export function InitSetup({
           null,
         provider: nextProvider,
         savedApiKey: nextApiKey !== null,
+        savedBaseURL: baseUrlEnvKey !== undefined && nextBaseURL !== null,
         savedLangSmithKey:
           nextLangSmithKey !== null && nextLangSmithKey.length > 0,
         savedModelId: nextModelId !== null,
@@ -350,6 +411,11 @@ export function InitSetup({
   }
 
   const needsCredentialPrompt = needsCredentialSetup(modelIdOverride);
+  const baseUrlEnvKey = getProviderBaseUrlEnvKey(provider);
+  const baseURLValue =
+    baseURL ??
+    process.env[baseUrlEnvKey ?? ""] ??
+    getProviderConfig(provider).baseURL;
 
   return (
     <Box flexDirection="column">
@@ -377,11 +443,30 @@ export function InitSetup({
                 : "pending"
           }
           detail={
-            process.env[getProviderApiKeyEnvKey(provider)]
-              ? "available from environment"
-              : `save ${getProviderApiKeyEnvKey(provider)} to ${openWikiEnvPath}`
+            hasOptionalApiKey(provider)
+              ? "optional (press Enter to skip)"
+              : process.env[getProviderApiKeyEnvKey(provider)]
+                ? "available from environment"
+                : `save ${getProviderApiKeyEnvKey(provider)} to ${openWikiEnvPath}`
           }
         />
+        {hasConfigurableBaseUrl(provider) ? (
+          <SetupStep
+            label="Base URL"
+            state={
+              process.env[baseUrlEnvKey ?? ""]
+                ? "done"
+                : step === "base-url"
+                  ? "current"
+                  : "pending"
+            }
+            detail={
+              baseURLValue
+                ? baseURLValue
+                : `save ${baseUrlEnvKey ?? ""} to ${openWikiEnvPath}`
+            }
+          />
+        ) : null}
         <SetupStep
           label="Model"
           state={
@@ -549,10 +634,36 @@ function Prompt({
   if (step === "api-key") {
     return (
       <Box flexDirection="column">
-        <Text>Paste your {getProviderLabel(provider)} API key.</Text>
+        <Text>
+          Paste your {getProviderLabel(provider)} API key
+          {hasOptionalApiKey(provider) ? " (optional)" : ""}.
+        </Text>
         <Text>
           <Text color="gray">$</Text> {getProviderApiKeyEnvKey(provider)}={" "}
           <Text color="yellow">{mask(input)}</Text>
+        </Text>
+        <Text color="gray">
+          {hasOptionalApiKey(provider)
+            ? "Press Enter to skip or save it."
+            : "Press Enter to save it."}
+        </Text>
+      </Box>
+    );
+  }
+
+  if (step === "base-url") {
+    const baseUrlEnvKey = getProviderBaseUrlEnvKey(provider);
+    const defaultBaseURL = getProviderConfig(provider).baseURL;
+
+    return (
+      <Box flexDirection="column">
+        <Text>
+          Paste your {getProviderLabel(provider)} base URL
+          {defaultBaseURL ? ` (default: ${defaultBaseURL})` : ""}.
+        </Text>
+        <Text>
+          <Text color="gray">$</Text> {baseUrlEnvKey ?? ""}={" "}
+          <Text color="yellow">{input || defaultBaseURL || ""}</Text>
         </Text>
         <Text color="gray">Press Enter to save it.</Text>
       </Box>
@@ -630,8 +741,21 @@ function getInitialStep(
     return "provider";
   }
 
-  if (!process.env[getProviderApiKeyEnvKey(provider)]) {
+  if (
+    !hasOptionalApiKey(provider) &&
+    !process.env[getProviderApiKeyEnvKey(provider)]
+  ) {
     return "api-key";
+  }
+
+  const baseUrlEnvKey = getProviderBaseUrlEnvKey(provider);
+
+  if (
+    baseUrlEnvKey !== undefined &&
+    process.env[baseUrlEnvKey] === undefined &&
+    getProviderConfig(provider).baseURL === undefined
+  ) {
+    return "base-url";
   }
 
   if (
@@ -652,14 +776,44 @@ function getNextStepAfterProvider(
   provider: OpenWikiProvider,
   modelIdOverride: string | null,
 ): PromptStep | null {
-  if (!process.env[getProviderApiKeyEnvKey(provider)]) {
+  if (
+    !hasOptionalApiKey(provider) &&
+    !process.env[getProviderApiKeyEnvKey(provider)]
+  ) {
     return "api-key";
   }
 
-  return getNextStepAfterApiKey(provider, modelIdOverride);
+  const baseUrlEnvKey = getProviderBaseUrlEnvKey(provider);
+
+  if (
+    baseUrlEnvKey !== undefined &&
+    process.env[baseUrlEnvKey] === undefined &&
+    getProviderConfig(provider).baseURL === undefined
+  ) {
+    return "base-url";
+  }
+
+  return getNextStepAfterBaseURL(provider, modelIdOverride);
 }
 
 function getNextStepAfterApiKey(
+  provider: OpenWikiProvider,
+  modelIdOverride: string | null,
+): PromptStep | null {
+  const baseUrlEnvKey = getProviderBaseUrlEnvKey(provider);
+
+  if (
+    baseUrlEnvKey !== undefined &&
+    process.env[baseUrlEnvKey] === undefined &&
+    getProviderConfig(provider).baseURL === undefined
+  ) {
+    return "base-url";
+  }
+
+  return getNextStepAfterBaseURL(provider, modelIdOverride);
+}
+
+function getNextStepAfterBaseURL(
   provider: OpenWikiProvider,
   modelIdOverride: string | null,
 ): PromptStep | null {

--- a/src/credentials.tsx
+++ b/src/credentials.tsx
@@ -42,10 +42,32 @@ type PromptStep = "api-key" | "base-url" | "langsmith" | "model" | "provider";
 
 export function needsCredentialSetup(
   modelIdOverride: string | null = null,
+  providerOverride: OpenWikiProvider | null = null,
+  baseUrlOverride: string | null = null,
 ): boolean {
-  const provider = resolveConfiguredProvider();
+  const configuredProvider = resolveConfiguredProvider();
+  const provider = providerOverride ?? configuredProvider;
   const apiKeyEnvKey = getProviderApiKeyEnvKey(provider);
   const baseUrlEnvKey = getProviderBaseUrlEnvKey(provider);
+
+  if (providerOverride !== null && providerOverride !== configuredProvider) {
+    return true;
+  }
+
+  if (
+    baseUrlOverride !== null &&
+    baseUrlEnvKey !== undefined &&
+    process.env[baseUrlEnvKey] !== baseUrlOverride
+  ) {
+    return true;
+  }
+
+  if (
+    modelIdOverride !== null &&
+    process.env[OPENWIKI_MODEL_ID_ENV_KEY] !== modelIdOverride
+  ) {
+    return true;
+  }
 
   return (
     process.env[OPENWIKI_PROVIDER_ENV_KEY] === undefined ||
@@ -57,6 +79,81 @@ export function needsCredentialSetup(
       process.env[OPENWIKI_MODEL_ID_ENV_KEY] === undefined) ||
     process.env.LANGSMITH_API_KEY === undefined
   );
+}
+
+export type CredentialSetupResult = {
+  nextApiKey: string | null;
+  nextBaseURL: string | null;
+  nextLangSmithKey: string | null;
+  nextModelId: string | null;
+  nextProvider: OpenWikiProvider;
+  savedApiKey: boolean;
+  savedBaseURL: boolean;
+  savedLangSmithKey: boolean;
+  savedModelId: boolean;
+  savedProvider: boolean;
+};
+
+export async function completeCredentialSetup({
+  nextApiKey,
+  nextBaseURL,
+  nextLangSmithKey,
+  nextModelId,
+  nextProvider,
+}: {
+  nextApiKey: string | null;
+  nextBaseURL: string | null;
+  nextLangSmithKey: string | null;
+  nextModelId: string | null;
+  nextProvider: OpenWikiProvider;
+}): Promise<CredentialSetupResult> {
+  const updates: Record<string, string> = {};
+  const providerEnvChanged =
+    process.env[OPENWIKI_PROVIDER_ENV_KEY] !== nextProvider;
+
+  if (providerEnvChanged) {
+    updates[OPENWIKI_PROVIDER_ENV_KEY] = nextProvider;
+  }
+
+  if (nextApiKey !== null) {
+    updates[getProviderApiKeyEnvKey(nextProvider)] = nextApiKey;
+  }
+
+  const nextBaseUrlEnvKey = getProviderBaseUrlEnvKey(nextProvider);
+
+  if (nextBaseUrlEnvKey !== undefined && nextBaseURL !== null) {
+    updates[nextBaseUrlEnvKey] = nextBaseURL;
+  }
+
+  if (nextModelId !== null) {
+    updates[OPENWIKI_MODEL_ID_ENV_KEY] = nextModelId;
+  }
+
+  if (nextLangSmithKey !== null) {
+    updates.LANGSMITH_API_KEY = nextLangSmithKey;
+
+    if (nextLangSmithKey.length > 0) {
+      updates.LANGCHAIN_PROJECT = "openwiki";
+      updates.LANGCHAIN_TRACING_V2 = "true";
+    }
+  }
+
+  if (Object.keys(updates).length > 0) {
+    await saveOpenWikiEnv(updates);
+  }
+
+  return {
+    nextApiKey,
+    nextBaseURL,
+    nextLangSmithKey,
+    nextModelId,
+    nextProvider,
+    savedApiKey: nextApiKey !== null,
+    savedBaseURL: nextBaseUrlEnvKey !== undefined && nextBaseURL !== null,
+    savedLangSmithKey: nextLangSmithKey !== null && nextLangSmithKey.length > 0,
+    savedModelId: nextModelId !== null,
+    savedProvider: providerEnvChanged,
+  };
 }
 
 export function InitSetup({
@@ -378,64 +475,24 @@ export function InitSetup({
     nextProvider: OpenWikiProvider;
   };
 
-  async function completeSetup({
-    nextApiKey,
-    nextBaseURL,
-    nextLangSmithKey,
-    nextModelId,
-    nextProvider,
-  }: CompleteSetupOptions) {
+  async function completeSetup(options: CompleteSetupOptions) {
     setIsSaving(true);
 
     try {
-      const updates: Record<string, string> = {};
-      const providerEnvChanged =
-        process.env[OPENWIKI_PROVIDER_ENV_KEY] !== nextProvider;
-
-      if (providerEnvChanged) {
-        updates[OPENWIKI_PROVIDER_ENV_KEY] = nextProvider;
-      }
-
-      if (nextApiKey !== null) {
-        updates[getProviderApiKeyEnvKey(nextProvider)] = nextApiKey;
-      }
-
-      const nextBaseUrlEnvKey = getProviderBaseUrlEnvKey(nextProvider);
-
-      if (nextBaseUrlEnvKey !== undefined && nextBaseURL !== null) {
-        updates[nextBaseUrlEnvKey] = nextBaseURL;
-      }
-
-      if (nextModelId !== null) {
-        updates[OPENWIKI_MODEL_ID_ENV_KEY] = nextModelId;
-      }
-
-      if (nextLangSmithKey !== null) {
-        updates.LANGSMITH_API_KEY = nextLangSmithKey;
-
-        if (nextLangSmithKey.length > 0) {
-          updates.LANGCHAIN_PROJECT = "openwiki";
-          updates.LANGCHAIN_TRACING_V2 = "true";
-        }
-      }
-
-      if (Object.keys(updates).length > 0) {
-        await saveOpenWikiEnv(updates);
-      }
+      const result = await completeCredentialSetup(options);
 
       onComplete({
         modelId:
-          nextModelId ??
+          result.nextModelId ??
           effectiveModelIdOverride ??
           process.env[OPENWIKI_MODEL_ID_ENV_KEY] ??
           null,
-        provider: nextProvider,
-        savedApiKey: nextApiKey !== null,
-        savedBaseURL: nextBaseUrlEnvKey !== undefined && nextBaseURL !== null,
-        savedLangSmithKey:
-          nextLangSmithKey !== null && nextLangSmithKey.length > 0,
-        savedModelId: nextModelId !== null || effectiveModelIdOverride !== null,
-        savedProvider: providerEnvChanged,
+        provider: result.nextProvider,
+        savedApiKey: result.savedApiKey,
+        savedBaseURL: result.savedBaseURL,
+        savedLangSmithKey: result.savedLangSmithKey,
+        savedModelId: result.savedModelId,
+        savedProvider: result.savedProvider,
       });
     } catch (saveError) {
       onError(

--- a/src/credentials.tsx
+++ b/src/credentials.tsx
@@ -31,9 +31,11 @@ export type InitSetupResult = {
 };
 
 type InitSetupProps = {
+  baseUrlOverride?: string | null;
   modelIdOverride?: string | null;
   onComplete: (result: InitSetupResult) => void;
   onError: (message: string) => void;
+  providerOverride?: OpenWikiProvider | null;
 };
 
 type PromptStep = "api-key" | "base-url" | "langsmith" | "model" | "provider";
@@ -58,15 +60,25 @@ export function needsCredentialSetup(
 }
 
 export function InitSetup({
+  baseUrlOverride = null,
   modelIdOverride = null,
   onComplete,
   onError,
+  providerOverride = null,
 }: InitSetupProps) {
-  const initialProvider = resolveConfiguredProvider();
+  const initialProvider = providerOverride ?? resolveConfiguredProvider();
+  const effectiveModelIdOverride =
+    modelIdOverride ??
+    (providerOverride ? getDefaultModelId(providerOverride) : null);
+  const defaultBaseUrl = getProviderConfig(initialProvider).baseURL;
+  const effectiveBaseUrlOverride =
+    baseUrlOverride ?? (defaultBaseUrl === undefined ? null : defaultBaseUrl);
   const [step, setStep] = useState<PromptStep | null>(null);
   const [provider, setProvider] = useState<OpenWikiProvider>(initialProvider);
   const [apiKey, setApiKey] = useState<string | null>(null);
-  const [baseURL, setBaseURL] = useState<string | null>(null);
+  const [baseURL, setBaseURL] = useState<string | null>(
+    effectiveBaseUrlOverride,
+  );
   const [modelId, setModelId] = useState<string | null>(null);
   const [langSmithKey, setLangSmithKey] = useState<string | null>(null);
   const [input, setInput] = useState("");
@@ -76,7 +88,7 @@ export function InitSetup({
   const [modelSelectionIndex, setModelSelectionIndex] = useState(() =>
     getModelSelectionIndex(
       initialProvider,
-      modelIdOverride ??
+      effectiveModelIdOverride ??
         process.env[OPENWIKI_MODEL_ID_ENV_KEY] ??
         getDefaultModelId(initialProvider),
     ),
@@ -86,35 +98,49 @@ export function InitSetup({
   const [isSaving, setIsSaving] = useState(false);
 
   useEffect(() => {
-    const initialStep = getInitialStep(modelIdOverride, initialProvider);
+    const initialStep = getInitialStep(
+      effectiveModelIdOverride,
+      initialProvider,
+      providerOverride,
+      effectiveBaseUrlOverride,
+    );
 
     if (initialStep === null) {
       onComplete({
         modelId:
-          modelIdOverride ?? process.env[OPENWIKI_MODEL_ID_ENV_KEY] ?? null,
+          effectiveModelIdOverride ??
+          process.env[OPENWIKI_MODEL_ID_ENV_KEY] ??
+          null,
         provider: initialProvider,
         savedApiKey: false,
         savedBaseURL: false,
         savedLangSmithKey: false,
-        savedModelId: false,
-        savedProvider: false,
+        savedModelId: effectiveModelIdOverride !== null,
+        savedProvider: providerOverride !== null,
       });
       return;
     }
 
     setProvider(initialProvider);
+    setBaseURL(effectiveBaseUrlOverride);
     setProviderSelectionIndex(getProviderSelectionIndex(initialProvider));
     setModelSelectionIndex(
       getModelSelectionIndex(
         initialProvider,
-        modelIdOverride ??
+        effectiveModelIdOverride ??
           process.env[OPENWIKI_MODEL_ID_ENV_KEY] ??
           getDefaultModelId(initialProvider),
       ),
     );
     setIsCustomModelInput(false);
     setStep(initialStep);
-  }, [initialProvider, modelIdOverride, onComplete]);
+  }, [
+    effectiveBaseUrlOverride,
+    effectiveModelIdOverride,
+    initialProvider,
+    providerOverride,
+    onComplete,
+  ]);
 
   useInput((inputValue, key) => {
     if (isSaving || step === null) {
@@ -187,6 +213,7 @@ export function InitSetup({
         DEFAULT_PROVIDER;
 
       setProvider(selectedProvider);
+      setBaseURL(getProviderConfig(selectedProvider).baseURL ?? null);
       setProviderSelectionIndex(getProviderSelectionIndex(selectedProvider));
       setModelSelectionIndex(
         getModelSelectionIndex(
@@ -198,7 +225,8 @@ export function InitSetup({
       setInput("");
       const nextStep = getNextStepAfterProvider(
         selectedProvider,
-        modelIdOverride,
+        effectiveModelIdOverride,
+        baseUrlOverride,
       );
 
       if (nextStep) {
@@ -238,7 +266,11 @@ export function InitSetup({
 
       setApiKey(nextApiKey);
       setInput("");
-      const nextStep = getNextStepAfterApiKey(provider, modelIdOverride);
+      const nextStep = getNextStepAfterApiKey(
+        provider,
+        effectiveModelIdOverride,
+        baseUrlOverride,
+      );
 
       if (nextStep) {
         setStep(nextStep);
@@ -257,13 +289,17 @@ export function InitSetup({
 
     if (step === "base-url") {
       const trimmedInput = input.trim();
-      const defaultBaseURL = getProviderConfig(provider).baseURL;
       const nextBaseURL =
-        trimmedInput.length > 0 ? trimmedInput : (defaultBaseURL ?? null);
+        trimmedInput.length > 0
+          ? trimmedInput
+          : (baseURL ?? getProviderConfig(provider).baseURL ?? null);
 
       setBaseURL(nextBaseURL);
       setInput("");
-      const nextStep = getNextStepAfterBaseURL(provider, modelIdOverride);
+      const nextStep = getNextStepAfterBaseURL(
+        provider,
+        effectiveModelIdOverride,
+      );
 
       if (nextStep) {
         setStep(nextStep);
@@ -364,10 +400,10 @@ export function InitSetup({
         updates[getProviderApiKeyEnvKey(nextProvider)] = nextApiKey;
       }
 
-      const baseUrlEnvKey = getProviderBaseUrlEnvKey(nextProvider);
+      const nextBaseUrlEnvKey = getProviderBaseUrlEnvKey(nextProvider);
 
-      if (baseUrlEnvKey !== undefined && nextBaseURL !== null) {
-        updates[baseUrlEnvKey] = nextBaseURL;
+      if (nextBaseUrlEnvKey !== undefined && nextBaseURL !== null) {
+        updates[nextBaseUrlEnvKey] = nextBaseURL;
       }
 
       if (nextModelId !== null) {
@@ -390,15 +426,15 @@ export function InitSetup({
       onComplete({
         modelId:
           nextModelId ??
-          modelIdOverride ??
+          effectiveModelIdOverride ??
           process.env[OPENWIKI_MODEL_ID_ENV_KEY] ??
           null,
         provider: nextProvider,
         savedApiKey: nextApiKey !== null,
-        savedBaseURL: baseUrlEnvKey !== undefined && nextBaseURL !== null,
+        savedBaseURL: nextBaseUrlEnvKey !== undefined && nextBaseURL !== null,
         savedLangSmithKey:
           nextLangSmithKey !== null && nextLangSmithKey.length > 0,
-        savedModelId: nextModelId !== null,
+        savedModelId: nextModelId !== null || effectiveModelIdOverride !== null,
         savedProvider: providerEnvChanged,
       });
     } catch (saveError) {
@@ -410,8 +446,15 @@ export function InitSetup({
     }
   }
 
-  const needsCredentialPrompt = needsCredentialSetup(modelIdOverride);
   const baseUrlEnvKey = getProviderBaseUrlEnvKey(provider);
+  const needsCredentialPrompt =
+    needsCredentialSetup(effectiveModelIdOverride) ||
+    (providerOverride !== null &&
+      !process.env[getProviderApiKeyEnvKey(provider)] &&
+      !hasOptionalApiKey(provider)) ||
+    (baseUrlOverride !== null &&
+      baseUrlEnvKey !== undefined &&
+      !process.env[baseUrlEnvKey]);
   const baseURLValue =
     baseURL ??
     process.env[baseUrlEnvKey ?? ""] ??
@@ -470,13 +513,13 @@ export function InitSetup({
         <SetupStep
           label="Model"
           state={
-            modelIdOverride || process.env[OPENWIKI_MODEL_ID_ENV_KEY]
+            effectiveModelIdOverride || process.env[OPENWIKI_MODEL_ID_ENV_KEY]
               ? "done"
               : step === "model"
                 ? "current"
                 : "pending"
           }
-          detail={getModelSetupDetail(modelIdOverride, provider)}
+          detail={getModelSetupDetail(effectiveModelIdOverride, provider)}
         />
         <SetupStep
           label="LangSmith"
@@ -736,8 +779,13 @@ function SelectionMarker({ isSelected }: { isSelected: boolean }) {
 function getInitialStep(
   modelIdOverride: string | null,
   provider: OpenWikiProvider,
+  providerOverride: OpenWikiProvider | null,
+  baseUrlOverride: string | null,
 ): PromptStep | null {
-  if (process.env[OPENWIKI_PROVIDER_ENV_KEY] === undefined) {
+  if (
+    process.env[OPENWIKI_PROVIDER_ENV_KEY] === undefined &&
+    providerOverride === null
+  ) {
     return "provider";
   }
 
@@ -753,7 +801,8 @@ function getInitialStep(
   if (
     baseUrlEnvKey !== undefined &&
     process.env[baseUrlEnvKey] === undefined &&
-    getProviderConfig(provider).baseURL === undefined
+    getProviderConfig(provider).baseURL === undefined &&
+    baseUrlOverride === null
   ) {
     return "base-url";
   }
@@ -775,6 +824,7 @@ function getInitialStep(
 function getNextStepAfterProvider(
   provider: OpenWikiProvider,
   modelIdOverride: string | null,
+  baseUrlOverride: string | null,
 ): PromptStep | null {
   if (
     !hasOptionalApiKey(provider) &&
@@ -788,7 +838,8 @@ function getNextStepAfterProvider(
   if (
     baseUrlEnvKey !== undefined &&
     process.env[baseUrlEnvKey] === undefined &&
-    getProviderConfig(provider).baseURL === undefined
+    getProviderConfig(provider).baseURL === undefined &&
+    baseUrlOverride === null
   ) {
     return "base-url";
   }
@@ -799,13 +850,15 @@ function getNextStepAfterProvider(
 function getNextStepAfterApiKey(
   provider: OpenWikiProvider,
   modelIdOverride: string | null,
+  baseUrlOverride: string | null,
 ): PromptStep | null {
   const baseUrlEnvKey = getProviderBaseUrlEnvKey(provider);
 
   if (
     baseUrlEnvKey !== undefined &&
     process.env[baseUrlEnvKey] === undefined &&
-    getProviderConfig(provider).baseURL === undefined
+    getProviderConfig(provider).baseURL === undefined &&
+    baseUrlOverride === null
   ) {
     return "base-url";
   }

--- a/src/env.ts
+++ b/src/env.ts
@@ -7,7 +7,10 @@ import {
   FIREWORKS_API_KEY_ENV_KEY,
   isValidModelId,
   normalizeProvider,
+  OLLAMA_API_KEY_ENV_KEY,
+  OLLAMA_BASE_URL_ENV_KEY,
   OPENAI_API_KEY_ENV_KEY,
+  OPENAI_BASE_URL_ENV_KEY,
   OPENROUTER_API_KEY_ENV_KEY,
   OPENWIKI_MODEL_ID_ENV_KEY,
   OPENWIKI_PROVIDER_ENV_KEY,
@@ -34,6 +37,9 @@ const managedEnvKeys = [
   BASETEN_API_KEY_ENV_KEY,
   FIREWORKS_API_KEY_ENV_KEY,
   OPENAI_API_KEY_ENV_KEY,
+  OLLAMA_API_KEY_ENV_KEY,
+  OLLAMA_BASE_URL_ENV_KEY,
+  OPENAI_BASE_URL_ENV_KEY,
   ANTHROPIC_API_KEY_ENV_KEY,
   OPENROUTER_API_KEY_ENV_KEY,
   OPENWIKI_PROVIDER_ENV_KEY,
@@ -43,11 +49,7 @@ const managedEnvKeys = [
   "LANGCHAIN_TRACING_V2",
 ];
 
-const deprecatedEnvKeys = [
-  "OPENAI_BASE_URL",
-  "OPENAI_ORG_ID",
-  "OPENAI_PROJECT",
-];
+const deprecatedEnvKeys = ["OPENAI_ORG_ID", "OPENAI_PROJECT"];
 
 export async function loadOpenWikiEnv(): Promise<EnvMap> {
   const env = await readOpenWikiEnv();
@@ -78,6 +80,9 @@ export async function getCredentialDiagnostics(): Promise<
     createCredentialDiagnostic(ANTHROPIC_API_KEY_ENV_KEY, fileEnv),
     createCredentialDiagnostic(OPENROUTER_API_KEY_ENV_KEY, fileEnv),
     createCredentialDiagnostic(OPENWIKI_MODEL_ID_ENV_KEY, fileEnv),
+    createCredentialDiagnostic(OLLAMA_API_KEY_ENV_KEY, fileEnv),
+    createCredentialDiagnostic(OLLAMA_BASE_URL_ENV_KEY, fileEnv),
+    createCredentialDiagnostic(OPENAI_BASE_URL_ENV_KEY, fileEnv),
     createCredentialDiagnostic("LANGSMITH_API_KEY", fileEnv),
   ];
 }


### PR DESCRIPTION
This PR adds Ollama as a supported inference provider and introduces non-interactive flags for `openwiki --init`.

### Motivation

- Closes #26 — adds support for custom OpenAI-compatible providers via `--provider`, `--base-url`, `--baseurl`, and `--model` flags.
- Addresses #23 — `--init` can now reconfigure provider, model, and API credentials without immediately calling the API when flags are provided.

### Changes

- Add `@langchain/ollama` dependency
- Add Ollama provider config, env keys, and onboarding flow
- Support custom base URL collection for Ollama and OpenAI
- Add `--provider`, `--base-url`, `--baseurl`, and `--model` CLI arguments to `openwiki --init`
- Update README to document new providers and flags

### Verification

- `pnpm install --frozen-lockfile` ✅
- `pnpm run build` ✅
- `pnpm run pack:check` ✅

### Related issues

- Closes #26
- Related to #23
- May help with #21 (init-time failures due to forced API calls)
