### PR TITLE
feat: add an OpenAI-compatible provider with a required base URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,4 +72,18 @@ These configuration options and secrets will be saved to `~/.openwiki/.env` on y
 
 OpenWiki supports OpenRouter, Fireworks, Baseten, OpenAI and Anthropic out of the box. By default, there are a few models pre-defined (GLM 5.2, Kimi K2.6, Sonnet 5, etc) but for each inference provider, OpenWiki will allow you to specify your own custom model ID.
 
+### Alternative base URLs
+
+To route the Anthropic provider at an alternative, Anthropic-compatible endpoint
+(for example a self-hosted or proxied gateway) instead of the default API, set
+`ANTHROPIC_BASE_URL` alongside `ANTHROPIC_API_KEY`:
+
+```bash
+OPENWIKI_PROVIDER=anthropic
+ANTHROPIC_API_KEY=your-key
+ANTHROPIC_BASE_URL=https://your-gateway.example.com/anthropic
+```
+
+The base URL can be set in your environment or stored in `~/.openwiki/.env`.
+
 If there's an inference provider or model you'd like to see added, please open a PR!

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ These configuration options and secrets will be saved to `~/.openwiki/.env` on y
 
 ## Customizing
 
-OpenWiki supports OpenRouter, Fireworks, Baseten, OpenAI and Anthropic out of the box. By default, there are a few models pre-defined (GLM 5.2, Kimi K2.6, Sonnet 5, etc) but for each inference provider, OpenWiki will allow you to specify your own custom model ID.
+OpenWiki supports OpenRouter, Fireworks, Baseten, OpenAI, an OpenAI-compatible provider, and Anthropic out of the box. By default, there are a few models pre-defined (GLM 5.2, Kimi K2.6, Sonnet 5, etc) but for each inference provider, OpenWiki will allow you to specify your own custom model ID.
 
 ### Alternative base URLs
 
@@ -84,6 +84,21 @@ ANTHROPIC_API_KEY=your-key
 ANTHROPIC_BASE_URL=https://your-gateway.example.com/anthropic
 ```
 
-The base URL can be set in your environment or stored in `~/.openwiki/.env`.
+### OpenAI-compatible endpoints
+
+The `openai-compatible` provider targets any OpenAI-compatible chat-completions
+endpoint via a required base URL. This can be used for OpenAI-compatible LLM
+endpoints like those exposed by a LiteLLM gateway when it is used as a gateway —
+letting you reach whatever upstream providers the gateway fronts through a single
+OpenAI-shaped API. Set the model ID to whatever name the gateway exposes:
+
+```bash
+OPENWIKI_PROVIDER=openai-compatible
+OPENAI_COMPATIBLE_API_KEY=your-gateway-key
+OPENAI_COMPATIBLE_BASE_URL=https://your-gateway.example.com/v1
+OPENWIKI_MODEL_ID=your-gateway-model-name
+```
+
+Base URLs (and all credentials) can be set in your environment or stored in `~/.openwiki/.env`.
 
 If there's an inference provider or model you'd like to see added, please open a PR!

--- a/openwiki/agent/workflow.md
+++ b/openwiki/agent/workflow.md
@@ -23,9 +23,11 @@ Chat runs skip metadata writes entirely.
 
 `createModel()` in `src/agent/index.ts` branches by provider:
 
-- **anthropic**: `new ChatAnthropic(modelId, { apiKey })` — uses `@langchain/anthropic` directly.
+- **anthropic**: `new ChatAnthropic(modelId, { apiKey, anthropicApiUrl? })` — uses `@langchain/anthropic` directly. When `ANTHROPIC_BASE_URL` is set, the resolved alternative base URL is passed as `anthropicApiUrl` so requests can be routed to a self-hosted or proxied Anthropic-compatible endpoint instead of the default API.
 - **openrouter**: `new ChatOpenRouter({ apiKey, baseURL, model, models, route: "fallback", siteName: "OpenWiki" })` — passes a fallback model list so OpenRouter can route around server-side failures.
-- **baseten / fireworks / openai**: `new ChatOpenAI({ apiKey, configuration: { baseURL? }, model })` — OpenAI-compatible clients using the provider's custom base URL when configured.
+- **baseten / fireworks / openai**: `new ChatOpenAI({ apiKey, configuration: { baseURL? }, model })` — OpenAI-compatible clients using the provider's base URL when configured.
+
+Base URLs are resolved through `resolveProviderBaseUrl()` in `src/constants.ts`, which prefers a provider's alternative base URL environment variable (`baseUrlEnvKey`) over the built-in default before falling back to the SDK's own default endpoint.
 
 ## Prompting strategy
 

--- a/openwiki/agent/workflow.md
+++ b/openwiki/agent/workflow.md
@@ -25,9 +25,9 @@ Chat runs skip metadata writes entirely.
 
 - **anthropic**: `new ChatAnthropic(modelId, { apiKey, anthropicApiUrl? })` — uses `@langchain/anthropic` directly. When `ANTHROPIC_BASE_URL` is set, the resolved alternative base URL is passed as `anthropicApiUrl` so requests can be routed to a self-hosted or proxied Anthropic-compatible endpoint instead of the default API.
 - **openrouter**: `new ChatOpenRouter({ apiKey, baseURL, model, models, route: "fallback", siteName: "OpenWiki" })` — passes a fallback model list so OpenRouter can route around server-side failures.
-- **baseten / fireworks / openai**: `new ChatOpenAI({ apiKey, configuration: { baseURL? }, model })` — OpenAI-compatible clients using the provider's base URL when configured.
+- **baseten / fireworks / openai / openai-compatible**: `new ChatOpenAI({ apiKey, configuration: { baseURL? }, model })` — OpenAI-compatible clients using the provider's base URL when configured. The `openai-compatible` provider has no default endpoint; its base URL is user-supplied via `OPENAI_COMPATIBLE_BASE_URL` and required (`requiresBaseUrl: true`), which lets OpenWiki target any OpenAI-compatible gateway (for example a LiteLLM gateway fronting upstream providers).
 
-Base URLs are resolved through `resolveProviderBaseUrl()` in `src/constants.ts`, which prefers a provider's alternative base URL environment variable (`baseUrlEnvKey`) over the built-in default before falling back to the SDK's own default endpoint.
+Base URLs are resolved through `resolveProviderBaseUrl()` in `src/constants.ts`, which prefers a provider's alternative base URL environment variable (`baseUrlEnvKey`) over the built-in default before falling back to the SDK's own default endpoint. Providers marked `requiresBaseUrl` are validated at startup by `ensureProviderBaseUrl()`.
 
 ## Prompting strategy
 

--- a/openwiki/cli/usage.md
+++ b/openwiki/cli/usage.md
@@ -62,9 +62,19 @@ Providers and their model options are defined in `PROVIDER_CONFIGS` in `src/cons
 | baseten    | `BASETEN_API_KEY`    | `https://inference.baseten.co/v1`       | GLM 5.2, Kimi K2.7 Code                                               |
 | fireworks  | `FIREWORKS_API_KEY`  | `https://api.fireworks.ai/inference/v1` | GLM 5.2, Kimi K2.7 Code                                               |
 | openai     | `OPENAI_API_KEY`     | (default)                               | GPT 5.4 mini, GPT 5.5                                                 |
