### PR TITLE
fix: skip binary file reads instead of crashing the run

### DIFF
--- a/src/agent/backend.ts
+++ b/src/agent/backend.ts
@@ -1,14 +1,37 @@
+import { Buffer } from "node:buffer";
 import { LocalShellBackend, type ReadResult } from "deepagents";
+
+const TEXT_MIME_TYPES = new Set([
+  "application/json",
+  "application/javascript",
+  "application/typescript",
+  "application/xml",
+  "image/svg+xml",
+]);
+
+const BINARY_MIME_TYPES = new Set([
+  "application/gzip",
+  "application/octet-stream",
+  "application/pdf",
+  "application/wasm",
+  "application/x-7z-compressed",
+  "application/x-gzip",
+  "application/x-rar-compressed",
+  "application/x-sqlite3",
+  "application/x-tar",
+  "application/zip",
+]);
+
+const BINARY_MIME_PREFIXES = ["audio/", "font/", "image/", "video/"];
 
 /**
  * LocalShellBackend that never returns raw binary content to the model.
  *
  * The base FilesystemBackend returns the full Uint8Array for any file whose
  * MIME type is not text (for example `__pycache__/*.pyc`, images, sqlite
- * files). Downstream, non-image binary content is serialized as a base64
- * `document` content block, and the Anthropic Messages API only accepts
- * `application/pdf` there — so a single binary read fails the request with
- * a 400 and aborts the entire run:
+ * files). Downstream, unsupported binary or multimodal content blocks can be
+ * rejected by providers such as Anthropic or OpenAI, so a single binary read
+ * can abort the entire run:
  * https://github.com/langchain-ai/openwiki/issues/114
  *
  * OpenWiki documents codebases, which is a text task; it never needs raw
@@ -22,16 +45,72 @@ export class OpenWikiShellBackend extends LocalShellBackend {
     limit?: number,
   ): Promise<ReadResult> {
     const result = await super.read(filePath, offset, limit);
+    const binaryByteLength = getBinaryByteLength(result.content);
 
-    if (result.content instanceof Uint8Array) {
+    if (binaryByteLength !== null) {
       return {
         content: `Binary file skipped: ${filePath} (${
           result.mimeType ?? "unknown type"
-        }, ${result.content.byteLength} bytes). OpenWiki reads text sources only.`,
+        }, ${binaryByteLength} bytes). OpenWiki reads text sources only.`,
+        mimeType: "text/plain",
+      };
+    }
+
+    if (
+      typeof result.content === "string" &&
+      isClearlyBinaryMimeType(result.mimeType)
+    ) {
+      return {
+        content: `Binary file skipped: ${filePath} (${
+          result.mimeType ?? "unknown type"
+        }, ${Buffer.byteLength(result.content)} bytes). OpenWiki reads text sources only.`,
         mimeType: "text/plain",
       };
     }
 
     return result;
   }
+}
+
+function getBinaryByteLength(content: unknown): number | null {
+  // In Node, Buffer extends Uint8Array, so this catches Buffers too.
+  if (content instanceof Uint8Array) {
+    return content.byteLength;
+  }
+
+  if (content instanceof ArrayBuffer) {
+    return content.byteLength;
+  }
+
+  if (ArrayBuffer.isView(content)) {
+    return content.byteLength;
+  }
+
+  return null;
+}
+
+function isClearlyBinaryMimeType(mimeType: string | undefined): boolean {
+  const normalized = normalizeMimeType(mimeType);
+
+  if (!normalized || isTextMimeType(normalized)) {
+    return false;
+  }
+
+  return (
+    BINARY_MIME_TYPES.has(normalized) ||
+    BINARY_MIME_PREFIXES.some((prefix) => normalized.startsWith(prefix))
+  );
+}
+
+function isTextMimeType(mimeType: string): boolean {
+  return (
+    mimeType.startsWith("text/") ||
+    TEXT_MIME_TYPES.has(mimeType) ||
+    mimeType.endsWith("+json") ||
+    mimeType.endsWith("+xml")
+  );
+}
+
+function normalizeMimeType(mimeType: string | undefined): string | null {
+  return mimeType?.split(";", 1)[0]?.trim().toLowerCase() || null;
 }

--- a/src/agent/backend.ts
+++ b/src/agent/backend.ts
@@ -1,0 +1,37 @@
+import { LocalShellBackend, type ReadResult } from "deepagents";
+
+/**
+ * LocalShellBackend that never returns raw binary content to the model.
+ *
+ * The base FilesystemBackend returns the full Uint8Array for any file whose
+ * MIME type is not text (for example `__pycache__/*.pyc`, images, sqlite
+ * files). Downstream, non-image binary content is serialized as a base64
+ * `document` content block, and the Anthropic Messages API only accepts
+ * `application/pdf` there — so a single binary read fails the request with
+ * a 400 and aborts the entire run:
+ * https://github.com/langchain-ai/openwiki/issues/114
+ *
+ * OpenWiki documents codebases, which is a text task; it never needs raw
+ * binary bytes. Replacing binary reads with a short text placeholder lets
+ * the agent note the file and move on instead of crashing the run.
+ */
+export class OpenWikiShellBackend extends LocalShellBackend {
+  override async read(
+    filePath: string,
+    offset?: number,
+    limit?: number,
+  ): Promise<ReadResult> {
+    const result = await super.read(filePath, offset, limit);
+
+    if (result.content instanceof Uint8Array) {
+      return {
+        content: `Binary file skipped: ${filePath} (${
+          result.mimeType ?? "unknown type"
+        }, ${result.content.byteLength} bytes). OpenWiki reads text sources only.`,
+        mimeType: "text/plain",
+      };
+    }
+
+    return result;
+  }
+}

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -5,9 +5,10 @@ import { ChatAnthropic } from "@langchain/anthropic";
 import { SqliteSaver } from "@langchain/langgraph-checkpoint-sqlite";
 import { ChatOpenAI } from "@langchain/openai";
 import { ChatOpenRouter } from "@langchain/openrouter";
