### PR TITLE
feat: add DeepSeek as a supported provider

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -4,6 +4,7 @@ export const BASETEN_API_KEY_ENV_KEY = "BASETEN_API_KEY";
 export const FIREWORKS_API_KEY_ENV_KEY = "FIREWORKS_API_KEY";
 export const OPENAI_API_KEY_ENV_KEY = "OPENAI_API_KEY";
 export const ANTHROPIC_API_KEY_ENV_KEY = "ANTHROPIC_API_KEY";
+export const DEEPSEEK_API_KEY_ENV_KEY = "DEEPSEEK_API_KEY";
 export const OPENROUTER_API_KEY_ENV_KEY = "OPENROUTER_API_KEY";
 export const OPENWIKI_PROVIDER_ENV_KEY = "OPENWIKI_PROVIDER";
 export const OPENWIKI_MODEL_ID_ENV_KEY = "OPENWIKI_MODEL_ID";
@@ -13,6 +14,7 @@ export const OPENROUTER_BASE_URL = "https://openrouter.ai/api/v1";
 export type OpenWikiProvider =
   | "anthropic"
   | "baseten"
+  | "deepseek"
   | "fireworks"
   | "openai"
   | "openrouter";
@@ -34,6 +36,7 @@ type ProviderConfig = {
 export const SELECTABLE_OPENWIKI_PROVIDERS = [
   "openrouter",
   "baseten",
+  "deepseek",
   "fireworks",
   "openai",
   "anthropic",
@@ -47,6 +50,15 @@ export const PROVIDER_CONFIGS: Record<OpenWikiProvider, ProviderConfig> = {
     modelOptions: [
       { id: "zai-org/GLM-5.2", label: "GLM 5.2" },
       { id: "moonshotai/Kimi-K2.7-Code", label: "Kimi K2.7 Code" },
+    ],
+  },
+  deepseek: {
+    apiKeyEnvKey: DEEPSEEK_API_KEY_ENV_KEY,
+    baseURL: "https://api.deepseek.com/v1",
+    label: "DeepSeek",
+    modelOptions: [
+      { id: "deepseek-chat", label: "DeepSeek V3" },
+      { id: "deepseek-reasoner", label: "DeepSeek R1" },
     ],
   },
   fireworks: {


### PR DESCRIPTION
## Summary

Adds DeepSeek as a first-class provider in OpenWiki. DeepSeek offers competitive pricing and strong coding capabilities through an OpenAI-compatible API, making it a natural fit for documentation generation.

## Changes

- `src/constants.ts` — +12 lines
  - Added `DEEPSEEK_API_KEY` env var constant
  - Added `"deepseek"` to `OpenWikiProvider` union type
  - Added `"deepseek"` to `SELECTABLE_OPENWIKI_PROVIDERS`
  - Added provider config with base URL `https://api.deepseek.com/v1`, API key env var, and model options (`deepseek-chat`, `deepseek-reasoner`)

## How it works

DeepSeek provides an OpenAI-compatible API, so it works through the existing `ChatOpenAI` codepath — no model creation changes needed. The provider config only sets the base URL and API key reference.

## Usage

```bash
# Via environment variables
OPENWIKI_PROVIDER=deepseek DEEPSEEK_API_KEY=sk-... openwiki --init

# Or set in ~/.openwiki/.env
OPENWIKI_PROVIDER=deepseek
DEEPSEEK_API_KEY=sk-...
```

## Note

DeepSeek's API doesn't support the `file` content type used by some LangChain tool messages. This is a LangChain-level compatibility issue tracked separately — it affects all OpenAI-compatible providers that lack `file` type support, not just DeepSeek. In practice, this may cause issues with `deepagents` file operations and should be addressed in a follow-up.