### PR TITLE
fix: use DeepAgents subagent middleware for Anthropic file blocks

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "@langchain/langgraph-checkpoint-sqlite": "^1.0.3",
     "@langchain/openai": "^1.5.3",
     "@langchain/openrouter": "^0.4.3",
-    "deepagents": "^1.10.5",
+    "deepagents": "https://pkg.pr.new/deepagents@63aa2e1",
     "ink": "^5.1.0",
     "langchain": "^1.5.1",
     "marked": "^18.0.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24,8 +24,8 @@ importers:
         specifier: ^0.4.3
         version: 0.4.3(@langchain/core@1.2.1(openai@6.44.0(ws@8.21.0)(zod@4.4.3))(ws@8.21.0))(ws@8.21.0)(zod@4.4.3)
       deepagents:
-        specifier: ^1.10.5
-        version: 1.10.5(langsmith@0.7.10(openai@6.44.0(ws@8.21.0)(zod@4.4.3))(ws@8.21.0))(openai@6.44.0(ws@8.21.0)(zod@4.4.3))(react@18.3.1)(ws@8.21.0)
+        specifier: https://pkg.pr.new/deepagents@63aa2e1
+        version: https://pkg.pr.new/deepagents@63aa2e1(@langchain/core@1.2.1(openai@6.44.0(ws@8.21.0)(zod@4.4.3))(ws@8.21.0))(@langchain/langgraph-checkpoint@1.1.2(@langchain/core@1.2.1(openai@6.44.0(ws@8.21.0)(zod@4.4.3))(ws@8.21.0)))(@langchain/langgraph-sdk@1.9.24(@langchain/core@1.2.1(openai@6.44.0(ws@8.21.0)(zod@4.4.3))(ws@8.21.0))(react@18.3.1))(@langchain/langgraph@1.4.5(@langchain/core@1.2.1(openai@6.44.0(ws@8.21.0)(zod@4.4.3))(ws@8.21.0))(react@18.3.1)(zod@4.4.3))(langchain@1.5.1(@langchain/core@1.2.1(openai@6.44.0(ws@8.21.0)(zod@4.4.3))(ws@8.21.0))(openai@6.44.0(ws@8.21.0)(zod@4.4.3))(react@18.3.1)(ws@8.21.0))(langsmith@0.7.10(openai@6.44.0(ws@8.21.0)(zod@4.4.3))(ws@8.21.0))
       ink:
         specifier: ^5.1.0
         version: 5.2.1(@types/react@18.3.31)(react@18.3.1)
@@ -574,9 +574,15 @@ packages:
   deep-is@0.1.4:
     resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
 
