### PR TITLE
feat: add DeepSeek as a new provider

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -5,14 +5,15 @@ export const FIREWORKS_API_KEY_ENV_KEY = "FIREWORKS_API_KEY";
 export const OPENAI_API_KEY_ENV_KEY = "OPENAI_API_KEY";
 export const ANTHROPIC_API_KEY_ENV_KEY = "ANTHROPIC_API_KEY";
 export const OPENROUTER_API_KEY_ENV_KEY = "OPENROUTER_API_KEY";
+export const DEEPSEEK_API_KEY_ENV_KEY = "DEEPSEEK_API_KEY";
 export const OPENWIKI_PROVIDER_ENV_KEY = "OPENWIKI_PROVIDER";
 export const OPENWIKI_MODEL_ID_ENV_KEY = "OPENWIKI_MODEL_ID";
 export const DEFAULT_PROVIDER = "openrouter";
 export const OPENROUTER_BASE_URL = "https://openrouter.ai/api/v1";
-
 export type OpenWikiProvider =
   | "anthropic"
   | "baseten"
+  | "deepseek"
   | "fireworks"
   | "openai"
   | "openrouter";
@@ -34,6 +35,7 @@ type ProviderConfig = {
 export const SELECTABLE_OPENWIKI_PROVIDERS = [
   "openrouter",
   "baseten",
+  "deepseek",
   "fireworks",
   "openai",
   "anthropic",
@@ -47,6 +49,15 @@ export const PROVIDER_CONFIGS: Record<OpenWikiProvider, ProviderConfig> = {
     modelOptions: [
       { id: "zai-org/GLM-5.2", label: "GLM 5.2" },
       { id: "moonshotai/Kimi-K2.7-Code", label: "Kimi K2.7 Code" },
+    ],
+  },
+  deepseek: {
+    apiKeyEnvKey: DEEPSEEK_API_KEY_ENV_KEY,
+    baseURL: "https://api.deepseek.com",
+    label: "DeepSeek",
+    modelOptions: [
+      { id: "deepseek-v4-flash", label: "V4 Flash" },
+      { id: "deepseek-v4-pro", label: "V4 Pro" },
     ],
   },
   fireworks: {

--- a/src/credentials.tsx
+++ b/src/credentials.tsx
@@ -776,7 +776,9 @@ function moveSelectionIndex(
 }
 
 function getProviderArticle(provider: OpenWikiProvider): "a" | "an" {
-  return provider === "baseten" || provider === "fireworks" ? "a" : "an";
+  return provider === "baseten" || provider === "deepseek" || provider === "fireworks"
+    ? "a"
+    : "an";
 }
 
 function sanitizeInputChunk(value: string): string {


### PR DESCRIPTION
## Summary

Adds DeepSeek as a supported model provider to OpenWiki. DeepSeek is an OpenAI-compatible API provider offering high-quality LLMs at competitive pricing.

Closes #77

## Changes

- Add DEEPSEEK_API_KEY_ENV_KEY constant
- Add "deepseek" to OpenWikiProvider type union
- Add "deepseek" to SELECTABLE_OPENWIKI_PROVIDERS
- Add DeepSeek provider config with base URL https://api.deepseek.com
- Add model options: deepseek-v4-flash and deepseek-v4-pro
- Update getProviderArticle() to return "a" for DeepSeek

## Provider Details

| Field | Value |
|-------|-------|
| Name | DeepSeek |
| Base URL | https://api.deepseek.com |
| Auth | Bearer token (OpenAI-compatible) |
| Website | https://platform.deepseek.com/ |

## Models

| Model ID | Label |
|----------|-------|
| deepseek-v4-flash | V4 Flash (fast and affordable) |
| deepseek-v4-pro | V4 Pro (frontier-level reasoning) |

## Implementation Notes

Since DeepSeek is OpenAI-compatible, the existing ChatOpenAI fallback in createModel() handles it automatically. No changes needed in src/agent/index.ts.

## Testing

- Build compiles successfully (pnpm run build)
- Type checking passes (tsc)
- Provider config follows existing patterns in PROVIDER_CONFIGS

## Related

- Issue: #77
- API Docs: https://platform.deepseek.com/api-docs
