### PR TITLE
feat: support alternative base URLs for the Anthropic provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,4 +72,18 @@ These configuration options and secrets will be saved to `~/.openwiki/.env` on y
 
 OpenWiki supports OpenRouter, Fireworks, Baseten, OpenAI and Anthropic out of the box. By default, there are a few models pre-defined (GLM 5.2, Kimi K2.6, Sonnet 5, etc) but for each inference provider, OpenWiki will allow you to specify your own custom model ID.
 
+### Alternative base URLs
+
+To route the Anthropic provider at an alternative, Anthropic-compatible endpoint
+(for example a self-hosted or proxied gateway) instead of the default API, set
+`ANTHROPIC_BASE_URL` alongside `ANTHROPIC_API_KEY`:
+
+```bash
+OPENWIKI_PROVIDER=anthropic
+ANTHROPIC_API_KEY=your-key
+ANTHROPIC_BASE_URL=https://your-gateway.example.com/anthropic
+```
+
+The base URL can be set in your environment or stored in `~/.openwiki/.env`.
+
 If there's an inference provider or model you'd like to see added, please open a PR!

--- a/openwiki/agent/workflow.md
+++ b/openwiki/agent/workflow.md
@@ -23,9 +23,11 @@ Chat runs skip metadata writes entirely.
 
 `createModel()` in `src/agent/index.ts` branches by provider:
 
-- **anthropic**: `new ChatAnthropic(modelId, { apiKey })` — uses `@langchain/anthropic` directly.
+- **anthropic**: `new ChatAnthropic(modelId, { apiKey, anthropicApiUrl? })` — uses `@langchain/anthropic` directly. When `ANTHROPIC_BASE_URL` is set, the resolved alternative base URL is passed as `anthropicApiUrl` so requests can be routed to a self-hosted or proxied Anthropic-compatible endpoint instead of the default API.
 - **openrouter**: `new ChatOpenRouter({ apiKey, baseURL, model, models, route: "fallback", siteName: "OpenWiki" })` — passes a fallback model list so OpenRouter can route around server-side failures.
-- **baseten / fireworks / openai**: `new ChatOpenAI({ apiKey, configuration: { baseURL? }, model })` — OpenAI-compatible clients using the provider's custom base URL when configured.
+- **baseten / fireworks / openai**: `new ChatOpenAI({ apiKey, configuration: { baseURL? }, model })` — OpenAI-compatible clients using the provider's base URL when configured.
+
+Base URLs are resolved through `resolveProviderBaseUrl()` in `src/constants.ts`, which prefers a provider's alternative base URL environment variable (`baseUrlEnvKey`) over the built-in default before falling back to the SDK's own default endpoint.
 
 ## Prompting strategy
 

--- a/openwiki/cli/usage.md
+++ b/openwiki/cli/usage.md
@@ -62,9 +62,19 @@ Providers and their model options are defined in `PROVIDER_CONFIGS` in `src/cons
 | baseten    | `BASETEN_API_KEY`    | `https://inference.baseten.co/v1`       | GLM 5.2, Kimi K2.7 Code                                               |
 | fireworks  | `FIREWORKS_API_KEY`  | `https://api.fireworks.ai/inference/v1` | GLM 5.2, Kimi K2.7 Code                                               |
 | openai     | `OPENAI_API_KEY`     | (default)                               | GPT 5.4 mini, GPT 5.5                                                 |
-| anthropic  | `ANTHROPIC_API_KEY`  | (default)                               | Haiku, Sonnet, Opus                                                   |
+| anthropic  | `ANTHROPIC_API_KEY`  | (default, or `ANTHROPIC_BASE_URL`)      | Haiku, Sonnet, Opus                                                   |
 
 The default provider is `openrouter`. `resolveConfiguredProvider()` picks the provider from `OPENWIKI_PROVIDER`, falling back to openrouter if `OPENROUTER_API_KEY` is set, then to `DEFAULT_PROVIDER`.
+
+### Alternative base URLs
+
+Set `ANTHROPIC_BASE_URL` to route the anthropic provider at an alternative,
+Anthropic-compatible endpoint (for example a self-hosted or proxied gateway)
+instead of the default API. When set, it is passed to `ChatAnthropic` as
+`anthropicApiUrl`; the `ANTHROPIC_API_KEY` is still sent as the request
+credential. Base URLs are resolved by `resolveProviderBaseUrl()` in
+`src/constants.ts`, which prefers a provider's `baseUrlEnvKey` override over the
+built-in default.
 
 ## Help text and validation
 
