### PR TITLE
feat: add Ollama provider support with configurable num_ctx and base_url

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,14 @@ These configuration options and secrets will be saved to `~/.openwiki/.env` on y
 
 ## Customizing
 
-OpenWiki supports OpenRouter, Fireworks, Baseten, OpenAI and Anthropic out of the box. By default, there are a few models pre-defined (GLM 5.2, Kimi K2.6, Sonnet 5, etc) but for each inference provider, OpenWiki will allow you to specify your own custom model ID.
+OpenWiki supports OpenRouter, Fireworks, Baseten, OpenAI, Anthropic, and Ollama out of the box. By default, there are a few models pre-defined (GLM 5.2, Kimi K2.6, Sonnet 5, etc) but for each inference provider, OpenWiki will allow you to specify your own custom model ID.
+
+### Ollama Configuration
+
+When using Ollama, no API key is required. During setup (or manually in `~/.openwiki/.env`), you can configure the following environment variables:
+
+- `OLLAMA_BASE_URL`: The URL where Ollama is running (defaults to `http://localhost:11434`).
+- `OLLAMA_NUM_CTX`: The size of the context window (defaults to `8192`). Setting a larger context window allows Ollama models to process more code at once, but consumes more VRAM.
 
 If there's an inference provider or model you'd like to see added, please open a PR!
+

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "@langchain/anthropic": "^1.5.1",
     "@langchain/core": "^1.2.1",
     "@langchain/langgraph-checkpoint-sqlite": "^1.0.3",
+    "@langchain/ollama": "^1.3.0",
     "@langchain/openai": "^1.5.3",
     "@langchain/openrouter": "^0.4.3",
     "deepagents": "^1.10.5",

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -1,8 +1,12 @@
 import { createHash } from "node:crypto";
 import { chmod, mkdir } from "node:fs/promises";
 import path from "node:path";
+import { CallbackManagerForLLMRun } from "@langchain/core/callbacks/manager";
+import { BaseMessage } from "@langchain/core/messages";
+import { ChatGenerationChunk, ChatResult } from "@langchain/core/outputs";
 import { ChatAnthropic } from "@langchain/anthropic";
 import { SqliteSaver } from "@langchain/langgraph-checkpoint-sqlite";
+import { ChatOllama } from "@langchain/ollama";
 import { ChatOpenAI } from "@langchain/openai";
 import { ChatOpenRouter } from "@langchain/openrouter";
 import { createDeepAgent, LocalShellBackend } from "deepagents";
