### PR TITLE
feat: add --config CLI flag for interactive provider/model setup

### DIFF
--- a/src/cli.tsx
+++ b/src/cli.tsx
@@ -225,7 +225,7 @@ function App({ command }: AppProps) {
       return;
     }
 
-    if (command.dryRun) {
+    if (command.kind === "run" && command.dryRun) {
       process.exitCode = 0;
       app.exit();
       return;
@@ -412,6 +412,10 @@ function App({ command }: AppProps) {
         userMessage={command.userMessage}
       />
     );
+  }
+
+  if (command.kind === "config") {
+    return <ConfigView modelIdOverride={command.modelId} />;
   }
 
   if (shouldRunInteractiveCredentialSetup) {
@@ -3019,10 +3023,93 @@ function Rows({ rows }: RowsProps) {
   );
 }
 
+type ConfigViewProps = {
+  modelIdOverride: string | null;
+};
+
+function ConfigView({ modelIdOverride }: ConfigViewProps) {
+  const app = useApp();
+  const [showSummary, setShowSummary] = useState(false);
+  const [configResult, setConfigResult] = useState<InitSetupResult | null>(
+    null,
+  );
+
+  useInput(() => {
+    if (showSummary) {
+      app.exit();
+    }
+  });
+
+  useEffect(() => {
+    if (showSummary) {
+      const timer = setTimeout(() => app.exit(), 3000);
+      return () => clearTimeout(timer);
+    }
+  }, [showSummary, app]);
+
+  if (showSummary && configResult) {
+    return (
+      <Box flexDirection="column">
+        <Header
+          modelId={configResult.modelId ?? getDefaultModelId(
+            configResult.provider ?? resolveConfiguredProvider(),
+          )}
+          subtitle="Configuration saved"
+        />
+        {configResult.savedProvider ? (
+          <StatusLine
+            tone="muted"
+            label="Provider"
+            value={
+              configResult.provider
+                ? getProviderLabel(configResult.provider)
+                : "unchanged"
+            }
+          />
+        ) : null}
+        {configResult.savedModelId ? (
+          <StatusLine
+            tone="muted"
+            label="Model"
+            value={configResult.modelId ?? "unchanged"}
+          />
+        ) : null}
+        {configResult.savedApiKey ? (
+          <StatusLine tone="success" label="API key" value="saved" />
+        ) : null}
+        <StatusLine
+          tone="active"
+          label="Press any key"
+          value="to exit"
+        />
+      </Box>
+    );
+  }
+
+  return (
+    <InitSetup
+      modelIdOverride={modelIdOverride}
+      forceConfig
+      onComplete={(result) => {
+        setConfigResult(result);
+        setShowSummary(true);
+      }}
+      onError={(message) => {
+        process.exitCode = 1;
+        app.exit();
+      }}
+    />
+  );
+}
+
 const argv = process.argv.slice(2);
 const parsedCommand = parseCommand(argv);
 
 if (parsedCommand.kind === "run" && !parsedCommand.dryRun) {
+  await loadOpenWikiEnv();
+}
+
+if (parsedCommand.kind === "config") {
   await loadOpenWikiEnv();
 }
 

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -48,6 +48,7 @@ export function parseCommand(argv: string[]): CliCommand {
   let dryRun = false;
   let modelId: string | null = null;
   let print = false;
+  let configSeen = false;
   let command: OpenWikiCommand = "chat";
   const userMessageParts: string[] = [];
 
@@ -92,11 +93,8 @@ export function parseCommand(argv: string[]): CliCommand {
     }
 
     if (arg === "--config") {
-      return {
-        kind: "config",
-        exitCode: 0,
-        modelId,
-      };
+      configSeen = true;
+      continue;
     }
 
     if (arg === "--modelId" || arg === "--model-id") {
@@ -155,6 +153,24 @@ export function parseCommand(argv: string[]): CliCommand {
   const userMessage =
     userMessageParts.length > 0 ? userMessageParts.join(" ") : null;
   const shouldStart = command !== "chat" || userMessage !== null;
+
+  if (configSeen) {
+    if (command !== "chat") {
+      return {
+        kind: "error",
+        exitCode: 1,
+        message: "--config cannot be combined with --init or --update.",
+      };
+    }
+    if (userMessage !== null) {
+      return {
+        kind: "error",
+        exitCode: 1,
+        message: "--config does not accept a message prompt.",
+      };
+    }
+    return { kind: "config", exitCode: 0, modelId };
+  }
 
   if (print && !shouldStart) {
     return {

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -30,6 +30,11 @@ export type CliCommand =
       userMessage: string | null;
     }
   | {
+      kind: "config";
+      exitCode: 0;
+      modelId: string | null;
+    }
+  | {
       kind: "error";
       exitCode: 1;
       message: string;
@@ -84,6 +89,14 @@ export function parseCommand(argv: string[]): CliCommand {
 
       command = nextCommand;
       continue;
+    }
+
+    if (arg === "--config") {
+      return {
+        kind: "config",
+        exitCode: 0,
+        modelId,
+      };
     }
 
     if (arg === "--modelId" || arg === "--model-id") {
@@ -178,6 +191,7 @@ export const helpContent: HelpContent = {
     "openwiki [--modelId <model>] [message]",
     "openwiki --init [message]",
     "openwiki --update [message]",
+    "openwiki --config",
   ],
   commands: [
     {
@@ -199,6 +213,11 @@ export const helpContent: HelpContent = {
       description: "Run once and print the final assistant output.",
     },
     {
+      label: "--config",
+      description:
+        "Open interactive configuration to change provider, model, and API keys.",
+    },
+    {
       label: "--modelId <id>",
       description: "Use a model ID for this run.",
     },
@@ -215,6 +234,8 @@ export const helpContent: HelpContent = {
     "openwiki --update",
     'openwiki "What can you do?"',
     'openwiki -p "Summarize what OpenWiki can do"',
+    "openwiki --config",
+    "openwiki --config --modelId claude-sonnet-5",
     "openwiki --modelId gpt-5.5",
     'openwiki --update --modelId gpt-5.5 "Please document the API routes first"',
   ],

--- a/src/credentials.tsx
+++ b/src/credentials.tsx
@@ -27,6 +27,7 @@ export type InitSetupResult = {
 
 type InitSetupProps = {
   modelIdOverride?: string | null;
+  forceConfig?: boolean;
   onComplete: (result: InitSetupResult) => void;
   onError: (message: string) => void;
 };
@@ -50,6 +51,7 @@ export function needsCredentialSetup(
 
 export function InitSetup({
   modelIdOverride = null,
+  forceConfig = false,
   onComplete,
   onError,
 }: InitSetupProps) {
@@ -76,7 +78,9 @@ export function InitSetup({
   const [isSaving, setIsSaving] = useState(false);
 
   useEffect(() => {
-    const initialStep = getInitialStep(modelIdOverride, initialProvider);
+    const initialStep = forceConfig
+      ? "provider"
+      : getInitialStep(modelIdOverride, initialProvider);
 
     if (initialStep === null) {
       onComplete({
@@ -103,7 +107,7 @@ export function InitSetup({
     );
     setIsCustomModelInput(false);
     setStep(initialStep);
-  }, [initialProvider, modelIdOverride, onComplete]);
+  }, [forceConfig, initialProvider, modelIdOverride, onComplete]);
 
   useInput((inputValue, key) => {
     if (isSaving || step === null) {


### PR DESCRIPTION
## Summary

Add `--config` CLI flag that opens an interactive wizard to change provider, model, and API key settings without running the main wiki session.

## Changes

- **`src/commands.ts`** — Added `config` command kind; parses `--config` flag; updated help text
- **`src/credentials.tsx`** — Added `forceConfig` prop to `InitSetup` so it always starts from provider selection step
- **`src/cli.tsx`** — Added `ConfigView` component that runs the wizard with `forceConfig`, shows a summary on completion, then auto-exits; wired up entry point to load env for config runs; fixed `command.dryRun` type guard

## What `--config` does

Running `openwiki --config` launches an interactive wizard that walks you through configuring OpenWiki:

1. **Provider** — Select from openrouter, baseten, fireworks, openai, or anthropic
2. **API key** — Enter the API key for the chosen provider
3. **Model** — Pick from the provider's preset models or type a custom model ID
4. **LangSmith** — Optionally set up LangSmith tracing

Each step is skipped if already configured. Changes are saved to `~/.openwiki/.env` and persist across sessions.

## Usage

```sh
openwiki --config                           # configure from scratch
openwiki --config --modelId claude-sonnet-5  # pre-select a model
```
