### PR TITLE
feat(anthropic): support ANTHROPIC_BASE_URL for gateways and cloud routing

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,4 +72,25 @@ These configuration options and secrets will be saved to `~/.openwiki/.env` on y
 
 OpenWiki supports OpenRouter, Fireworks, Baseten, OpenAI and Anthropic out of the box. By default, there are a few models pre-defined (GLM 5.2, Kimi K2.6, Sonnet 5, etc) but for each inference provider, OpenWiki will allow you to specify your own custom model ID.
 
+### Anthropic base URL (gateways, Bedrock, Vertex)
+
+The Anthropic provider talks to `api.anthropic.com` by default. To route it
+somewhere else — an OpenAI/Anthropic-compatible gateway such as
+[LiteLLM](https://docs.litellm.ai/), AWS Bedrock or GCP Vertex AI through a
+compatible proxy, or a self-hosted endpoint — set `ANTHROPIC_BASE_URL`:
+
+```sh
+# ~/.openwiki/.env
+OPENWIKI_PROVIDER="anthropic"
+OPENWIKI_MODEL_ID="claude-sonnet-5"
+ANTHROPIC_API_KEY="..."          # key/token your gateway expects
+ANTHROPIC_BASE_URL="https://your-gateway.example.com/anthropic"
+```
+
+`ANTHROPIC_BASE_URL` overrides the default and is threaded into the underlying
+`ChatAnthropic` client as `anthropicApiUrl`. Leave it unset to use Anthropic's
+public API. This is the path for enterprise deployments that must route model
+traffic through their own cloud contract or gateway rather than direct API
+billing.
+
 If there's an inference provider or model you'd like to see added, please open a PR!

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -31,6 +31,7 @@ import {
   OPENWIKI_MODEL_ID_ENV_KEY,
   OPENWIKI_PROVIDER_ENV_KEY,
   resolveConfiguredProvider,
+  resolveProviderBaseURL,
   type OpenWikiProvider,
 } from "../constants.js";
 import {
@@ -379,8 +380,11 @@ function resolveModelId(
 
 async function createModel(provider: OpenWikiProvider, modelId: string) {
   if (provider === "anthropic") {
+    const anthropicApiUrl = resolveProviderBaseURL(provider);
+
     return new ChatAnthropic(modelId, {
       apiKey: process.env[getProviderApiKeyEnvKey(provider)],
+      ...(anthropicApiUrl ? { anthropicApiUrl } : {}),
     });
   }
 
@@ -397,13 +401,13 @@ async function createModel(provider: OpenWikiProvider, modelId: string) {
     });
   }
 
-  const providerConfig = getProviderConfig(provider);
+  const baseURL = resolveProviderBaseURL(provider);
 
   return new ChatOpenAI({
     apiKey: process.env[getProviderApiKeyEnvKey(provider)],
-    configuration: providerConfig.baseURL
+    configuration: baseURL
       ? {
-          baseURL: providerConfig.baseURL,
+          baseURL,
         }
       : undefined,
     model: modelId,

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -4,6 +4,7 @@ export const BASETEN_API_KEY_ENV_KEY = "BASETEN_API_KEY";
 export const FIREWORKS_API_KEY_ENV_KEY = "FIREWORKS_API_KEY";
 export const OPENAI_API_KEY_ENV_KEY = "OPENAI_API_KEY";
 export const ANTHROPIC_API_KEY_ENV_KEY = "ANTHROPIC_API_KEY";
+export const ANTHROPIC_BASE_URL_ENV_KEY = "ANTHROPIC_BASE_URL";
 export const OPENROUTER_API_KEY_ENV_KEY = "OPENROUTER_API_KEY";
 export const OPENWIKI_PROVIDER_ENV_KEY = "OPENWIKI_PROVIDER";
 export const OPENWIKI_MODEL_ID_ENV_KEY = "OPENWIKI_MODEL_ID";
@@ -116,6 +117,29 @@ export function getProviderLabel(provider: OpenWikiProvider): string {
 
 export function getProviderApiKeyEnvKey(provider: OpenWikiProvider): string {
   return getProviderConfig(provider).apiKeyEnvKey;
+}
+
+/**
+ * Resolves the base URL a provider should talk to, letting an environment
+ * variable override the built-in default. Today only the Anthropic provider
+ * exposes an override (via ANTHROPIC_BASE_URL) so it can be pointed at an
+ * OpenAI-compatible gateway (LiteLLM), AWS Bedrock, GCP Vertex AI, or a
+ * self-hosted proxy. Returns `undefined` when no base URL is configured, so
+ * the underlying client falls back to the provider's public API.
+ */
+export function resolveProviderBaseURL(
+  provider: OpenWikiProvider,
+  env: NodeJS.ProcessEnv = process.env,
+): string | undefined {
+  if (provider === "anthropic") {
+    const override = env[ANTHROPIC_BASE_URL_ENV_KEY]?.trim();
+
+    if (override) {
+      return override;
+    }
+  }
+
+  return getProviderConfig(provider).baseURL;
 }
 
 export function getProviderModelOptions(

--- a/src/env.ts
+++ b/src/env.ts
@@ -3,6 +3,7 @@ import os from "node:os";
 import path from "node:path";
 import {
   ANTHROPIC_API_KEY_ENV_KEY,
+  ANTHROPIC_BASE_URL_ENV_KEY,
   BASETEN_API_KEY_ENV_KEY,
   FIREWORKS_API_KEY_ENV_KEY,
   isValidModelId,
@@ -35,6 +36,7 @@ const managedEnvKeys = [
   FIREWORKS_API_KEY_ENV_KEY,
   OPENAI_API_KEY_ENV_KEY,
   ANTHROPIC_API_KEY_ENV_KEY,
+  ANTHROPIC_BASE_URL_ENV_KEY,
   OPENROUTER_API_KEY_ENV_KEY,
   OPENWIKI_PROVIDER_ENV_KEY,
   OPENWIKI_MODEL_ID_ENV_KEY,
@@ -76,6 +78,7 @@ export async function getCredentialDiagnostics(): Promise<
     createCredentialDiagnostic(FIREWORKS_API_KEY_ENV_KEY, fileEnv),
     createCredentialDiagnostic(OPENAI_API_KEY_ENV_KEY, fileEnv),
     createCredentialDiagnostic(ANTHROPIC_API_KEY_ENV_KEY, fileEnv),
+    createCredentialDiagnostic(ANTHROPIC_BASE_URL_ENV_KEY, fileEnv),
     createCredentialDiagnostic(OPENROUTER_API_KEY_ENV_KEY, fileEnv),
     createCredentialDiagnostic(OPENWIKI_MODEL_ID_ENV_KEY, fileEnv),
     createCredentialDiagnostic("LANGSMITH_API_KEY", fileEnv),
@@ -134,7 +137,9 @@ function createCredentialDiagnostic(
     source,
     length: value.length,
     preview:
-      key === OPENWIKI_MODEL_ID_ENV_KEY || key === OPENWIKI_PROVIDER_ENV_KEY
+      key === OPENWIKI_MODEL_ID_ENV_KEY ||
+      key === OPENWIKI_PROVIDER_ENV_KEY ||
+      key === ANTHROPIC_BASE_URL_ENV_KEY
         ? JSON.stringify(value)
         : createCredentialPreview(value),
     warnings:


### PR DESCRIPTION
## Summary

The Anthropic provider was hardcoded to `api.anthropic.com`. Unlike the OpenAI, Baseten, Fireworks, and OpenRouter providers — which all thread a base URL into their client — the Anthropic branch in `createModel()` passed only `apiKey`, with no way to override the endpoint.

This blocks enterprise deployments that must route Claude traffic through their own cloud contract or gateway rather than direct Anthropic API billing:

- an OpenAI/Anthropic-compatible gateway such as [LiteLLM](https://docs.litellm.ai/)
- AWS Bedrock or GCP Vertex AI via a compatible proxy
- a self-hosted / on-prem proxy

## Changes

- Add an `ANTHROPIC_BASE_URL` env key and a `resolveProviderBaseURL(provider, env)` helper that lets the env var override a provider's built-in `baseURL`.
- Thread the resolved URL into `ChatAnthropic` as `anthropicApiUrl` (the field `@langchain/anthropic` exposes for a custom endpoint). Route the OpenAI-compatible providers through the same helper so base-URL resolution is uniform.
- Persist `ANTHROPIC_BASE_URL` in `~/.openwiki/.env` as a managed key and surface it in credential diagnostics as a plaintext (non-secret) value, alongside model/provider.
- Document the setting in the README **Customizing** section.

## Behavior

Unset by default → identical to today (calls `api.anthropic.com`). Existing API-key users are unaffected.

```sh
# ~/.openwiki/.env
OPENWIKI_PROVIDER="anthropic"
OPENWIKI_MODEL_ID="claude-sonnet-5"
ANTHROPIC_API_KEY="..."          # key/token your gateway expects
ANTHROPIC_BASE_URL="https://your-gateway.example.com/anthropic"
```

## Testing

- `pnpm run build` — passes (tsc, no errors)
- `pnpm run lint:check` — passes (exit 0)
- `pnpm run format:check` — passes (Prettier clean)

## Notes

This deliberately does **not** attempt to authenticate against a claude.ai Pro/Team/Enterprise subscription. Anthropic's [legal & compliance docs](https://code.claude.com/docs/en/legal-and-compliance) explicitly prohibit third-party tools from routing requests through subscription OAuth credentials. This PR only adds a standard, ToS-compliant base-URL override for API-key/gateway routing.