-| anthropic  | `ANTHROPIC_API_KEY`  | (default)                               | Haiku, Sonnet, Opus                                                   |
+| anthropic  | `ANTHROPIC_API_KEY`  | (default, or `ANTHROPIC_BASE_URL`)      | Haiku, Sonnet, Opus                                                   |
 
 The default provider is `openrouter`. `resolveConfiguredProvider()` picks the provider from `OPENWIKI_PROVIDER`, falling back to openrouter if `OPENROUTER_API_KEY` is set, then to `DEFAULT_PROVIDER`.
+
+### Alternative base URLs
+
+Set `ANTHROPIC_BASE_URL` to route the anthropic provider at an alternative,
+Anthropic-compatible endpoint (for example a self-hosted or proxied gateway)
+instead of the default API. When set, it is passed to `ChatAnthropic` as
+`anthropicApiUrl`; the `ANTHROPIC_API_KEY` is still sent as the request
+credential. Base URLs are resolved by `resolveProviderBaseUrl()` in
+`src/constants.ts`, which prefers a provider's `baseUrlEnvKey` override over the
+built-in default.
 
 ## Help text and validation
 
@@ -81,6 +91,7 @@ The help content is centralized in `src/commands.ts` and is used by the CLI UI. 
 - Then update any user-visible text in `src/cli.tsx` and `README.md`.
 - If new options affect run behavior, make sure `src/agent/index.ts` and `src/credentials.tsx` still receive the right inputs.
 - If adding a provider, update `PROVIDER_CONFIGS` and `SELECTABLE_OPENWIKI_PROVIDERS` in `src/constants.ts`, `managedEnvKeys` in `src/env.ts`, and the `createModel` branch in `src/agent/index.ts`.
+- To let a provider accept an alternative base URL, set `baseUrlEnvKey` on its `PROVIDER_CONFIGS` entry, add that key to `managedEnvKeys` in `src/env.ts`, and read it through `resolveProviderBaseUrl()` in the provider's `createModel` branch.
 - Re-check the `package.json` bin entry and scripts if the entrypoint changes.
 
 ## Source map

--- a/openwiki/cli/usage.md
+++ b/openwiki/cli/usage.md
@@ -43,8 +43,9 @@ The UI persists provider and model selection back to `~/.openwiki/.env` through 
 
 The first interactive run can prompt for:
 
