### PR TITLE
feat: add DeepSeek as a first-class provider

### DIFF
--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -387,6 +387,7 @@ async function createModel(provider: OpenWikiProvider, modelId: string) {
   }
 
   if (provider === "deepseek") {
+    installDeepSeekFetchRewriter();
     return new ChatOpenAI({
       apiKey: process.env[DEEPSEEK_API_KEY_ENV_KEY],
       configuration: {
@@ -1035,6 +1036,75 @@ type OpenRouterResponseSummary = {
 
 const OPENROUTER_DEBUG_PROPERTY = "openRouterDebug";
 const OPENROUTER_DEBUG_BODY_LIMIT = 4_000;
+
+const DEEPSEEK_FETCH_REWRITER_INSTALLED = Symbol.for(
+  "openwiki.deepseekFetchRewriterInstalled",
+);
+
+function installDeepSeekFetchRewriter(): void {
+  const flaggedGlobal = globalThis as { [key: symbol]: boolean };
+
+  if (flaggedGlobal[DEEPSEEK_FETCH_REWRITER_INSTALLED]) {
+    return;
+  }
+  flaggedGlobal[DEEPSEEK_FETCH_REWRITER_INSTALLED] = true;
+
+  const originalFetch = globalThis.fetch;
+
+  globalThis.fetch = (async (input, init) => {
+    const url = getFetchInputUrl(input);
+
+    if (
+      url === null ||
+      !url.includes("api.deepseek.com") ||
+      !init ||
+      typeof init.body !== "string"
+    ) {
+      return originalFetch(input, init);
+    }
+
+    let parsedBody: unknown;
+    try {
+      parsedBody = JSON.parse(init.body);
+    } catch {
+      return originalFetch(input, init);
+    }
+
+    if (!isRecord(parsedBody) || !Array.isArray(parsedBody.messages)) {
+      return originalFetch(input, init);
+    }
+
+    const rewrittenMessages = parsedBody.messages.map((message) =>
+      rewriteMessageContentForDeepSeek(message),
+    );
+
+    return originalFetch(input, {
+      ...init,
+      body: JSON.stringify({ ...parsedBody, messages: rewrittenMessages }),
+    });
+  }) satisfies typeof fetch;
+}
+
+function rewriteMessageContentForDeepSeek(message: unknown): unknown {
+  if (!isRecord(message) || !Array.isArray(message.content)) {
+    return message;
+  }
+
+  const textParts: string[] = [];
+  for (const block of message.content) {
+    if (
+      isRecord(block) &&
+      block.type === "text" &&
+      typeof block.text === "string"
+    ) {
+      textParts.push(block.text);
+    } else if (isRecord(block) && typeof block.type === "string") {
+      textParts.push(`[omitted ${block.type} block]`);
+    }
+  }
+
+  return { ...message, content: textParts.join("\n") };
+}
 
 function installOpenRouterDebugFetch(
   options: OpenWikiRunOptions,

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -17,6 +17,8 @@ import type {
 import {
   ANTHROPIC_API_KEY_ENV_KEY,
   BASETEN_API_KEY_ENV_KEY,
+  DEEPSEEK_API_KEY_ENV_KEY,
+  DEEPSEEK_BASE_URL,
   FIREWORKS_API_KEY_ENV_KEY,
   getDefaultModelId,
   getProviderApiKeyEnvKey,
@@ -381,6 +383,16 @@ async function createModel(provider: OpenWikiProvider, modelId: string) {
   if (provider === "anthropic") {
     return new ChatAnthropic(modelId, {
       apiKey: process.env[getProviderApiKeyEnvKey(provider)],
+    });
+  }
+
+  if (provider === "deepseek") {
+    return new ChatOpenAI({
+      apiKey: process.env[DEEPSEEK_API_KEY_ENV_KEY],
+      configuration: {
+        baseURL: DEEPSEEK_BASE_URL,
+      },
+      model: modelId,
     });
   }
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -4,15 +4,18 @@ export const BASETEN_API_KEY_ENV_KEY = "BASETEN_API_KEY";
 export const FIREWORKS_API_KEY_ENV_KEY = "FIREWORKS_API_KEY";
 export const OPENAI_API_KEY_ENV_KEY = "OPENAI_API_KEY";
 export const ANTHROPIC_API_KEY_ENV_KEY = "ANTHROPIC_API_KEY";
+export const DEEPSEEK_API_KEY_ENV_KEY = "DEEPSEEK_API_KEY";
 export const OPENROUTER_API_KEY_ENV_KEY = "OPENROUTER_API_KEY";
 export const OPENWIKI_PROVIDER_ENV_KEY = "OPENWIKI_PROVIDER";
 export const OPENWIKI_MODEL_ID_ENV_KEY = "OPENWIKI_MODEL_ID";
 export const DEFAULT_PROVIDER = "openrouter";
 export const OPENROUTER_BASE_URL = "https://openrouter.ai/api/v1";
+export const DEEPSEEK_BASE_URL = "https://api.deepseek.com/v1";
 
 export type OpenWikiProvider =
   | "anthropic"
   | "baseten"
+  | "deepseek"
   | "fireworks"
   | "openai"
   | "openrouter";
@@ -35,6 +38,7 @@ export const SELECTABLE_OPENWIKI_PROVIDERS = [
   "openrouter",
   "baseten",
   "fireworks",
+  "deepseek",
   "openai",
   "anthropic",
 ] as const satisfies readonly SelectableOpenWikiProvider[];
@@ -59,6 +63,15 @@ export const PROVIDER_CONFIGS: Record<OpenWikiProvider, ProviderConfig> = {
         id: "accounts/fireworks/models/kimi-k2p7-code",
         label: "Kimi K2.7 Code",
       },
+    ],
+  },
+  deepseek: {
+    apiKeyEnvKey: DEEPSEEK_API_KEY_ENV_KEY,
+    baseURL: DEEPSEEK_BASE_URL,
+    label: "DeepSeek",
+    modelOptions: [
+      { id: "deepseek-chat", label: "DeepSeek Chat (V3)" },
+      { id: "deepseek-reasoner", label: "DeepSeek Reasoner (R1)" },
     ],
   },
   openai: {

--- a/src/env.ts
+++ b/src/env.ts
@@ -4,6 +4,7 @@ import path from "node:path";
 import {
   ANTHROPIC_API_KEY_ENV_KEY,
   BASETEN_API_KEY_ENV_KEY,
+  DEEPSEEK_API_KEY_ENV_KEY,
   FIREWORKS_API_KEY_ENV_KEY,
   isValidModelId,
   normalizeProvider,
@@ -33,6 +34,7 @@ export type CredentialDiagnostic = {
 const managedEnvKeys = [
   BASETEN_API_KEY_ENV_KEY,
   FIREWORKS_API_KEY_ENV_KEY,
+  DEEPSEEK_API_KEY_ENV_KEY,
   OPENAI_API_KEY_ENV_KEY,
   ANTHROPIC_API_KEY_ENV_KEY,
   OPENROUTER_API_KEY_ENV_KEY,
@@ -74,6 +76,7 @@ export async function getCredentialDiagnostics(): Promise<
     createCredentialDiagnostic(OPENWIKI_PROVIDER_ENV_KEY, fileEnv),
     createCredentialDiagnostic(BASETEN_API_KEY_ENV_KEY, fileEnv),
     createCredentialDiagnostic(FIREWORKS_API_KEY_ENV_KEY, fileEnv),
+    createCredentialDiagnostic(DEEPSEEK_API_KEY_ENV_KEY, fileEnv),
     createCredentialDiagnostic(OPENAI_API_KEY_ENV_KEY, fileEnv),
     createCredentialDiagnostic(ANTHROPIC_API_KEY_ENV_KEY, fileEnv),
     createCredentialDiagnostic(OPENROUTER_API_KEY_ENV_KEY, fileEnv),


### PR DESCRIPTION
## Summary

DeepSeek exposes an OpenAI-compatible API at `https://api.deepseek.com/v1`. This PR adds it as a first-class provider in OpenWiki, alongside the existing `openai`, `anthropic`, `baseten`, `fireworks`, and `openrouter` providers.

It also patches a DeepSeek-API limitation: the chat completions endpoint only accepts `text` content blocks and rejects every other variant (file, image, …) with a 400. The deepagents agent loop emits non-text blocks on subsequent turns, which made `--init`/`--update` unusable against DeepSeek. A targeted, DeepSeek-only fetch rewriter flattens array content into a single text string before sending.

## Changes

| File | Change |
|---|---|
| `src/constants.ts` | Add `DEEPSEEK_API_KEY_ENV_KEY` + `DEEPSEEK_BASE_URL`; extend `OpenWikiProvider` and `SELECTABLE_OPENWIKI_PROVIDERS` with `"deepseek"`; add `deepseek` entry to `PROVIDER_CONFIGS` exposing `deepseek-chat` (V3) and `deepseek-reasoner` (R1). |
| `src/env.ts` | Add `DEEPSEEK_API_KEY` to `managedEnvKeys` and the credential diagnostics report. |
| `src/agent/index.ts` | (1) Add an explicit `provider === "deepseek"` branch in `createModel` that uses `ChatOpenAI` with `DEEPSEEK_BASE_URL` + `DEEPSEEK_API_KEY`. (2) Install a one-time global fetch rewriter for `api.deepseek.com` requests that flattens array content into text so DeepSeek's spec-compliant endpoint accepts the payload. |

98 lines added across 2 commits, no deletions. `dist/` and `node_modules/` are gitignored.

## Why an explicit `provider === "deepseek"` branch?

The generic `ChatOpenAI` fallthrough in `createModel` would handle `deepseek` automatically (it reads `providerConfig.baseURL` and `getProviderApiKeyEnvKey(provider)`). I added an explicit branch anyway because:
1. It makes intent self-documenting — future readers see DeepSeek is a first-class target, not a config-only afterthought.
2. It isolates future provider-specific tweaks (headers, model defaults, response shaping) from the OpenAI path.

## Operator setup

No secrets in this PR. To run OpenWiki against DeepSeek:

`~/.openwiki/.env`:
```env
OPENWIKI_PROVIDER="deepseek"
OPENWIKI_MODEL_ID="deepseek-chat"
DEEPSEEK_API_KEY="<your deepseek key>"
```

Or in shell:
```bash
export OPENWIKI_PROVIDER=deepseek
export OPENWIKI_MODEL_ID=deepseek-chat
export DEEPSEEK_API_KEY='<your deepseek key>'
openwiki --init
```

Default model is `deepseek-chat`. Set `OPENWIKI_MODEL_ID=deepseek-reasoner` to switch to R1. LangSmith tracing remains optional via `LANGSMITH_API_KEY`.

## Verification

- `pnpm install --frozen-lockfile` ✅
- `pnpm run build` (tsc, strict) ✅
- `pnpm run lint:check` ✅
- `pnpm run format:check` ✅
- `--print` smoke test against `deepseek-chat` via the DeepSeek API using `DEEPSEEK_API_KEY` from env: ✅
- Full `--init` end-to-end against `langchain-ai/openwiki#55` (a small TypeScript repo): agent loop completed without `400 unknown variant 'file'`, generated 8 markdown pages + AGENTS.md. Key sourced from env, not committed.

## Notes for reviewer

- `OPENAI_BASE_URL` is in `deprecatedEnvKeys` and is intentionally skipped on env load — the existing code path does not support overriding `openai` base URL via env. Adding a first-class provider is the supported way to add a new OpenAI-compatible endpoint.
- I did not touch any existing provider config, credential handling, or onboarding UI flow. `SELECTABLE_OPENWIKI_PROVIDERS` and `getProviderModelOptions` are data-driven, so `src/credentials.tsx` automatically surfaces the new provider and its two models with no further edits.
- The fetch rewriter is gated on `Symbol.for("openwiki.deepseekFetchRewriterInstalled")` and only rewrites requests whose URL contains `api.deepseek.com`. Other providers see the original `globalThis.fetch` and are unaffected.
- The rewriter intentionally drops non-text content (file, image, etc.) by replacing each block with `[omitted <type> block]`. DeepSeek cannot consume those blocks anyway; this avoids the 400. If we ever need to forward tool/file payloads to DeepSeek, that would be a follow-up.