### PR TITLE
feat: add reconfigure option, support Gemini and custom providers, and resolve role content error

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   "scripts": {
     "openwiki": "node dist/cli.js",
     "build": "tsc -p tsconfig.json",
-    "clean": "rm -rf dist",
+    "clean": "node -e \"require('fs').rmSync('dist', { recursive: true, force: true })\"",
     "dev": "tsx src/cli.tsx",
     "format": "prettier --write .",
     "format:check": "prettier --check .",

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -2,6 +2,7 @@ import { createHash } from "node:crypto";
 import { chmod, mkdir } from "node:fs/promises";
 import path from "node:path";
 import { ChatAnthropic } from "@langchain/anthropic";
+import { BaseMessage } from "@langchain/core/messages";
 import { SqliteSaver } from "@langchain/langgraph-checkpoint-sqlite";
 import { ChatOpenAI } from "@langchain/openai";
 import { ChatOpenRouter } from "@langchain/openrouter";
@@ -377,6 +378,89 @@ function resolveModelId(
   return modelId;
 }
 
+function modelPrefersResponsesAPI(model: string): boolean {
+  if (model.includes("gpt-5.2-pro")) return true;
+  if (model.includes("gpt-5.4-pro")) return true;
+  if (model.includes("gpt-5.5-pro")) return true;
+  if (model.includes("codex")) return true;
+  return false;
+}
+
+function sanitizeMessagesForOpenAI(
+  messages: BaseMessage[],
+  model: string,
+): BaseMessage[] {
+  const prefersResponses = modelPrefersResponsesAPI(model);
+
+  if (prefersResponses) {
+    return messages;
+  }
+
+  return messages.map((message) => {
+    if (!message.content) {
+      return message;
+    }
+
+    if (typeof message.content === "string") {
+      return message;
+    }
+
+    if (Array.isArray(message.content)) {
+      const sanitizedContent = message.content.map((block) => {
+        if (typeof block === "object" && block !== null) {
+          const b = block as Record<string, unknown>;
+          if (b.type === "file") {
+            return {
+              type: "text",
+              text: `[Binary file content: ${b.mimeType || "unknown"}]`,
+            };
+          }
+        }
+        return block;
+      });
+
+      const clonedMessage = Object.create(Object.getPrototypeOf(message));
+      Object.assign(clonedMessage, message, { content: sanitizedContent });
+      return clonedMessage;
+    }
+
+    return message;
+  });
+}
+
+class SanitizedChatOpenAI extends ChatOpenAI {
+  private sanitize(messages: BaseMessage[]): BaseMessage[] {
+    return sanitizeMessagesForOpenAI(messages, this.model);
+  }
+
+  async _generate(...args: Parameters<ChatOpenAI["_generate"]>) {
+    const [messages, options, runManager] = args;
+    return super._generate(this.sanitize(messages), options, runManager);
+  }
+
+  async *_streamChatModelEvents(
+    ...args: Parameters<ChatOpenAI["_streamChatModelEvents"]>
+  ) {
+    const [messages, options, runManager] = args;
+    yield* super._streamChatModelEvents(
+      this.sanitize(messages),
+      options,
+      runManager,
+    );
+  }
+
+  async *_streamResponseChunks(
+    ...args: Parameters<ChatOpenAI["_streamResponseChunks"]>
+  ) {
+    const [messages, options, runManager] = args;
+    yield* super._streamResponseChunks(
+      this.sanitize(messages),
+      options,
+      runManager,
+    );
+  }
+}
+
 async function createModel(provider: OpenWikiProvider, modelId: string) {
   if (provider === "anthropic") {
     return new ChatAnthropic(modelId, {
@@ -399,7 +483,7 @@ async function createModel(provider: OpenWikiProvider, modelId: string) {
 
   const providerConfig = getProviderConfig(provider);
 
-  return new ChatOpenAI({
+  return new SanitizedChatOpenAI({
     apiKey: process.env[getProviderApiKeyEnvKey(provider)],
     configuration: providerConfig.baseURL
       ? {

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -2,7 +2,6 @@ import { createHash } from "node:crypto";
 import { chmod, mkdir } from "node:fs/promises";
 import path from "node:path";
 import { ChatAnthropic } from "@langchain/anthropic";
-import { BaseMessage } from "@langchain/core/messages";
 import { SqliteSaver } from "@langchain/langgraph-checkpoint-sqlite";
 import { ChatOpenAI } from "@langchain/openai";
 import { ChatOpenRouter } from "@langchain/openrouter";
@@ -386,79 +385,97 @@ function modelPrefersResponsesAPI(model: string): boolean {
   return false;
 }
 
-function sanitizeMessagesForOpenAI(
-  messages: BaseMessage[],
-  model: string,
-): BaseMessage[] {
+function sanitizeMessagesForOpenAI(messages: unknown, model: string): unknown {
   const prefersResponses = modelPrefersResponsesAPI(model);
 
   if (prefersResponses) {
     return messages;
   }
 
-  return messages.map((message) => {
-    if (!message.content) {
-      return message;
-    }
+  if (typeof messages === "string") {
+    return messages;
+  }
 
-    if (typeof message.content === "string") {
-      return message;
-    }
+  if (Array.isArray(messages)) {
+    return messages.map((message) => sanitizeSingleMessage(message));
+  }
 
-    if (Array.isArray(message.content)) {
-      const sanitizedContent = message.content.map((block) => {
-        if (typeof block === "object" && block !== null) {
-          const b = block as Record<string, unknown>;
-          if (b.type === "file") {
-            return {
-              type: "text",
-              text: `[Binary file content: ${b.mimeType || "unknown"}]`,
-            };
-          }
-        }
-        return block;
-      });
-
-      const clonedMessage = Object.create(Object.getPrototypeOf(message));
-      Object.assign(clonedMessage, message, { content: sanitizedContent });
-      return clonedMessage;
-    }
-
-    return message;
-  });
+  return sanitizeSingleMessage(messages);
 }
 
-class SanitizedChatOpenAI extends ChatOpenAI {
-  private sanitize(messages: BaseMessage[]): BaseMessage[] {
-    return sanitizeMessagesForOpenAI(messages, this.model);
+function sanitizeSingleMessage(message: unknown): unknown {
+  if (typeof message !== "object" || message === null) {
+    return message;
   }
 
-  async _generate(...args: Parameters<ChatOpenAI["_generate"]>) {
-    const [messages, options, runManager] = args;
-    return super._generate(this.sanitize(messages), options, runManager);
+  const msg = message as Record<string, unknown>;
+
+  if (!msg.content) {
+    return message;
   }
 
-  async *_streamChatModelEvents(
-    ...args: Parameters<ChatOpenAI["_streamChatModelEvents"]>
-  ) {
-    const [messages, options, runManager] = args;
-    yield* super._streamChatModelEvents(
-      this.sanitize(messages),
-      options,
-      runManager,
-    );
+  if (typeof msg.content === "string") {
+    return message;
   }
 
-  async *_streamResponseChunks(
-    ...args: Parameters<ChatOpenAI["_streamResponseChunks"]>
-  ) {
-    const [messages, options, runManager] = args;
-    yield* super._streamResponseChunks(
-      this.sanitize(messages),
-      options,
-      runManager,
-    );
+  if (Array.isArray(msg.content)) {
+    const sanitizedContent = msg.content.map((block) => {
+      if (typeof block === "object" && block !== null) {
+        const b = block as Record<string, unknown>;
+        if (b.type === "file") {
+          return {
+            type: "text",
+            text: `[Binary file content: ${b.mimeType || "unknown"}]`,
+          };
+        }
+      }
+      return block;
+    });
+
+    const clonedMessage = Object.create(Object.getPrototypeOf(message));
+    Object.assign(clonedMessage, message, { content: sanitizedContent });
+    return clonedMessage;
   }
+
+  return message;
+}
+
+function wrapModelWithSanitizer(model: ChatOpenAI): ChatOpenAI {
+  return new Proxy(model, {
+    get(target, prop, receiver) {
+      const value = Reflect.get(target, prop, receiver);
+      if (typeof value === "function") {
+        return function (this: unknown, ...args: unknown[]) {
+          if (
+            typeof prop === "string" &&
+            [
+              "invoke",
+              "stream",
+              "batch",
+              "_generate",
+              "_streamResponseChunks",
+              "_streamChatModelEvents",
+            ].includes(prop)
+          ) {
+            const messages = args[0];
+            if (messages !== undefined) {
+              if (prop === "batch") {
+                if (Array.isArray(messages)) {
+                  args[0] = messages.map((msgs) =>
+                    sanitizeMessagesForOpenAI(msgs, target.model),
+                  );
+                }
+              } else {
+                args[0] = sanitizeMessagesForOpenAI(messages, target.model);
+              }
+            }
+          }
+          return Reflect.apply(value, this === receiver ? target : this, args);
+        };
+      }
+      return value;
+    },
+  });
 }
 
 async function createModel(provider: OpenWikiProvider, modelId: string) {
@@ -483,7 +500,7 @@ async function createModel(provider: OpenWikiProvider, modelId: string) {
 
   const providerConfig = getProviderConfig(provider);
 
-  return new SanitizedChatOpenAI({
+  const model = new ChatOpenAI({
     apiKey: process.env[getProviderApiKeyEnvKey(provider)],
     configuration: providerConfig.baseURL
       ? {
@@ -492,6 +509,8 @@ async function createModel(provider: OpenWikiProvider, modelId: string) {
       : undefined,
     model: modelId,
   });
+
+  return wrapModelWithSanitizer(model);
 }
 
 function createModelRoute(

--- a/src/cli.tsx
+++ b/src/cli.tsx
@@ -147,12 +147,12 @@ function App({ command }: AppProps) {
       command.kind === "run" && command.shouldStart ? command.command : null,
     );
   const shouldRunInteractiveCredentialSetup =
-    command.kind === "run" &&
-    resolvedCommand !== null &&
-    !command.dryRun &&
+    (command.kind === "config" ||
+      (command.kind === "run" && resolvedCommand !== null)) &&
+    !(command.kind === "run" && command.dryRun) &&
     process.stdin.isTTY &&
     runState.status === "idle" &&
-    needsCredentialSetup(sessionModelId);
+    (command.kind === "config" || needsCredentialSetup(sessionModelId));
   const displayModelId = sessionModelId ?? startupModelId;
 
   function submitChatMessage(message: string) {
@@ -219,13 +219,20 @@ function App({ command }: AppProps) {
   }, []);
 
   useEffect(() => {
+    if (command.kind === "config" && runState.status === "init-setup-saved") {
+      process.exitCode = 0;
+      app.exit();
+    }
+  }, [command.kind, runState.status, app]);
+
+  useEffect(() => {
     if (command.kind === "help" || command.kind === "error") {
       process.exitCode = command.exitCode;
       app.exit();
       return;
     }
 
-    if (command.dryRun) {
+    if (command.kind === "run" && command.dryRun) {
       process.exitCode = 0;
       app.exit();
       return;
@@ -417,7 +424,8 @@ function App({ command }: AppProps) {
   if (shouldRunInteractiveCredentialSetup) {
     return (
       <InitSetup
-        modelIdOverride={command.modelId}
+        modelIdOverride={command.kind === "run" ? command.modelId : null}
+        reconfigure={command.kind === "config"}
         onComplete={(result) => {
           if (result.modelId) {
             setSessionModelId(result.modelId);
@@ -462,7 +470,11 @@ function App({ command }: AppProps) {
             value={runState.result.modelId}
           />
         ) : null}
-        <StatusLine tone="active" label="Next" value="starting openwiki" />
+        {command.kind === "config" ? (
+          <StatusLine tone="success" label="Setup" value="complete" />
+        ) : (
+          <StatusLine tone="active" label="Next" value="starting openwiki" />
+        )}
       </Box>
     );
   }
@@ -3022,7 +3034,10 @@ function Rows({ rows }: RowsProps) {
 const argv = process.argv.slice(2);
 const parsedCommand = parseCommand(argv);
 
-if (parsedCommand.kind === "run" && !parsedCommand.dryRun) {
+if (
+  (parsedCommand.kind === "run" && !parsedCommand.dryRun) ||
+  parsedCommand.kind === "config"
+) {
   await loadOpenWikiEnv();
 }
 

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -19,6 +19,7 @@ export type HelpContent = {
 
 export type CliCommand =
   | { kind: "help"; exitCode: 0 }
+  | { kind: "config"; exitCode: 0 }
   | {
       kind: "run";
       exitCode: 0;
@@ -48,6 +49,14 @@ export function parseCommand(argv: string[]): CliCommand {
 
   for (let index = 0; index < argv.length; index += 1) {
     const arg = argv[index];
+
+    if (arg === "--help" || arg === "-h") {
+      return { kind: "help", exitCode: 0 };
+    }
+
+    if (arg === "--config") {
+      return { kind: "config", exitCode: 0 };
+    }
 
     if (arg === "--help" || arg === "-h") {
       return { kind: "help", exitCode: 0 };
@@ -178,6 +187,7 @@ export const helpContent: HelpContent = {
     "openwiki [--modelId <model>] [message]",
     "openwiki --init [message]",
     "openwiki --update [message]",
+    "openwiki --config",
   ],
   commands: [
     {
@@ -193,6 +203,11 @@ export const helpContent: HelpContent = {
     {
       label: "--update",
       description: "Update existing OpenWiki documentation.",
+    },
+    {
+      label: "--config",
+      description:
+        "Configure or update model provider, API keys, and defaults.",
     },
     {
       label: "-p, --print",
@@ -213,6 +228,7 @@ export const helpContent: HelpContent = {
     "openwiki",
     "openwiki --init",
     "openwiki --update",
+    "openwiki --config",
     'openwiki "What can you do?"',
     'openwiki -p "Summarize what OpenWiki can do"',
     "openwiki --modelId gpt-5.5",

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -15,7 +15,9 @@ export type OpenWikiProvider =
   | "baseten"
   | "fireworks"
   | "openai"
-  | "openrouter";
+  | "openrouter"
+  | "gemini"
+  | "custom";
 
 export type SelectableOpenWikiProvider = OpenWikiProvider;
 
@@ -37,6 +39,8 @@ export const SELECTABLE_OPENWIKI_PROVIDERS = [
   "fireworks",
   "openai",
   "anthropic",
+  "gemini",
+  "custom",
 ] as const satisfies readonly SelectableOpenWikiProvider[];
 
 export const PROVIDER_CONFIGS: Record<OpenWikiProvider, ProviderConfig> = {
@@ -91,6 +95,23 @@ export const PROVIDER_CONFIGS: Record<OpenWikiProvider, ProviderConfig> = {
       { id: "openai/gpt-5.4-mini", label: "GPT 5.4 mini" },
       { id: "openai/gpt-5.5", label: "GPT 5.5" },
     ],
+  },
+  gemini: {
+    apiKeyEnvKey: "GEMINI_API_KEY",
+    baseURL: "https://generativelanguage.googleapis.com/v1beta/openai",
+    label: "Gemini",
+    modelOptions: [
+      { id: "gemini-2.5-flash", label: "Gemini 2.5 Flash" },
+      { id: "gemini-2.5-pro", label: "Gemini 2.5 Pro" },
+    ],
+  },
+  custom: {
+    apiKeyEnvKey: "OPENWIKI_CUSTOM_API_KEY",
+    get baseURL() {
+      return process.env.OPENWIKI_CUSTOM_BASE_URL || "";
+    },
+    label: "Custom (OpenAI-compatible)",
+    modelOptions: [{ id: "custom-model", label: "Custom Model" }],
   },
 };
 

--- a/src/credentials.tsx
+++ b/src/credentials.tsx
@@ -27,11 +27,17 @@ export type InitSetupResult = {
 
 type InitSetupProps = {
   modelIdOverride?: string | null;
+  reconfigure?: boolean;
   onComplete: (result: InitSetupResult) => void;
   onError: (message: string) => void;
 };
 
-type PromptStep = "api-key" | "langsmith" | "model" | "provider";
+type PromptStep =
+  | "api-key"
+  | "langsmith"
+  | "model"
+  | "provider"
+  | "custom-base-url";
 
 export function needsCredentialSetup(
   modelIdOverride: string | null = null,
@@ -41,6 +47,7 @@ export function needsCredentialSetup(
 
   return (
     process.env[OPENWIKI_PROVIDER_ENV_KEY] === undefined ||
+    (provider === "custom" && !process.env.OPENWIKI_CUSTOM_BASE_URL) ||
     !process.env[apiKeyEnvKey] ||
     (modelIdOverride === null &&
       process.env[OPENWIKI_MODEL_ID_ENV_KEY] === undefined) ||
@@ -50,6 +57,7 @@ export function needsCredentialSetup(
 
 export function InitSetup({
   modelIdOverride = null,
+  reconfigure = false,
   onComplete,
   onError,
 }: InitSetupProps) {
@@ -57,6 +65,7 @@ export function InitSetup({
   const [step, setStep] = useState<PromptStep | null>(null);
   const [provider, setProvider] = useState<OpenWikiProvider>(initialProvider);
   const [apiKey, setApiKey] = useState<string | null>(null);
+  const [customBaseUrl, setCustomBaseUrl] = useState<string | null>(null);
   const [modelId, setModelId] = useState<string | null>(null);
   const [langSmithKey, setLangSmithKey] = useState<string | null>(null);
   const [input, setInput] = useState("");
@@ -76,7 +85,11 @@ export function InitSetup({
   const [isSaving, setIsSaving] = useState(false);
 
   useEffect(() => {
-    const initialStep = getInitialStep(modelIdOverride, initialProvider);
+    const initialStep = getInitialStep(
+      modelIdOverride,
+      initialProvider,
+      reconfigure,
+    );
 
     if (initialStep === null) {
       onComplete({
@@ -103,7 +116,7 @@ export function InitSetup({
     );
     setIsCustomModelInput(false);
     setStep(initialStep);
-  }, [initialProvider, modelIdOverride, onComplete]);
+  }, [initialProvider, modelIdOverride, reconfigure, onComplete]);
 
   useInput((inputValue, key) => {
     if (isSaving || step === null) {
@@ -188,6 +201,7 @@ export function InitSetup({
       const nextStep = getNextStepAfterProvider(
         selectedProvider,
         modelIdOverride,
+        reconfigure,
       );
 
       if (nextStep) {
@@ -197,9 +211,63 @@ export function InitSetup({
 
       await completeSetup({
         nextApiKey: apiKey,
+        nextCustomBaseUrl: customBaseUrl,
         nextLangSmithKey: langSmithKey,
         nextModelId: modelId,
         nextProvider: selectedProvider,
+      });
+      return;
+    }
+
+    if (step === "custom-base-url") {
+      const trimmedInput = input.trim();
+
+      if (trimmedInput.length === 0) {
+        const existingBaseUrl = process.env.OPENWIKI_CUSTOM_BASE_URL;
+        if (reconfigure && existingBaseUrl) {
+          setCustomBaseUrl(null);
+          setInput("");
+          const nextStep = getNextStepAfterCustomBaseUrl(
+            provider,
+            modelIdOverride,
+            reconfigure,
+          );
+          if (nextStep) {
+            setStep(nextStep);
+            return;
+          }
+          await completeSetup({
+            nextApiKey: apiKey,
+            nextCustomBaseUrl: null,
+            nextLangSmithKey: langSmithKey,
+            nextModelId: modelId,
+            nextProvider: provider,
+          });
+          return;
+        }
+        setError("OPENWIKI_CUSTOM_BASE_URL is required.");
+        return;
+      }
+
+      setCustomBaseUrl(trimmedInput);
+      setInput("");
+      const nextStep = getNextStepAfterCustomBaseUrl(
+        provider,
+        modelIdOverride,
+        reconfigure,
+      );
+
+      if (nextStep) {
+        setStep(nextStep);
+        return;
+      }
+
+      await completeSetup({
+        nextApiKey: apiKey,
+        nextCustomBaseUrl: trimmedInput,
+        nextLangSmithKey: langSmithKey,
+        nextModelId: modelId,
+        nextProvider: provider,
       });
       return;
     }
@@ -208,13 +276,39 @@ export function InitSetup({
       const trimmedInput = input.trim();
 
       if (trimmedInput.length === 0) {
+        const existingKey = process.env[getProviderApiKeyEnvKey(provider)];
+        if (reconfigure && existingKey) {
+          setApiKey(null);
+          setInput("");
+          const nextStep = getNextStepAfterApiKey(
+            provider,
+            modelIdOverride,
+            reconfigure,
+          );
+          if (nextStep) {
+            setStep(nextStep);
+            return;
+          }
+          await completeSetup({
+            nextApiKey: null,
+            nextCustomBaseUrl: customBaseUrl,
+            nextLangSmithKey: langSmithKey,
+            nextModelId: modelId,
+            nextProvider: provider,
+          });
+          return;
+        }
         setError(`${getProviderApiKeyEnvKey(provider)} is required.`);
         return;
       }
 
       setApiKey(trimmedInput);
       setInput("");
-      const nextStep = getNextStepAfterApiKey(provider, modelIdOverride);
+      const nextStep = getNextStepAfterApiKey(
+        provider,
+        modelIdOverride,
+        reconfigure,
+      );
 
       if (nextStep) {
         setStep(nextStep);
@@ -223,6 +317,7 @@ export function InitSetup({
 
       await completeSetup({
         nextApiKey: trimmedInput,
+        nextCustomBaseUrl: customBaseUrl,
         nextLangSmithKey: langSmithKey,
         nextModelId: modelId,
         nextProvider: provider,
@@ -253,13 +348,14 @@ export function InitSetup({
       setInput("");
       setIsCustomModelInput(false);
 
-      if (process.env.LANGSMITH_API_KEY === undefined) {
+      if (reconfigure || process.env.LANGSMITH_API_KEY === undefined) {
         setStep("langsmith");
         return;
       }
 
       await completeSetup({
         nextApiKey: apiKey,
+        nextCustomBaseUrl: customBaseUrl,
         nextLangSmithKey: langSmithKey,
         nextModelId: selectedModelId,
         nextProvider: provider,
@@ -268,13 +364,21 @@ export function InitSetup({
     }
 
     if (step === "langsmith") {
-      const nextLangSmithKey = input.trim();
+      let nextLangSmithKey: string | null = input.trim();
+      const hasExisting = process.env.LANGSMITH_API_KEY !== undefined;
+
+      if (reconfigure && hasExisting && nextLangSmithKey.length === 0) {
+        nextLangSmithKey = null;
+      } else if (nextLangSmithKey.toLowerCase() === "none") {
+        nextLangSmithKey = "";
+      }
 
       setLangSmithKey(nextLangSmithKey);
       setInput("");
 
       await completeSetup({
         nextApiKey: apiKey,
+        nextCustomBaseUrl: customBaseUrl,
         nextLangSmithKey,
         nextModelId: modelId,
         nextProvider: provider,
@@ -284,6 +388,7 @@ export function InitSetup({
 
   type CompleteSetupOptions = {
     nextApiKey: string | null;
+    nextCustomBaseUrl?: string | null;
     nextLangSmithKey: string | null;
     nextModelId: string | null;
     nextProvider: OpenWikiProvider;
@@ -291,6 +396,7 @@ export function InitSetup({
 
   async function completeSetup({
     nextApiKey,
+    nextCustomBaseUrl,
     nextLangSmithKey,
     nextModelId,
     nextProvider,
@@ -310,6 +416,10 @@ export function InitSetup({
         updates[getProviderApiKeyEnvKey(nextProvider)] = nextApiKey;
       }
 
+      if (nextCustomBaseUrl !== undefined && nextCustomBaseUrl !== null) {
+        updates.OPENWIKI_CUSTOM_BASE_URL = nextCustomBaseUrl;
+      }
+
       if (nextModelId !== null) {
         updates[OPENWIKI_MODEL_ID_ENV_KEY] = nextModelId;
       }
@@ -320,6 +430,9 @@ export function InitSetup({
         if (nextLangSmithKey.length > 0) {
           updates.LANGCHAIN_PROJECT = "openwiki";
           updates.LANGCHAIN_TRACING_V2 = "true";
+        } else {
+          updates.LANGCHAIN_PROJECT = "";
+          updates.LANGCHAIN_TRACING_V2 = "";
         }
       }
 
@@ -367,6 +480,23 @@ export function InitSetup({
           }
           detail={getProviderSetupDetail(provider)}
         />
+        {provider === "custom" ? (
+          <SetupStep
+            label="Custom base URL"
+            state={
+              process.env.OPENWIKI_CUSTOM_BASE_URL
+                ? "done"
+                : step === "custom-base-url"
+                  ? "current"
+                  : "pending"
+            }
+            detail={
+              process.env.OPENWIKI_CUSTOM_BASE_URL
+                ? process.env.OPENWIKI_CUSTOM_BASE_URL
+                : `save OPENWIKI_CUSTOM_BASE_URL to ${openWikiEnvPath}`
+            }
+          />
+        ) : null}
         <SetupStep
           label="Provider key"
           state={
@@ -546,15 +676,47 @@ function Prompt({
     );
   }
 
-  if (step === "api-key") {
+  if (step === "custom-base-url") {
+    const hasExisting = process.env.OPENWIKI_CUSTOM_BASE_URL !== undefined;
     return (
       <Box flexDirection="column">
-        <Text>Paste your {getProviderLabel(provider)} API key.</Text>
+        <Text>
+          {hasExisting
+            ? "Paste a new custom OpenAI-compatible API base URL, or press Enter to keep current URL."
+            : "Paste your custom OpenAI-compatible API base URL (e.g., http://localhost:11434/v1)."}
+        </Text>
+        <Text>
+          <Text color="gray">$</Text> OPENWIKI_CUSTOM_BASE_URL={" "}
+          <Text color="yellow">{input}</Text>
+        </Text>
+        <Text color="gray">
+          {hasExisting
+            ? "Press Enter to keep current URL."
+            : "Press Enter to save."}
+        </Text>
+      </Box>
+    );
+  }
+
+  if (step === "api-key") {
+    const hasExisting =
+      process.env[getProviderApiKeyEnvKey(provider)] !== undefined;
+    return (
+      <Box flexDirection="column">
+        <Text>
+          {hasExisting
+            ? `Paste a new ${getProviderApiKeyEnvKey(provider)}, or press Enter to keep current key.`
+            : `Paste your ${getProviderLabel(provider)} API key.`}
+        </Text>
         <Text>
           <Text color="gray">$</Text> {getProviderApiKeyEnvKey(provider)}={" "}
           <Text color="yellow">{mask(input)}</Text>
         </Text>
-        <Text color="gray">Press Enter to save it.</Text>
+        <Text color="gray">
+          {hasExisting
+            ? "Press Enter to keep current key."
+            : "Press Enter to save."}
+        </Text>
       </Box>
     );
   }
@@ -605,11 +767,24 @@ function Prompt({
   }
 
   if (step === "langsmith") {
+    const hasExisting = process.env.LANGSMITH_API_KEY !== undefined;
     return (
-      <Text>
-        <Text color="gray">$</Text> LANGSMITH_API_KEY optional={" "}
-        <Text color="yellow">{mask(input)}</Text>
-      </Text>
+      <Box flexDirection="column">
+        <Text>
+          {hasExisting
+            ? "Paste a new LangSmith API key, or press Enter to keep current key."
+            : "Paste an optional LangSmith API key."}
+        </Text>
+        <Text>
+          <Text color="gray">$</Text> LANGSMITH_API_KEY={" "}
+          <Text color="yellow">{mask(input)}</Text>
+        </Text>
+        <Text color="gray">
+          {hasExisting
+            ? "Press Enter to keep current key. Type 'none' or leave empty to disable."
+            : "Press Enter to save (optional)."}
+        </Text>
+      </Box>
     );
   }
 
@@ -625,9 +800,18 @@ function SelectionMarker({ isSelected }: { isSelected: boolean }) {
 function getInitialStep(
   modelIdOverride: string | null,
   provider: OpenWikiProvider,
+  reconfigure = false,
 ): PromptStep | null {
+  if (reconfigure) {
+    return "provider";
+  }
+
   if (process.env[OPENWIKI_PROVIDER_ENV_KEY] === undefined) {
     return "provider";
+  }
+
+  if (provider === "custom" && !process.env.OPENWIKI_CUSTOM_BASE_URL) {
+    return "custom-base-url";
   }
 
   if (!process.env[getProviderApiKeyEnvKey(provider)]) {
@@ -651,26 +835,48 @@ function getInitialStep(
 function getNextStepAfterProvider(
   provider: OpenWikiProvider,
   modelIdOverride: string | null,
+  reconfigure = false,
 ): PromptStep | null {
-  if (!process.env[getProviderApiKeyEnvKey(provider)]) {
+  if (
+    provider === "custom" &&
+    (reconfigure || !process.env.OPENWIKI_CUSTOM_BASE_URL)
+  ) {
+    return "custom-base-url";
+  }
+
+  if (reconfigure || !process.env[getProviderApiKeyEnvKey(provider)]) {
     return "api-key";
   }
 
-  return getNextStepAfterApiKey(provider, modelIdOverride);
+  return getNextStepAfterApiKey(provider, modelIdOverride, reconfigure);
+}
+
+function getNextStepAfterCustomBaseUrl(
+  provider: OpenWikiProvider,
+  modelIdOverride: string | null,
+  reconfigure = false,
+): PromptStep | null {
+  if (reconfigure || !process.env[getProviderApiKeyEnvKey(provider)]) {
+    return "api-key";
+  }
+
+  return getNextStepAfterApiKey(provider, modelIdOverride, reconfigure);
 }
 
 function getNextStepAfterApiKey(
   provider: OpenWikiProvider,
   modelIdOverride: string | null,
+  reconfigure = false,
 ): PromptStep | null {
   if (
-    modelIdOverride === null &&
-    process.env[OPENWIKI_MODEL_ID_ENV_KEY] === undefined
+    reconfigure ||
+    (modelIdOverride === null &&
+      process.env[OPENWIKI_MODEL_ID_ENV_KEY] === undefined)
   ) {
     return "model";
   }
 
-  if (process.env.LANGSMITH_API_KEY === undefined) {
+  if (reconfigure || process.env.LANGSMITH_API_KEY === undefined) {
     return "langsmith";
   }
 
@@ -776,7 +982,11 @@ function moveSelectionIndex(
 }
 
 function getProviderArticle(provider: OpenWikiProvider): "a" | "an" {
-  return provider === "baseten" || provider === "fireworks" ? "a" : "an";
+  return provider === "baseten" ||
+    provider === "fireworks" ||
+    provider === "custom"
+    ? "a"
+    : "an";
 }
 
 function sanitizeInputChunk(value: string): string {

--- a/src/env.ts
+++ b/src/env.ts
@@ -36,6 +36,9 @@ const managedEnvKeys = [
   OPENAI_API_KEY_ENV_KEY,
   ANTHROPIC_API_KEY_ENV_KEY,
   OPENROUTER_API_KEY_ENV_KEY,
+  "GEMINI_API_KEY",
+  "OPENWIKI_CUSTOM_API_KEY",
+  "OPENWIKI_CUSTOM_BASE_URL",
   OPENWIKI_PROVIDER_ENV_KEY,
   OPENWIKI_MODEL_ID_ENV_KEY,
   "LANGSMITH_API_KEY",
@@ -77,6 +80,9 @@ export async function getCredentialDiagnostics(): Promise<
     createCredentialDiagnostic(OPENAI_API_KEY_ENV_KEY, fileEnv),
     createCredentialDiagnostic(ANTHROPIC_API_KEY_ENV_KEY, fileEnv),
     createCredentialDiagnostic(OPENROUTER_API_KEY_ENV_KEY, fileEnv),
+    createCredentialDiagnostic("GEMINI_API_KEY", fileEnv),
+    createCredentialDiagnostic("OPENWIKI_CUSTOM_API_KEY", fileEnv),
+    createCredentialDiagnostic("OPENWIKI_CUSTOM_BASE_URL", fileEnv),
     createCredentialDiagnostic(OPENWIKI_MODEL_ID_ENV_KEY, fileEnv),
     createCredentialDiagnostic("LANGSMITH_API_KEY", fileEnv),
   ];
@@ -129,6 +135,17 @@ function createCredentialDiagnostic(
     };
   }
 
+  const warnings =
+    key === OPENWIKI_MODEL_ID_ENV_KEY
+      ? getModelWarnings(value)
+      : key === OPENWIKI_PROVIDER_ENV_KEY
+        ? getProviderWarnings(value)
+        : getCredentialWarnings(value);
+
+  if (source === "process.env over ~/.openwiki/.env") {
+    warnings.push("shadowed by exported shell variable");
+  }
+
   return {
     key,
     source,
@@ -137,12 +154,7 @@ function createCredentialDiagnostic(
       key === OPENWIKI_MODEL_ID_ENV_KEY || key === OPENWIKI_PROVIDER_ENV_KEY
         ? JSON.stringify(value)
         : createCredentialPreview(value),
-    warnings:
-      key === OPENWIKI_MODEL_ID_ENV_KEY
-        ? getModelWarnings(value)
-        : key === OPENWIKI_PROVIDER_ENV_KEY
-          ? getProviderWarnings(value)
-          : getCredentialWarnings(value),
+    warnings,
   };
 }
 


### PR DESCRIPTION
This pull request addresses several key defects and enhancements:

1. **Reconfigure API key credentials (Issue #23)**:
   - Adds a dedicated `--config` flag to unconditionally run the interactive credentials setup and exit cleanly.
   - Updates `InitSetup` with a `reconfigure` mode that displays current settings and allows users to press **Enter** to keep existing configuration values (instead of requiring re-entry or resetting them).

2. **Support for Gemini (Issue #29)**:
   - Integrates the `gemini` provider using the OpenAI-compatible endpoint (`https://generativelanguage.googleapis.com/v1beta/openai`) and `GEMINI_API_KEY`, pre-populating Gemini flash and pro model presets.

3. **Custom OpenAI-compatible base URL (Issue #26)**:
   - Configures a `custom` provider allowing users to configure any custom OpenAI-compatible API base URL (`OPENWIKI_CUSTOM_BASE_URL`) and custom API key (`OPENWIKI_CUSTOM_API_KEY`).

4. **Invalid value: 'file' error (Issue #21)**:
   - Implements a custom `SanitizedChatOpenAI` wrapper that filters and sanitizes message content blocks before sending them to the API. If the model is not a native Responses-API model, it dynamically replaces `{ type: 'file' }` blocks with a text-based block containing file metadata, preventing completions from crashing when loading binary-read tool results from the SQLite checkpointer.

5. **Environment Precedence Warnings**:
   - Warns users in the diagnostics display if a saved key is shadowed by a shell-exported environment variable (`process.env over ~/.openwiki/.env`).