-  deepagents@1.10.5:
-    resolution: {integrity: sha512-UFXoH3obz+/3ACuq515UHxXGiDQXHlXvK99ywZ2FSw/HrlrKwI0SKgd0damIj7Tpz7UYrCk4YRzufeDzaOEaQg==}
+  deepagents@https://pkg.pr.new/deepagents@63aa2e1:
+    resolution: {integrity: sha512-6/qQEDD3Qe3aQtlM+CoeTWaYGAU9f0kUS2WajetuTcGt5+rAnoigobHYl5ajz/GGKmUx5U8AEhJDAC1sip3fuA==, tarball: https://pkg.pr.new/deepagents@63aa2e1}
+    version: 1.10.5
     peerDependencies:
+      '@langchain/core': ^1.2.0
+      '@langchain/langgraph': ^1.4.4
+      '@langchain/langgraph-checkpoint': ^1.1.2
+      '@langchain/langgraph-sdk': ^1.9.23
+      langchain: ^1.5.0
       langsmith: ^0.7.1
 
   detect-libc@2.1.2:
@@ -1653,10 +1659,11 @@ snapshots:
 
   deep-is@0.1.4: {}
 
-  deepagents@1.10.5(langsmith@0.7.10(openai@6.44.0(ws@8.21.0)(zod@4.4.3))(ws@8.21.0))(openai@6.44.0(ws@8.21.0)(zod@4.4.3))(react@18.3.1)(ws@8.21.0):
+  deepagents@https://pkg.pr.new/deepagents@63aa2e1(@langchain/core@1.2.1(openai@6.44.0(ws@8.21.0)(zod@4.4.3))(ws@8.21.0))(@langchain/langgraph-checkpoint@1.1.2(@langchain/core@1.2.1(openai@6.44.0(ws@8.21.0)(zod@4.4.3))(ws@8.21.0)))(@langchain/langgraph-sdk@1.9.24(@langchain/core@1.2.1(openai@6.44.0(ws@8.21.0)(zod@4.4.3))(ws@8.21.0))(react@18.3.1))(@langchain/langgraph@1.4.5(@langchain/core@1.2.1(openai@6.44.0(ws@8.21.0)(zod@4.4.3))(ws@8.21.0))(react@18.3.1)(zod@4.4.3))(langchain@1.5.1(@langchain/core@1.2.1(openai@6.44.0(ws@8.21.0)(zod@4.4.3))(ws@8.21.0))(openai@6.44.0(ws@8.21.0)(zod@4.4.3))(react@18.3.1)(ws@8.21.0))(langsmith@0.7.10(openai@6.44.0(ws@8.21.0)(zod@4.4.3))(ws@8.21.0)):
     dependencies:
       '@langchain/core': 1.2.1(openai@6.44.0(ws@8.21.0)(zod@4.4.3))(ws@8.21.0)
       '@langchain/langgraph': 1.4.5(@langchain/core@1.2.1(openai@6.44.0(ws@8.21.0)(zod@4.4.3))(ws@8.21.0))(react@18.3.1)(zod@4.4.3)
+      '@langchain/langgraph-checkpoint': 1.1.2(@langchain/core@1.2.1(openai@6.44.0(ws@8.21.0)(zod@4.4.3))(ws@8.21.0))
       '@langchain/langgraph-sdk': 1.9.24(@langchain/core@1.2.1(openai@6.44.0(ws@8.21.0)(zod@4.4.3))(ws@8.21.0))(react@18.3.1)
       fast-glob: 3.3.3
       langchain: 1.5.1(@langchain/core@1.2.1(openai@6.44.0(ws@8.21.0)(zod@4.4.3))(ws@8.21.0))(openai@6.44.0(ws@8.21.0)(zod@4.4.3))(react@18.3.1)(ws@8.21.0)
@@ -1664,17 +1671,6 @@ snapshots:
       micromatch: 4.0.8
       yaml: 2.9.0
       zod: 4.4.3
-    transitivePeerDependencies:
-      - '@opentelemetry/api'
-      - '@opentelemetry/exporter-trace-otlp-proto'
-      - '@opentelemetry/sdk-trace-base'
-      - openai
-      - react
-      - react-dom
-      - svelte
-      - vue
-      - ws
-      - zod-to-json-schema
 
   detect-libc@2.1.2: {}
 

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -3,18 +3,10 @@ import { chmod, mkdir } from "node:fs/promises";
 import path from "node:path";
 import { ChatAnthropic } from "@langchain/anthropic";
 import { ToolMessage } from "@langchain/core/messages";
-import type { StructuredTool } from "@langchain/core/tools";
 import { SqliteSaver } from "@langchain/langgraph-checkpoint-sqlite";
 import { ChatOpenAI } from "@langchain/openai";
 import { ChatOpenRouter } from "@langchain/openrouter";
-import {
-  createDeepAgent,
-  GENERAL_PURPOSE_SUBAGENT,
-  getHarnessProfile,
-  LocalShellBackend,
-  type HarnessProfile,
-  type SubAgent,
-} from "deepagents";
+import { createDeepAgent, LocalShellBackend } from "deepagents";
 import { createMiddleware } from "langchain";
 import { loadOpenWikiEnv, openWikiEnvDir } from "../env.js";
 import { createSystemPrompt, createUserPrompt } from "./prompt.js";
@@ -161,17 +153,13 @@ async function runOpenWikiAgentWithModelFallbacks(
 }
 
 /**
- * deepagents' read_file tool returns binary files as one of `{ type: "file" }`,
+ * deepagents' read_file tool returns binary/media files as `{ type: "file" }`,
  * `{ type: "image" }`, `{ type: "audio" }`, or `{ type: "video" }` content
- * blocks (based on the file's extension-derived mimeType), each carrying that
- * mimeType and base64 data. Anthropic's API only accepts a narrow subset of
- * these: "file"/document blocks must be application/pdf, "image" blocks must
- * be one of a handful of raster formats, and it has no audio or video content
- * block type at all. Anything outside that subset — including extensionless
- * files (Dockerfile, LICENSE, CHANGELOG, ...), which deepagents' MIME lookup
- * defaults to application/octet-stream — gets rejected by the API and crashes
- * the whole run. Swap those blocks for a text placeholder instead of sending
- * them to the model.
+ * blocks, each carrying a mimeType and base64 data. Anthropic's API only
+ * accepts a narrow subset of these: "file"/document blocks must be
+ * application/pdf, "image" blocks must be one of a handful of raster formats,
+ * and it has no audio or video content block type at all. Swap unsupported
+ * blocks for a text placeholder instead of sending them to the model.
  */
 const sanitizeBinaryFileToolResultsMiddleware = createMiddleware({
   name: "SanitizeBinaryFileToolResults",
@@ -229,113 +217,6 @@ function isUnsupportedMultimodalBlock(
   return type === "audio" || type === "video";
 }
 
-/**
- * deepagents auto-adds the general-purpose subagent using a harness profile
- * resolved for the configured model (e.g. registered prompt suffixes for
- * specific Anthropic/OpenAI models), and that subagent doesn't inherit the
- * main agent's `middleware`. To attach our sanitizer to it we have to
- * redeclare it ourselves (deepagents' documented pattern for customizing the
- * GP subagent), which means reproducing that same profile-aware default
- * instead of hardcoding the bare `GENERAL_PURPOSE_SUBAGENT` — otherwise we'd
- * silently drop any model-specific prompt tuning for other users' models.
- *
- * `tools` should be the same array passed to the main agent's `createDeepAgent`
- * call: deepagents' own auto-add path threads the main agent's tools through to
- * the GP subagent, but once we redeclare the subagent ourselves its `tools`
- * field is locked in as-is (no fallback to the main agent's tools), so we have
- * to pass them through explicitly too. (There's no equivalent `skills` wiring
- * yet since the main agent doesn't set `skills` either — if it ever does, that
- * needs to be threaded through here the same way.)
- *
- * Returns `null` when the resolved profile explicitly disables the GP
- * subagent, matching deepagents' own auto-add condition.
- */
-function createGeneralPurposeSubagentWithSanitizer(
-  provider: OpenWikiProvider,
-  modelId: string,
-  tools: StructuredTool[],
-): SubAgent | null {
-  const harnessProfile = resolveOpenWikiHarnessProfile(provider, modelId);
-  const generalPurposeConfig = harnessProfile?.generalPurposeSubagent;
-
-  if (generalPurposeConfig?.enabled === false) {
-    return null;
-  }
-
-  return {
-    ...GENERAL_PURPOSE_SUBAGENT,
-    description:
-      generalPurposeConfig?.description ?? GENERAL_PURPOSE_SUBAGENT.description,
-    systemPrompt:
-      generalPurposeConfig?.systemPrompt ??
-      applyHarnessProfilePrompt(harnessProfile, GENERAL_PURPOSE_SUBAGENT.systemPrompt),
-    tools,
-    middleware: [sanitizeBinaryFileToolResultsMiddleware],
-  };
-}
-
-/**
- * Maps an OpenWiki provider to the model-class-based provider hint deepagents'
- * internal harness-profile resolution uses. deepagents only recognizes a
- * model instance's provider by class name (ChatAnthropic -> "anthropic",
- * ChatOpenAI -> "openai", ChatGoogleGenerativeAI -> "google"). `createModel`
- * below instantiates ChatOpenAI for openai/baseten/fireworks alike, and
- * ChatOpenRouter (unrecognized by deepagents) for openrouter — so those must
- * map the same way here, or profile lookups silently diverge from what
- * deepagents itself resolves for the main agent.
- */
-function toHarnessProfileProviderHint(
-  provider: OpenWikiProvider,
-): string | undefined {
-  if (provider === "anthropic") {
-    return "anthropic";
-  }
-
-  if (provider === "openrouter") {
-    return undefined;
-  }
-
-  return "openai";
-}
-
-/** Mirrors deepagents' internal (unexported) `resolveHarnessProfile` resolution order. */
-function resolveOpenWikiHarnessProfile(
-  provider: OpenWikiProvider,
-  modelId: string,
-): HarnessProfile | undefined {
-  const providerHint = toHarnessProfileProviderHint(provider);
-
-  if (providerHint && !modelId.includes(":")) {
-    const profile = getHarnessProfile(`${providerHint}:${modelId}`);
-
-    if (profile) {
-      return profile;
-    }
-  }
-
-  if (modelId.includes(":")) {
-    const profile = getHarnessProfile(modelId);
-
-    if (profile) {
-      return profile;
-    }
-  }
-
-  return providerHint ? getHarnessProfile(providerHint) : undefined;
-}
-
-/** Mirrors deepagents' internal (unexported) prompt-assembly rule for a resolved harness profile. */
-function applyHarnessProfilePrompt(
-  profile: HarnessProfile | undefined,
-  basePrompt: string,
-): string {
-  const prompt = profile?.baseSystemPrompt ?? basePrompt;
-
-  return profile?.systemPromptSuffix !== undefined
-    ? `${prompt}\n\n${profile.systemPromptSuffix}`
-    : prompt;
-}
-
 async function runOpenWikiAgentCore(
   command: OpenWikiCommand,
   cwd: string,
@@ -363,15 +244,9 @@ async function runOpenWikiAgentCore(
   emitDebug(options, `checkpointer=${formatUrlDebugValue(checkpointPath)}`);
   const threadId = options.threadId ?? createThreadId(cwd, createRunThreadId());
   emitDebug(options, `thread=${threadId}`);
-  const mainAgentTools: StructuredTool[] = [];
-  const generalPurposeSubagent = createGeneralPurposeSubagentWithSanitizer(
-    provider,
-    modelId,
-    mainAgentTools,
-  );
   const agent = createDeepAgent({
     model,
-    tools: mainAgentTools,
+    tools: [],
     checkpointer,
     backend: new LocalShellBackend({
       maxOutputBytes: 100_000,
@@ -381,7 +256,7 @@ async function runOpenWikiAgentCore(
     }),
     systemPrompt: createSystemPrompt(command),
     middleware: [sanitizeBinaryFileToolResultsMiddleware],
-    subagents: generalPurposeSubagent ? [generalPurposeSubagent] : [],
+    generalPurposeSubagentMiddleware: [sanitizeBinaryFileToolResultsMiddleware],
   });
   emitDebug(options, "agent=created");
 

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -3,6 +3,7 @@ import { chmod, mkdir } from "node:fs/promises";
 import path from "node:path";
 import { ChatAnthropic } from "@langchain/anthropic";
 import { ToolMessage } from "@langchain/core/messages";
+import type { StructuredTool } from "@langchain/core/tools";
 import { SqliteSaver } from "@langchain/langgraph-checkpoint-sqlite";
 import { ChatOpenAI } from "@langchain/openai";
 import { ChatOpenRouter } from "@langchain/openrouter";
@@ -160,13 +161,17 @@ async function runOpenWikiAgentWithModelFallbacks(
 }
 
 /**
- * deepagents' read_file tool returns non-text, non-image/audio/video files as a
- * generic `{ type: "file", mimeType, data }` content block. When mimeType isn't
- * "application/pdf", Anthropic's API rejects the resulting document content block
- * (it only accepts application/pdf for base64 documents), crashing the whole run.
- * Extensionless files (Dockerfile, LICENSE, CHANGELOG, ...) hit this because
- * deepagents' MIME lookup defaults unknown extensions to application/octet-stream.
- * Swap those blocks for a text placeholder instead of sending them to the model.
+ * deepagents' read_file tool returns binary files as one of `{ type: "file" }`,
+ * `{ type: "image" }`, `{ type: "audio" }`, or `{ type: "video" }` content
+ * blocks (based on the file's extension-derived mimeType), each carrying that
+ * mimeType and base64 data. Anthropic's API only accepts a narrow subset of
+ * these: "file"/document blocks must be application/pdf, "image" blocks must
+ * be one of a handful of raster formats, and it has no audio or video content
+ * block type at all. Anything outside that subset — including extensionless
+ * files (Dockerfile, LICENSE, CHANGELOG, ...), which deepagents' MIME lookup
+ * defaults to application/octet-stream — gets rejected by the API and crashes
+ * the whole run. Swap those blocks for a text placeholder instead of sending
+ * them to the model.
  */
 const sanitizeBinaryFileToolResultsMiddleware = createMiddleware({
   name: "SanitizeBinaryFileToolResults",
@@ -178,10 +183,10 @@ const sanitizeBinaryFileToolResultsMiddleware = createMiddleware({
     }
 
     result.content = result.content.map((block) =>
-      isUnsupportedBinaryFileBlock(block)
+      isUnsupportedMultimodalBlock(block)
         ? {
             type: "text",
-            text: `[OpenWiki] Skipped binary file (mime type "${block.mimeType}"): unsupported for inline preview. Anthropic's document content blocks only accept "application/pdf".`,
+            text: `[OpenWiki] Skipped ${block.type} content (mime type "${block.mimeType}"): unsupported for inline preview by this model.`,
           }
         : block,
     );
@@ -190,16 +195,38 @@ const sanitizeBinaryFileToolResultsMiddleware = createMiddleware({
   },
 });
 
-function isUnsupportedBinaryFileBlock(
+/** Raster image formats Anthropic's "image" content blocks accept (e.g. not HEIC/HEIF). */
+const ANTHROPIC_SUPPORTED_IMAGE_MIME_TYPES = new Set([
+  "image/jpeg",
+  "image/png",
+  "image/gif",
+  "image/webp",
+]);
+
+function isUnsupportedMultimodalBlock(
   block: unknown,
-): block is { type: "file"; mimeType: string } {
-  return (
-    typeof block === "object" &&
-    block !== null &&
-    (block as { type?: unknown }).type === "file" &&
-    typeof (block as { mimeType?: unknown }).mimeType === "string" &&
-    (block as { mimeType: string }).mimeType !== "application/pdf"
-  );
+): block is { type: string; mimeType: string } {
+  if (typeof block !== "object" || block === null) {
+    return false;
+  }
+
+  const type = (block as { type?: unknown }).type;
+  const mimeType = (block as { mimeType?: unknown }).mimeType;
+
+  if (typeof mimeType !== "string") {
+    return false;
+  }
+
+  if (type === "file") {
+    return mimeType !== "application/pdf";
+  }
+
+  if (type === "image") {
+    return !ANTHROPIC_SUPPORTED_IMAGE_MIME_TYPES.has(mimeType);
+  }
+
+  // Anthropic's Messages API has no audio or video content block type.
+  return type === "audio" || type === "video";
 }
 
 /**
@@ -212,14 +239,23 @@ function isUnsupportedBinaryFileBlock(
  * instead of hardcoding the bare `GENERAL_PURPOSE_SUBAGENT` — otherwise we'd
  * silently drop any model-specific prompt tuning for other users' models.
  *
+ * `tools` should be the same array passed to the main agent's `createDeepAgent`
+ * call: deepagents' own auto-add path threads the main agent's tools through to
+ * the GP subagent, but once we redeclare the subagent ourselves its `tools`
+ * field is locked in as-is (no fallback to the main agent's tools), so we have
+ * to pass them through explicitly too. (There's no equivalent `skills` wiring
+ * yet since the main agent doesn't set `skills` either — if it ever does, that
+ * needs to be threaded through here the same way.)
+ *
  * Returns `null` when the resolved profile explicitly disables the GP
  * subagent, matching deepagents' own auto-add condition.
  */
 function createGeneralPurposeSubagentWithSanitizer(
   provider: OpenWikiProvider,
   modelId: string,
+  tools: StructuredTool[],
 ): SubAgent | null {
-  const harnessProfile = getHarnessProfile(`${provider}:${modelId}`);
+  const harnessProfile = resolveOpenWikiHarnessProfile(provider, modelId);
   const generalPurposeConfig = harnessProfile?.generalPurposeSubagent;
 
   if (generalPurposeConfig?.enabled === false) {
@@ -233,8 +269,59 @@ function createGeneralPurposeSubagentWithSanitizer(
     systemPrompt:
       generalPurposeConfig?.systemPrompt ??
       applyHarnessProfilePrompt(harnessProfile, GENERAL_PURPOSE_SUBAGENT.systemPrompt),
+    tools,
     middleware: [sanitizeBinaryFileToolResultsMiddleware],
   };
+}
+
+/**
+ * Maps an OpenWiki provider to the model-class-based provider hint deepagents'
+ * internal harness-profile resolution uses. deepagents only recognizes a
+ * model instance's provider by class name (ChatAnthropic -> "anthropic",
+ * ChatOpenAI -> "openai", ChatGoogleGenerativeAI -> "google"). `createModel`
+ * below instantiates ChatOpenAI for openai/baseten/fireworks alike, and
+ * ChatOpenRouter (unrecognized by deepagents) for openrouter — so those must
+ * map the same way here, or profile lookups silently diverge from what
+ * deepagents itself resolves for the main agent.
+ */
+function toHarnessProfileProviderHint(
+  provider: OpenWikiProvider,
+): string | undefined {
+  if (provider === "anthropic") {
+    return "anthropic";
+  }
+
+  if (provider === "openrouter") {
+    return undefined;
+  }
+
+  return "openai";
+}
+
+/** Mirrors deepagents' internal (unexported) `resolveHarnessProfile` resolution order. */
+function resolveOpenWikiHarnessProfile(
+  provider: OpenWikiProvider,
+  modelId: string,
+): HarnessProfile | undefined {
+  const providerHint = toHarnessProfileProviderHint(provider);
+
+  if (providerHint && !modelId.includes(":")) {
+    const profile = getHarnessProfile(`${providerHint}:${modelId}`);
+
+    if (profile) {
+      return profile;
+    }
+  }
+
+  if (modelId.includes(":")) {
+    const profile = getHarnessProfile(modelId);
+
+    if (profile) {
+      return profile;
+    }
+  }
+
+  return providerHint ? getHarnessProfile(providerHint) : undefined;
 }
 
 /** Mirrors deepagents' internal (unexported) prompt-assembly rule for a resolved harness profile. */
@@ -276,13 +363,15 @@ async function runOpenWikiAgentCore(
   emitDebug(options, `checkpointer=${formatUrlDebugValue(checkpointPath)}`);
   const threadId = options.threadId ?? createThreadId(cwd, createRunThreadId());
   emitDebug(options, `thread=${threadId}`);
+  const mainAgentTools: StructuredTool[] = [];
   const generalPurposeSubagent = createGeneralPurposeSubagentWithSanitizer(
     provider,
     modelId,
+    mainAgentTools,
   );
   const agent = createDeepAgent({
     model,
-    tools: [],
+    tools: mainAgentTools,
     checkpointer,
     backend: new LocalShellBackend({
       maxOutputBytes: 100_000,

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -2,10 +2,19 @@ import { createHash } from "node:crypto";
 import { chmod, mkdir } from "node:fs/promises";
 import path from "node:path";
 import { ChatAnthropic } from "@langchain/anthropic";
+import { ToolMessage } from "@langchain/core/messages";
 import { SqliteSaver } from "@langchain/langgraph-checkpoint-sqlite";
 import { ChatOpenAI } from "@langchain/openai";
 import { ChatOpenRouter } from "@langchain/openrouter";
-import { createDeepAgent, LocalShellBackend } from "deepagents";
+import {
+  createDeepAgent,
+  GENERAL_PURPOSE_SUBAGENT,
+  getHarnessProfile,
+  LocalShellBackend,
+  type HarnessProfile,
+  type SubAgent,
+} from "deepagents";
+import { createMiddleware } from "langchain";
 import { loadOpenWikiEnv, openWikiEnvDir } from "../env.js";
 import { createSystemPrompt, createUserPrompt } from "./prompt.js";
 import type {
@@ -150,6 +159,96 @@ async function runOpenWikiAgentWithModelFallbacks(
     : new Error("OpenWiki run failed after model fallback attempts.");
 }
 
+/**
+ * deepagents' read_file tool returns non-text, non-image/audio/video files as a
+ * generic `{ type: "file", mimeType, data }` content block. When mimeType isn't
+ * "application/pdf", Anthropic's API rejects the resulting document content block
+ * (it only accepts application/pdf for base64 documents), crashing the whole run.
+ * Extensionless files (Dockerfile, LICENSE, CHANGELOG, ...) hit this because
+ * deepagents' MIME lookup defaults unknown extensions to application/octet-stream.
+ * Swap those blocks for a text placeholder instead of sending them to the model.
+ */
+const sanitizeBinaryFileToolResultsMiddleware = createMiddleware({
+  name: "SanitizeBinaryFileToolResults",
+  wrapToolCall: async (request, handler) => {
+    const result = await handler(request);
+
+    if (!(result instanceof ToolMessage) || !Array.isArray(result.content)) {
+      return result;
+    }
+
+    result.content = result.content.map((block) =>
+      isUnsupportedBinaryFileBlock(block)
+        ? {
+            type: "text",
+            text: `[OpenWiki] Skipped binary file (mime type "${block.mimeType}"): unsupported for inline preview. Anthropic's document content blocks only accept "application/pdf".`,
+          }
+        : block,
+    );
+
+    return result;
+  },
+});
+
+function isUnsupportedBinaryFileBlock(
+  block: unknown,
+): block is { type: "file"; mimeType: string } {
+  return (
+    typeof block === "object" &&
+    block !== null &&
+    (block as { type?: unknown }).type === "file" &&
+    typeof (block as { mimeType?: unknown }).mimeType === "string" &&
+    (block as { mimeType: string }).mimeType !== "application/pdf"
+  );
+}
+
+/**
+ * deepagents auto-adds the general-purpose subagent using a harness profile
+ * resolved for the configured model (e.g. registered prompt suffixes for
+ * specific Anthropic/OpenAI models), and that subagent doesn't inherit the
+ * main agent's `middleware`. To attach our sanitizer to it we have to
+ * redeclare it ourselves (deepagents' documented pattern for customizing the
+ * GP subagent), which means reproducing that same profile-aware default
+ * instead of hardcoding the bare `GENERAL_PURPOSE_SUBAGENT` — otherwise we'd
+ * silently drop any model-specific prompt tuning for other users' models.
+ *
+ * Returns `null` when the resolved profile explicitly disables the GP
+ * subagent, matching deepagents' own auto-add condition.
+ */
+function createGeneralPurposeSubagentWithSanitizer(
+  provider: OpenWikiProvider,
+  modelId: string,
+): SubAgent | null {
+  const harnessProfile = getHarnessProfile(`${provider}:${modelId}`);
+  const generalPurposeConfig = harnessProfile?.generalPurposeSubagent;
+
+  if (generalPurposeConfig?.enabled === false) {
+    return null;
+  }
+
+  return {
+    ...GENERAL_PURPOSE_SUBAGENT,
+    description:
+      generalPurposeConfig?.description ?? GENERAL_PURPOSE_SUBAGENT.description,
+    systemPrompt:
+      generalPurposeConfig?.systemPrompt ??
+      applyHarnessProfilePrompt(harnessProfile, GENERAL_PURPOSE_SUBAGENT.systemPrompt),
+    middleware: [sanitizeBinaryFileToolResultsMiddleware],
+  };
+}
+
+/** Mirrors deepagents' internal (unexported) prompt-assembly rule for a resolved harness profile. */
+function applyHarnessProfilePrompt(
+  profile: HarnessProfile | undefined,
+  basePrompt: string,
+): string {
+  const prompt = profile?.baseSystemPrompt ?? basePrompt;
+
+  return profile?.systemPromptSuffix !== undefined
+    ? `${prompt}\n\n${profile.systemPromptSuffix}`
+    : prompt;
+}
+
 async function runOpenWikiAgentCore(
   command: OpenWikiCommand,
   cwd: string,
@@ -177,6 +276,10 @@ async function runOpenWikiAgentCore(
   emitDebug(options, `checkpointer=${formatUrlDebugValue(checkpointPath)}`);
   const threadId = options.threadId ?? createThreadId(cwd, createRunThreadId());
   emitDebug(options, `thread=${threadId}`);
+  const generalPurposeSubagent = createGeneralPurposeSubagentWithSanitizer(
+    provider,
+    modelId,
+  );
   const agent = createDeepAgent({
     model,
     tools: [],
@@ -188,6 +291,8 @@ async function runOpenWikiAgentCore(
       virtualMode: true,
     }),
     systemPrompt: createSystemPrompt(command),
+    middleware: [sanitizeBinaryFileToolResultsMiddleware],
+    subagents: generalPurposeSubagent ? [generalPurposeSubagent] : [],
   });
   emitDebug(options, "agent=created");
 


### PR DESCRIPTION
## Summary

- Builds on OpenWiki [#67](https://github.com/langchain-ai/openwiki/pull/67) by removing the local reimplementation of DeepAgents' default `general-purpose` subagent.
- Uses DeepAgents' new `generalPurposeSubagentMiddleware` option from DeepAgentsJS [#645](https://github.com/langchain-ai/deepagentsjs/pull/645) so OpenWiki can attach the Anthropic binary/media sanitizer to the default subagent without copying harness-profile internals.
- Uses the DeepAgentsJS [#645](https://github.com/langchain-ai/deepagentsjs/pull/645) preview package (`https://pkg.pr.new/deepagents@63aa2e1`) so this draft branch is buildable and testable before the upstream API is released.
- Keeps OpenWiki's provider-facing sanitizer focused on true unsupported binary/media content blocks; extensionless UTF-8 text recognition is handled upstream in DeepAgentsJS [#645](https://github.com/langchain-ai/deepagentsjs/pull/645).

## Problem

OpenWiki [#67](https://github.com/langchain-ai/openwiki/pull/67) fixed the Anthropic crash by sanitizing unsupported file/media content blocks before they reach the model. The hard part was applying that sanitizer to the default DeepAgents `general-purpose` subagent: DeepAgents creates that subagent internally, and it does not inherit the main agent middleware stack.

The current OpenWiki [#67](https://github.com/langchain-ai/openwiki/pull/67) branch therefore duplicates DeepAgents internals to redeclare the default subagent. That makes OpenWiki responsible for provider/model harness-profile lookup, prompt composition, and future DeepAgents default changes. This follow-up removes that duplication and uses the upstream extension point instead.

## Fix

This PR changes OpenWiki to call `createDeepAgent` with:

```ts
generalPurposeSubagentMiddleware: [sanitizeBinaryFileToolResultsMiddleware]
```

The main agent still keeps the same sanitizer in `middleware`, so unsupported binary/media blocks are sanitized in both places. The default DeepAgents subagent remains profile-aware and internally owned by DeepAgents.

The dependency currently points to the DeepAgentsJS [#645](https://github.com/langchain-ai/deepagentsjs/pull/645) preview package so reviewers can build and test this branch before the upstream release is available.

## Cross-Repo Rollout

- OpenWiki [#67](https://github.com/langchain-ai/openwiki/pull/67): original sanitizer PR and review context.
- DeepAgentsJS [#645](https://github.com/langchain-ai/deepagentsjs/pull/645): upstream API and extensionless UTF-8 file recognition. This PR depends on it.
- LangChainJS [#11143](https://github.com/langchain-ai/langchainjs/pull/11143): complementary Anthropic formatter hardening so unknown MIME binaries are not mislabeled as PDFs.

Suggested review order: review DeepAgentsJS [#645](https://github.com/langchain-ai/deepagentsjs/pull/645) first, then this PR.

## Merge Notes

This PR is intentionally draft because it uses `https://pkg.pr.new/deepagents@63aa2e1`. Before merge:

- DeepAgentsJS [#645](https://github.com/langchain-ai/deepagentsjs/pull/645) should land and publish.
- This branch should replace the pkg.pr.new dependency with the released DeepAgents version.
- OpenWiki [#67](https://github.com/langchain-ai/openwiki/pull/67) should either be superseded by this branch or rebased so it no longer carries the duplicated subagent implementation.

## Reviewer Notes

Please focus on:

- whether OpenWiki should keep the provider-specific sanitizer at this layer;
- whether applying the same sanitizer to both `middleware` and `generalPurposeSubagentMiddleware` covers the root-agent and subagent tool-result paths cleanly;
- whether any OpenWiki behavior from [#67](https://github.com/langchain-ai/openwiki/pull/67) was lost when removing the local subagent redeclaration;
- whether the dependency strategy is acceptable for a draft review branch.

## Test Plan

- [x] `pnpm install`
- [x] `pnpm run format:check`
- [x] `pnpm run lint:check`
- [x] `pnpm run build`
- [x] direct DeepAgents `read_file` smoke via OpenWiki dependency: extensionless `Dockerfile` returns a text block; real extensionless binary remains `application/octet-stream`
- [x] live Anthropic smoke from local validation: OpenWiki general-purpose subagent read `/Dockerfile` as text and skipped a real binary safely without a 400