### PR TITLE
feat: support excluding folders from documentation via .openwikiignore

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,19 @@ On the first interactive run, OpenWiki will have you configure your inference pr
 
 These configuration options and secrets will be saved to `~/.openwiki/.env` on your local machine.
 
+## Excluding Folders From Documentation
+
+To keep parts of your repository out of the wiki, add a `.openwikiignore` file to the repository root. Each line is a path or glob pattern relative to the repository root. Blank lines and lines starting with `#` are ignored. Negation patterns (lines starting with `!`) are not supported.
+
+```
+# Internal tooling that should not be documented
+scripts/internal
+vendor/
+**/legacy/**
+```
+
+OpenWiki will not explore or document excluded paths, and update runs remove existing wiki content that covers newly excluded paths.
+
 ## Customizing
 
 OpenWiki supports OpenRouter, Fireworks, Baseten, OpenAI and Anthropic out of the box. By default, there are a few models pre-defined (GLM 5.2, Kimi K2.6, Sonnet 5, etc) but for each inference provider, OpenWiki will allow you to specify your own custom model ID.

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -159,6 +159,7 @@ async function runOpenWikiAgentCore(
 ): Promise<OpenWikiRunResult> {
   const context = await createRunContext(command, cwd);
   emitDebug(options, "context=created");
+  emitDebug(options, `ignore.patterns=${context.ignoredPaths.length}`);
   const openWikiSnapshotBefore =
     command === "chat" ? null : await createOpenWikiContentSnapshot(cwd);
   emitDebug(options, "openwiki.snapshot=created");
@@ -187,7 +188,7 @@ async function runOpenWikiAgentCore(
       timeout: 120,
       virtualMode: true,
     }),
-    systemPrompt: createSystemPrompt(command),
+    systemPrompt: createSystemPrompt(command, context.ignoredPaths),
   });
   emitDebug(options, "agent=created");
 