@@ -81,6 +91,7 @@ The help content is centralized in `src/commands.ts` and is used by the CLI UI. 
 - Then update any user-visible text in `src/cli.tsx` and `README.md`.
 - If new options affect run behavior, make sure `src/agent/index.ts` and `src/credentials.tsx` still receive the right inputs.
 - If adding a provider, update `PROVIDER_CONFIGS` and `SELECTABLE_OPENWIKI_PROVIDERS` in `src/constants.ts`, `managedEnvKeys` in `src/env.ts`, and the `createModel` branch in `src/agent/index.ts`.
+- To let a provider accept an alternative base URL, set `baseUrlEnvKey` on its `PROVIDER_CONFIGS` entry, add that key to `managedEnvKeys` in `src/env.ts`, and read it through `resolveProviderBaseUrl()` in the provider's `createModel` branch.
 - Re-check the `package.json` bin entry and scripts if the entrypoint changes.
 
 ## Source map

--- a/openwiki/operations/credentials-and-updates.md
+++ b/openwiki/operations/credentials-and-updates.md
@@ -19,6 +19,7 @@ The file stores provider configuration and API keys:
 - `OPENWIKI_PROVIDER` — the selected model provider
 - `OPENWIKI_MODEL_ID` — the default model ID
 - Provider API keys: `OPENROUTER_API_KEY`, `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, `BASETEN_API_KEY`, `FIREWORKS_API_KEY`
+- Optional alternative base URL: `ANTHROPIC_BASE_URL` — routes the anthropic provider at an Anthropic-compatible endpoint other than the default API
 - Optional LangSmith settings: `LANGSMITH_API_KEY`, `LANGCHAIN_PROJECT`, `LANGCHAIN_TRACING_V2`
 
 The loader merges those values into `process.env`, while preferring existing process-level values over file values. Deprecated keys (`OPENAI_BASE_URL`, `OPENAI_ORG_ID`, `OPENAI_PROJECT`) are skipped on load and removed on save.
@@ -56,7 +57,7 @@ The env layer also produces diagnostics for the CLI UI. Those diagnostics report
 - invalid model IDs,
 - invalid provider values.
 
-Diagnostics cover all five provider keys plus `OPENWIKI_PROVIDER`, `OPENWIKI_MODEL_ID`, and `LANGSMITH_API_KEY`. This makes startup problems easier to diagnose without exposing secret values.
+Diagnostics cover all five provider keys plus `OPENWIKI_PROVIDER`, `OPENWIKI_MODEL_ID`, `ANTHROPIC_BASE_URL`, and `LANGSMITH_API_KEY`. This makes startup problems easier to diagnose without exposing secret values (non-secret values such as the provider, model ID, and base URL are shown in full).
 
 ## Update metadata
 

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -16,11 +16,11 @@ import type {
 } from "./types.js";
 import {
   ANTHROPIC_API_KEY_ENV_KEY,
+  ANTHROPIC_BASE_URL_ENV_KEY,
   BASETEN_API_KEY_ENV_KEY,
   FIREWORKS_API_KEY_ENV_KEY,
   getDefaultModelId,
   getProviderApiKeyEnvKey,
-  getProviderConfig,
   getProviderLabel,
   isValidModelId,
   normalizeModelId,
@@ -31,6 +31,7 @@ import {
   OPENWIKI_MODEL_ID_ENV_KEY,
   OPENWIKI_PROVIDER_ENV_KEY,
   resolveConfiguredProvider,
+  resolveProviderBaseUrl,
   type OpenWikiProvider,
 } from "../constants.js";
 import {
@@ -57,13 +58,10 @@ export async function runOpenWikiAgent(
   emitDebug(options, "env=loaded ~/.openwiki/.env");
   emitDebug(options, `env.afterLoad ${formatEnvironmentDebug()}`);
   const provider = resolveConfiguredProvider();
-  const providerConfig = getProviderConfig(provider);
+  const providerBaseUrl = resolveProviderBaseUrl(provider);
   emitDebug(options, `provider=${provider}`);
-  if (providerConfig.baseURL) {
-    emitDebug(
-      options,
-      `provider.baseUrl=${JSON.stringify(providerConfig.baseURL)}`,
-    );
+  if (providerBaseUrl) {
+    emitDebug(options, `provider.baseUrl=${JSON.stringify(providerBaseUrl)}`);
   }
   ensureProviderKey(provider);
   emitDebug(options, `credentials=${provider} key present`);
@@ -379,8 +377,11 @@ function resolveModelId(
 
 async function createModel(provider: OpenWikiProvider, modelId: string) {
   if (provider === "anthropic") {
+    const baseURL = resolveProviderBaseUrl(provider);
+
     return new ChatAnthropic(modelId, {
       apiKey: process.env[getProviderApiKeyEnvKey(provider)],
+      ...(baseURL ? { anthropicApiUrl: baseURL } : {}),
     });
   }
 
@@ -397,13 +398,13 @@ async function createModel(provider: OpenWikiProvider, modelId: string) {
     });
   }
 
-  const providerConfig = getProviderConfig(provider);
+  const baseURL = resolveProviderBaseUrl(provider);
 
   return new ChatOpenAI({
     apiKey: process.env[getProviderApiKeyEnvKey(provider)],
-    configuration: providerConfig.baseURL
+    configuration: baseURL
       ? {
-          baseURL: providerConfig.baseURL,
+          baseURL,
         }
       : undefined,
     model: modelId,
@@ -1263,6 +1264,7 @@ function formatEnvironmentDebug(): string {
     FIREWORKS_API_KEY_ENV_KEY,
     OPENAI_API_KEY_ENV_KEY,
     ANTHROPIC_API_KEY_ENV_KEY,
+    ANTHROPIC_BASE_URL_ENV_KEY,
     OPENROUTER_API_KEY_ENV_KEY,
     OPENWIKI_MODEL_ID_ENV_KEY,
     "LANGCHAIN_TRACING_V2",
@@ -1280,7 +1282,7 @@ function formatDebugValue(key: string, value: string | undefined): string {
     return "unset";
   }
 
-  if (key === "LANGCHAIN_ENDPOINT") {
+  if (key === "LANGCHAIN_ENDPOINT" || key === ANTHROPIC_BASE_URL_ENV_KEY) {
     return formatUrlDebugValue(value);
   }
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -4,6 +4,7 @@ export const BASETEN_API_KEY_ENV_KEY = "BASETEN_API_KEY";
 export const FIREWORKS_API_KEY_ENV_KEY = "FIREWORKS_API_KEY";
 export const OPENAI_API_KEY_ENV_KEY = "OPENAI_API_KEY";
 export const ANTHROPIC_API_KEY_ENV_KEY = "ANTHROPIC_API_KEY";
+export const ANTHROPIC_BASE_URL_ENV_KEY = "ANTHROPIC_BASE_URL";
 export const OPENROUTER_API_KEY_ENV_KEY = "OPENROUTER_API_KEY";
 export const OPENWIKI_PROVIDER_ENV_KEY = "OPENWIKI_PROVIDER";
 export const OPENWIKI_MODEL_ID_ENV_KEY = "OPENWIKI_MODEL_ID";
@@ -27,6 +28,11 @@ export type ProviderModelOption = {
 type ProviderConfig = {
   apiKeyEnvKey: string;
   baseURL?: string;
+  /**
+   * Environment variable that, when set, overrides {@link ProviderConfig.baseURL}
+   * with an alternative base URL (e.g. a self-hosted or proxied endpoint).
+   */
+  baseUrlEnvKey?: string;
   label: string;
   modelOptions: ProviderModelOption[];
 };
@@ -71,6 +77,7 @@ export const PROVIDER_CONFIGS: Record<OpenWikiProvider, ProviderConfig> = {
   },
   anthropic: {
     apiKeyEnvKey: ANTHROPIC_API_KEY_ENV_KEY,
+    baseUrlEnvKey: ANTHROPIC_BASE_URL_ENV_KEY,
     label: "Anthropic",
     modelOptions: [
       { id: "claude-haiku-4-5", label: "Haiku" },
@@ -116,6 +123,27 @@ export function getProviderLabel(provider: OpenWikiProvider): string {
 
 export function getProviderApiKeyEnvKey(provider: OpenWikiProvider): string {
   return getProviderConfig(provider).apiKeyEnvKey;
+}
+
+/**
+ * Resolves the base URL for a provider, preferring an alternative base URL from
+ * the provider's configured environment variable over the built-in default.
+ * Returns `undefined` when neither is set, so callers fall back to the SDK's
+ * own default endpoint.
+ */
+export function resolveProviderBaseUrl(
+  provider: OpenWikiProvider,
+  env: NodeJS.ProcessEnv = process.env,
+): string | undefined {
+  const config = getProviderConfig(provider);
+  const override = config.baseUrlEnvKey ? env[config.baseUrlEnvKey] : undefined;
+  const trimmedOverride = override?.trim();
+
+  if (trimmedOverride) {
+    return trimmedOverride;
+  }
+
+  return config.baseURL;
 }
 
 export function getProviderModelOptions(

--- a/src/env.ts
+++ b/src/env.ts
@@ -3,6 +3,7 @@ import os from "node:os";
 import path from "node:path";
 import {
   ANTHROPIC_API_KEY_ENV_KEY,
+  ANTHROPIC_BASE_URL_ENV_KEY,
   BASETEN_API_KEY_ENV_KEY,
   FIREWORKS_API_KEY_ENV_KEY,
   isValidModelId,
@@ -35,6 +36,7 @@ const managedEnvKeys = [
   FIREWORKS_API_KEY_ENV_KEY,
   OPENAI_API_KEY_ENV_KEY,
   ANTHROPIC_API_KEY_ENV_KEY,
+  ANTHROPIC_BASE_URL_ENV_KEY,
   OPENROUTER_API_KEY_ENV_KEY,
   OPENWIKI_PROVIDER_ENV_KEY,
   OPENWIKI_MODEL_ID_ENV_KEY,
@@ -76,6 +78,7 @@ export async function getCredentialDiagnostics(): Promise<
     createCredentialDiagnostic(FIREWORKS_API_KEY_ENV_KEY, fileEnv),
     createCredentialDiagnostic(OPENAI_API_KEY_ENV_KEY, fileEnv),
     createCredentialDiagnostic(ANTHROPIC_API_KEY_ENV_KEY, fileEnv),
+    createCredentialDiagnostic(ANTHROPIC_BASE_URL_ENV_KEY, fileEnv),
     createCredentialDiagnostic(OPENROUTER_API_KEY_ENV_KEY, fileEnv),
     createCredentialDiagnostic(OPENWIKI_MODEL_ID_ENV_KEY, fileEnv),
     createCredentialDiagnostic("LANGSMITH_API_KEY", fileEnv),
@@ -133,10 +136,9 @@ function createCredentialDiagnostic(
     key,
     source,
     length: value.length,
-    preview:
-      key === OPENWIKI_MODEL_ID_ENV_KEY || key === OPENWIKI_PROVIDER_ENV_KEY
-        ? JSON.stringify(value)
-        : createCredentialPreview(value),
+    preview: isNonSecretDiagnosticKey(key)
+      ? JSON.stringify(value)
+      : createCredentialPreview(value),
     warnings:
       key === OPENWIKI_MODEL_ID_ENV_KEY
         ? getModelWarnings(value)
@@ -163,6 +165,14 @@ function getCredentialSource(
   }
 
   return "unset";
+}
+
+function isNonSecretDiagnosticKey(key: string): boolean {
+  return (
+    key === OPENWIKI_MODEL_ID_ENV_KEY ||
+    key === OPENWIKI_PROVIDER_ENV_KEY ||
+    key === ANTHROPIC_BASE_URL_ENV_KEY
+  );
 }
 
 function createCredentialPreview(value: string): string {


### PR DESCRIPTION
## Summary

The Anthropic provider previously always talked to the default Anthropic API endpoint. Unlike the OpenAI-compatible providers (which thread a base URL into `ChatOpenAI`), the Anthropic branch in `createModel` constructed `ChatAnthropic` with only an API key, so there was no way to point it at an alternative, Anthropic-compatible base URL (e.g. a self-hosted or proxied gateway).

This PR adds support for an alternative base URL for the Anthropic provider via a new `ANTHROPIC_BASE_URL` environment variable, and generalizes base-URL resolution so it's easy to extend to other providers.

## Changes

- **`src/constants.ts`**: add an optional `baseUrlEnvKey` to `ProviderConfig`, wire it up for the anthropic provider (`ANTHROPIC_BASE_URL`), and add a `resolveProviderBaseUrl()` helper that prefers a provider's alternative base URL env var over the built-in default (falling back to the SDK default when neither is set).
- **`src/agent/index.ts`**: pass the resolved base URL to `ChatAnthropic` as `anthropicApiUrl`, route the OpenAI-compatible branch through the same helper, and surface the resolved base URL in debug output.
- **`src/env.ts`**: persist `ANTHROPIC_BASE_URL` in `~/.openwiki/.env` handling and include it in credential diagnostics, treating the base URL as a non-secret value (shown in full rather than masked).
- **Docs**: document alternative base URLs in the README and the OpenWiki docs (`cli/usage`, `agent/workflow`, `operations/credentials-and-updates`).

## Usage

```bash
OPENWIKI_PROVIDER=anthropic
ANTHROPIC_API_KEY=your-key
ANTHROPIC_BASE_URL=https://your-gateway.example.com/anthropic
```

When `ANTHROPIC_BASE_URL` is unset, behavior is unchanged (the default Anthropic API endpoint is used).

## Testing

- `pnpm build`, `pnpm lint:check`, and `pnpm format:check` pass.
- Verified end-to-end against a local build: with `ANTHROPIC_BASE_URL` pointed at a local HTTP server, the Anthropic client issued its `POST /v1/messages` request to the alternative base URL instead of the default API endpoint. With the variable unset, requests continue to go to the default endpoint.