### PR TITLE
fix: skip binary files and compiled directories in snapshot traversal

### DIFF
--- a/src/agent/prompt.ts
+++ b/src/agent/prompt.ts
@@ -23,6 +23,7 @@ Run discipline:
 - Shell execute commands run on the host. If you use execute, run commands from the target repository directory and keep them inside that repository.
 - Do not exhaustively read every file. Inspect the repository tree, package/config files, README-style files, entrypoints, routing files, database/schema files, and representative files for each major domain.
 - Do not call glob with **/* from the repository root. Use targeted discovery by directory and extension. Prefer shell commands like rg --files with excludes for .git, node_modules, dist, build, cache directories, and existing generated wiki output.
+- Never read binary files or directories containing compiled artifacts. Skip these directories entirely: __pycache__, .pyc, .pyo, .class, .o, .so, .dll, .exe, .bin, .git/objects, .svn, .hg. Reading binary content will crash the LLM API with a 400 error.
 - Prefer grep/glob and short targeted reads over full-file reads when files are large.
 - Create a strong first-pass wiki that is accurate and navigable, then stop. The wiki can be refined in later update runs.
 - Keep the initial documentation set focused: quickstart plus the smallest set of section pages needed to explain the repo clearly.

--- a/src/agent/utils.ts
+++ b/src/agent/utils.ts
@@ -12,6 +12,36 @@ import type {
 } from "./types.js";
 import type { Dirent } from "node:fs";
 
+/**
+ * Directories to skip during snapshot traversal.
+ * These contain compiled artifacts, vendored dependencies, or version control data.
+ */
+const SNAPSHOT_EXCLUDED_DIRS = new Set([
+  "__pycache__",
+  "node_modules",
+  ".git",
+  ".svn",
+  ".hg",
+  "dist",
+  "build",
+  "cache",
+]);
+
+/**
+ * File extensions to skip during snapshot traversal.
+ * These are binary files or compiled artifacts that should not be hashed.
+ */
+const SNAPSHOT_EXCLUDED_EXTENSIONS = new Set([
+  ".pyc",
+  ".pyo",
+  ".class",
+  ".o",
+  ".so",
+  ".dll",
+  ".exe",
+  ".bin",
+]);
+
 const execFileAsync = promisify(execFile);
 
 export type OpenWikiContentSnapshot = string;
@@ -209,6 +239,13 @@ async function addDirectoryToSnapshot(
       continue;
     }
 
+    if (
+      entry.isDirectory() &&
+      SNAPSHOT_EXCLUDED_DIRS.has(entry.name)
+    ) {
+      continue;
+    }
+
     if (entry.isDirectory()) {
       hash.update(`dir:${relativePath}\0`);
       await addDirectoryToSnapshot(hash, entryPath, relativePath);
@@ -216,6 +253,12 @@ async function addDirectoryToSnapshot(
     }
 
     if (!entry.isFile()) {
+      continue;
+    }
+
+    if (
+      SNAPSHOT_EXCLUDED_EXTENSIONS.has(path.extname(entry.name).toLowerCase())
+    ) {
       continue;
     }
 


### PR DESCRIPTION
## Summary

Fixes #114 — Binary files (Python `__pycache__/*.pyc`) crash the Anthropic provider with a 400 error.

When the agent explores Python repos, it reads `__pycache__/*.pyc` files. The deepagents library correctly detects these as binary but still passes raw bytes to the LLM API. Anthropic rejects non-PDF binary content with a 400 error, killing the entire run.

## Changes

**`src/agent/utils.ts`**
- Added `SNAPSHOT_EXCLUDED_DIRS` set: `__pycache__`, `node_modules`, `.git`, `.svn`, `.hg`, `dist`, `build`, `cache`
- Added `SNAPSHOT_EXCLUDED_EXTENSIONS` set: `.pyc`, `.pyo`, `.class`, `.o`, `.so`, `.dll`, `.exe`, `.bin`
- Skip matching directories and files during snapshot traversal

**`src/agent/prompt.ts`**
- Added explicit instruction to never read binary files or compiled artifact directories
- Explains that reading binary content crashes the LLM API with a 400 error

## Testing

- Build passes
- Lint passes
- Format passes
- All 6 existing tests pass
