### PR TITLE
feat: add Z.AI (GLM Coding Plan) provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,6 @@ These configuration options and secrets will be saved to `~/.openwiki/.env` on y
 
 ## Customizing
 
-OpenWiki supports OpenRouter, Fireworks, Baseten, OpenAI and Anthropic out of the box. By default, there are a few models pre-defined (GLM 5.2, Kimi K2.6, Sonnet 5, etc) but for each inference provider, OpenWiki will allow you to specify your own custom model ID.
+OpenWiki supports OpenRouter, Z.AI, Fireworks, Baseten, OpenAI and Anthropic out of the box. By default, there are a few models pre-defined (GLM 5.2, Kimi K2.6, Sonnet 5, etc) but for each inference provider, OpenWiki will allow you to specify your own custom model ID.
 
 If there's an inference provider or model you'd like to see added, please open a PR!

--- a/openwiki/agent/workflow.md
+++ b/openwiki/agent/workflow.md
@@ -23,7 +23,7 @@ Chat runs skip metadata writes entirely.
 
 `createModel()` in `src/agent/index.ts` branches by provider:
 
-- **anthropic**: `new ChatAnthropic(modelId, { apiKey })` — uses `@langchain/anthropic` directly.
+- **anthropic / zai**: `new ChatAnthropic(modelId, { apiKey, anthropicApiUrl })` — uses `@langchain/anthropic` directly (`zai` sets `anthropicApiUrl` to the Z.AI GLM Coding Plan Anthropic endpoint, `https://api.z.ai/api/anthropic`).
 - **openrouter**: `new ChatOpenRouter({ apiKey, baseURL, model, models, route: "fallback", siteName: "OpenWiki" })` — passes a fallback model list so OpenRouter can route around server-side failures.
 - **baseten / fireworks / openai**: `new ChatOpenAI({ apiKey, configuration: { baseURL? }, model })` — OpenAI-compatible clients using the provider's custom base URL when configured.
 

