### PR TITLE
feat: add Ollama as a model provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,8 @@ These configuration options and secrets will be saved to `~/.openwiki/.env` on y
 
 ## Customizing
 
-OpenWiki supports OpenRouter, Fireworks, Baseten, OpenAI and Anthropic out of the box. By default, there are a few models pre-defined (GLM 5.2, Kimi K2.6, Sonnet 5, etc) but for each inference provider, OpenWiki will allow you to specify your own custom model ID.
+OpenWiki supports OpenRouter, Fireworks, Baseten, OpenAI, Anthropic, and Ollama out of the box. By default, there are a few models pre-defined (GLM 5.2, Kimi K2.6, Sonnet 5, etc) but for each inference provider, OpenWiki will allow you to specify your own custom model ID.
+
+Ollama runs locally and needs no API key by default (it connects to `http://localhost:11434/v1`). To use a remote daemon or [Ollama Cloud](https://docs.ollama.com/cloud), set `OLLAMA_BASE_URL` (e.g. `https://ollama.com/v1`) and `OLLAMA_API_KEY` in `~/.openwiki/.env`.
 
 If there's an inference provider or model you'd like to see added, please open a PR!

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -21,9 +21,13 @@ import {
   getDefaultModelId,
   getProviderApiKeyEnvKey,
   getProviderConfig,
+  getProviderDefaultApiKey,
   getProviderLabel,
   isValidModelId,
   normalizeModelId,
+  OLLAMA_API_KEY_ENV_KEY,
+  OLLAMA_BASE_URL_ENV_KEY,
+  OLLAMA_DEFAULT_BASE_URL,
   OPENAI_API_KEY_ENV_KEY,
   OPENROUTER_API_KEY_ENV_KEY,
   OPENROUTER_BASE_URL,
@@ -57,13 +61,10 @@ export async function runOpenWikiAgent(
   emitDebug(options, "env=loaded ~/.openwiki/.env");
   emitDebug(options, `env.afterLoad ${formatEnvironmentDebug()}`);
   const provider = resolveConfiguredProvider();
-  const providerConfig = getProviderConfig(provider);
+  const providerBaseURL = resolveProviderBaseURL(provider);
   emitDebug(options, `provider=${provider}`);
-  if (providerConfig.baseURL) {
-    emitDebug(
-      options,
-      `provider.baseUrl=${JSON.stringify(providerConfig.baseURL)}`,
-    );
+  if (providerBaseURL) {
+    emitDebug(options, `provider.baseUrl=${JSON.stringify(providerBaseURL)}`);
   }
   ensureProviderKey(provider);
   emitDebug(options, `credentials=${provider} key present`);
@@ -349,6 +350,10 @@ function isFileNotFoundError(error: unknown): boolean {
 }
 
 function ensureProviderKey(provider: OpenWikiProvider): void {
+  if (getProviderDefaultApiKey(provider) !== null) {
+    return;
+  }
+
   const apiKeyEnvKey = getProviderApiKeyEnvKey(provider);
 
   if (!process.env[apiKeyEnvKey]) {
@@ -397,17 +402,30 @@ async function createModel(provider: OpenWikiProvider, modelId: string) {
     });
   }
 
-  const providerConfig = getProviderConfig(provider);
+  const baseURL = resolveProviderBaseURL(provider);
 
   return new ChatOpenAI({
-    apiKey: process.env[getProviderApiKeyEnvKey(provider)],
-    configuration: providerConfig.baseURL
+    apiKey:
+      process.env[getProviderApiKeyEnvKey(provider)] ||
+      getProviderDefaultApiKey(provider) ||
+      undefined,
+    configuration: baseURL
       ? {
-          baseURL: providerConfig.baseURL,
+          baseURL,
         }
       : undefined,
     model: modelId,
   });
+}
+
+function resolveProviderBaseURL(
+  provider: OpenWikiProvider,
+): string | undefined {
+  if (provider === "ollama") {
+    return process.env[OLLAMA_BASE_URL_ENV_KEY] || OLLAMA_DEFAULT_BASE_URL;
+  }
+
+  return getProviderConfig(provider).baseURL;
 }
 
 function createModelRoute(
@@ -1264,6 +1282,8 @@ function formatEnvironmentDebug(): string {
     OPENAI_API_KEY_ENV_KEY,
     ANTHROPIC_API_KEY_ENV_KEY,
     OPENROUTER_API_KEY_ENV_KEY,
+    OLLAMA_API_KEY_ENV_KEY,
+    OLLAMA_BASE_URL_ENV_KEY,
     OPENWIKI_MODEL_ID_ENV_KEY,
     "LANGCHAIN_TRACING_V2",
     "LANGCHAIN_PROJECT",

--- a/src/cli.tsx
+++ b/src/cli.tsx
@@ -31,6 +31,7 @@ import {
   FIREWORKS_API_KEY_ENV_KEY,
   getDefaultModelId,
   getProviderApiKeyEnvKey,
+  getProviderDefaultApiKey,
   getProviderLabel,
   getProviderModelOptions,
   isValidModelId,
@@ -241,7 +242,11 @@ function App({ command }: AppProps) {
 
     const apiKeyEnvKey = getProviderApiKeyEnvKey(sessionProvider);
 
-    if (!process.env[apiKeyEnvKey] && !process.stdin.isTTY) {
+    if (
+      !process.env[apiKeyEnvKey] &&
+      getProviderDefaultApiKey(sessionProvider) === null &&
+      !process.stdin.isTTY
+    ) {
       setRunState({
         status: "error",
         message: `${apiKeyEnvKey} is required. Run openwiki in an interactive terminal to save credentials.`,
@@ -1506,7 +1511,7 @@ function ChatInput({
 
     if (provider === null) {
       setError(
-        "Enter a valid provider: openrouter, baseten, fireworks, openai, or anthropic.",
+        "Enter a valid provider: openrouter, baseten, fireworks, openai, anthropic, or ollama.",
       );
       return;
     }
@@ -1521,7 +1526,7 @@ function ChatInput({
       setNotice(
         `Provider switched to ${getProviderLabel(provider)} with model ${getDefaultModelId(
           provider,
-        )}. Ensure ${getProviderApiKeyEnvKey(provider)} is set.`,
+        )}. ${getProviderKeyNotice(provider)}`,
       );
     } catch (saveError) {
       setError(
@@ -3120,7 +3125,9 @@ function resolveStartupCommand(command: CliCommand): CliCommand {
   ) {
     const provider = resolveConfiguredProvider();
     const apiKeyEnvKey = getProviderApiKeyEnvKey(provider);
-    const hasProviderKey = Boolean(process.env[apiKeyEnvKey]);
+    const hasProviderKey =
+      Boolean(process.env[apiKeyEnvKey]) ||
+      getProviderDefaultApiKey(provider) !== null;
 
     if (!hasProviderKey) {
       return {
@@ -3145,4 +3152,14 @@ function resolveStartupCommand(command: CliCommand): CliCommand {
   }
 
   return command;
+}
+
+function getProviderKeyNotice(provider: OpenWikiProvider): string {
+  const apiKeyEnvKey = getProviderApiKeyEnvKey(provider);
+
+  if (getProviderDefaultApiKey(provider) === null) {
+    return `Ensure ${apiKeyEnvKey} is set.`;
+  }
+
+  return `Set ${apiKeyEnvKey} only for remote Ollama or Ollama Cloud.`;
 }

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -5,6 +5,10 @@ export const FIREWORKS_API_KEY_ENV_KEY = "FIREWORKS_API_KEY";
 export const OPENAI_API_KEY_ENV_KEY = "OPENAI_API_KEY";
 export const ANTHROPIC_API_KEY_ENV_KEY = "ANTHROPIC_API_KEY";
 export const OPENROUTER_API_KEY_ENV_KEY = "OPENROUTER_API_KEY";
+export const OLLAMA_API_KEY_ENV_KEY = "OLLAMA_API_KEY";
+export const OLLAMA_BASE_URL_ENV_KEY = "OLLAMA_BASE_URL";
+export const OLLAMA_DEFAULT_BASE_URL = "http://localhost:11434/v1";
+export const OLLAMA_DEFAULT_API_KEY = "ollama";
 export const OPENWIKI_PROVIDER_ENV_KEY = "OPENWIKI_PROVIDER";
 export const OPENWIKI_MODEL_ID_ENV_KEY = "OPENWIKI_MODEL_ID";
 export const DEFAULT_PROVIDER = "openrouter";
@@ -14,6 +18,7 @@ export type OpenWikiProvider =
   | "anthropic"
   | "baseten"
   | "fireworks"
+  | "ollama"
   | "openai"
   | "openrouter";
 
@@ -37,6 +42,7 @@ export const SELECTABLE_OPENWIKI_PROVIDERS = [
   "fireworks",
   "openai",
   "anthropic",
+  "ollama",
 ] as const satisfies readonly SelectableOpenWikiProvider[];
 
 export const PROVIDER_CONFIGS: Record<OpenWikiProvider, ProviderConfig> = {
@@ -92,6 +98,17 @@ export const PROVIDER_CONFIGS: Record<OpenWikiProvider, ProviderConfig> = {
       { id: "openai/gpt-5.5", label: "GPT 5.5" },
     ],
   },
+  ollama: {
+    apiKeyEnvKey: OLLAMA_API_KEY_ENV_KEY,
+    baseURL: OLLAMA_DEFAULT_BASE_URL,
+    label: "Ollama",
+    modelOptions: [
+      { id: "qwen2.5-coder:32b", label: "Qwen2.5 Coder 32B" },
+      { id: "qwen2.5-coder:7b", label: "Qwen2.5 Coder 7B" },
+      { id: "deepseek-coder-v2:16b", label: "DeepSeek Coder V2 16B" },
+      { id: "llama3.1:8b", label: "Llama 3.1 8B" },
+    ],
+  },
 };
 
 export const DEFAULT_MODEL_ID =
@@ -116,6 +133,49 @@ export function getProviderLabel(provider: OpenWikiProvider): string {
 
 export function getProviderApiKeyEnvKey(provider: OpenWikiProvider): string {
   return getProviderConfig(provider).apiKeyEnvKey;
+}
+
+const LOCAL_OLLAMA_HOSTS = new Set([
+  "localhost",
+  "127.0.0.1",
+  "::1",
+  "0.0.0.0",
+]);
+
+/**
+ * Ollama is keyless only when it points at a local daemon. When OLLAMA_BASE_URL
+ * is overridden to a remote host (e.g. Ollama Cloud at https://ollama.com/v1),
+ * a real OLLAMA_API_KEY is required, just like any other remote provider.
+ */
+export function ollamaUsesLocalBaseURL(
+  env: NodeJS.ProcessEnv = process.env,
+): boolean {
+  const override = env[OLLAMA_BASE_URL_ENV_KEY]?.trim();
+
+  if (!override) {
+    return true;
+  }
+
+  try {
+    const host = new URL(override).hostname.toLowerCase();
+    const normalized =
+      host.startsWith("[") && host.endsWith("]") ? host.slice(1, -1) : host;
+
+    return LOCAL_OLLAMA_HOSTS.has(normalized);
+  } catch {
+    return false;
+  }
+}
+
+export function getProviderDefaultApiKey(
+  provider: OpenWikiProvider,
+  env: NodeJS.ProcessEnv = process.env,
+): string | null {
+  if (provider !== "ollama") {
+    return null;
+  }
+
+  return ollamaUsesLocalBaseURL(env) ? OLLAMA_DEFAULT_API_KEY : null;
 }
 
 export function getProviderModelOptions(

--- a/src/credentials.tsx
+++ b/src/credentials.tsx
@@ -4,6 +4,7 @@ import {
   DEFAULT_PROVIDER,
   getDefaultModelId,
   getProviderApiKeyEnvKey,
+  getProviderDefaultApiKey,
   getProviderLabel,
   getProviderModelOptions,
   isValidModelId,
@@ -41,7 +42,7 @@ export function needsCredentialSetup(
 
   return (
     process.env[OPENWIKI_PROVIDER_ENV_KEY] === undefined ||
-    !process.env[apiKeyEnvKey] ||
+    (providerRequiresApiKey(provider) && !process.env[apiKeyEnvKey]) ||
     (modelIdOverride === null &&
       process.env[OPENWIKI_MODEL_ID_ENV_KEY] === undefined) ||
     process.env.LANGSMITH_API_KEY === undefined
@@ -369,18 +370,8 @@ export function InitSetup({
         />
         <SetupStep
           label="Provider key"
-          state={
-            process.env[getProviderApiKeyEnvKey(provider)]
-              ? "done"
-              : step === "api-key"
-                ? "current"
-                : "pending"
-          }
-          detail={
-            process.env[getProviderApiKeyEnvKey(provider)]
-              ? "available from environment"
-              : `save ${getProviderApiKeyEnvKey(provider)} to ${openWikiEnvPath}`
-          }
+          state={getProviderKeyState(provider, step)}
+          detail={getProviderKeyDetail(provider)}
         />
         <SetupStep
           label="Model"
@@ -630,7 +621,10 @@ function getInitialStep(
     return "provider";
   }
 
-  if (!process.env[getProviderApiKeyEnvKey(provider)]) {
+  if (
+    providerRequiresApiKey(provider) &&
+    !process.env[getProviderApiKeyEnvKey(provider)]
+  ) {
     return "api-key";
   }
 
@@ -652,7 +646,10 @@ function getNextStepAfterProvider(
   provider: OpenWikiProvider,
   modelIdOverride: string | null,
 ): PromptStep | null {
-  if (!process.env[getProviderApiKeyEnvKey(provider)]) {
+  if (
+    providerRequiresApiKey(provider) &&
+    !process.env[getProviderApiKeyEnvKey(provider)]
+  ) {
     return "api-key";
   }
 
@@ -777,6 +774,37 @@ function moveSelectionIndex(
 
 function getProviderArticle(provider: OpenWikiProvider): "a" | "an" {
   return provider === "baseten" || provider === "fireworks" ? "a" : "an";
+}
+
+function providerRequiresApiKey(provider: OpenWikiProvider): boolean {
+  return getProviderDefaultApiKey(provider) === null;
+}
+
+function getProviderKeyState(
+  provider: OpenWikiProvider,
+  step: PromptStep | null,
+): "current" | "done" | "optional" | "pending" {
+  if (process.env[getProviderApiKeyEnvKey(provider)]) {
+    return "done";
+  }
+
+  if (!providerRequiresApiKey(provider)) {
+    return "optional";
+  }
+
+  return step === "api-key" ? "current" : "pending";
+}
+
+function getProviderKeyDetail(provider: OpenWikiProvider): string {
+  if (process.env[getProviderApiKeyEnvKey(provider)]) {
+    return "available from environment";
+  }
+
+  if (!providerRequiresApiKey(provider)) {
+    return "optional — Ollama runs without a key";
+  }
+
+  return `save ${getProviderApiKeyEnvKey(provider)} to ${openWikiEnvPath}`;
 }
 
 function sanitizeInputChunk(value: string): string {

--- a/src/env.ts
+++ b/src/env.ts
@@ -7,6 +7,8 @@ import {
   FIREWORKS_API_KEY_ENV_KEY,
   isValidModelId,
   normalizeProvider,
+  OLLAMA_API_KEY_ENV_KEY,
+  OLLAMA_BASE_URL_ENV_KEY,
   OPENAI_API_KEY_ENV_KEY,
   OPENROUTER_API_KEY_ENV_KEY,
   OPENWIKI_MODEL_ID_ENV_KEY,
@@ -36,6 +38,8 @@ const managedEnvKeys = [
   OPENAI_API_KEY_ENV_KEY,
   ANTHROPIC_API_KEY_ENV_KEY,
   OPENROUTER_API_KEY_ENV_KEY,
+  OLLAMA_API_KEY_ENV_KEY,
+  OLLAMA_BASE_URL_ENV_KEY,
   OPENWIKI_PROVIDER_ENV_KEY,
   OPENWIKI_MODEL_ID_ENV_KEY,
   "LANGSMITH_API_KEY",
@@ -77,6 +81,8 @@ export async function getCredentialDiagnostics(): Promise<
     createCredentialDiagnostic(OPENAI_API_KEY_ENV_KEY, fileEnv),
     createCredentialDiagnostic(ANTHROPIC_API_KEY_ENV_KEY, fileEnv),
     createCredentialDiagnostic(OPENROUTER_API_KEY_ENV_KEY, fileEnv),
+    createCredentialDiagnostic(OLLAMA_API_KEY_ENV_KEY, fileEnv),
+    createCredentialDiagnostic(OLLAMA_BASE_URL_ENV_KEY, fileEnv),
     createCredentialDiagnostic(OPENWIKI_MODEL_ID_ENV_KEY, fileEnv),
     createCredentialDiagnostic("LANGSMITH_API_KEY", fileEnv),
   ];
@@ -188,7 +194,7 @@ function getCredentialWarnings(value: string): string[] {
     warnings.push("contains quote character");
   }
 
-  if (/\[[^\]]+\]/u.test(value)) {
+  if (/\[[^\]]+\]/u.test(value) && !/^https?:\/\//iu.test(value)) {
     warnings.push("contains bracketed suffix/text");
   }
 


### PR DESCRIPTION
Add Ollama as a first-class LLM provider, reusing the existing ChatOpenAI path against Ollama's OpenAI-compatible /v1 endpoint (no new dependency).

Ollama is keyless by default for local daemons (http://localhost:11434/v1). OLLAMA_BASE_URL overrides the endpoint, and a real OLLAMA_API_KEY is required when the base URL points at a remote host (e.g. Ollama Cloud at https://ollama.com/v1) -- detected via ollamaUsesLocalBaseURL, which treats localhost/127.0.0.1/::1/0.0.0.0 as local.

- src/constants.ts: ollama provider config + env keys; getProviderDefaultApiKey and ollamaUsesLocalBaseURL make the keyless behavior base-URL-aware so remote/cloud targets still require a key.
- src/agent/index.ts: resolveProviderBaseURL (honors OLLAMA_BASE_URL) and a default-key fallback in createModel. Use || instead of ?? for the OLLAMA_API_KEY / OLLAMA_BASE_URL fallbacks so empty-string values fall back to the default rather than being kept (which crashed or misrouted requests).
- src/cli.tsx / src/credentials.tsx: skip the API-key step for keyless ollama in the startup guards and interactive onboarding.
- src/env.ts: register OLLAMA_API_KEY / OLLAMA_BASE_URL as managed env keys and in credential diagnostics; suppress the false "contains bracketed suffix/text" warning for http(s) URLs so IPv6 hosts like [::1] are accepted.
- README.md: document Ollama + Ollama Cloud setup.