--- a/src/agent/prompt.ts
+++ b/src/agent/prompt.ts
@@ -1,4 +1,8 @@
-import { OPEN_WIKI_DIR, UPDATE_METADATA_PATH } from "../constants.js";
+import {
+  OPEN_WIKI_DIR,
+  OPENWIKI_IGNORE_PATH,
+  UPDATE_METADATA_PATH,
+} from "../constants.js";
 import { OpenWikiCommand, RunContext, UpdateMetadata } from "./types.js";
 
 function formatLastUpdate(lastUpdate: UpdateMetadata | null): string {
@@ -9,7 +13,28 @@ function formatLastUpdate(lastUpdate: UpdateMetadata | null): string {
   return JSON.stringify(lastUpdate, null, 2);
 }
 
-export function createSystemPrompt(command: OpenWikiCommand): string {
+function createExclusionInstructions(ignoredPaths: string[]): string {
+  if (ignoredPaths.length === 0) {
+    return "";
+  }
+
+  return `
+Exclusions discipline:
+- The repository owner listed paths in ${OPENWIKI_IGNORE_PATH} that must be hidden from documentation. Treat each quoted entry as a path or glob pattern relative to the repository root; the quotes are not part of the pattern.
+- Excluded paths:
+${ignoredPaths.map((ignoredPath) => `  - ${JSON.stringify(ignoredPath)}`).join("\n")}
+- Do not list, read, glob, or grep excluded paths, do not run shell commands against them, and do not ask subagents to inspect them.
+- Excluded paths may still appear in git change summaries. Ignore them there; changes under excluded paths never require documentation updates.
+- Do not document excluded paths. Do not mention their contents, structure, or purpose anywhere in ${OPEN_WIKI_DIR}/ or in top-level agent instruction files.
+- During update runs, if existing documentation covers an excluded path, remove that content instead of refreshing it.
+- If an excluded path seems essential to explain the repository, document the surrounding behavior without describing the excluded path.
+`;
+}
+
+export function createSystemPrompt(
+  command: OpenWikiCommand,
+  ignoredPaths: string[] = [],
+): string {
   return `
 You are OpenWiki, an expert technical writer, software architect, and product analyst.
 
@@ -27,7 +52,7 @@ Run discipline:
 - Create a strong first-pass wiki that is accurate and navigable, then stop. The wiki can be refined in later update runs.
 - Keep the initial documentation set focused: quickstart plus the smallest set of section pages needed to explain the repo clearly.
 - Do not run commands that search outside the target repository.
-
+${createExclusionInstructions(ignoredPaths)}
 Subagent discipline:
 - You may use the task tool to parallelize read-only research during init and update runs when the repository has multiple substantial domains.
 - Default to 1-2 subagents for large or unfamiliar repositories. Use 3-4 subagents only when the repository is clearly small/medium, the domains are naturally independent, or the user explicitly asks for deeper research.

--- a/src/agent/types.ts
+++ b/src/agent/types.ts
@@ -48,4 +48,5 @@ export type UpdateMetadata = {
 export type RunContext = {
   lastUpdate: UpdateMetadata | null;
   gitSummary: string;
+  ignoredPaths: string[];
 };

--- a/src/agent/utils.ts
+++ b/src/agent/utils.ts
@@ -3,7 +3,11 @@ import { createHash } from "node:crypto";
 import { mkdir, readdir, readFile, writeFile } from "node:fs/promises";
 import path from "node:path";
 import { promisify } from "node:util";
-import { OPEN_WIKI_DIR, UPDATE_METADATA_PATH } from "../constants.js";
+import {
+  OPEN_WIKI_DIR,
+  OPENWIKI_IGNORE_PATH,
+  UPDATE_METADATA_PATH,
+} from "../constants.js";
 import type { OpenWikiCommand, RunContext, UpdateMetadata } from "./types.js";
 import type { Dirent } from "node:fs";
 
@@ -19,17 +23,20 @@ export async function createRunContext(
   cwd: string,
 ): Promise<RunContext> {
   const lastUpdate = await readLastUpdate(cwd);
+  const ignoredPaths = await readIgnoredPaths(cwd);
 
   if (command === "chat") {
     return {
       lastUpdate,
       gitSummary: "Not applicable for chat.",
+      ignoredPaths,
     };
   }
 
   return {
     lastUpdate,
     gitSummary: await createGitSummary(command, cwd, lastUpdate),
+    ignoredPaths,
   };
 }
 
@@ -69,6 +76,67 @@ export async function createOpenWikiContentSnapshot(
   await addDirectoryToSnapshot(hash, openWikiDir, "");
 
   return hash.digest("hex");
+}
+
+const MAX_IGNORED_PATHS = 200;
+const MAX_IGNORED_PATH_LENGTH = 200;
+
+/**
+ * Reads user-defined documentation exclusions from .openwikiignore at the repo root.
+ */
+async function readIgnoredPaths(cwd: string): Promise<string[]> {
+  const ignoreFile = path.join(cwd, OPENWIKI_IGNORE_PATH);
+  let rawIgnoreContent: string;
+
+  try {
+    rawIgnoreContent = await readFile(ignoreFile, "utf8");
+  } catch (error) {
+    if (isFileNotFoundError(error)) {
+      return [];
+    }
+
+    throw error;
+  }
+
+  const lines = rawIgnoreContent.split("\n").map((line) => line.trim());
+  const patterns: string[] = [];
+
+  for (const [lineIndex, line] of lines.entries()) {
+    if (line.length === 0 || line.startsWith("#")) {
+      continue;
+    }
+
+    if (line.startsWith("!")) {
+      throw new Error(
+        `${OPENWIKI_IGNORE_PATH}:${lineIndex + 1}: negation patterns are not supported. Remove the leading "!" or delete the line.`,
+      );
+    }
+
+    if (line.length > MAX_IGNORED_PATH_LENGTH) {
+      throw new Error(
+        `${OPENWIKI_IGNORE_PATH}:${lineIndex + 1}: pattern is longer than ${MAX_IGNORED_PATH_LENGTH} characters. Shorten or remove it.`,
+      );
+    }
+
+    // eslint-disable-next-line no-control-regex
+    if (/[\u0000-\u001f]/.test(line)) {
+      throw new Error(
+        `${OPENWIKI_IGNORE_PATH}:${lineIndex + 1}: pattern contains control characters. Remove them.`,
+      );
+    }
+
+    patterns.push(line);
+  }
+
+  const uniquePatterns = Array.from(new Set(patterns));
+
+  if (uniquePatterns.length > MAX_IGNORED_PATHS) {
+    throw new Error(
+      `${OPENWIKI_IGNORE_PATH} lists ${uniquePatterns.length} patterns; the maximum is ${MAX_IGNORED_PATHS}. Consolidate entries with broader glob patterns.`,
+    );
+  }
+
+  return uniquePatterns;
 }
 
 /**

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,5 +1,6 @@
 export const OPEN_WIKI_DIR = "openwiki";
 export const UPDATE_METADATA_PATH = `${OPEN_WIKI_DIR}/.last-update.json`;
+export const OPENWIKI_IGNORE_PATH = ".openwikiignore";
 export const BASETEN_API_KEY_ENV_KEY = "BASETEN_API_KEY";
 export const FIREWORKS_API_KEY_ENV_KEY = "FIREWORKS_API_KEY";
 export const OPENAI_API_KEY_ENV_KEY = "OPENAI_API_KEY";


### PR DESCRIPTION
## Summary

Adds a way to hide or skip folders from documentation. Repositories can create a `.openwikiignore` file at the repo root listing paths or glob patterns — one pattern per line, blank lines and `#` comments ignored. Negation patterns (`!`) are not supported and are rejected with a clear error rather than misread as exclusions:

```
# Internal tooling that should not be documented
scripts/internal
vendor/
**/legacy/**
```

The CLI reads the file when building run context and injects an "Exclusions discipline" section into the agent's system prompt, alongside the existing run/subagent/git discipline sections. The agent is instructed to:

- never `ls` / `read` / `glob` / `grep` excluded paths, run shell commands against them, or send subagents into them
- never document excluded paths or mention their contents, structure, or purpose in `openwiki/` or top-level agent instruction files
- ignore excluded paths when they show up in git change summaries — they never require documentation updates
- remove existing wiki content covering newly excluded paths during `--update` runs
- document surrounding behavior without describing an excluded path if one seems essential to explain the repo

## Why a file instead of a CLI flag

Exclusions need to persist across `--update` runs and the scheduled GitHub Action (`examples/openwiki-update.yml`); a repo-committed file gives every future run (and every contributor) the same exclusions with no extra CLI surface. The naming follows the `.gitignore` / `.dockerignore` convention.

## Implementation notes

- `readIgnoredPaths` in `src/agent/utils.ts` validates the file loudly instead of silently dropping entries: negation patterns, control characters, lines over 200 chars, and more than 200 patterns each fail with an error naming the offending line and the fix. An owner's exclusion list is honored in full or the run stops — it is never partially applied.
- Entries are rendered JSON-quoted in the prompt so they read as data rather than instruction text.
- Exclusions flow through `RunContext` and apply to init, update, and chat runs (so chat answers don't leak hidden folders either).
- With no `.openwikiignore` present, the system prompt is byte-identical to before.
- `--debug` reports `ignore.patterns=<count>`.

## Testing

- `pnpm run build`, `pnpm run lint:check`, and prettier all pass.
- Verified against the built `dist/` output: parsing (comments, blanks, dedupe, trimming, missing file), all four rejection paths (negation, over-long line, control characters, pattern-count cap), and prompt rendering (quoted entries and git-summary rule present with patterns; absent and byte-identical without).
