### PR TITLE
Fix: Strip provider prefix from Anthropic model ID to prevent 404 (Fi…

### DIFF
--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -379,7 +379,9 @@ function resolveModelId(
 
 async function createModel(provider: OpenWikiProvider, modelId: string) {
   if (provider === "anthropic") {
-    return new ChatAnthropic(modelId, {
+    // Strip provider prefix if present (e.g., "anthropic/claude-sonnet-5" -> "claude-sonnet-5")
+    const bareModelId = modelId.includes('/') ? modelId.split('/').pop()! : modelId;
+    return new ChatAnthropic(bareModelId, {
       apiKey: process.env[getProviderApiKeyEnvKey(provider)],
     });
   }

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -380,7 +380,9 @@ function resolveModelId(
 async function createModel(provider: OpenWikiProvider, modelId: string) {
   if (provider === "anthropic") {
     // Strip provider prefix if present (e.g., "anthropic/claude-sonnet-5" -> "claude-sonnet-5")
-    const bareModelId = modelId.includes('/') ? modelId.split('/').pop()! : modelId;
+    const bareModelId = modelId.startsWith("anthropic/") 
+  ? modelId.slice("anthropic/".length) 
+  : modelId;
     return new ChatAnthropic(bareModelId, {
       apiKey: process.env[getProviderApiKeyEnvKey(provider)],
     });


### PR DESCRIPTION
### Description
This PR resolves the issue where predefined Anthropic model IDs (like `anthropic/claude-sonnet-5`) cause a 404 error on the first run when passed directly to `ChatAnthropic`. 

The Anthropic API expects a bare model ID, but the predefined options include the provider prefix.

### Changes Made
- Added logic in `src/agent/index.ts` to strip the provider prefix from the `modelId` before instantiating the direct-provider client.
- This ensures the model receives `claude-sonnet-5` instead of `anthropic/claude-sonnet-5`, preventing the `not_found_error`.

Fixes #71