### PR TITLE
fix: blank LangSmith input should disable tracing

### DIFF
--- a/src/credentials.tsx
+++ b/src/credentials.tsx
@@ -320,6 +320,11 @@ export function InitSetup({
         if (nextLangSmithKey.length > 0) {
           updates.LANGCHAIN_PROJECT = "openwiki";
           updates.LANGCHAIN_TRACING_V2 = "true";
+        } else {
+          // Blank input must act as an off switch: without this, a
+          // LANGCHAIN_TRACING_V2=true saved by an earlier setup stays in
+          // ~/.openwiki/.env and tracing silently remains enabled.
+          updates.LANGCHAIN_TRACING_V2 = "false";
         }
       }
 


### PR DESCRIPTION
## Problem

During `--init` setup, entering a LangSmith key writes `LANGCHAIN_TRACING_V2=true` to `~/.openwiki/.env`. But if the user later re-runs setup and leaves the LangSmith prompt **blank** (intending to opt out), the old `true` flag survives: `saveOpenWikiEnv` merges updates and nothing ever clears it. Tracing silently stays enabled with whatever stale key/config remains — the user believes they've opted out.

## Fix

Blank LangSmith input now acts as an explicit off switch: `LANGCHAIN_TRACING_V2` is written as `false`. One conditional branch in `src/credentials.tsx`, 5 lines.

## Verification

- `pnpm run build`, `pnpm run lint:check`, `pnpm run format:check` all pass.
- Repro before fix: run setup with a LangSmith key, re-run setup leaving the prompt blank → `~/.openwiki/.env` still contains `LANGCHAIN_TRACING_V2=true`. After fix: it's `false`.

Surfaced during an automated documentation audit of the repo (same review pass that produced #50/#49, but this is an independent fix — kept as its own PR so each change reviews on its own merits).

🤖 Generated with [Claude Code](https://claude.com/claude-code)