-import { createDeepAgent, LocalShellBackend } from "deepagents";
+import { createDeepAgent } from "deepagents";
 import { DEBUG_ENV_KEYS, loadOpenWikiEnv, openWikiEnvDir } from "../env.js";
 import { isFileNotFoundError } from "../fs-errors.js";
+import { OpenWikiShellBackend } from "./backend.js";
 import { createSystemPrompt, createUserPrompt } from "./prompt.js";
 import type {
   OpenWikiCommand,
@@ -204,7 +205,7 @@ async function runOpenWikiAgentCore(
     model,
     tools: [],
     checkpointer,
-    backend: new LocalShellBackend({
+    backend: new OpenWikiShellBackend({
       maxOutputBytes: 100_000,
       rootDir: cwd,
       timeout: 120,

--- a/test/backend.test.ts
+++ b/test/backend.test.ts
@@ -1,0 +1,162 @@
+import { Buffer } from "node:buffer";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { LocalShellBackend, type ReadResult } from "deepagents";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { OpenWikiShellBackend } from "../src/agent/backend.ts";
+
+const tempDirs: string[] = [];
+
+afterEach(async () => {
+  vi.restoreAllMocks();
+  await Promise.all(
+    tempDirs
+      .splice(0)
+      .map((tempDir) => rm(tempDir, { force: true, recursive: true })),
+  );
+});
+
+describe("OpenWikiShellBackend", () => {
+  it("returns a text placeholder for png files", async () => {
+    const pngContent = Uint8Array.from([
+      0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a,
+    ]);
+    const backend = await createBackend({ "image.png": pngContent });
+
+    const result = await backend.read("/image.png");
+
+    expectBinaryPlaceholder(result, "/image.png", "image/png", 8);
+    expect(result.content).not.toBeInstanceOf(Uint8Array);
+  });
+
+  it("returns a text placeholder for pyc files", async () => {
+    const pycContent = Uint8Array.from([0x42, 0x0d, 0x0d, 0x0a]);
+    const backend = await createBackend({ "module.pyc": pycContent });
+
+    const result = await backend.read("/module.pyc");
+
+    expectBinaryPlaceholder(
+      result,
+      "/module.pyc",
+      "application/octet-stream",
+      4,
+    );
+  });
+
+  it("returns normal text files unchanged", async () => {
+    const sourceContent = "export const answer = 42;\n";
+    const backend = await createBackend({ "source.ts": sourceContent });
+
+    const result = await backend.read("/source.ts");
+
+    expect(result).toEqual({
+      content: sourceContent,
+      mimeType: "text/plain",
+    });
+  });
+
+  it("returns a text/plain placeholder for Uint8Array content", async () => {
+    const content = Uint8Array.from([1, 2, 3]);
+    mockSuperRead({ content, mimeType: "application/octet-stream" });
+    const backend = new OpenWikiShellBackend();
+
+    const result = await backend.read("/blob");
+
+    expectBinaryPlaceholder(result, "/blob", "application/octet-stream", 3);
+  });
+
+  it("returns a text/plain placeholder for non-Uint8Array binary content", async () => {
+    const content = new DataView(new ArrayBuffer(6));
+    mockSuperRead({
+      content: content as unknown as ReadResult["content"],
+      mimeType: "application/octet-stream",
+    });
+    const backend = new OpenWikiShellBackend();
+
+    const result = await backend.read("/blob");
+
+    expectBinaryPlaceholder(result, "/blob", "application/octet-stream", 6);
+  });
+
+  it("returns a placeholder for string content with binary MIME", async () => {
+    const content = "base64-ish";
+    mockSuperRead({ content, mimeType: "application/octet-stream" });
+    const backend = new OpenWikiShellBackend();
+
+    const result = await backend.read("/blob");
+
+    expectBinaryPlaceholder(
+      result,
+      "/blob",
+      "application/octet-stream",
+      Buffer.byteLength(content),
+    );
+  });
+
+  it("passes through string content with text MIME", async () => {
+    const readResult: ReadResult = {
+      content: "normal source\n",
+      mimeType: "text/plain",
+    };
+    mockSuperRead(readResult);
+    const backend = new OpenWikiShellBackend();
+
+    const result = await backend.read("/source");
+
+    expect(result).toBe(readResult);
+  });
+
+  it.each([
+    "application/json",
+    "application/javascript",
+    "application/typescript",
+    "application/xml",
+    undefined,
+  ])("passes through source MIME %s", async (mimeType) => {
+    const readResult: ReadResult = {
+      content: "normal source\n",
+      ...(mimeType ? { mimeType } : {}),
+    };
+    mockSuperRead(readResult);
+    const backend = new OpenWikiShellBackend();
+
+    const result = await backend.read("/source");
+
+    expect(result).toBe(readResult);
+  });
+});
+
+async function createBackend(
+  files: Record<string, string | Uint8Array>,
+): Promise<OpenWikiShellBackend> {
+  const tempDir = await mkdtemp(path.join(tmpdir(), "openwiki-backend-"));
+  tempDirs.push(tempDir);
+
+  await Promise.all(
+    Object.entries(files).map(([fileName, content]) =>
+      writeFile(path.join(tempDir, fileName), content),
+    ),
+  );
+
+  return new OpenWikiShellBackend({
+    rootDir: tempDir,
+    virtualMode: true,
+  });
+}
+
+function mockSuperRead(result: ReadResult): void {
+  vi.spyOn(LocalShellBackend.prototype, "read").mockResolvedValue(result);
+}
+
+function expectBinaryPlaceholder(
+  result: ReadResult,
+  filePath: string,
+  mimeType: string,
+  byteLength: number,
+): void {
+  expect(result).toEqual({
+    content: `Binary file skipped: ${filePath} (${mimeType}, ${byteLength} bytes). OpenWiki reads text sources only.`,
+    mimeType: "text/plain",
+  });
+}


### PR DESCRIPTION
Fixes #114 (and removes the most common trigger of the crash class described in #86).

**Problem.** `FilesystemBackend.read()` returns raw `Uint8Array` content for any file whose MIME type isn't text. Non-image binary content is then serialized as a base64 `document` content block, and the Anthropic Messages API only accepts `application/pdf` there — so a single read of e.g. `__pycache__/*.pyc` fails the request with a 400 and aborts the entire run. Since virtually every Python repo contains bytecode, `openwiki --init` reliably crashes on Python projects with the Anthropic provider.

**Fix.** `OpenWikiShellBackend` (new, extends `LocalShellBackend`) overrides `read()` to return a short text placeholder for binary content — `Binary file skipped: <path> (<mime>, <bytes>). OpenWiki reads text sources only.` Wiki generation is a text task; the agent notes the file and moves on. Text reads pass through unchanged.

Scoped here rather than in `deepagents` deliberately: OpenWiki never needs raw bytes, so this is correct for OpenWiki regardless of whether deepagents later adds native binary handling upstream (this wrapper stays harmless if it does).

**Verification.**
- The repro from #114 (Python repo, 26 `.pyc` + 1 `.png`): unpatched crashed 2/2 runs within ~2 min; patched completes `--init` end-to-end in ~5 min with a full wiki generated.
- Unit-checked the override directly: `.pyc` → placeholder, `.png` → placeholder, `README.md` → unchanged passthrough.
- `pnpm lint:check`, `pnpm format:check`, `pnpm build` all clean.

Happy to adjust scope (e.g., pass through Anthropic-supported image types) if you'd prefer.
