### PR TITLE
feat: add Z.AI (GLM Coding Plan) as a first-class provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,6 @@ These configuration options and secrets will be saved to `~/.openwiki/.env` on y
 
 ## Customizing
 
-OpenWiki supports OpenRouter, Fireworks, Baseten, OpenAI and Anthropic out of the box. By default, there are a few models pre-defined (GLM 5.2, Kimi K2.6, Sonnet 5, etc) but for each inference provider, OpenWiki will allow you to specify your own custom model ID.
+OpenWiki supports OpenRouter, Fireworks, Baseten, OpenAI, Anthropic, and Z.AI (GLM Coding Plan) out of the box. By default, there are a few models pre-defined (GLM 5.2, Kimi K2.6, Sonnet 5, etc) but for each inference provider, OpenWiki will allow you to specify your own custom model ID.
 
 If there's an inference provider or model you'd like to see added, please open a PR!

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -31,6 +31,8 @@ import {
   OPENWIKI_MODEL_ID_ENV_KEY,
   OPENWIKI_PROVIDER_ENV_KEY,
   resolveConfiguredProvider,
+  ZAI_API_KEY_ENV_KEY,
+  ZAI_BASE_URL,
   type OpenWikiProvider,
 } from "../constants.js";
 import {
@@ -71,6 +73,12 @@ export async function runOpenWikiAgent(
   emitDebug(options, `model=${modelId}`);
 
   const debugFetchCapture = installOpenRouterDebugFetch(options);
+  // Z.AI's streaming endpoint occasionally emits a final tool-call chunk with no
+  // assistant role, which langchain assembles into a ChatMessageChunk that
+  // deepagents rejects. The normalizer backfills the role so the agent loop
+  // (--init/--update) completes. Only installed for the zai provider.
+  const restoreZaiFetch =
+    provider === "zai" ? installZaiStreamingNormalizer(options) : null;
 
   try {
     return await runOpenWikiAgentWithModelFallbacks(
@@ -86,6 +94,7 @@ export async function runOpenWikiAgent(
     throw error;
   } finally {
     debugFetchCapture.restore();
+    restoreZaiFetch?.restore();
   }
 }
 
@@ -394,6 +403,16 @@ async function createModel(provider: OpenWikiProvider, modelId: string) {
       models,
       route: "fallback",
       siteName: "OpenWiki",
+    });
+  }
+
+  if (provider === "zai") {
+    return new ChatOpenAI({
+      apiKey: process.env[ZAI_API_KEY_ENV_KEY],
+      configuration: {
+        baseURL: ZAI_BASE_URL,
+      },
+      model: modelId,
     });
   }
 
@@ -1021,9 +1040,262 @@ type OpenRouterResponseSummary = {
   statusText: string;
 };
 
+// Z.AI fetch normalizer
+//
+// GLM's coding-plan endpoint is OpenAI-compatible but stricter than the
+// providers deepagents was built around. Two response/request shapes that the
+// agent loop produces crash `--init`/`--update`; this normalizer patches both,
+// scoped to api.z.ai so other providers are unaffected.
+//
+// 1. RESPONSE — streaming role-less tool-call chunks. GLM sometimes ends a
+//    tool-call turn with an SSE chunk whose `delta` has no `role` field (e.g. a
+//    trailing usage-only chunk with `finish_reason: "tool_calls"`). LangChain's
+//    completions converter maps a role-less assistant delta to the generic
+//    `ChatMessageChunk`, which deepagents' `patchToolCallsMiddleware` rejects
+//    with "expected AIMessage or Command, got object". We backfill
+//    `role: "assistant"` on assistant-turn chunks that are missing one.
+//
+// 2. REQUEST — non-text content blocks. The agent loop emits Anthropic-style
+//    array content (text plus non-text blocks such as tool/file payloads) on
+//    later turns. GLM's chat-completions endpoint rejects every non-text block
+//    variant with `400 ...content[0].type type error`. We flatten array content
+//    into a single text string, replacing each non-text block with a placeholder
+//    so GLM never sees an unsupported type. (GLM cannot consume those blocks
+//    anyway; if it ever needs them it would be a follow-up.)
+type ZaiFetchRestore = {
+  restore: () => void;
+};
+
+function installZaiStreamingNormalizer(
+  options: OpenWikiRunOptions,
+): ZaiFetchRestore {
+  const originalFetch = globalThis.fetch;
+
+  globalThis.fetch = (async (input, init) => {
+    const url = getZaiFetchUrl(input);
+
+    if (url === null || !url.includes("api.z.ai")) {
+      return originalFetch(input, init);
+    }
+
+    // REQUEST-SIDE: flatten non-text content blocks before sending.
+    const normalizedInit = normalizeZaiRequestInit(init, options);
+
+    const response = await originalFetch(input, normalizedInit);
+    const contentType = response.headers.get("content-type") ?? "";
+
+    // RESPONSE-SIDE: only streaming chat-completion responses need role
+    // normalization. Non-streaming (JSON) and non-event content types pass
+    // through unchanged.
+    if (
+      !contentType.includes("text/event-stream") &&
+      !contentType.includes("application/x-ndjson")
+    ) {
+      return response;
+    }
+
+    const originalBody = await response.text();
+    const normalizedBody = normalizeZaiStreamingBody(originalBody);
+
+    if (normalizedBody === originalBody) {
+      // Nothing changed; hand back a body the caller can re-read.
+      return new Response(originalBody, {
+        headers: response.headers,
+        status: response.status,
+        statusText: response.statusText,
+      });
+    }
+
+    emitDebug(options, "zai.streaming normalized tool-call chunk roles");
+
+    const headers = new Headers(response.headers);
+    // The rewritten body may differ in length from the original; fall back to
+    // chunked framing by dropping the static content-length so clients stream.
+    headers.delete("content-length");
+
+    return new Response(normalizedBody, {
+      headers,
+      status: response.status,
+      statusText: response.statusText,
+    });
+  }) satisfies typeof fetch;
+
+  return {
+    restore: () => {
+      globalThis.fetch = originalFetch;
+    },
+  };
+}
+
+function normalizeZaiRequestInit(
+  init: RequestInit | undefined,
+  options: OpenWikiRunOptions,
+): RequestInit | undefined {
+  if (init?.body === undefined || typeof init.body !== "string") {
+    return init;
+  }
+
+  let parsed: unknown;
+
+  try {
+    parsed = JSON.parse(init.body) as unknown;
+  } catch {
+    return init;
+  }
+
+  if (!isRecord(parsed) || !Array.isArray(parsed.messages)) {
+    return init;
+  }
+
+  let changed = false;
+
+  for (const message of parsed.messages) {
+    if (!isRecord(message) || !Array.isArray(message.content)) {
+      continue;
+    }
+
+    const flattened = flattenZaiContentBlocks(message.content);
+
+    if (flattened !== null) {
+      message.content = flattened;
+      changed = true;
+    }
+  }
+
+  if (!changed) {
+    return init;
+  }
+
+  emitDebug(options, "zai.request flattened non-text content blocks");
+
+  return { ...init, body: JSON.stringify(parsed) };
+}
+
+// Returns a single text string if the blocks contain any non-text payload
+// (which GLM rejects), or null if the content is already plain text and can be
+// left untouched.
+function flattenZaiContentBlocks(blocks: unknown[]): string | null {
+  let hasNonText = false;
+  const parts: string[] = [];
+
+  for (const block of blocks) {
+    if (!isRecord(block)) {
+      hasNonText = true;
+      parts.push("[omitted non-text content]");
+      continue;
+    }
+
+    const type = typeof block.type === "string" ? block.type : "unknown";
+
+    if (type === "text" && typeof block.text === "string") {
+      parts.push(block.text);
+      continue;
+    }
+
+    hasNonText = true;
+    parts.push(`[omitted ${type} block]`);
+  }
+
+  return hasNonText ? parts.join("\n") : null;
+}
+
+function getZaiFetchUrl(input: Parameters<typeof fetch>[0]): string | null {
+  if (typeof input === "string") {
+    return input;
+  }
+
+  if (input instanceof URL) {
+    return input.toString();
+  }
+
+  return "url" in input && typeof input.url === "string" ? input.url : null;
+}
+
+function normalizeZaiStreamingBody(body: string): string {
+  const lines = body.split(/\r?\n/u);
+  let changed = false;
+
+  for (let i = 0; i < lines.length; i += 1) {
+    const line = lines[i];
+
+    if (typeof line !== "string" || !line.startsWith("data:")) {
+      continue;
+    }
+
+    const payload = line.slice(5).trim();
+
+    if (payload.length === 0 || payload === "[DONE]") {
+      continue;
+    }
+
+    const normalized = normalizeZaiSsePayload(payload);
+
+    if (normalized !== null && normalized !== payload) {
+      lines[i] = `data: ${normalized}`;
+      changed = true;
+    }
+  }
+
+  return changed ? lines.join("\n") : body;
+}
+
+function normalizeZaiSsePayload(payload: string): string | null {
+  let parsed: unknown;
+
+  try {
+    parsed = JSON.parse(payload) as unknown;
+  } catch {
+    return null;
+  }
+
+  if (!isRecord(parsed)) {
+    return null;
+  }
+
+  const choices = parsed.choices;
+
+  if (!Array.isArray(choices) || choices.length === 0) {
+    return null;
+  }
+
+  let patched = false;
+
+  for (const choice of choices) {
+    if (!isRecord(choice) || !isRecord(choice.delta)) {
+      continue;
+    }
+
+    // A chunk belongs to an assistant turn if it carries tool calls, ends with a
+    // tool-call finish reason, or already declares the assistant role. Any such
+    // chunk that is missing a role is ambiguous to langchain's converter and is
+    // normalized to "assistant".
+    const isAssistantTurn =
+      Array.isArray(choice.delta.tool_calls) ||
+      choice.finish_reason === "tool_calls" ||
+      choice.delta.role === "assistant" ||
+      (typeof choice.delta.content === "string" &&
+        !("role" in choice.delta) &&
+        hasReasoningContent(choice.delta));
+
+    if (isAssistantTurn && choice.delta.role === undefined) {
+      choice.delta.role = "assistant";
+      patched = true;
+    }
+  }
+
+  return patched ? JSON.stringify(parsed) : null;
+}
+
+function hasReasoningContent(delta: Record<string, unknown>): boolean {
+  return (
+    "reasoning_content" in delta &&
+    typeof delta.reasoning_content === "string" &&
+    delta.reasoning_content.length > 0
+  );
+}
+
 const OPENROUTER_DEBUG_PROPERTY = "openRouterDebug";
 const OPENROUTER_DEBUG_BODY_LIMIT = 4_000;
-
 function installOpenRouterDebugFetch(
   options: OpenWikiRunOptions,
 ): OpenRouterFetchCapture {
@@ -1264,6 +1536,7 @@ function formatEnvironmentDebug(): string {
     OPENAI_API_KEY_ENV_KEY,
     ANTHROPIC_API_KEY_ENV_KEY,
     OPENROUTER_API_KEY_ENV_KEY,
+    ZAI_API_KEY_ENV_KEY,
     OPENWIKI_MODEL_ID_ENV_KEY,
     "LANGCHAIN_TRACING_V2",
     "LANGCHAIN_PROJECT",

--- a/src/cli.tsx
+++ b/src/cli.tsx
@@ -1506,7 +1506,7 @@ function ChatInput({
 
     if (provider === null) {
       setError(
-        "Enter a valid provider: openrouter, baseten, fireworks, openai, or anthropic.",
+        "Enter a valid provider: openrouter, baseten, fireworks, openai, anthropic, or zai.",
       );
       return;
     }

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -5,17 +5,20 @@ export const FIREWORKS_API_KEY_ENV_KEY = "FIREWORKS_API_KEY";
 export const OPENAI_API_KEY_ENV_KEY = "OPENAI_API_KEY";
 export const ANTHROPIC_API_KEY_ENV_KEY = "ANTHROPIC_API_KEY";
 export const OPENROUTER_API_KEY_ENV_KEY = "OPENROUTER_API_KEY";
+export const ZAI_API_KEY_ENV_KEY = "ZAI_API_KEY";
 export const OPENWIKI_PROVIDER_ENV_KEY = "OPENWIKI_PROVIDER";
 export const OPENWIKI_MODEL_ID_ENV_KEY = "OPENWIKI_MODEL_ID";
 export const DEFAULT_PROVIDER = "openrouter";
 export const OPENROUTER_BASE_URL = "https://openrouter.ai/api/v1";
+export const ZAI_BASE_URL = "https://api.z.ai/api/coding/paas/v4";
 
 export type OpenWikiProvider =
   | "anthropic"
   | "baseten"
   | "fireworks"
   | "openai"
-  | "openrouter";
+  | "openrouter"
+  | "zai";
 
 export type SelectableOpenWikiProvider = OpenWikiProvider;
 
@@ -37,6 +40,7 @@ export const SELECTABLE_OPENWIKI_PROVIDERS = [
   "fireworks",
   "openai",
   "anthropic",
+  "zai",
 ] as const satisfies readonly SelectableOpenWikiProvider[];
 
 export const PROVIDER_CONFIGS: Record<OpenWikiProvider, ProviderConfig> = {
@@ -77,6 +81,12 @@ export const PROVIDER_CONFIGS: Record<OpenWikiProvider, ProviderConfig> = {
       { id: "claude-sonnet-5", label: "Sonnet" },
       { id: "claude-opus-4.8", label: "Opus" },
     ],
+  },
+  zai: {
+    apiKeyEnvKey: ZAI_API_KEY_ENV_KEY,
+    baseURL: ZAI_BASE_URL,
+    label: "Z.AI",
+    modelOptions: [{ id: "glm-5.2", label: "GLM 5.2" }],
   },
   openrouter: {
     apiKeyEnvKey: OPENROUTER_API_KEY_ENV_KEY,

--- a/src/credentials.tsx
+++ b/src/credentials.tsx
@@ -776,7 +776,11 @@ function moveSelectionIndex(
 }
 
 function getProviderArticle(provider: OpenWikiProvider): "a" | "an" {
-  return provider === "baseten" || provider === "fireworks" ? "a" : "an";
+  return provider === "baseten" ||
+    provider === "fireworks" ||
+    provider === "zai"
+    ? "a"
+    : "an";
 }
 
 function sanitizeInputChunk(value: string): string {

--- a/src/env.ts
+++ b/src/env.ts
@@ -11,6 +11,7 @@ import {
   OPENROUTER_API_KEY_ENV_KEY,
   OPENWIKI_MODEL_ID_ENV_KEY,
   OPENWIKI_PROVIDER_ENV_KEY,
+  ZAI_API_KEY_ENV_KEY,
 } from "./constants.js";
 
 export const openWikiEnvDir = path.join(os.homedir(), ".openwiki");
@@ -36,6 +37,7 @@ const managedEnvKeys = [
   OPENAI_API_KEY_ENV_KEY,
   ANTHROPIC_API_KEY_ENV_KEY,
   OPENROUTER_API_KEY_ENV_KEY,
+  ZAI_API_KEY_ENV_KEY,
   OPENWIKI_PROVIDER_ENV_KEY,
   OPENWIKI_MODEL_ID_ENV_KEY,
   "LANGSMITH_API_KEY",
@@ -77,6 +79,7 @@ export async function getCredentialDiagnostics(): Promise<
     createCredentialDiagnostic(OPENAI_API_KEY_ENV_KEY, fileEnv),
     createCredentialDiagnostic(ANTHROPIC_API_KEY_ENV_KEY, fileEnv),
     createCredentialDiagnostic(OPENROUTER_API_KEY_ENV_KEY, fileEnv),
+    createCredentialDiagnostic(ZAI_API_KEY_ENV_KEY, fileEnv),
     createCredentialDiagnostic(OPENWIKI_MODEL_ID_ENV_KEY, fileEnv),
     createCredentialDiagnostic("LANGSMITH_API_KEY", fileEnv),
   ];


### PR DESCRIPTION
## Summary

Z.AI exposes an OpenAI-compatible chat-completions endpoint for GLM Coding Plan subscribers at `https://api.z.ai/api/coding/paas/v4`. This PR adds it as a first-class provider, alongside the existing `openrouter`, `baseten`, `fireworks`, `openai`, and `anthropic` providers.

- **Provider id:** `zai`
- **Label:** \"Z.AI\"
- **Env key:** `ZAI_API_KEY` (matches the convention used in Z.AI's own docs/tooling)
- **Preset model:** `glm-5.2` (custom model IDs remain selectable via onboarding)

The credential onboarding UI in `src/credentials.tsx` is fully data-driven from `PROVIDER_CONFIGS`, so it surfaces the new provider and model automatically with no edits required there.

## Why this is larger than the DeepSeek PR (#68)

The DeepSeek PR added 99 lines. This PR adds 295 because GLM's coding-plan endpoint has **two** incompatibilities with the deepagents agent loop, both of which crash `--init`/`--update` and both of which needed fixing for the provider to be usable. I reproduced each against the real `--init` flow before writing the fix.

### 1. RESPONSE — role-less streaming chunks (the `--init` crash)

GLM occasionally ends a tool-call turn with an SSE chunk whose `delta` has no `role` field (e.g. a trailing usage-only chunk with `finish_reason: \"tool_calls\"` and an empty content delta). LangChain's completions converter maps a role-less assistant delta to the generic `ChatMessageChunk`, which deepagents' `patchToolCallsMiddleware` rejects:

```
Error: Invalid response from \"wrapModelCall\" in middleware \"patchToolCallsMiddleware\": expected AIMessage or Command, got object
```

I instrumented `langchain`'s `AgentNode` validator to dump the exact failing object, which confirmed it:

```
constructor: ChatMessageChunk
isAIMessage: false
kwargs: { content: \"\", additional_kwargs: {}, response_metadata: {...}, id: \"run-...\" }
```

**Fix:** the normalizer backfills `role: \"assistant\"` on assistant-turn streaming chunks that are missing one. Every chunk in a chat-completions assistant response is an assistant message, so this is always correct for the coding-plan endpoint.

### 2. REQUEST — non-text content blocks (intermittent `400`)

On later turns the agent loop emits Anthropic-style array content with non-text blocks (tool/file payloads). GLM's chat-completions endpoint rejects every non-text block variant with:

```
400 messages[N].content[0].type type error
```

This is the same class of problem DeepSeek hit, so the fix mirrors DeepSeek's proven approach: the normalizer flattens array content into a single text string, replacing each non-text block with `[omitted <type> block]`. (GLM cannot consume those blocks anyway; forwarding them would be a follow-up.)

## Changes

| File | Change |
|------|--------|
| `src/constants.ts` | Add `ZAI_API_KEY_ENV_KEY` + `ZAI_BASE_URL`; extend `OpenWikiProvider` and `SELECTABLE_OPENWIKI_PROVIDERS` with `\"zai\"`; add `zai` entry to `PROVIDER_CONFIGS` exposing `glm-5.2`. |
| `src/env.ts` | Add `ZAI_API_KEY` to `managedEnvKeys` and the credential diagnostics report. |
| `src/agent/index.ts` | (1) Explicit `provider === \"zai\"` branch in `createModel` using `ChatOpenAI` with the coding-plan base URL. (2) `installZaiStreamingNormalizer` — an api.z.ai-scoped fetch normalizer (installed only for the `zai` provider, with save/restore) that patches both the response-side role-less chunks and the request-side non-text content blocks. (3) `ZAI_API_KEY_ENV_KEY` added to the debug env dump. |
| `src/cli.tsx` | Add `zai` to the hardcoded provider list in the validation error message (a gap that the DeepSeek PR left out of date). |
| `src/credentials.tsx` | Add `zai` to `getProviderArticle`'s `\"a\"` branch (\"Z.AI\" is pronounced with a leading consonant sound). |
| `README.md` | Append Z.AI to the user-facing provider list. |

## Operator setup

No secrets in this PR. To run OpenWiki against Z.AI:

**\`~/.openwiki/.env\`:**

\`\`\`
OPENWIKI_PROVIDER=\"zai\"
OPENWIKI_MODEL_ID=\"glm-5.2\"
ZAI_API_KEY=\"<your coding-plan key>\"
\`\`\`

**Or in shell:**

\`\`\`bash
export OPENWIKI_PROVIDER=zai
export OPENWIKI_MODEL_ID=glm-5.2
export ZAI_API_KEY='<your coding-plan key>'
openwiki --init
\`\`\`

LangSmith tracing remains optional via `LANGSMITH_API_KEY`.

## Verification

- ✅ \`pnpm install --frozen-lockfile\`
- ✅ \`pnpm run build\` (tsc, strict)
- ✅ \`pnpm run lint:check\`
- ✅ \`pnpm run format:check\` (clean under \`--end-of-line auto\`; local \`format:check\` on Windows is affected by a pre-existing CRLF/autocrlf condition that also flags untouched files)
- ✅ \`--print\` smoke test against \`glm-5.2\` via \`api.z.ai/api/coding/paas/v4\` returns correct responses
- ✅ Network-level probe confirms requests hit \`api.z.ai/api/coding/paas/v4/chat/completions\`
- ✅ **Full \`--init\` agent loop (the previously crashing path) — 3 consecutive successful runs** (71 / 64 / 69 tool calls each), with both normalizers firing as expected. Keys sourced from env, not committed.

## Notes for reviewer

- The fetch normalizer is gated on \`provider === \"zai\"\`, installed with save/restore semantics (matching the existing \`installOpenRouterDebugFetch\` pattern), and only rewrites requests/responses whose URL contains \`api.z.ai\`. Other providers see the original \`globalThis.fetch\`.
- The response-side role backfill is structurally similar to DeepSeek's rewriter but targets a different layer (streaming response chunks vs. request body), because the Z.AI incompatibility is in stream assembly rather than content blocks.
- I did not touch any existing provider config, credential handling, or onboarding UI flow beyond the two single-line gating additions noted above.
- \`OPENAI_BASE_URL\` remains in \`deprecatedEnvKeys\` and is intentionally skipped on env load; adding a first-class provider is the supported way to add a new OpenAI-compatible endpoint.

Closes langchain-ai/openwiki#58