### PR TITLE
feat: add support for custom API keys and base URLs in command parsing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 node_modules/
 dist/
-
+package-lock.json
 *.log
 .DS_Store

--- a/hello.py
+++ b/hello.py
@@ -1,0 +1,1 @@
+print("Hello, world!")

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -379,17 +379,26 @@ function resolveModelId(
 
 async function createModel(provider: OpenWikiProvider, modelId: string) {
   if (provider === "anthropic") {
+    const customBaseUrl =
+      process.env.ANTHROPIC_BASE_URL ??
+      process.env.ANTHROPIC_API_BASE ??
+      process.env.ANTHROPIC_API_URL;
     return new ChatAnthropic(modelId, {
       apiKey: process.env[getProviderApiKeyEnvKey(provider)],
+      anthropicApiUrl: customBaseUrl,
     });
   }
 
   if (provider === "openrouter") {
     const models = createModelRoute(provider, modelId);
+    const customBaseUrl =
+      process.env.OPENROUTER_BASE_URL ??
+      process.env.OPENROUTER_API_BASE ??
+      OPENROUTER_BASE_URL;
 
     return new ChatOpenRouter({
       apiKey: process.env[OPENROUTER_API_KEY_ENV_KEY],
-      baseURL: OPENROUTER_BASE_URL,
+      baseURL: customBaseUrl,
       model: modelId,
       models,
       route: "fallback",
@@ -398,12 +407,16 @@ async function createModel(provider: OpenWikiProvider, modelId: string) {
   }
 
   const providerConfig = getProviderConfig(provider);
+  const customBaseUrl =
+    process.env[`${provider.toUpperCase()}_BASE_URL`] ??
+    process.env[`${provider.toUpperCase()}_API_BASE`] ??
+    providerConfig.baseURL;
 
   return new ChatOpenAI({
     apiKey: process.env[getProviderApiKeyEnvKey(provider)],
-    configuration: providerConfig.baseURL
+    configuration: customBaseUrl
       ? {
-          baseURL: providerConfig.baseURL,
+          baseURL: customBaseUrl,
         }
       : undefined,
     model: modelId,

--- a/src/cli.tsx
+++ b/src/cli.tsx
@@ -1602,13 +1602,7 @@ type ChatInputMenuState =
   | { kind: "none" };
 
 type SlashCommandId =
-  | "clear"
-  | "exit"
-  | "help"
-  | "init"
-  | "model"
-  | "provider"
-  | "update";
+  "clear" | "exit" | "help" | "init" | "model" | "provider" | "update";
 
 type SlashCommandOption = {
   description: string;
@@ -3023,7 +3017,17 @@ const argv = process.argv.slice(2);
 const parsedCommand = parseCommand(argv);
 
 if (parsedCommand.kind === "run" && !parsedCommand.dryRun) {
+  if (parsedCommand.provider) {
+    process.env[OPENWIKI_PROVIDER_ENV_KEY] = parsedCommand.provider;
+  }
   await loadOpenWikiEnv();
+  const provider = resolveConfiguredProvider();
+  if (parsedCommand.apiKey) {
+    process.env[getProviderApiKeyEnvKey(provider)] = parsedCommand.apiKey;
+  }
+  if (parsedCommand.baseUrl) {
+    process.env[`${provider.toUpperCase()}_BASE_URL`] = parsedCommand.baseUrl;
+  }
 }
 
 const command = resolveStartupCommand(parsedCommand);

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -28,6 +28,9 @@ export type CliCommand =
       print: boolean;
       shouldStart: boolean;
       userMessage: string | null;
+      apiKey: string | null;
+      baseUrl: string | null;
+      provider: string | null;
     }
   | {
       kind: "error";
@@ -42,6 +45,9 @@ export function parseCommand(argv: string[]): CliCommand {
 
   let dryRun = false;
   let modelId: string | null = null;
+  let provider: string | null = null;
+  let apiKey: string | null = null;
+  let baseUrl: string | null = null;
   let print = false;
   let command: OpenWikiCommand = "chat";
   const userMessageParts: string[] = [];
@@ -128,6 +134,72 @@ export function parseCommand(argv: string[]): CliCommand {
       continue;
     }
 
+    if (arg === "--provider") {
+      const nextArg = argv[index + 1];
+
+      if (!nextArg || nextArg.startsWith("-")) {
+        return {
+          kind: "error",
+          exitCode: 1,
+          message: `${arg} requires a provider.`,
+        };
+      }
+
+      provider = nextArg;
+      index += 1;
+      continue;
+    }
+
+    if (arg.startsWith("--provider=")) {
+      const [, val = ""] = arg.split("=", 2);
+      provider = val;
+      continue;
+    }
+
+    if (arg === "--apiKey" || arg === "--api-key") {
+      const nextArg = argv[index + 1];
+
+      if (!nextArg || nextArg.startsWith("-")) {
+        return {
+          kind: "error",
+          exitCode: 1,
+          message: `${arg} requires an API key.`,
+        };
+      }
+
+      apiKey = nextArg;
+      index += 1;
+      continue;
+    }
+
+    if (arg.startsWith("--apiKey=") || arg.startsWith("--api-key=")) {
+      const [, val = ""] = arg.split("=", 2);
+      apiKey = val;
+      continue;
+    }
+
+    if (arg === "--baseUrl" || arg === "--base-url") {
+      const nextArg = argv[index + 1];
+
+      if (!nextArg || nextArg.startsWith("-")) {
+        return {
+          kind: "error",
+          exitCode: 1,
+          message: `${arg} requires a base URL.`,
+        };
+      }
+
+      baseUrl = nextArg;
+      index += 1;
+      continue;
+    }
+
+    if (arg.startsWith("--baseUrl=") || arg.startsWith("--base-url=")) {
+      const [, val = ""] = arg.split("=", 2);
+      baseUrl = val;
+      continue;
+    }
+
     if (arg.startsWith("-")) {
       return {
         kind: "error",
@@ -160,6 +232,9 @@ export function parseCommand(argv: string[]): CliCommand {
     print,
     shouldStart,
     userMessage,
+    apiKey,
+    baseUrl,
+    provider,
   };
 }
 
@@ -201,6 +276,18 @@ export const helpContent: HelpContent = {
     {
       label: "--modelId <id>",
       description: "Use a model ID for this run.",
+    },
+    {
+      label: "--provider <provider>",
+      description: "Use a model provider.",
+    },
+    {
+      label: "--apiKey <key>",
+      description: "Override the API key for the provider.",
+    },
+    {
+      label: "--baseUrl <url>",
+      description: "Override the base URL for the provider.",
     },
   ],
   developmentOptions: [

--- a/src/env.ts
+++ b/src/env.ts
@@ -41,13 +41,20 @@ const managedEnvKeys = [
   "LANGSMITH_API_KEY",
   "LANGCHAIN_PROJECT",
   "LANGCHAIN_TRACING_V2",
+  "OPENAI_BASE_URL",
+  "OPENAI_API_BASE",
+  "ANTHROPIC_BASE_URL",
+  "ANTHROPIC_API_BASE",
+  "ANTHROPIC_API_URL",
+  "BASETEN_BASE_URL",
+  "BASETEN_API_BASE",
+  "FIREWORKS_BASE_URL",
+  "FIREWORKS_API_BASE",
+  "OPENROUTER_BASE_URL",
+  "OPENROUTER_API_BASE",
 ];
 
-const deprecatedEnvKeys = [
-  "OPENAI_BASE_URL",
-  "OPENAI_ORG_ID",
-  "OPENAI_PROJECT",
-];
+const deprecatedEnvKeys = ["OPENAI_ORG_ID", "OPENAI_PROJECT"];
 
 export async function loadOpenWikiEnv(): Promise<EnvMap> {
   const env = await readOpenWikiEnv();
@@ -73,10 +80,15 @@ export async function getCredentialDiagnostics(): Promise<
   return [
     createCredentialDiagnostic(OPENWIKI_PROVIDER_ENV_KEY, fileEnv),
     createCredentialDiagnostic(BASETEN_API_KEY_ENV_KEY, fileEnv),
+    createCredentialDiagnostic("BASETEN_BASE_URL", fileEnv),
     createCredentialDiagnostic(FIREWORKS_API_KEY_ENV_KEY, fileEnv),
+    createCredentialDiagnostic("FIREWORKS_BASE_URL", fileEnv),
     createCredentialDiagnostic(OPENAI_API_KEY_ENV_KEY, fileEnv),
+    createCredentialDiagnostic("OPENAI_BASE_URL", fileEnv),
     createCredentialDiagnostic(ANTHROPIC_API_KEY_ENV_KEY, fileEnv),
+    createCredentialDiagnostic("ANTHROPIC_BASE_URL", fileEnv),
     createCredentialDiagnostic(OPENROUTER_API_KEY_ENV_KEY, fileEnv),
+    createCredentialDiagnostic("OPENROUTER_BASE_URL", fileEnv),
     createCredentialDiagnostic(OPENWIKI_MODEL_ID_ENV_KEY, fileEnv),
     createCredentialDiagnostic("LANGSMITH_API_KEY", fileEnv),
   ];
@@ -134,7 +146,11 @@ function createCredentialDiagnostic(
     source,
     length: value.length,
     preview:
-      key === OPENWIKI_MODEL_ID_ENV_KEY || key === OPENWIKI_PROVIDER_ENV_KEY
+      key === OPENWIKI_MODEL_ID_ENV_KEY ||
+      key === OPENWIKI_PROVIDER_ENV_KEY ||
+      key.endsWith("_BASE_URL") ||
+      key.endsWith("_API_BASE") ||
+      key.endsWith("_API_URL")
         ? JSON.stringify(value)
         : createCredentialPreview(value),
     warnings:


### PR DESCRIPTION
fix: update .gitignore to include package-lock.json
feat: introduce hello.py for initial greeting example

ps: Would you be able to add in gui so user can edit the base url.