@@ -22,8 +26,13 @@ import {
   getProviderApiKeyEnvKey,
   getProviderConfig,
   getProviderLabel,
+  getProviderRequiresApiKey,
   isValidModelId,
   normalizeModelId,
+  OLLAMA_BASE_URL_ENV_KEY,
+  OLLAMA_DEFAULT_BASE_URL,
+  OLLAMA_DEFAULT_NUM_CTX,
+  OLLAMA_NUM_CTX_ENV_KEY,
   OPENAI_API_KEY_ENV_KEY,
   OPENROUTER_API_KEY_ENV_KEY,
   OPENROUTER_BASE_URL,
@@ -349,6 +358,10 @@ function isFileNotFoundError(error: unknown): boolean {
 }
 
 function ensureProviderKey(provider: OpenWikiProvider): void {
+  if (!getProviderRequiresApiKey(provider)) {
+    return;
+  }
+
   const apiKeyEnvKey = getProviderApiKeyEnvKey(provider);
 
   if (!process.env[apiKeyEnvKey]) {
@@ -377,10 +390,62 @@ function resolveModelId(
   return modelId;
 }
 
+class SafeChatOllama extends ChatOllama {
+  private cleanMessages(messages: BaseMessage[]): BaseMessage[] {
+    return messages.map((msg) => {
+      if (msg._getType() === "tool" && typeof msg.content !== "string") {
+        return Object.assign(Object.create(Object.getPrototypeOf(msg)), msg, {
+          content:
+            typeof msg.content === "object"
+              ? JSON.stringify(msg.content)
+              : String(msg.content),
+        });
+      }
+      return msg;
+    });
+  }
+
+  override async _generate(
+    messages: BaseMessage[],
+    options: this["ParsedCallOptions"],
+    runManager?: CallbackManagerForLLMRun,
+  ): Promise<ChatResult> {
+    return super._generate(this.cleanMessages(messages), options, runManager);
+  }
+
+  override async *_streamResponseChunks(
+    messages: BaseMessage[],
+    options: this["ParsedCallOptions"],
+    runManager?: CallbackManagerForLLMRun,
+  ): AsyncGenerator<ChatGenerationChunk> {
+    yield* super._streamResponseChunks(
+      this.cleanMessages(messages),
+      options,
+      runManager,
+    );
+  }
+}
+
 async function createModel(provider: OpenWikiProvider, modelId: string) {
   if (provider === "anthropic") {
     return new ChatAnthropic(modelId, {
       apiKey: process.env[getProviderApiKeyEnvKey(provider)],
+    });
+  }
+
+  if (provider === "ollama") {
+    const baseUrl =
+      process.env[OLLAMA_BASE_URL_ENV_KEY] ?? OLLAMA_DEFAULT_BASE_URL;
+    const rawNumCtx = process.env[OLLAMA_NUM_CTX_ENV_KEY];
+    const numCtx =
+      rawNumCtx !== undefined
+        ? parseInt(rawNumCtx, 10)
+        : OLLAMA_DEFAULT_NUM_CTX;
+
+    return new SafeChatOllama({
+      model: modelId,
+      baseUrl,
+      numCtx: Number.isFinite(numCtx) ? numCtx : OLLAMA_DEFAULT_NUM_CTX,
     });
   }
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -9,11 +9,16 @@ export const OPENWIKI_PROVIDER_ENV_KEY = "OPENWIKI_PROVIDER";
 export const OPENWIKI_MODEL_ID_ENV_KEY = "OPENWIKI_MODEL_ID";
 export const DEFAULT_PROVIDER = "openrouter";
 export const OPENROUTER_BASE_URL = "https://openrouter.ai/api/v1";
+export const OLLAMA_BASE_URL_ENV_KEY = "OLLAMA_BASE_URL";
+export const OLLAMA_NUM_CTX_ENV_KEY = "OLLAMA_NUM_CTX";
+export const OLLAMA_DEFAULT_BASE_URL = "http://localhost:11434";
+export const OLLAMA_DEFAULT_NUM_CTX = 8192;
 
 export type OpenWikiProvider =
   | "anthropic"
   | "baseten"
   | "fireworks"
+  | "ollama"
   | "openai"
   | "openrouter";
 
@@ -29,6 +34,7 @@ type ProviderConfig = {
   baseURL?: string;
   label: string;
   modelOptions: ProviderModelOption[];
+  requiresApiKey: boolean;
 };
 
 export const SELECTABLE_OPENWIKI_PROVIDERS = [
@@ -37,6 +43,7 @@ export const SELECTABLE_OPENWIKI_PROVIDERS = [
   "fireworks",
   "openai",
   "anthropic",
+  "ollama",
 ] as const satisfies readonly SelectableOpenWikiProvider[];
 
 export const PROVIDER_CONFIGS: Record<OpenWikiProvider, ProviderConfig> = {
@@ -48,6 +55,7 @@ export const PROVIDER_CONFIGS: Record<OpenWikiProvider, ProviderConfig> = {
       { id: "zai-org/GLM-5.2", label: "GLM 5.2" },
       { id: "moonshotai/Kimi-K2.7-Code", label: "Kimi K2.7 Code" },
     ],
+    requiresApiKey: true,
   },
   fireworks: {
     apiKeyEnvKey: FIREWORKS_API_KEY_ENV_KEY,
@@ -60,6 +68,17 @@ export const PROVIDER_CONFIGS: Record<OpenWikiProvider, ProviderConfig> = {
         label: "Kimi K2.7 Code",
       },
     ],
+    requiresApiKey: true,
+  },
+  ollama: {
+    apiKeyEnvKey: "",
+    label: "Ollama",
+    modelOptions: [
+      { id: "gemma4:26b-a4b-it-qat", label: "Gemma 4 26B" },
+      { id: "nemotron3:33b", label: "Nemotron3 33B" },
+      { id: "qwen3.6:27b", label: "Qwen3.6 27B" },
+    ],
+    requiresApiKey: false,
   },
   openai: {
     apiKeyEnvKey: OPENAI_API_KEY_ENV_KEY,
@@ -68,6 +87,7 @@ export const PROVIDER_CONFIGS: Record<OpenWikiProvider, ProviderConfig> = {
       { id: "gpt-5.4-mini", label: "5.4 mini" },
       { id: "gpt-5.5", label: "5.5" },
     ],
+    requiresApiKey: true,
   },
   anthropic: {
     apiKeyEnvKey: ANTHROPIC_API_KEY_ENV_KEY,
@@ -77,6 +97,7 @@ export const PROVIDER_CONFIGS: Record<OpenWikiProvider, ProviderConfig> = {
       { id: "claude-sonnet-5", label: "Sonnet" },
       { id: "claude-opus-4.8", label: "Opus" },
     ],
+    requiresApiKey: true,
   },
   openrouter: {
     apiKeyEnvKey: OPENROUTER_API_KEY_ENV_KEY,
@@ -91,6 +112,7 @@ export const PROVIDER_CONFIGS: Record<OpenWikiProvider, ProviderConfig> = {
       { id: "openai/gpt-5.4-mini", label: "GPT 5.4 mini" },
       { id: "openai/gpt-5.5", label: "GPT 5.5" },
     ],
+    requiresApiKey: true,
   },
 };
 
@@ -116,6 +138,10 @@ export function getProviderLabel(provider: OpenWikiProvider): string {
 
 export function getProviderApiKeyEnvKey(provider: OpenWikiProvider): string {
   return getProviderConfig(provider).apiKeyEnvKey;
+}
+
+export function getProviderRequiresApiKey(provider: OpenWikiProvider): boolean {
+  return getProviderConfig(provider).requiresApiKey;
 }
 
 export function getProviderModelOptions(

--- a/src/credentials.tsx
+++ b/src/credentials.tsx
@@ -6,8 +6,13 @@ import {
   getProviderApiKeyEnvKey,
   getProviderLabel,
   getProviderModelOptions,
+  getProviderRequiresApiKey,
   isValidModelId,
   normalizeModelId,
+  OLLAMA_BASE_URL_ENV_KEY,
+  OLLAMA_DEFAULT_BASE_URL,
+  OLLAMA_DEFAULT_NUM_CTX,
+  OLLAMA_NUM_CTX_ENV_KEY,
   OPENWIKI_MODEL_ID_ENV_KEY,
   OPENWIKI_PROVIDER_ENV_KEY,
   type OpenWikiProvider,
@@ -31,7 +36,8 @@ type InitSetupProps = {
   onError: (message: string) => void;
 };
 
-type PromptStep = "api-key" | "langsmith" | "model" | "provider";
+type PromptStep =
+  "api-key" | "langsmith" | "model" | "ollama-options" | "provider";
 
 export function needsCredentialSetup(
   modelIdOverride: string | null = null,
@@ -41,7 +47,7 @@ export function needsCredentialSetup(
 
   return (
     process.env[OPENWIKI_PROVIDER_ENV_KEY] === undefined ||
-    !process.env[apiKeyEnvKey] ||
+    (getProviderRequiresApiKey(provider) && !process.env[apiKeyEnvKey]) ||
     (modelIdOverride === null &&
       process.env[OPENWIKI_MODEL_ID_ENV_KEY] === undefined) ||
     process.env.LANGSMITH_API_KEY === undefined
@@ -59,6 +65,8 @@ export function InitSetup({
   const [apiKey, setApiKey] = useState<string | null>(null);
   const [modelId, setModelId] = useState<string | null>(null);
   const [langSmithKey, setLangSmithKey] = useState<string | null>(null);
+  const [ollamaBaseUrl, setOllamaBaseUrl] = useState("");
+  const [ollamaNumCtx, setOllamaNumCtx] = useState("");
   const [input, setInput] = useState("");
   const [providerSelectionIndex, setProviderSelectionIndex] = useState(() =>
     getProviderSelectionIndex(initialProvider),
@@ -125,6 +133,26 @@ export function InitSetup({
 
       if (key.return) {
         void submit();
+      }
+
+      return;
+    }
+
+    if (step === "ollama-options") {
+      if (key.return) {
+        void submit();
+        return;
+      }
+
+      if (key.backspace || key.delete) {
+        setInput((value) => value.slice(0, -1));
+        return;
+      }
+
+      const sanitizedChunk = sanitizeInputChunk(inputValue);
+
+      if (sanitizedChunk && !key.ctrl && !key.meta) {
+        setInput((value) => value + sanitizedChunk);
       }
 
       return;
@@ -200,6 +228,46 @@ export function InitSetup({
         nextLangSmithKey: langSmithKey,
         nextModelId: modelId,
         nextProvider: selectedProvider,
+      });
+      return;
+    }
+
+    if (step === "ollama-options") {
+      const trimmedBaseUrl = input.trim();
+      const nextBaseUrl = trimmedBaseUrl.length > 0 ? trimmedBaseUrl : null;
+
+      // Store current input as base URL, then reset for num_ctx prompt.
+      // We use a two-field sub-step driven by ollamaBaseUrl/ollamaNumCtx state.
+      if (ollamaBaseUrl === "" && ollamaNumCtx === "") {
+        // First field: base URL
+        setOllamaBaseUrl(nextBaseUrl ?? OLLAMA_DEFAULT_BASE_URL);
+        setInput("");
+        // Stay on same step to collect num_ctx
+        return;
+      }
+
+      // Second field: num_ctx
+      const trimmedNumCtx = input.trim();
+      const nextNumCtx =
+        trimmedNumCtx.length > 0
+          ? trimmedNumCtx
+          : String(OLLAMA_DEFAULT_NUM_CTX);
+
+      setOllamaNumCtx(nextNumCtx);
+      setInput("");
+
+      const nextStep = getNextStepAfterOllamaOptions(modelIdOverride);
+
+      if (nextStep) {
+        setStep(nextStep);
+        return;
+      }
+
+      await completeSetup({
+        nextApiKey: null,
+        nextLangSmithKey: langSmithKey,
+        nextModelId: modelId,
+        nextProvider: provider,
       });
       return;
     }
@@ -314,6 +382,18 @@ export function InitSetup({
         updates[OPENWIKI_MODEL_ID_ENV_KEY] = nextModelId;
       }
 
+      if (nextProvider === "ollama") {
+        const resolvedBaseUrl =
+          ollamaBaseUrl.length > 0 ? ollamaBaseUrl : OLLAMA_DEFAULT_BASE_URL;
+        const resolvedNumCtx =
+          ollamaNumCtx.length > 0
+            ? ollamaNumCtx
+            : String(OLLAMA_DEFAULT_NUM_CTX);
+
+        updates[OLLAMA_BASE_URL_ENV_KEY] = resolvedBaseUrl;
+        updates[OLLAMA_NUM_CTX_ENV_KEY] = resolvedNumCtx;
+      }
+
       if (nextLangSmithKey !== null) {
         updates.LANGSMITH_API_KEY = nextLangSmithKey;
 
@@ -367,21 +447,39 @@ export function InitSetup({
           }
           detail={getProviderSetupDetail(provider)}
         />
-        <SetupStep
-          label="Provider key"
-          state={
-            process.env[getProviderApiKeyEnvKey(provider)]
-              ? "done"
-              : step === "api-key"
-                ? "current"
-                : "pending"
-          }
-          detail={
-            process.env[getProviderApiKeyEnvKey(provider)]
-              ? "available from environment"
-              : `save ${getProviderApiKeyEnvKey(provider)} to ${openWikiEnvPath}`
-          }
-        />
+        {provider === "ollama" ? (
+          <SetupStep
+            label="Ollama options"
+            state={
+              process.env[OLLAMA_NUM_CTX_ENV_KEY]
+                ? "done"
+                : step === "ollama-options"
+                  ? "current"
+                  : "pending"
+            }
+            detail={
+              process.env[OLLAMA_NUM_CTX_ENV_KEY]
+                ? `num_ctx=${process.env[OLLAMA_NUM_CTX_ENV_KEY]}`
+                : `default num_ctx=${OLLAMA_DEFAULT_NUM_CTX}`
+            }
+          />
+        ) : (
+          <SetupStep
+            label="Provider key"
+            state={
+              process.env[getProviderApiKeyEnvKey(provider)]
+                ? "done"
+                : step === "api-key"
+                  ? "current"
+                  : "pending"
+            }
+            detail={
+              process.env[getProviderApiKeyEnvKey(provider)]
+                ? "available from environment"
+                : `save ${getProviderApiKeyEnvKey(provider)} to ${openWikiEnvPath}`
+            }
+          />
+        )}
         <SetupStep
           label="Model"
           state={
@@ -417,6 +515,7 @@ export function InitSetup({
             input={input}
             isCustomModelInput={isCustomModelInput}
             modelSelectionIndex={modelSelectionIndex}
+            ollamaBaseUrl={ollamaBaseUrl}
             provider={provider}
             providerSelectionIndex={providerSelectionIndex}
             step={step}
@@ -514,6 +613,7 @@ type PromptProps = {
   input: string;
   isCustomModelInput: boolean;
   modelSelectionIndex: number;
+  ollamaBaseUrl: string;
   provider: OpenWikiProvider;
   providerSelectionIndex: number;
   step: PromptStep;
@@ -523,6 +623,7 @@ function Prompt({
   input,
   isCustomModelInput,
   modelSelectionIndex,
+  ollamaBaseUrl,
   provider,
   providerSelectionIndex,
   step,
@@ -555,6 +656,43 @@ function Prompt({
           <Text color="yellow">{mask(input)}</Text>
         </Text>
         <Text color="gray">Press Enter to save it.</Text>
+      </Box>
+    );
+  }
+
+  if (step === "ollama-options") {
+    const isBaseUrlPhase = ollamaBaseUrl === "";
+
+    if (isBaseUrlPhase) {
+      return (
+        <Box flexDirection="column">
+          <Text bold>Ollama base URL</Text>
+          <Text>
+            <Text color="gray">$</Text> {OLLAMA_BASE_URL_ENV_KEY}={" "}
+            <Text color="yellow">
+              {input.length > 0 ? input : OLLAMA_DEFAULT_BASE_URL}
+            </Text>
+          </Text>
+          <Text color="gray">
+            Press Enter to accept default ({OLLAMA_DEFAULT_BASE_URL}).
+          </Text>
+        </Box>
+      );
+    }
+
+    return (
+      <Box flexDirection="column">
+        <Text bold>Ollama context window (num_ctx)</Text>
+        <Text>
+          <Text color="gray">$</Text> {OLLAMA_NUM_CTX_ENV_KEY}={" "}
+          <Text color="yellow">
+            {input.length > 0 ? input : String(OLLAMA_DEFAULT_NUM_CTX)}
+          </Text>
+        </Text>
+        <Text color="gray">
+          Larger values use more VRAM. Press Enter to accept default (
+          {OLLAMA_DEFAULT_NUM_CTX}).
+        </Text>
       </Box>
     );
   }
@@ -630,8 +768,18 @@ function getInitialStep(
     return "provider";
   }
 
-  if (!process.env[getProviderApiKeyEnvKey(provider)]) {
+  if (
+    getProviderRequiresApiKey(provider) &&
+    !process.env[getProviderApiKeyEnvKey(provider)]
+  ) {
     return "api-key";
+  }
+
+  if (
+    provider === "ollama" &&
+    process.env[OLLAMA_NUM_CTX_ENV_KEY] === undefined
+  ) {
+    return "ollama-options";
   }
 
   if (
@@ -652,11 +800,38 @@ function getNextStepAfterProvider(
   provider: OpenWikiProvider,
   modelIdOverride: string | null,
 ): PromptStep | null {
-  if (!process.env[getProviderApiKeyEnvKey(provider)]) {
+  if (
+    getProviderRequiresApiKey(provider) &&
+    !process.env[getProviderApiKeyEnvKey(provider)]
+  ) {
     return "api-key";
   }
 
+  if (
+    provider === "ollama" &&
+    process.env[OLLAMA_NUM_CTX_ENV_KEY] === undefined
+  ) {
+    return "ollama-options";
+  }
+
   return getNextStepAfterApiKey(provider, modelIdOverride);
+}
+
+function getNextStepAfterOllamaOptions(
+  modelIdOverride: string | null,
+): PromptStep | null {
+  if (
+    modelIdOverride === null &&
+    process.env[OPENWIKI_MODEL_ID_ENV_KEY] === undefined
+  ) {
+    return "model";
+  }
+
+  if (process.env.LANGSMITH_API_KEY === undefined) {
+    return "langsmith";
+  }
+
+  return null;
 }
 
 function getNextStepAfterApiKey(

--- a/src/env.ts
+++ b/src/env.ts
@@ -7,6 +7,8 @@ import {
   FIREWORKS_API_KEY_ENV_KEY,
   isValidModelId,
   normalizeProvider,
+  OLLAMA_BASE_URL_ENV_KEY,
+  OLLAMA_NUM_CTX_ENV_KEY,
   OPENAI_API_KEY_ENV_KEY,
   OPENROUTER_API_KEY_ENV_KEY,
   OPENWIKI_MODEL_ID_ENV_KEY,
@@ -38,6 +40,8 @@ const managedEnvKeys = [
   OPENROUTER_API_KEY_ENV_KEY,
   OPENWIKI_PROVIDER_ENV_KEY,
   OPENWIKI_MODEL_ID_ENV_KEY,
+  OLLAMA_BASE_URL_ENV_KEY,
+  OLLAMA_NUM_CTX_ENV_KEY,
   "LANGSMITH_API_KEY",
   "LANGCHAIN_PROJECT",
   "LANGCHAIN_TRACING_V2",
@@ -78,6 +82,8 @@ export async function getCredentialDiagnostics(): Promise<
     createCredentialDiagnostic(ANTHROPIC_API_KEY_ENV_KEY, fileEnv),
     createCredentialDiagnostic(OPENROUTER_API_KEY_ENV_KEY, fileEnv),
     createCredentialDiagnostic(OPENWIKI_MODEL_ID_ENV_KEY, fileEnv),
+    createCredentialDiagnostic(OLLAMA_BASE_URL_ENV_KEY, fileEnv),
+    createCredentialDiagnostic(OLLAMA_NUM_CTX_ENV_KEY, fileEnv),
     createCredentialDiagnostic("LANGSMITH_API_KEY", fileEnv),
   ];
 }


### PR DESCRIPTION
This PR adds native support for local models running under Ollama. It introduces configuration options for the context window length (num_ctx) and base URL, skips API key checks, and dynamically stringifies complex ToolMessage outputs to bypass ChatOllama strict types serialization restrictions.

In my opinion, the implementation using the native Ollama API is better than the implementation using the OpenAI API, which does not allow for configuring the context window size.: https://github.com/langchain-ai/openwiki/pull/87