### PR TITLE
feat: add DeepSeek, Qwen, and custom OpenAI-compatible providers

### DIFF
--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -17,6 +17,7 @@ import type {
 import {
   ANTHROPIC_API_KEY_ENV_KEY,
   BASETEN_API_KEY_ENV_KEY,
+  DEEPSEEK_API_KEY_ENV_KEY,
   FIREWORKS_API_KEY_ENV_KEY,
   getDefaultModelId,
   getProviderApiKeyEnvKey,
@@ -30,6 +31,10 @@ import {
   OPENROUTER_FALLBACK_MODEL_IDS,
   OPENWIKI_MODEL_ID_ENV_KEY,
   OPENWIKI_PROVIDER_ENV_KEY,
+  OPENWIKI_CUSTOM_API_KEY_ENV_KEY,
+  OPENWIKI_CUSTOM_BASE_URL_ENV_KEY,
+  QWEN_API_KEY_ENV_KEY,
+  QWEN_CN_API_KEY_ENV_KEY,
   resolveConfiguredProvider,
   type OpenWikiProvider,
 } from "../constants.js";
@@ -394,6 +399,20 @@ async function createModel(provider: OpenWikiProvider, modelId: string) {
       models,
       route: "fallback",
       siteName: "OpenWiki",
+    });
+  }
+
+  if (provider === "custom") {
+    const baseURL = process.env[OPENWIKI_CUSTOM_BASE_URL_ENV_KEY];
+
+    if (!baseURL) {
+      throw new Error(`${OPENWIKI_CUSTOM_BASE_URL_ENV_KEY} is required for custom provider.`);
+    }
+
+    return new ChatOpenAI({
+      apiKey: process.env[OPENWIKI_CUSTOM_API_KEY_ENV_KEY],
+      configuration: { baseURL },
+      model: modelId,
     });
   }
 