--- a/openwiki/architecture/overview.md
+++ b/openwiki/architecture/overview.md
@@ -40,7 +40,7 @@ The agent runtime resolves the provider via `resolveConfiguredProvider()` in `sr
 
 Model creation branches by provider in `src/agent/index.ts` (`createModel`):
 
-- **anthropic** → `ChatAnthropic` with the Anthropic API key.
+- **anthropic / zai** → `ChatAnthropic` with the provider's API key and optional `anthropicApiUrl` from `PROVIDER_CONFIGS` (`zai` points at the Z.AI GLM Coding Plan Anthropic endpoint).
 - **openrouter** → `ChatOpenRouter` with `route: "fallback"` and a list of fallback models.
 - **baseten / fireworks / openai** → `ChatOpenAI` with the provider's API key and optional custom `baseURL` from `PROVIDER_CONFIGS`.
 

--- a/openwiki/cli/usage.md
+++ b/openwiki/cli/usage.md
@@ -43,8 +43,8 @@ The UI persists provider and model selection back to `~/.openwiki/.env` through 
 
 The first interactive run can prompt for:
 
-- a **provider** (`OPENWIKI_PROVIDER`) — openrouter, baseten, fireworks, openai, or anthropic,
-- the **provider API key** (e.g. `OPENROUTER_API_KEY`, `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, `BASETEN_API_KEY`, `FIREWORKS_API_KEY`),
+- a **provider** (`OPENWIKI_PROVIDER`) — openrouter, zai, baseten, fireworks, openai, or anthropic,
+- the **provider API key** (e.g. `OPENROUTER_API_KEY`, `ZAI_API_KEY`, `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, `BASETEN_API_KEY`, `FIREWORKS_API_KEY`),
 - a **model ID** stored as `OPENWIKI_MODEL_ID` — chosen from the provider's model list or a custom ID,
 - optional `LANGSMITH_API_KEY` for tracing.
 
@@ -59,6 +59,7 @@ Providers and their model options are defined in `PROVIDER_CONFIGS` in `src/cons
 | Provider   | Env key              | Base URL                                | Models                                                                |
 | ---------- | -------------------- | --------------------------------------- | --------------------------------------------------------------------- |
 | openrouter | `OPENROUTER_API_KEY` | `https://openrouter.ai/api/v1`          | GLM 5.2, Fusion, Kimi K2.7 Code, Claude Opus/Sonnet, GPT 5.4 mini/5.5 |
+| zai        | `ZAI_API_KEY`        | `https://api.z.ai/api/anthropic`        | GLM 5.2                                                               |
 | baseten    | `BASETEN_API_KEY`    | `https://inference.baseten.co/v1`       | GLM 5.2, Kimi K2.7 Code                                               |
 | fireworks  | `FIREWORKS_API_KEY`  | `https://api.fireworks.ai/inference/v1` | GLM 5.2, Kimi K2.7 Code                                               |
 | openai     | `OPENAI_API_KEY`     | (default)                               | GPT 5.4 mini, GPT 5.5                                                 |

--- a/openwiki/operations/credentials-and-updates.md
+++ b/openwiki/operations/credentials-and-updates.md
@@ -18,7 +18,7 @@ The file stores provider configuration and API keys:
 
 - `OPENWIKI_PROVIDER` — the selected model provider
 - `OPENWIKI_MODEL_ID` — the default model ID
-- Provider API keys: `OPENROUTER_API_KEY`, `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, `BASETEN_API_KEY`, `FIREWORKS_API_KEY`
+- Provider API keys: `OPENROUTER_API_KEY`, `ZAI_API_KEY`, `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, `BASETEN_API_KEY`, `FIREWORKS_API_KEY`
 - Optional LangSmith settings: `LANGSMITH_API_KEY`, `LANGCHAIN_PROJECT`, `LANGCHAIN_TRACING_V2`
 
 The loader merges those values into `process.env`, while preferring existing process-level values over file values. Deprecated keys (`OPENAI_BASE_URL`, `OPENAI_ORG_ID`, `OPENAI_PROJECT`) are skipped on load and removed on save.
@@ -56,7 +56,7 @@ The env layer also produces diagnostics for the CLI UI. Those diagnostics report
 - invalid model IDs,
 - invalid provider values.
 
-Diagnostics cover all five provider keys plus `OPENWIKI_PROVIDER`, `OPENWIKI_MODEL_ID`, and `LANGSMITH_API_KEY`. This makes startup problems easier to diagnose without exposing secret values.
+Diagnostics cover all six provider keys plus `OPENWIKI_PROVIDER`, `OPENWIKI_MODEL_ID`, and `LANGSMITH_API_KEY`. This makes startup problems easier to diagnose without exposing secret values.
 
 ## Update metadata
 

--- a/openwiki/quickstart.md
+++ b/openwiki/quickstart.md
@@ -6,7 +6,7 @@ OpenWiki is a TypeScript CLI that writes and maintains documentation for a repos
 
 - Launches an interactive Ink-based terminal app for chatting with the OpenWiki agent.
 - Supports one-shot documentation runs with `--init`, `--update`, and `--print`.
-- Supports multiple model providers — OpenRouter (default), Anthropic, OpenAI, Baseten, and Fireworks — each with their own API key and model list.
+- Supports multiple model providers — OpenRouter (default), Z.AI, Anthropic, OpenAI, Baseten, and Fireworks — each with their own API key and model list.
 - Uses a DeepAgents local shell backend with virtual filesystem paths rooted at the target repository.
 - Creates or refreshes documentation under the target repository's `openwiki/` directory.
 - Auto-exits after successful `--init` or `--update` runs in an interactive terminal, so the CLI works as both a one-shot and interactive tool.

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -31,6 +31,7 @@ import {
   OPENWIKI_MODEL_ID_ENV_KEY,
   OPENWIKI_PROVIDER_ENV_KEY,
   resolveConfiguredProvider,
+  ZAI_API_KEY_ENV_KEY,
   type OpenWikiProvider,
 } from "../constants.js";
 import {
@@ -378,9 +379,12 @@ function resolveModelId(
 }
 
 async function createModel(provider: OpenWikiProvider, modelId: string) {
-  if (provider === "anthropic") {
+  if (provider === "anthropic" || provider === "zai") {
+    const providerConfig = getProviderConfig(provider);
+
     return new ChatAnthropic(modelId, {
       apiKey: process.env[getProviderApiKeyEnvKey(provider)],
+      anthropicApiUrl: providerConfig.baseURL,
     });
   }
 
@@ -1264,6 +1268,7 @@ function formatEnvironmentDebug(): string {
     OPENAI_API_KEY_ENV_KEY,
     ANTHROPIC_API_KEY_ENV_KEY,
     OPENROUTER_API_KEY_ENV_KEY,
+    ZAI_API_KEY_ENV_KEY,
     OPENWIKI_MODEL_ID_ENV_KEY,
     "LANGCHAIN_TRACING_V2",
     "LANGCHAIN_PROJECT",

--- a/src/cli.tsx
+++ b/src/cli.tsx
@@ -44,6 +44,7 @@ import {
   resolveConfiguredProvider,
   SELECTABLE_OPENWIKI_PROVIDERS,
   OPENWIKI_VERSION,
+  ZAI_API_KEY_ENV_KEY,
   type OpenWikiProvider,
 } from "./constants.js";
 import type { OpenWikiCommand } from "./agent/types.js";
@@ -2925,6 +2926,7 @@ function sanitizeDiagnosticText(value: string): string {
     OPENAI_API_KEY_ENV_KEY,
     ANTHROPIC_API_KEY_ENV_KEY,
     OPENROUTER_API_KEY_ENV_KEY,
+    ZAI_API_KEY_ENV_KEY,
     "LANGSMITH_API_KEY",
   ]) {
     const secret = process.env[key];

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -5,17 +5,20 @@ export const FIREWORKS_API_KEY_ENV_KEY = "FIREWORKS_API_KEY";
 export const OPENAI_API_KEY_ENV_KEY = "OPENAI_API_KEY";
 export const ANTHROPIC_API_KEY_ENV_KEY = "ANTHROPIC_API_KEY";
 export const OPENROUTER_API_KEY_ENV_KEY = "OPENROUTER_API_KEY";
+export const ZAI_API_KEY_ENV_KEY = "ZAI_API_KEY";
 export const OPENWIKI_PROVIDER_ENV_KEY = "OPENWIKI_PROVIDER";
 export const OPENWIKI_MODEL_ID_ENV_KEY = "OPENWIKI_MODEL_ID";
 export const DEFAULT_PROVIDER = "openrouter";
 export const OPENROUTER_BASE_URL = "https://openrouter.ai/api/v1";
+export const ZAI_ANTHROPIC_BASE_URL = "https://api.z.ai/api/anthropic";
 
 export type OpenWikiProvider =
   | "anthropic"
   | "baseten"
   | "fireworks"
   | "openai"
-  | "openrouter";
+  | "openrouter"
+  | "zai";
 
 export type SelectableOpenWikiProvider = OpenWikiProvider;
 
@@ -33,6 +36,7 @@ type ProviderConfig = {
 
 export const SELECTABLE_OPENWIKI_PROVIDERS = [
   "openrouter",
+  "zai",
   "baseten",
   "fireworks",
   "openai",
@@ -91,6 +95,12 @@ export const PROVIDER_CONFIGS: Record<OpenWikiProvider, ProviderConfig> = {
       { id: "openai/gpt-5.4-mini", label: "GPT 5.4 mini" },
       { id: "openai/gpt-5.5", label: "GPT 5.5" },
     ],
+  },
+  zai: {
+    apiKeyEnvKey: ZAI_API_KEY_ENV_KEY,
+    baseURL: ZAI_ANTHROPIC_BASE_URL,
+    label: "Z.AI",
+    modelOptions: [{ id: "glm-5.2", label: "GLM 5.2" }],
   },
 };
 

--- a/src/credentials.tsx
+++ b/src/credentials.tsx
@@ -776,7 +776,11 @@ function moveSelectionIndex(
 }
 
 function getProviderArticle(provider: OpenWikiProvider): "a" | "an" {
-  return provider === "baseten" || provider === "fireworks" ? "a" : "an";
+  return provider === "baseten" ||
+    provider === "fireworks" ||
+    provider === "zai"
+    ? "a"
+    : "an";
 }
 
 function sanitizeInputChunk(value: string): string {

--- a/src/env.ts
+++ b/src/env.ts
@@ -11,6 +11,7 @@ import {
   OPENROUTER_API_KEY_ENV_KEY,
   OPENWIKI_MODEL_ID_ENV_KEY,
   OPENWIKI_PROVIDER_ENV_KEY,
+  ZAI_API_KEY_ENV_KEY,
 } from "./constants.js";
 
 export const openWikiEnvDir = path.join(os.homedir(), ".openwiki");
@@ -36,6 +37,7 @@ const managedEnvKeys = [
   OPENAI_API_KEY_ENV_KEY,
   ANTHROPIC_API_KEY_ENV_KEY,
   OPENROUTER_API_KEY_ENV_KEY,
+  ZAI_API_KEY_ENV_KEY,
   OPENWIKI_PROVIDER_ENV_KEY,
   OPENWIKI_MODEL_ID_ENV_KEY,
   "LANGSMITH_API_KEY",
@@ -77,6 +79,7 @@ export async function getCredentialDiagnostics(): Promise<
     createCredentialDiagnostic(OPENAI_API_KEY_ENV_KEY, fileEnv),
     createCredentialDiagnostic(ANTHROPIC_API_KEY_ENV_KEY, fileEnv),
     createCredentialDiagnostic(OPENROUTER_API_KEY_ENV_KEY, fileEnv),
+    createCredentialDiagnostic(ZAI_API_KEY_ENV_KEY, fileEnv),
     createCredentialDiagnostic(OPENWIKI_MODEL_ID_ENV_KEY, fileEnv),
     createCredentialDiagnostic("LANGSMITH_API_KEY", fileEnv),
   ];


### PR DESCRIPTION
## What this adds

A new `zai` provider so OpenWiki can run GLM-5.2 against **Z.AI's GLM Coding Plan**. Z.AI serves an Anthropic-protocol endpoint at `https://api.z.ai/api/anthropic` for coding-plan subscribers, so this provider routes through `ChatAnthropic` with `anthropicApiUrl`.

## Why the Anthropic protocol (not the OpenAI one)

Z.AI's coding plan exposes two protocols:

- OpenAI: `https://api.z.ai/api/coding/paas/v4`
- Anthropic: `https://api.z.ai/api/anthropic`

I first wired `zai` through the OpenAI endpoint via `ChatOpenAI` (mirroring baseten/fireworks/openai). That path crashes at runtime against GLM-5.2:

```
Invalid response from "wrapModelCall" in middleware "patchToolCallsMiddleware": expected AIMessage or Command, got object
```

Root cause: GLM-5.2 is a reasoning model whose streaming tool-call payloads don't reassemble into a valid `AIMessage` inside `@langchain/openai`'s `ChatOpenAI`. `patchToolCallsMiddleware` is just the messenger (it forwards `handler(request)` unchanged; the bad object originates in the model layer), and `deepagents` adds it unconditionally with no opt-out, so the fix has to be at the protocol layer.

Routing through `ChatAnthropic` at the Anthropic endpoint sidesteps this entirely — the Messages API has native tool-use streaming semantics and is parsed into proper `AIMessage` instances. This is also the endpoint Z.AI recommends for agentic coding tools (Claude Code uses this exact endpoint).

## Changes

- **`src/constants.ts`** — `ZAI_API_KEY_ENV_KEY` (`ZAI_API_KEY`), `ZAI_ANTHROPIC_BASE_URL`, `zai` in the `OpenWikiProvider` union + `SELECTABLE_OPENWIKI_PROVIDERS` (2nd, after openrouter), and the `zai` `PROVIDER_CONFIGS` entry (GLM 5.2).
- **`src/agent/index.ts`** — generalized the `anthropic` branch to `anthropic || zai`, constructing `ChatAnthropic` with `anthropicApiUrl: providerConfig.baseURL` (undefined for plain `anthropic` → behavior unchanged).
- **`src/env.ts`** — `ZAI_API_KEY` in `managedEnvKeys` + credential diagnostics.
- **`src/credentials.tsx`** — `getProviderArticle()` returns `"a"` for `zai`.
- **`src/cli.tsx`** — `ZAI_API_KEY` in the secret-redaction loop.
- **Docs** — README, quickstart, CLI usage (provider table), architecture overview, agent workflow, operations. Doc edits are hand-applied to the existing prose only (no full regen bundled in).

Default provider is unchanged (`openrouter`).

## How to test

```sh
rm -f ~/.openwiki/.env
unset OPENWIKI_PROVIDER ZAI_API_KEY OPENWIKI_MODEL_ID
pnpm dev --init
```

Pick **Z.AI** → paste a coding-plan key → **GLM 5.2** → skip LangSmith. With `OPENWIKI_DEBUG=1`, debug output shows `provider=zai`, `provider.baseUrl="https://api.z.ai/api/anthropic"`, `model=glm-5.2`. The init run streams agent text/tool events and completes without the middleware error.

Verified locally: `pnpm build`, `pnpm lint:check`, and `prettier --check` on all changed files pass.

## Notes

- The `ZAI_API_KEY` works with both the OpenAI and Anthropic coding-plan endpoints (same key, different base URL). I scoped this to the Anthropic endpoint because that's what actually works with the current `@langchain/openai` streaming path.
- No CI workflow changes — the existing workflows only pass `OPENROUTER_API_KEY`. Happy to add `ZAI_API_KEY` passthrough in a follow-up if useful.

Sources for the endpoint:
- [Z.AI Tool Integration](https://docs.z.ai/devpack/tool/others)
- [Z.AI Claude Code guide](https://docs.z.ai/devpack/tool/claude)