-- a **provider** (`OPENWIKI_PROVIDER`) — openrouter, baseten, fireworks, openai, or anthropic,
-- the **provider API key** (e.g. `OPENROUTER_API_KEY`, `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, `BASETEN_API_KEY`, `FIREWORKS_API_KEY`),
+- a **provider** (`OPENWIKI_PROVIDER`) — openrouter, baseten, fireworks, openai, openai-compatible, or anthropic,
+- the **provider API key** (e.g. `OPENROUTER_API_KEY`, `OPENAI_API_KEY`, `OPENAI_COMPATIBLE_API_KEY`, `ANTHROPIC_API_KEY`, `BASETEN_API_KEY`, `FIREWORKS_API_KEY`),
+- a **base URL** for providers that require one (the openai-compatible provider prompts for `OPENAI_COMPATIBLE_BASE_URL`),
 - a **model ID** stored as `OPENWIKI_MODEL_ID` — chosen from the provider's model list or a custom ID,
 - optional `LANGSMITH_API_KEY` for tracing.
 
@@ -56,13 +57,14 @@ If a LangSmith key is provided, onboarding also enables `LANGCHAIN_PROJECT=openw
 
 Providers and their model options are defined in `PROVIDER_CONFIGS` in `src/constants.ts`:
 
-| Provider   | Env key              | Base URL                                | Models                                                                |
-| ---------- | -------------------- | --------------------------------------- | --------------------------------------------------------------------- |
-| openrouter | `OPENROUTER_API_KEY` | `https://openrouter.ai/api/v1`          | GLM 5.2, Fusion, Kimi K2.7 Code, Claude Opus/Sonnet, GPT 5.4 mini/5.5 |
-| baseten    | `BASETEN_API_KEY`    | `https://inference.baseten.co/v1`       | GLM 5.2, Kimi K2.7 Code                                               |
-| fireworks  | `FIREWORKS_API_KEY`  | `https://api.fireworks.ai/inference/v1` | GLM 5.2, Kimi K2.7 Code                                               |
-| openai     | `OPENAI_API_KEY`     | (default)                               | GPT 5.4 mini, GPT 5.5                                                 |
-| anthropic  | `ANTHROPIC_API_KEY`  | (default, or `ANTHROPIC_BASE_URL`)      | Haiku, Sonnet, Opus                                                   |
+| Provider          | Env key                     | Base URL                                | Models                                                                |
+| ----------------- | --------------------------- | --------------------------------------- | --------------------------------------------------------------------- |
+| openrouter        | `OPENROUTER_API_KEY`        | `https://openrouter.ai/api/v1`          | GLM 5.2, Fusion, Kimi K2.7 Code, Claude Opus/Sonnet, GPT 5.4 mini/5.5 |
+| baseten           | `BASETEN_API_KEY`           | `https://inference.baseten.co/v1`       | GLM 5.2, Kimi K2.7 Code                                               |
+| fireworks         | `FIREWORKS_API_KEY`         | `https://api.fireworks.ai/inference/v1` | GLM 5.2, Kimi K2.7 Code                                               |
+| openai            | `OPENAI_API_KEY`            | (default)                               | GPT 5.4 mini, GPT 5.5                                                 |
+| openai-compatible | `OPENAI_COMPATIBLE_API_KEY` | `OPENAI_COMPATIBLE_BASE_URL` (required) | custom model ID only                                                  |
+| anthropic         | `ANTHROPIC_API_KEY`         | (default, or `ANTHROPIC_BASE_URL`)      | Haiku, Sonnet, Opus                                                   |
 
 The default provider is `openrouter`. `resolveConfiguredProvider()` picks the provider from `OPENWIKI_PROVIDER`, falling back to openrouter if `OPENROUTER_API_KEY` is set, then to `DEFAULT_PROVIDER`.
 
@@ -72,9 +74,29 @@ Set `ANTHROPIC_BASE_URL` to route the anthropic provider at an alternative,
 Anthropic-compatible endpoint (for example a self-hosted or proxied gateway)
 instead of the default API. When set, it is passed to `ChatAnthropic` as
 `anthropicApiUrl`; the `ANTHROPIC_API_KEY` is still sent as the request
-credential. Base URLs are resolved by `resolveProviderBaseUrl()` in
-`src/constants.ts`, which prefers a provider's `baseUrlEnvKey` override over the
-built-in default.
+credential.
+
+### OpenAI-compatible provider
+
+The `openai-compatible` provider targets any OpenAI-compatible chat-completions
+endpoint. It has no default endpoint, so `OPENAI_COMPATIBLE_BASE_URL` is
+**required** (the interactive setup prompts for it, and a run aborts early if it
+is missing). This is useful for OpenAI-compatible LLM endpoints such as those
+exposed by a LiteLLM gateway, which lets you reach whatever upstream providers
+the gateway fronts through a single OpenAI-shaped API.
+Because the provider has no preset model
+list, set `OPENWIKI_MODEL_ID` (or pick "custom model ID" in setup) to whatever
+name the gateway exposes.
+
+```bash
+OPENWIKI_PROVIDER=openai-compatible
+OPENAI_COMPATIBLE_API_KEY=<gateway key>
+OPENAI_COMPATIBLE_BASE_URL=https://<gateway>/v1
+OPENWIKI_MODEL_ID=<model name the gateway exposes>
+```
+
+Base URLs are resolved by `resolveProviderBaseUrl()` in `src/constants.ts`, which
+prefers a provider's `baseUrlEnvKey` override over the built-in default.
 
 ## Help text and validation
 
@@ -92,6 +114,7 @@ The help content is centralized in `src/commands.ts` and is used by the CLI UI. 
 - If new options affect run behavior, make sure `src/agent/index.ts` and `src/credentials.tsx` still receive the right inputs.
 - If adding a provider, update `PROVIDER_CONFIGS` and `SELECTABLE_OPENWIKI_PROVIDERS` in `src/constants.ts`, `managedEnvKeys` in `src/env.ts`, and the `createModel` branch in `src/agent/index.ts`.
 - To let a provider accept an alternative base URL, set `baseUrlEnvKey` on its `PROVIDER_CONFIGS` entry, add that key to `managedEnvKeys` in `src/env.ts`, and read it through `resolveProviderBaseUrl()` in the provider's `createModel` branch.
+- To require a user-supplied base URL (a provider with no default endpoint, like `openai-compatible`), also set `requiresBaseUrl: true`. `ensureProviderBaseUrl()` in `src/agent/index.ts` enforces it at runtime, and the interactive setup adds a base-URL step for such providers.
 - Re-check the `package.json` bin entry and scripts if the entrypoint changes.
 
 ## Source map

--- a/openwiki/operations/credentials-and-updates.md
+++ b/openwiki/operations/credentials-and-updates.md
@@ -19,6 +19,7 @@ The file stores provider configuration and API keys:
 - `OPENWIKI_PROVIDER` — the selected model provider
 - `OPENWIKI_MODEL_ID` — the default model ID
 - Provider API keys: `OPENROUTER_API_KEY`, `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, `BASETEN_API_KEY`, `FIREWORKS_API_KEY`
+- Optional alternative base URL: `ANTHROPIC_BASE_URL` — routes the anthropic provider at an Anthropic-compatible endpoint other than the default API
 - Optional LangSmith settings: `LANGSMITH_API_KEY`, `LANGCHAIN_PROJECT`, `LANGCHAIN_TRACING_V2`
 
 The loader merges those values into `process.env`, while preferring existing process-level values over file values. Deprecated keys (`OPENAI_BASE_URL`, `OPENAI_ORG_ID`, `OPENAI_PROJECT`) are skipped on load and removed on save.
@@ -56,7 +57,7 @@ The env layer also produces diagnostics for the CLI UI. Those diagnostics report
 - invalid model IDs,
 - invalid provider values.
 
-Diagnostics cover all five provider keys plus `OPENWIKI_PROVIDER`, `OPENWIKI_MODEL_ID`, and `LANGSMITH_API_KEY`. This makes startup problems easier to diagnose without exposing secret values.
+Diagnostics cover all five provider keys plus `OPENWIKI_PROVIDER`, `OPENWIKI_MODEL_ID`, `ANTHROPIC_BASE_URL`, and `LANGSMITH_API_KEY`. This makes startup problems easier to diagnose without exposing secret values (non-secret values such as the provider, model ID, and base URL are shown in full).
 
 ## Update metadata
 

--- a/openwiki/operations/credentials-and-updates.md
+++ b/openwiki/operations/credentials-and-updates.md
@@ -18,8 +18,8 @@ The file stores provider configuration and API keys:
 
 - `OPENWIKI_PROVIDER` — the selected model provider
 - `OPENWIKI_MODEL_ID` — the default model ID
-- Provider API keys: `OPENROUTER_API_KEY`, `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, `BASETEN_API_KEY`, `FIREWORKS_API_KEY`
-- Optional alternative base URL: `ANTHROPIC_BASE_URL` — routes the anthropic provider at an Anthropic-compatible endpoint other than the default API
+- Provider API keys: `OPENROUTER_API_KEY`, `OPENAI_API_KEY`, `OPENAI_COMPATIBLE_API_KEY`, `ANTHROPIC_API_KEY`, `BASETEN_API_KEY`, `FIREWORKS_API_KEY`
+- Base URLs: `ANTHROPIC_BASE_URL` (optional — routes the anthropic provider at an Anthropic-compatible endpoint other than the default API) and `OPENAI_COMPATIBLE_BASE_URL` (required by the openai-compatible provider, which has no default endpoint)
 - Optional LangSmith settings: `LANGSMITH_API_KEY`, `LANGCHAIN_PROJECT`, `LANGCHAIN_TRACING_V2`
 
 The loader merges those values into `process.env`, while preferring existing process-level values over file values. Deprecated keys (`OPENAI_BASE_URL`, `OPENAI_ORG_ID`, `OPENAI_PROJECT`) are skipped on load and removed on save.
@@ -57,7 +57,7 @@ The env layer also produces diagnostics for the CLI UI. Those diagnostics report
 - invalid model IDs,
 - invalid provider values.
 
-Diagnostics cover all five provider keys plus `OPENWIKI_PROVIDER`, `OPENWIKI_MODEL_ID`, `ANTHROPIC_BASE_URL`, and `LANGSMITH_API_KEY`. This makes startup problems easier to diagnose without exposing secret values (non-secret values such as the provider, model ID, and base URL are shown in full).
+Diagnostics cover all six provider keys plus `OPENWIKI_PROVIDER`, `OPENWIKI_MODEL_ID`, the base URLs (`ANTHROPIC_BASE_URL`, `OPENAI_COMPATIBLE_BASE_URL`), and `LANGSMITH_API_KEY`. This makes startup problems easier to diagnose without exposing secret values (non-secret values such as the provider, model ID, and base URLs are shown in full).
 
 ## Update metadata
 

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -16,11 +16,11 @@ import type {
 } from "./types.js";
 import {
   ANTHROPIC_API_KEY_ENV_KEY,
+  ANTHROPIC_BASE_URL_ENV_KEY,
   BASETEN_API_KEY_ENV_KEY,
   FIREWORKS_API_KEY_ENV_KEY,
   getDefaultModelId,
   getProviderApiKeyEnvKey,
-  getProviderConfig,
   getProviderLabel,
   isValidModelId,
   normalizeModelId,
@@ -31,6 +31,7 @@ import {
   OPENWIKI_MODEL_ID_ENV_KEY,
   OPENWIKI_PROVIDER_ENV_KEY,
   resolveConfiguredProvider,
+  resolveProviderBaseUrl,
   type OpenWikiProvider,
 } from "../constants.js";
 import {
@@ -57,13 +58,10 @@ export async function runOpenWikiAgent(
   emitDebug(options, "env=loaded ~/.openwiki/.env");
   emitDebug(options, `env.afterLoad ${formatEnvironmentDebug()}`);
   const provider = resolveConfiguredProvider();
-  const providerConfig = getProviderConfig(provider);
+  const providerBaseUrl = resolveProviderBaseUrl(provider);
   emitDebug(options, `provider=${provider}`);
-  if (providerConfig.baseURL) {
-    emitDebug(
-      options,
-      `provider.baseUrl=${JSON.stringify(providerConfig.baseURL)}`,
-    );
+  if (providerBaseUrl) {
+    emitDebug(options, `provider.baseUrl=${JSON.stringify(providerBaseUrl)}`);
   }
   ensureProviderKey(provider);
   emitDebug(options, `credentials=${provider} key present`);
@@ -379,8 +377,11 @@ function resolveModelId(
 
 async function createModel(provider: OpenWikiProvider, modelId: string) {
   if (provider === "anthropic") {
+    const baseURL = resolveProviderBaseUrl(provider);
+
     return new ChatAnthropic(modelId, {
       apiKey: process.env[getProviderApiKeyEnvKey(provider)],
+      ...(baseURL ? { anthropicApiUrl: baseURL } : {}),
     });
   }
 
@@ -397,13 +398,13 @@ async function createModel(provider: OpenWikiProvider, modelId: string) {
     });
   }
 
-  const providerConfig = getProviderConfig(provider);
+  const baseURL = resolveProviderBaseUrl(provider);
 
   return new ChatOpenAI({
     apiKey: process.env[getProviderApiKeyEnvKey(provider)],
-    configuration: providerConfig.baseURL
+    configuration: baseURL
       ? {
-          baseURL: providerConfig.baseURL,
+          baseURL,
         }
       : undefined,
     model: modelId,
@@ -1263,6 +1264,7 @@ function formatEnvironmentDebug(): string {
     FIREWORKS_API_KEY_ENV_KEY,
     OPENAI_API_KEY_ENV_KEY,
     ANTHROPIC_API_KEY_ENV_KEY,
+    ANTHROPIC_BASE_URL_ENV_KEY,
     OPENROUTER_API_KEY_ENV_KEY,
     OPENWIKI_MODEL_ID_ENV_KEY,
     "LANGCHAIN_TRACING_V2",
@@ -1280,7 +1282,7 @@ function formatDebugValue(key: string, value: string | undefined): string {
     return "unset";
   }
 
-  if (key === "LANGCHAIN_ENDPOINT") {
+  if (key === "LANGCHAIN_ENDPOINT" || key === ANTHROPIC_BASE_URL_ENV_KEY) {
     return formatUrlDebugValue(value);
   }
 

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -21,15 +21,19 @@ import {
   FIREWORKS_API_KEY_ENV_KEY,
   getDefaultModelId,
   getProviderApiKeyEnvKey,
+  getProviderBaseUrlEnvKey,
   getProviderLabel,
   isValidModelId,
   normalizeModelId,
   OPENAI_API_KEY_ENV_KEY,
+  OPENAI_COMPATIBLE_API_KEY_ENV_KEY,
+  OPENAI_COMPATIBLE_BASE_URL_ENV_KEY,
   OPENROUTER_API_KEY_ENV_KEY,
   OPENROUTER_BASE_URL,
   OPENROUTER_FALLBACK_MODEL_IDS,
   OPENWIKI_MODEL_ID_ENV_KEY,
   OPENWIKI_PROVIDER_ENV_KEY,
+  providerRequiresBaseUrl,
   resolveConfiguredProvider,
   resolveProviderBaseUrl,
   type OpenWikiProvider,
@@ -65,6 +69,7 @@ export async function runOpenWikiAgent(
   }
   ensureProviderKey(provider);
   emitDebug(options, `credentials=${provider} key present`);
+  ensureProviderBaseUrl(provider);
   const modelId = resolveModelId(options, provider);
   emitDebug(options, `model=${modelId}`);
 
@@ -352,6 +357,20 @@ function ensureProviderKey(provider: OpenWikiProvider): void {
   if (!process.env[apiKeyEnvKey]) {
     throw new Error(
       `${apiKeyEnvKey} is required to run OpenWiki with ${getProviderLabel(provider)}.`,
+    );
+  }
+}
+
+function ensureProviderBaseUrl(provider: OpenWikiProvider): void {
+  if (!providerRequiresBaseUrl(provider)) {
+    return;
+  }
+
+  if (!resolveProviderBaseUrl(provider)) {
+    const baseUrlEnvKey = getProviderBaseUrlEnvKey(provider) ?? "base URL";
+
+    throw new Error(
+      `${baseUrlEnvKey} is required to run OpenWiki with ${getProviderLabel(provider)}.`,
     );
   }
 }
@@ -1263,6 +1282,8 @@ function formatEnvironmentDebug(): string {
     BASETEN_API_KEY_ENV_KEY,
     FIREWORKS_API_KEY_ENV_KEY,
     OPENAI_API_KEY_ENV_KEY,
+    OPENAI_COMPATIBLE_API_KEY_ENV_KEY,
+    OPENAI_COMPATIBLE_BASE_URL_ENV_KEY,
     ANTHROPIC_API_KEY_ENV_KEY,
     ANTHROPIC_BASE_URL_ENV_KEY,
     OPENROUTER_API_KEY_ENV_KEY,
@@ -1282,7 +1303,11 @@ function formatDebugValue(key: string, value: string | undefined): string {
     return "unset";
   }
 
-  if (key === "LANGCHAIN_ENDPOINT" || key === ANTHROPIC_BASE_URL_ENV_KEY) {
+  if (
+    key === "LANGCHAIN_ENDPOINT" ||
+    key === ANTHROPIC_BASE_URL_ENV_KEY ||
+    key === OPENAI_COMPATIBLE_BASE_URL_ENV_KEY
+  ) {
     return formatUrlDebugValue(value);
   }
 

--- a/src/cli.tsx
+++ b/src/cli.tsx
@@ -444,6 +444,7 @@ function App({ command }: AppProps) {
         />
         {runState.result.savedApiKey ||
         runState.result.savedProvider ||
+        runState.result.savedBaseUrl ||
         runState.result.savedModelId ||
         runState.result.savedLangSmithKey ? (
           <StatusLine tone="success" label="Credentials" value="saved" />

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -4,6 +4,7 @@ export const BASETEN_API_KEY_ENV_KEY = "BASETEN_API_KEY";
 export const FIREWORKS_API_KEY_ENV_KEY = "FIREWORKS_API_KEY";
 export const OPENAI_API_KEY_ENV_KEY = "OPENAI_API_KEY";
 export const ANTHROPIC_API_KEY_ENV_KEY = "ANTHROPIC_API_KEY";
+export const ANTHROPIC_BASE_URL_ENV_KEY = "ANTHROPIC_BASE_URL";
 export const OPENROUTER_API_KEY_ENV_KEY = "OPENROUTER_API_KEY";
 export const OPENWIKI_PROVIDER_ENV_KEY = "OPENWIKI_PROVIDER";
 export const OPENWIKI_MODEL_ID_ENV_KEY = "OPENWIKI_MODEL_ID";
@@ -27,6 +28,11 @@ export type ProviderModelOption = {
 type ProviderConfig = {
   apiKeyEnvKey: string;
   baseURL?: string;
+  /**
+   * Environment variable that, when set, overrides {@link ProviderConfig.baseURL}
+   * with an alternative base URL (e.g. a self-hosted or proxied endpoint).
+   */
+  baseUrlEnvKey?: string;
   label: string;
   modelOptions: ProviderModelOption[];
 };
@@ -71,6 +77,7 @@ export const PROVIDER_CONFIGS: Record<OpenWikiProvider, ProviderConfig> = {
   },
   anthropic: {
     apiKeyEnvKey: ANTHROPIC_API_KEY_ENV_KEY,
+    baseUrlEnvKey: ANTHROPIC_BASE_URL_ENV_KEY,
     label: "Anthropic",
     modelOptions: [
       { id: "claude-haiku-4-5", label: "Haiku" },
@@ -116,6 +123,27 @@ export function getProviderLabel(provider: OpenWikiProvider): string {
 
 export function getProviderApiKeyEnvKey(provider: OpenWikiProvider): string {
   return getProviderConfig(provider).apiKeyEnvKey;
+}
+
+/**
+ * Resolves the base URL for a provider, preferring an alternative base URL from
+ * the provider's configured environment variable over the built-in default.
+ * Returns `undefined` when neither is set, so callers fall back to the SDK's
+ * own default endpoint.
+ */
+export function resolveProviderBaseUrl(
+  provider: OpenWikiProvider,
+  env: NodeJS.ProcessEnv = process.env,
+): string | undefined {
+  const config = getProviderConfig(provider);
+  const override = config.baseUrlEnvKey ? env[config.baseUrlEnvKey] : undefined;
+  const trimmedOverride = override?.trim();
+
+  if (trimmedOverride) {
+    return trimmedOverride;
+  }
+
+  return config.baseURL;
 }
 
 export function getProviderModelOptions(

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -3,6 +3,8 @@ export const UPDATE_METADATA_PATH = `${OPEN_WIKI_DIR}/.last-update.json`;
 export const BASETEN_API_KEY_ENV_KEY = "BASETEN_API_KEY";
 export const FIREWORKS_API_KEY_ENV_KEY = "FIREWORKS_API_KEY";
 export const OPENAI_API_KEY_ENV_KEY = "OPENAI_API_KEY";
+export const OPENAI_COMPATIBLE_API_KEY_ENV_KEY = "OPENAI_COMPATIBLE_API_KEY";
+export const OPENAI_COMPATIBLE_BASE_URL_ENV_KEY = "OPENAI_COMPATIBLE_BASE_URL";
 export const ANTHROPIC_API_KEY_ENV_KEY = "ANTHROPIC_API_KEY";
 export const ANTHROPIC_BASE_URL_ENV_KEY = "ANTHROPIC_BASE_URL";
 export const OPENROUTER_API_KEY_ENV_KEY = "OPENROUTER_API_KEY";
@@ -16,6 +18,7 @@ export type OpenWikiProvider =
   | "baseten"
   | "fireworks"
   | "openai"
+  | "openai-compatible"
   | "openrouter";
 
 export type SelectableOpenWikiProvider = OpenWikiProvider;
@@ -33,6 +36,11 @@ type ProviderConfig = {
    * with an alternative base URL (e.g. a self-hosted or proxied endpoint).
    */
   baseUrlEnvKey?: string;
+  /**
+   * When true, the provider has no default endpoint and requires a base URL to
+   * be supplied via {@link ProviderConfig.baseUrlEnvKey}.
+   */
+  requiresBaseUrl?: boolean;
   label: string;
   modelOptions: ProviderModelOption[];
 };
@@ -42,6 +50,7 @@ export const SELECTABLE_OPENWIKI_PROVIDERS = [
   "baseten",
   "fireworks",
   "openai",
+  "openai-compatible",
   "anthropic",
 ] as const satisfies readonly SelectableOpenWikiProvider[];
 
@@ -74,6 +83,13 @@ export const PROVIDER_CONFIGS: Record<OpenWikiProvider, ProviderConfig> = {
       { id: "gpt-5.4-mini", label: "5.4 mini" },
       { id: "gpt-5.5", label: "5.5" },
     ],
+  },
+  "openai-compatible": {
+    apiKeyEnvKey: OPENAI_COMPATIBLE_API_KEY_ENV_KEY,
+    baseUrlEnvKey: OPENAI_COMPATIBLE_BASE_URL_ENV_KEY,
+    requiresBaseUrl: true,
+    label: "OpenAI-compatible",
+    modelOptions: [],
   },
   anthropic: {
     apiKeyEnvKey: ANTHROPIC_API_KEY_ENV_KEY,
@@ -144,6 +160,32 @@ export function resolveProviderBaseUrl(
   }
 
   return config.baseURL;
+}
+
+export function getProviderBaseUrlEnvKey(
+  provider: OpenWikiProvider,
+): string | undefined {
+  return getProviderConfig(provider).baseUrlEnvKey;
+}
+
+export function providerRequiresBaseUrl(provider: OpenWikiProvider): boolean {
+  return getProviderConfig(provider).requiresBaseUrl === true;
+}
+
+export function isValidBaseUrl(value: string): boolean {
+  const trimmed = value.trim();
+
+  if (trimmed.length === 0) {
+    return false;
+  }
+
+  try {
+    const url = new URL(trimmed);
+
+    return url.protocol === "http:" || url.protocol === "https:";
+  } catch {
+    return false;
+  }
 }
 
 export function getProviderModelOptions(

--- a/src/credentials.tsx
+++ b/src/credentials.tsx
@@ -122,7 +122,10 @@ export function InitSetup({
           getDefaultModelId(initialProvider),
       ),
     );
-    setIsCustomModelInput(false);
+    setIsCustomModelInput(
+      initialStep === "model" &&
+        shouldStartWithCustomModelInput(initialProvider),
+    );
     setStep(initialStep);
   }, [initialProvider, modelIdOverride, onComplete]);
 
@@ -204,7 +207,6 @@ export function InitSetup({
           getDefaultModelId(selectedProvider),
         ),
       );
-      setIsCustomModelInput(false);
       setInput("");
       const nextStep = getNextStepAfterProvider(
         selectedProvider,
@@ -212,6 +214,10 @@ export function InitSetup({
       );
 
       if (nextStep) {
+        setIsCustomModelInput(
+          nextStep === "model" &&
+            shouldStartWithCustomModelInput(selectedProvider),
+        );
         setStep(nextStep);
         return;
       }
@@ -239,6 +245,9 @@ export function InitSetup({
       const nextStep = getNextStepAfterApiKey(provider, modelIdOverride);
 
       if (nextStep) {
+        setIsCustomModelInput(
+          nextStep === "model" && shouldStartWithCustomModelInput(provider),
+        );
         setStep(nextStep);
         return;
       }
@@ -273,6 +282,9 @@ export function InitSetup({
       const nextStep = getNextStepAfterBaseUrl(provider, modelIdOverride);
 
       if (nextStep) {
+        setIsCustomModelInput(
+          nextStep === "model" && shouldStartWithCustomModelInput(provider),
+        );
         setStep(nextStep);
         return;
       }
@@ -839,6 +851,10 @@ function getModelSelectionOptions(
     })),
     { kind: "custom" },
   ];
+}
+
+function shouldStartWithCustomModelInput(provider: OpenWikiProvider): boolean {
+  return getProviderModelOptions(provider).length === 0;
 }
 
 function getSelectedModelId(

--- a/src/credentials.tsx
+++ b/src/credentials.tsx
@@ -4,13 +4,16 @@ import {
   DEFAULT_PROVIDER,
   getDefaultModelId,
   getProviderApiKeyEnvKey,
+  getProviderBaseUrlEnvKey,
   getProviderLabel,
   getProviderModelOptions,
+  isValidBaseUrl,
   isValidModelId,
   normalizeModelId,
   OPENWIKI_MODEL_ID_ENV_KEY,
   OPENWIKI_PROVIDER_ENV_KEY,
   type OpenWikiProvider,
+  providerRequiresBaseUrl,
   resolveConfiguredProvider,
   SELECTABLE_OPENWIKI_PROVIDERS,
 } from "./constants.js";
@@ -20,6 +23,7 @@ export type InitSetupResult = {
   modelId: string | null;
   provider: OpenWikiProvider | null;
   savedApiKey: boolean;
+  savedBaseUrl: boolean;
   savedLangSmithKey: boolean;
   savedModelId: boolean;
   savedProvider: boolean;
@@ -31,7 +35,7 @@ type InitSetupProps = {
   onError: (message: string) => void;
 };
 
-type PromptStep = "api-key" | "langsmith" | "model" | "provider";
+type PromptStep = "api-key" | "base-url" | "langsmith" | "model" | "provider";
 
 export function needsCredentialSetup(
   modelIdOverride: string | null = null,
@@ -42,10 +46,25 @@ export function needsCredentialSetup(
   return (
     process.env[OPENWIKI_PROVIDER_ENV_KEY] === undefined ||
     !process.env[apiKeyEnvKey] ||
+    needsBaseUrlStep(provider) ||
     (modelIdOverride === null &&
       process.env[OPENWIKI_MODEL_ID_ENV_KEY] === undefined) ||
     process.env.LANGSMITH_API_KEY === undefined
   );
+}
+
+function needsBaseUrlStep(provider: OpenWikiProvider): boolean {
+  if (!providerRequiresBaseUrl(provider)) {
+    return false;
+  }
+
+  return !isBaseUrlConfigured(provider);
+}
+
+function isBaseUrlConfigured(provider: OpenWikiProvider): boolean {
+  const baseUrlEnvKey = getProviderBaseUrlEnvKey(provider);
+
+  return baseUrlEnvKey ? Boolean(process.env[baseUrlEnvKey]) : false;
 }
 
 export function InitSetup({
@@ -57,6 +76,7 @@ export function InitSetup({
   const [step, setStep] = useState<PromptStep | null>(null);
   const [provider, setProvider] = useState<OpenWikiProvider>(initialProvider);
   const [apiKey, setApiKey] = useState<string | null>(null);
+  const [baseUrl, setBaseUrl] = useState<string | null>(null);
   const [modelId, setModelId] = useState<string | null>(null);
   const [langSmithKey, setLangSmithKey] = useState<string | null>(null);
   const [input, setInput] = useState("");
@@ -84,6 +104,7 @@ export function InitSetup({
           modelIdOverride ?? process.env[OPENWIKI_MODEL_ID_ENV_KEY] ?? null,
         provider: initialProvider,
         savedApiKey: false,
+        savedBaseUrl: false,
         savedLangSmithKey: false,
         savedModelId: false,
         savedProvider: false,
@@ -197,6 +218,7 @@ export function InitSetup({
 
       await completeSetup({
         nextApiKey: apiKey,
+        nextBaseUrl: baseUrl,
         nextLangSmithKey: langSmithKey,
         nextModelId: modelId,
         nextProvider: selectedProvider,
@@ -223,6 +245,41 @@ export function InitSetup({
 
       await completeSetup({
         nextApiKey: trimmedInput,
+        nextBaseUrl: baseUrl,
+        nextLangSmithKey: langSmithKey,
+        nextModelId: modelId,
+        nextProvider: provider,
+      });
+      return;
+    }
+
+    if (step === "base-url") {
+      const trimmedInput = input.trim();
+
+      if (trimmedInput.length === 0) {
+        setError(
+          `${getProviderBaseUrlEnvKey(provider) ?? "Base URL"} is required.`,
+        );
+        return;
+      }
+
+      if (!isValidBaseUrl(trimmedInput)) {
+        setError("Enter a valid http(s) base URL.");
+        return;
+      }
+
+      setBaseUrl(trimmedInput);
+      setInput("");
+      const nextStep = getNextStepAfterBaseUrl(provider, modelIdOverride);
+
+      if (nextStep) {
+        setStep(nextStep);
+        return;
+      }
+
+      await completeSetup({
+        nextApiKey: apiKey,
+        nextBaseUrl: trimmedInput,
         nextLangSmithKey: langSmithKey,
         nextModelId: modelId,
         nextProvider: provider,
@@ -260,6 +317,7 @@ export function InitSetup({
 
       await completeSetup({
         nextApiKey: apiKey,
+        nextBaseUrl: baseUrl,
         nextLangSmithKey: langSmithKey,
         nextModelId: selectedModelId,
         nextProvider: provider,
@@ -275,6 +333,7 @@ export function InitSetup({
 
       await completeSetup({
         nextApiKey: apiKey,
+        nextBaseUrl: baseUrl,
         nextLangSmithKey,
         nextModelId: modelId,
         nextProvider: provider,
@@ -284,6 +343,7 @@ export function InitSetup({
 
   type CompleteSetupOptions = {
     nextApiKey: string | null;
+    nextBaseUrl: string | null;
     nextLangSmithKey: string | null;
     nextModelId: string | null;
     nextProvider: OpenWikiProvider;
@@ -291,6 +351,7 @@ export function InitSetup({
 
   async function completeSetup({
     nextApiKey,
+    nextBaseUrl,
     nextLangSmithKey,
     nextModelId,
     nextProvider,
@@ -308,6 +369,14 @@ export function InitSetup({
 
       if (nextApiKey !== null) {
         updates[getProviderApiKeyEnvKey(nextProvider)] = nextApiKey;
+      }
+
+      if (nextBaseUrl !== null) {
+        const baseUrlEnvKey = getProviderBaseUrlEnvKey(nextProvider);
+
+        if (baseUrlEnvKey) {
+          updates[baseUrlEnvKey] = nextBaseUrl;
+        }
       }
 
       if (nextModelId !== null) {
@@ -335,6 +404,7 @@ export function InitSetup({
           null,
         provider: nextProvider,
         savedApiKey: nextApiKey !== null,
+        savedBaseUrl: nextBaseUrl !== null,
         savedLangSmithKey:
           nextLangSmithKey !== null && nextLangSmithKey.length > 0,
         savedModelId: nextModelId !== null,
@@ -382,6 +452,23 @@ export function InitSetup({
               : `save ${getProviderApiKeyEnvKey(provider)} to ${openWikiEnvPath}`
           }
         />
+        {providerRequiresBaseUrl(provider) ? (
+          <SetupStep
+            label="Base URL"
+            state={
+              isBaseUrlConfigured(provider)
+                ? "done"
+                : step === "base-url"
+                  ? "current"
+                  : "pending"
+            }
+            detail={
+              isBaseUrlConfigured(provider)
+                ? "available from environment"
+                : `save ${getProviderBaseUrlEnvKey(provider)} to ${openWikiEnvPath}`
+            }
+          />
+        ) : null}
         <SetupStep
           label="Model"
           state={
@@ -559,6 +646,22 @@ function Prompt({
     );
   }
 
+  if (step === "base-url") {
+    return (
+      <Box flexDirection="column">
+        <Text>Enter the {getProviderLabel(provider)} base URL.</Text>
+        <Text>
+          <Text color="gray">$</Text> {getProviderBaseUrlEnvKey(provider)}={" "}
+          <Text color="yellow">{input}</Text>
+        </Text>
+        <Text color="gray">
+          For example an OpenAI-compatible gateway endpoint (such as a LiteLLM
+          gateway). Press Enter to save it.
+        </Text>
+      </Box>
+    );
+  }
+
   if (step === "model") {
     if (isCustomModelInput) {
       return (
@@ -634,6 +737,10 @@ function getInitialStep(
     return "api-key";
   }
 
+  if (needsBaseUrlStep(provider)) {
+    return "base-url";
+  }
+
   if (
     modelIdOverride === null &&
     process.env[OPENWIKI_MODEL_ID_ENV_KEY] === undefined
@@ -660,6 +767,17 @@ function getNextStepAfterProvider(
 }
 
 function getNextStepAfterApiKey(
+  provider: OpenWikiProvider,
+  modelIdOverride: string | null,
+): PromptStep | null {
+  if (needsBaseUrlStep(provider)) {
+    return "base-url";
+  }
+
+  return getNextStepAfterBaseUrl(provider, modelIdOverride);
+}
+
+function getNextStepAfterBaseUrl(
   provider: OpenWikiProvider,
   modelIdOverride: string | null,
 ): PromptStep | null {

--- a/src/env.ts
+++ b/src/env.ts
@@ -3,6 +3,7 @@ import os from "node:os";
 import path from "node:path";
 import {
   ANTHROPIC_API_KEY_ENV_KEY,
+  ANTHROPIC_BASE_URL_ENV_KEY,
   BASETEN_API_KEY_ENV_KEY,
   FIREWORKS_API_KEY_ENV_KEY,
   isValidModelId,
@@ -35,6 +36,7 @@ const managedEnvKeys = [
   FIREWORKS_API_KEY_ENV_KEY,
   OPENAI_API_KEY_ENV_KEY,
   ANTHROPIC_API_KEY_ENV_KEY,
+  ANTHROPIC_BASE_URL_ENV_KEY,
   OPENROUTER_API_KEY_ENV_KEY,
   OPENWIKI_PROVIDER_ENV_KEY,
   OPENWIKI_MODEL_ID_ENV_KEY,
@@ -76,6 +78,7 @@ export async function getCredentialDiagnostics(): Promise<
     createCredentialDiagnostic(FIREWORKS_API_KEY_ENV_KEY, fileEnv),
     createCredentialDiagnostic(OPENAI_API_KEY_ENV_KEY, fileEnv),
     createCredentialDiagnostic(ANTHROPIC_API_KEY_ENV_KEY, fileEnv),
+    createCredentialDiagnostic(ANTHROPIC_BASE_URL_ENV_KEY, fileEnv),
     createCredentialDiagnostic(OPENROUTER_API_KEY_ENV_KEY, fileEnv),
     createCredentialDiagnostic(OPENWIKI_MODEL_ID_ENV_KEY, fileEnv),
     createCredentialDiagnostic("LANGSMITH_API_KEY", fileEnv),
@@ -133,10 +136,9 @@ function createCredentialDiagnostic(
     key,
     source,
     length: value.length,
-    preview:
-      key === OPENWIKI_MODEL_ID_ENV_KEY || key === OPENWIKI_PROVIDER_ENV_KEY
-        ? JSON.stringify(value)
-        : createCredentialPreview(value),
+    preview: isNonSecretDiagnosticKey(key)
+      ? JSON.stringify(value)
+      : createCredentialPreview(value),
     warnings:
       key === OPENWIKI_MODEL_ID_ENV_KEY
         ? getModelWarnings(value)
@@ -163,6 +165,14 @@ function getCredentialSource(
   }
 
   return "unset";
+}
+
+function isNonSecretDiagnosticKey(key: string): boolean {
+  return (
+    key === OPENWIKI_MODEL_ID_ENV_KEY ||
+    key === OPENWIKI_PROVIDER_ENV_KEY ||
+    key === ANTHROPIC_BASE_URL_ENV_KEY
+  );
 }
 
 function createCredentialPreview(value: string): string {

--- a/src/env.ts
+++ b/src/env.ts
@@ -9,6 +9,8 @@ import {
   isValidModelId,
   normalizeProvider,
   OPENAI_API_KEY_ENV_KEY,
+  OPENAI_COMPATIBLE_API_KEY_ENV_KEY,
+  OPENAI_COMPATIBLE_BASE_URL_ENV_KEY,
   OPENROUTER_API_KEY_ENV_KEY,
   OPENWIKI_MODEL_ID_ENV_KEY,
   OPENWIKI_PROVIDER_ENV_KEY,
@@ -35,6 +37,8 @@ const managedEnvKeys = [
   BASETEN_API_KEY_ENV_KEY,
   FIREWORKS_API_KEY_ENV_KEY,
   OPENAI_API_KEY_ENV_KEY,
+  OPENAI_COMPATIBLE_API_KEY_ENV_KEY,
+  OPENAI_COMPATIBLE_BASE_URL_ENV_KEY,
   ANTHROPIC_API_KEY_ENV_KEY,
   ANTHROPIC_BASE_URL_ENV_KEY,
   OPENROUTER_API_KEY_ENV_KEY,
@@ -77,6 +81,8 @@ export async function getCredentialDiagnostics(): Promise<
     createCredentialDiagnostic(BASETEN_API_KEY_ENV_KEY, fileEnv),
     createCredentialDiagnostic(FIREWORKS_API_KEY_ENV_KEY, fileEnv),
     createCredentialDiagnostic(OPENAI_API_KEY_ENV_KEY, fileEnv),
+    createCredentialDiagnostic(OPENAI_COMPATIBLE_API_KEY_ENV_KEY, fileEnv),
+    createCredentialDiagnostic(OPENAI_COMPATIBLE_BASE_URL_ENV_KEY, fileEnv),
     createCredentialDiagnostic(ANTHROPIC_API_KEY_ENV_KEY, fileEnv),
     createCredentialDiagnostic(ANTHROPIC_BASE_URL_ENV_KEY, fileEnv),
     createCredentialDiagnostic(OPENROUTER_API_KEY_ENV_KEY, fileEnv),
@@ -171,7 +177,8 @@ function isNonSecretDiagnosticKey(key: string): boolean {
   return (
     key === OPENWIKI_MODEL_ID_ENV_KEY ||
     key === OPENWIKI_PROVIDER_ENV_KEY ||
-    key === ANTHROPIC_BASE_URL_ENV_KEY
+    key === ANTHROPIC_BASE_URL_ENV_KEY ||
+    key === OPENAI_COMPATIBLE_BASE_URL_ENV_KEY
   );
 }
 


### PR DESCRIPTION
## Summary

Adds a new **`openai-compatible`** provider that targets any OpenAI-compatible chat-completions endpoint via a user-supplied base URL. Unlike the existing OpenAI-compatible providers (`baseten` / `fireworks`), which hardcode their endpoints and ship curated model lists, this provider has **no default endpoint** and **no preset models** — so it can front arbitrary gateways and the upstream providers behind them. This is useful for OpenAI-compatible LLM endpoints such as those exposed by a LiteLLM gateway, which lets you reach whatever upstream providers the gateway fronts through a single OpenAI-shaped API.

> Stacked on #80 (alternative base URLs for the Anthropic provider). It reuses the `resolveProviderBaseUrl()` / `baseUrlEnvKey` mechanism added there. Until #80 merges, this PR's diff includes that commit; review the top commit (`feat: add an OpenAI-compatible provider…`) here.

## Changes

- **`src/constants.ts`**: add the provider to `OpenWikiProvider`, `SELECTABLE_OPENWIKI_PROVIDERS`, and `PROVIDER_CONFIGS` (`OPENAI_COMPATIBLE_API_KEY` + `OPENAI_COMPATIBLE_BASE_URL`, custom-only model list); add a `requiresBaseUrl` flag to `ProviderConfig` plus `providerRequiresBaseUrl()`, `getProviderBaseUrlEnvKey()`, and `isValidBaseUrl()` helpers.
- **`src/agent/index.ts`**: `ensureProviderBaseUrl()` aborts a run early with a clear message when a `requiresBaseUrl` provider has no base URL. The provider itself flows through the existing `ChatOpenAI` + `resolveProviderBaseUrl()` path (no new client branch).
- **`src/credentials.tsx`**: interactive onboarding gains a **base-URL step** for providers that require one, validated as an `http(s)` URL, wired into the existing step machine and `~/.openwiki/.env` persistence.
- **`src/env.ts`**: persist and diagnose the new keys; the base URL is treated as a non-secret value (shown in full in diagnostics).
- **Docs**: README + OpenWiki docs describe the provider, including reaching upstream providers through an OpenAI-compatible gateway.

## Usage

```bash
OPENWIKI_PROVIDER=openai-compatible
OPENAI_COMPATIBLE_API_KEY=<gateway key>
OPENAI_COMPATIBLE_BASE_URL=https://<gateway>/v1
OPENWIKI_MODEL_ID=<model name the gateway exposes>
```

Model IDs are passed through verbatim, so gateway-specific aliases work as-is.

## Testing

- `pnpm build`, `pnpm lint:check`, and `pnpm format:check` pass.
- Verified end-to-end against a local build:
  - With `OPENAI_COMPATIBLE_BASE_URL` unset, a run aborts with `OPENAI_COMPATIBLE_BASE_URL is required to run OpenWiki with OpenAI-compatible.`
  - With it set to a local HTTP server, the client issued `POST /v1/chat/completions` to the configured base URL (OpenAI Chat Completions format), confirming requests are routed to the gateway.