### PR TITLE
fix: use dash-delimited Anthropic model id for Opus (claude-opus-4-8)

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -75,7 +75,7 @@ export const PROVIDER_CONFIGS: Record<OpenWikiProvider, ProviderConfig> = {
     modelOptions: [
       { id: "claude-haiku-4-5", label: "Haiku" },
       { id: "claude-sonnet-5", label: "Sonnet" },
-      { id: "claude-opus-4.8", label: "Opus" },
+      { id: "claude-opus-4-8", label: "Opus" },
     ],
   },
   openrouter: {


### PR DESCRIPTION
## Problem

The Anthropic provider's **Opus** option is `claude-opus-4.8` (dotted), but Anthropic API model ids are **dash-delimited**. Selecting Opus with `OPENWIKI_PROVIDER=anthropic` fails immediately:

```
Error 404 not_found_error  model: claude-opus-4.8
```

(`claude-haiku-4-5` and `claude-sonnet-5` in the same list are already dashed and work.)

## Fix

One-character data fix in `src/constants.ts`: `claude-opus-4.8` → `claude-opus-4-8`.

The OpenRouter entry (`anthropic/claude-opus-4.8`) is intentionally left as-is — OpenRouter slugs use dotted versions.