@@ -1260,10 +1279,15 @@ function formatEnvironmentDebug(): string {
   const keys = [
     OPENWIKI_PROVIDER_ENV_KEY,
     BASETEN_API_KEY_ENV_KEY,
+    DEEPSEEK_API_KEY_ENV_KEY,
     FIREWORKS_API_KEY_ENV_KEY,
     OPENAI_API_KEY_ENV_KEY,
     ANTHROPIC_API_KEY_ENV_KEY,
     OPENROUTER_API_KEY_ENV_KEY,
+    QWEN_API_KEY_ENV_KEY,
+    QWEN_CN_API_KEY_ENV_KEY,
+    OPENWIKI_CUSTOM_BASE_URL_ENV_KEY,
+    OPENWIKI_CUSTOM_API_KEY_ENV_KEY,
     OPENWIKI_MODEL_ID_ENV_KEY,
     "LANGCHAIN_TRACING_V2",
     "LANGCHAIN_PROJECT",

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -34,7 +34,6 @@ import {
   OPENWIKI_CUSTOM_API_KEY_ENV_KEY,
   OPENWIKI_CUSTOM_BASE_URL_ENV_KEY,
   QWEN_API_KEY_ENV_KEY,
-  QWEN_CN_API_KEY_ENV_KEY,
   resolveConfiguredProvider,
   type OpenWikiProvider,
 } from "../constants.js";
@@ -1285,7 +1284,6 @@ function formatEnvironmentDebug(): string {
     ANTHROPIC_API_KEY_ENV_KEY,
     OPENROUTER_API_KEY_ENV_KEY,
     QWEN_API_KEY_ENV_KEY,
-    QWEN_CN_API_KEY_ENV_KEY,
     OPENWIKI_CUSTOM_BASE_URL_ENV_KEY,
     OPENWIKI_CUSTOM_API_KEY_ENV_KEY,
     OPENWIKI_MODEL_ID_ENV_KEY,

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,10 +1,15 @@
 export const OPEN_WIKI_DIR = "openwiki";
 export const UPDATE_METADATA_PATH = `${OPEN_WIKI_DIR}/.last-update.json`;
 export const BASETEN_API_KEY_ENV_KEY = "BASETEN_API_KEY";
+export const DEEPSEEK_API_KEY_ENV_KEY = "DEEPSEEK_API_KEY";
 export const FIREWORKS_API_KEY_ENV_KEY = "FIREWORKS_API_KEY";
 export const OPENAI_API_KEY_ENV_KEY = "OPENAI_API_KEY";
 export const ANTHROPIC_API_KEY_ENV_KEY = "ANTHROPIC_API_KEY";
 export const OPENROUTER_API_KEY_ENV_KEY = "OPENROUTER_API_KEY";
+export const QWEN_API_KEY_ENV_KEY = "QWEN_API_KEY";
+export const QWEN_CN_API_KEY_ENV_KEY = "QWEN_CN_API_KEY";
+export const OPENWIKI_CUSTOM_BASE_URL_ENV_KEY = "OPENWIKI_CUSTOM_BASE_URL";
+export const OPENWIKI_CUSTOM_API_KEY_ENV_KEY = "OPENWIKI_CUSTOM_API_KEY";
 export const OPENWIKI_PROVIDER_ENV_KEY = "OPENWIKI_PROVIDER";
 export const OPENWIKI_MODEL_ID_ENV_KEY = "OPENWIKI_MODEL_ID";
 export const DEFAULT_PROVIDER = "openrouter";
@@ -13,9 +18,13 @@ export const OPENROUTER_BASE_URL = "https://openrouter.ai/api/v1";
 export type OpenWikiProvider =
   | "anthropic"
   | "baseten"
+  | "deepseek"
   | "fireworks"
   | "openai"
-  | "openrouter";
+  | "openrouter"
+  | "qwen"
+  | "qwen-cn"
+  | "custom";
 
 export type SelectableOpenWikiProvider = OpenWikiProvider;
 
@@ -34,12 +43,30 @@ type ProviderConfig = {
 export const SELECTABLE_OPENWIKI_PROVIDERS = [
   "openrouter",
   "baseten",
+  "deepseek",
   "fireworks",
   "openai",
   "anthropic",
+  "qwen",
+  "qwen-cn",
+  "custom",
 ] as const satisfies readonly SelectableOpenWikiProvider[];
 
 export const PROVIDER_CONFIGS: Record<OpenWikiProvider, ProviderConfig> = {
+  custom: {
+    apiKeyEnvKey: OPENWIKI_CUSTOM_API_KEY_ENV_KEY,
+    label: "Custom",
+    modelOptions: [],
+  },
+  deepseek: {
+    apiKeyEnvKey: DEEPSEEK_API_KEY_ENV_KEY,
+    baseURL: "https://api.deepseek.com/v1",
+    label: "DeepSeek",
+    modelOptions: [
+      { id: "deepseek-v4-flash", label: "V4 Flash" },
+      { id: "deepseek-v4-pro", label: "V4 Pro" },
+    ],
+  },
   baseten: {
     apiKeyEnvKey: BASETEN_API_KEY_ENV_KEY,
     baseURL: "https://inference.baseten.co/v1",
@@ -76,6 +103,30 @@ export const PROVIDER_CONFIGS: Record<OpenWikiProvider, ProviderConfig> = {
       { id: "claude-haiku-4-5", label: "Haiku" },
       { id: "claude-sonnet-5", label: "Sonnet" },
       { id: "claude-opus-4.8", label: "Opus" },
+    ],
+  },
+  qwen: {
+    apiKeyEnvKey: QWEN_API_KEY_ENV_KEY,
+    baseURL: "https://dashscope-intl.aliyuncs.com/compatible-mode/v1",
+    label: "Qwen (International)",
+    modelOptions: [
+      { id: "qwen3.7-max", label: "Qwen 3.7 Max" },
+      { id: "qwen3.7-plus", label: "Qwen 3.7 Plus" },
+      { id: "qwen3.6-max", label: "Qwen 3.6 Max" },
+      { id: "qwen3.6-plus", label: "Qwen 3.6 Plus" },
+      { id: "qwen3.6-flash", label: "Qwen 3.6 Flash" },
+    ],
+  },
+  "qwen-cn": {
+    apiKeyEnvKey: QWEN_CN_API_KEY_ENV_KEY,
+    baseURL: "https://dashscope.aliyuncs.com/compatible-mode/v1",
+    label: "Qwen (China)",
+    modelOptions: [
+      { id: "qwen3.7-max", label: "Qwen 3.7 Max" },
+      { id: "qwen3.7-plus", label: "Qwen 3.7 Plus" },
+      { id: "qwen3.6-max", label: "Qwen 3.6 Max" },
+      { id: "qwen3.6-plus", label: "Qwen 3.6 Plus" },
+      { id: "qwen3.6-flash", label: "Qwen 3.6 Flash" },
     ],
   },
   openrouter: {
@@ -169,3 +220,12 @@ export function isValidModelId(value: string): boolean {
 }
 
 export const OPENWIKI_VERSION = "0.0.1";
+
+export function isValidEndpointUrl(value: string): boolean {
+  try {
+    const url = new URL(value.trim());
+    return url.protocol === "http:" || url.protocol === "https:";
+  } catch {
+    return false;
+  }
+}

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -7,7 +7,6 @@ export const OPENAI_API_KEY_ENV_KEY = "OPENAI_API_KEY";
 export const ANTHROPIC_API_KEY_ENV_KEY = "ANTHROPIC_API_KEY";
 export const OPENROUTER_API_KEY_ENV_KEY = "OPENROUTER_API_KEY";
 export const QWEN_API_KEY_ENV_KEY = "QWEN_API_KEY";
-export const QWEN_CN_API_KEY_ENV_KEY = "QWEN_CN_API_KEY";
 export const OPENWIKI_CUSTOM_BASE_URL_ENV_KEY = "OPENWIKI_CUSTOM_BASE_URL";
 export const OPENWIKI_CUSTOM_API_KEY_ENV_KEY = "OPENWIKI_CUSTOM_API_KEY";
 export const OPENWIKI_PROVIDER_ENV_KEY = "OPENWIKI_PROVIDER";
@@ -23,7 +22,6 @@ export type OpenWikiProvider =
   | "openai"
   | "openrouter"
   | "qwen"
-  | "qwen-cn"
   | "custom";
 
 export type SelectableOpenWikiProvider = OpenWikiProvider;
@@ -48,7 +46,6 @@ export const SELECTABLE_OPENWIKI_PROVIDERS = [
   "openai",
   "anthropic",
   "qwen",
-  "qwen-cn",
   "custom",
 ] as const satisfies readonly SelectableOpenWikiProvider[];
 
@@ -109,18 +106,6 @@ export const PROVIDER_CONFIGS: Record<OpenWikiProvider, ProviderConfig> = {
     apiKeyEnvKey: QWEN_API_KEY_ENV_KEY,
     baseURL: "https://dashscope-intl.aliyuncs.com/compatible-mode/v1",
     label: "Qwen (International)",
-    modelOptions: [
-      { id: "qwen3.7-max", label: "Qwen 3.7 Max" },
-      { id: "qwen3.7-plus", label: "Qwen 3.7 Plus" },
-      { id: "qwen3.6-max", label: "Qwen 3.6 Max" },
-      { id: "qwen3.6-plus", label: "Qwen 3.6 Plus" },
-      { id: "qwen3.6-flash", label: "Qwen 3.6 Flash" },
-    ],
-  },
-  "qwen-cn": {
-    apiKeyEnvKey: QWEN_CN_API_KEY_ENV_KEY,
-    baseURL: "https://dashscope.aliyuncs.com/compatible-mode/v1",
-    label: "Qwen (China)",
     modelOptions: [
       { id: "qwen3.7-max", label: "Qwen 3.7 Max" },
       { id: "qwen3.7-plus", label: "Qwen 3.7 Plus" },

--- a/src/credentials.tsx
+++ b/src/credentials.tsx
@@ -6,8 +6,10 @@ import {
   getProviderApiKeyEnvKey,
   getProviderLabel,
   getProviderModelOptions,
+  isValidEndpointUrl,
   isValidModelId,
   normalizeModelId,
+  OPENWIKI_CUSTOM_BASE_URL_ENV_KEY,
   OPENWIKI_MODEL_ID_ENV_KEY,
   OPENWIKI_PROVIDER_ENV_KEY,
   type OpenWikiProvider,
@@ -31,7 +33,7 @@ type InitSetupProps = {
   onError: (message: string) => void;
 };
 
-type PromptStep = "api-key" | "langsmith" | "model" | "provider";
+type PromptStep = "api-key" | "endpoint" | "langsmith" | "model" | "provider";
 
 export function needsCredentialSetup(
   modelIdOverride: string | null = null,
@@ -41,6 +43,8 @@ export function needsCredentialSetup(
 
   return (
     process.env[OPENWIKI_PROVIDER_ENV_KEY] === undefined ||
+    (provider === "custom" &&
+      !process.env[OPENWIKI_CUSTOM_BASE_URL_ENV_KEY]) ||
     !process.env[apiKeyEnvKey] ||
     (modelIdOverride === null &&
       process.env[OPENWIKI_MODEL_ID_ENV_KEY] === undefined) ||
@@ -57,6 +61,7 @@ export function InitSetup({
   const [step, setStep] = useState<PromptStep | null>(null);
   const [provider, setProvider] = useState<OpenWikiProvider>(initialProvider);
   const [apiKey, setApiKey] = useState<string | null>(null);
+  const [customBaseUrl, setCustomBaseUrl] = useState<string | null>(null);
   const [modelId, setModelId] = useState<string | null>(null);
   const [langSmithKey, setLangSmithKey] = useState<string | null>(null);
   const [input, setInput] = useState("");
@@ -197,9 +202,37 @@ export function InitSetup({
 
       await completeSetup({
         nextApiKey: apiKey,
+        nextCustomBaseUrl: customBaseUrl,
         nextLangSmithKey: langSmithKey,
         nextModelId: modelId,
         nextProvider: selectedProvider,
+      });
+      return;
+    }
+
+    if (step === "endpoint") {
+      const trimmedInput = input.trim();
+
+      if (!isValidEndpointUrl(trimmedInput)) {
+        setError("Enter a valid HTTP/HTTPS endpoint URL (e.g. https://my-proxy.com/v1).");
+        return;
+      }
+
+      setCustomBaseUrl(trimmedInput);
+      setInput("");
+      const nextStep = getNextStepAfterEndpoint(provider, modelIdOverride);
+
+      if (nextStep) {
+        setStep(nextStep);
+        return;
+      }
+
+      await completeSetup({
+        nextApiKey: apiKey,
+        nextCustomBaseUrl: trimmedInput,
+        nextLangSmithKey: langSmithKey,
+        nextModelId: modelId,
+        nextProvider: provider,
       });
       return;
     }
@@ -223,6 +256,7 @@ export function InitSetup({
 
       await completeSetup({
         nextApiKey: trimmedInput,
+        nextCustomBaseUrl: customBaseUrl,
         nextLangSmithKey: langSmithKey,
         nextModelId: modelId,
         nextProvider: provider,
@@ -260,6 +294,7 @@ export function InitSetup({
 
       await completeSetup({
         nextApiKey: apiKey,
+        nextCustomBaseUrl: customBaseUrl,
         nextLangSmithKey: langSmithKey,
         nextModelId: selectedModelId,
         nextProvider: provider,
@@ -275,6 +310,7 @@ export function InitSetup({
 
       await completeSetup({
         nextApiKey: apiKey,
+        nextCustomBaseUrl: customBaseUrl,
         nextLangSmithKey,
         nextModelId: modelId,
         nextProvider: provider,
@@ -284,6 +320,7 @@ export function InitSetup({
 
   type CompleteSetupOptions = {
     nextApiKey: string | null;
+    nextCustomBaseUrl: string | null;
     nextLangSmithKey: string | null;
     nextModelId: string | null;
     nextProvider: OpenWikiProvider;
@@ -291,6 +328,7 @@ export function InitSetup({
 
   async function completeSetup({
     nextApiKey,
+    nextCustomBaseUrl,
     nextLangSmithKey,
     nextModelId,
     nextProvider,
@@ -304,6 +342,10 @@ export function InitSetup({
 
       if (providerEnvChanged) {
         updates[OPENWIKI_PROVIDER_ENV_KEY] = nextProvider;
+      }
+
+      if (nextCustomBaseUrl !== null) {
+        updates[OPENWIKI_CUSTOM_BASE_URL_ENV_KEY] = nextCustomBaseUrl;
       }
 
       if (nextApiKey !== null) {
@@ -367,6 +409,23 @@ export function InitSetup({
           }
           detail={getProviderSetupDetail(provider)}
         />
+        {provider === "custom" ? (
+          <SetupStep
+            label="Endpoint"
+            state={
+              process.env[OPENWIKI_CUSTOM_BASE_URL_ENV_KEY]
+                ? "done"
+                : step === "endpoint"
+                  ? "current"
+                  : "pending"
+            }
+            detail={
+              process.env[OPENWIKI_CUSTOM_BASE_URL_ENV_KEY]
+                ? process.env[OPENWIKI_CUSTOM_BASE_URL_ENV_KEY]
+                : `save ${OPENWIKI_CUSTOM_BASE_URL_ENV_KEY} to ${openWikiEnvPath}`
+            }
+          />
+        ) : null}
         <SetupStep
           label="Provider key"
           state={
@@ -546,6 +605,20 @@ function Prompt({
     );
   }
 
+  if (step === "endpoint") {
+    return (
+      <Box flexDirection="column">
+        <Text>Paste your OpenAI-compatible endpoint URL.</Text>
+        <Text>
+          <Text color="gray">$</Text> {OPENWIKI_CUSTOM_BASE_URL_ENV_KEY}={" "}
+          <Text color="yellow">{input}</Text>
+        </Text>
+        <Text color="gray">Example: https://my-proxy.com/v1</Text>
+        <Text color="gray">Press Enter to save it.</Text>
+      </Box>
+    );
+  }
+
   if (step === "api-key") {
     return (
       <Box flexDirection="column">
@@ -630,6 +703,10 @@ function getInitialStep(
     return "provider";
   }
 
+  if (provider === "custom" && !process.env[OPENWIKI_CUSTOM_BASE_URL_ENV_KEY]) {
+    return "endpoint";
+  }
+
   if (!process.env[getProviderApiKeyEnvKey(provider)]) {
     return "api-key";
   }
@@ -649,6 +726,21 @@ function getInitialStep(
 }
 
 function getNextStepAfterProvider(
+  provider: OpenWikiProvider,
+  modelIdOverride: string | null,
+): PromptStep | null {
+  if (provider === "custom" && !process.env[OPENWIKI_CUSTOM_BASE_URL_ENV_KEY]) {
+    return "endpoint";
+  }
+
+  if (!process.env[getProviderApiKeyEnvKey(provider)]) {
+    return "api-key";
+  }
+
+  return getNextStepAfterApiKey(provider, modelIdOverride);
+}
+
+function getNextStepAfterEndpoint(
   provider: OpenWikiProvider,
   modelIdOverride: string | null,
 ): PromptStep | null {
@@ -776,7 +868,14 @@ function moveSelectionIndex(
 }
 
 function getProviderArticle(provider: OpenWikiProvider): "a" | "an" {
-  return provider === "baseten" || provider === "fireworks" ? "a" : "an";
+  return provider === "baseten"
+    || provider === "custom"
+    || provider === "deepseek"
+    || provider === "fireworks"
+    || provider === "qwen"
+    || provider === "qwen-cn"
+    ? "a"
+    : "an";
 }
 
 function sanitizeInputChunk(value: string): string {

--- a/src/credentials.tsx
+++ b/src/credentials.tsx
@@ -873,7 +873,6 @@ function getProviderArticle(provider: OpenWikiProvider): "a" | "an" {
     || provider === "deepseek"
     || provider === "fireworks"
     || provider === "qwen"
-    || provider === "qwen-cn"
     ? "a"
     : "an";
 }


### PR DESCRIPTION
## Summary

- **DeepSeek**: adds `deepseek-v4-flash` and `deepseek-v4-pro` models via `https://api.deepseek.com/v1`
- **Qwen (International)**: adds `qwen3.7-max`, `qwen3.7-plus`, `qwen3.6-max`, `qwen3.6-plus`, `qwen3.6-flash` via Alibaba Cloud international endpoint
- **Custom**: adds a generic OpenAI-compatible provider where users can configure their own endpoint URL, API key, and model ID — covers self-hosted models, proxies, and regional API endpoints

## Changes

**`src/constants.ts`**
- Added `DEEPSEEK_API_KEY_ENV_KEY`, `QWEN_API_KEY_ENV_KEY`, `OPENWIKI_CUSTOM_BASE_URL_ENV_KEY`, `OPENWIKI_CUSTOM_API_KEY_ENV_KEY`
- Extended `OpenWikiProvider` union type with `"deepseek"`, `"qwen"`, `"custom"`
- Added provider configs for all three new providers
- Added `isValidEndpointUrl()` helper for endpoint validation

**`src/credentials.tsx`**
- Added `"endpoint"` step to `PromptStep` type for custom provider setup flow
- Extended `needsCredentialSetup()` to require `OPENWIKI_CUSTOM_BASE_URL` for custom provider
- Added `getNextStepAfterEndpoint()` and wired endpoint step into `getInitialStep()` / `getNextStepAfterProvider()`
- Renders an "Endpoint" setup step in the TUI when provider is `custom`

**`src/agent/index.ts`**
- Added explicit `custom` branch in `createModel()` that reads `OPENWIKI_CUSTOM_BASE_URL` at runtime and passes it to `ChatOpenAI` as `configuration.baseURL`
- Added new env keys to `formatEnvironmentDebug()` output

## Notes

- All OpenAI-compatible providers (including existing ones) require `/v1` in `baseURL` since `ChatOpenAI` appends paths without adding it. DeepSeek config uses `https://api.deepseek.com/v1` accordingly.
- The `custom` provider intentionally has no pre-defined `modelOptions` — the model ID is entered freeform during setup.
- This supersedes PR #78 (DeepSeek only, missing `/v1` in baseURL).