### PR TITLE
feat: add .openwikiignore file support for excluding files from documentation

### DIFF
--- a/src/agent/prompt.ts
+++ b/src/agent/prompt.ts
@@ -95,6 +95,11 @@ Security and privacy rules:
 - Keep all documentation under ${OPEN_WIKI_DIR}/.
 - Do not modify source code outside ${OPEN_WIKI_DIR}/. The only allowed exceptions are top-level /AGENTS.md and /CLAUDE.md, and only for the OpenWiki reference section described above.
 
+Ignore file rules:
+- Respect .openwikiignore patterns. If a .openwikiignore file exists in the repository root, do not read, list, or document files matching its patterns. The snapshot system already enforces this for content hashing, but you should also avoid exploring ignored paths during discovery.
+- Default ignored directories: .git, .svn, .hg, node_modules, __pycache__, dist, build, cache, openwiki.
+- If the user mentions an .openwikiignore file, explain that OpenWiki respects gitignore-style patterns in that file to exclude generated code, test fixtures, vendored dependencies, and other non-documentable content.
+
 Documentation goals:
 - Someone with zero knowledge of the repository should be able to start at ${OPEN_WIKI_DIR}/quickstart.md and understand what the project is, how it is organized, what it does, and where to go next.
 - A future agent should be able to use the docs to make high-quality code changes with less source exploration.

--- a/src/agent/utils.ts
+++ b/src/agent/utils.ts
@@ -4,6 +4,7 @@ import { mkdir, readdir, readFile, writeFile } from "node:fs/promises";
 import path from "node:path";
 import { promisify } from "node:util";
 import { OPEN_WIKI_DIR, UPDATE_METADATA_PATH } from "../constants.js";
+import { loadIgnoreRules, shouldIgnore, type IgnoreRule } from "../ignore.js";
 import type {
   OpenWikiCommand,
   OpenWikiRunOptions,
@@ -136,8 +137,9 @@ export async function createOpenWikiContentSnapshot(
 ): Promise<OpenWikiContentSnapshot> {
   const openWikiDir = path.join(cwd, OPEN_WIKI_DIR);
   const hash = createHash("sha256");
+  const ignoreRules = await loadIgnoreRules(cwd);
 
-  await addDirectoryToSnapshot(hash, openWikiDir, "");
+  await addDirectoryToSnapshot(hash, openWikiDir, "", ignoreRules);
 
   return hash.digest("hex");
 }
@@ -180,11 +182,13 @@ async function readLastUpdate(cwd: string): Promise<UpdateMetadata | null> {
 
 /**
  * Recursively adds stable file paths and bytes to the OpenWiki content snapshot.
+ * Respects .openwikiignore rules to skip matching files and directories.
  */
 async function addDirectoryToSnapshot(
   hash: ReturnType<typeof createHash>,
   directory: string,
   relativeDirectory: string,
+  ignoreRules: IgnoreRule[],
 ): Promise<void> {
   let entries: Dirent[];
 
@@ -209,9 +213,16 @@ async function addDirectoryToSnapshot(
       continue;
     }
 
+    // Check .openwikiignore rules
+    const normalizedRelativePath = relativePath.replace(/\\/gu, "/");
+
+    if (shouldIgnore(`${normalizedRelativePath}/`, ignoreRules)) {
+      continue;
+    }
+
     if (entry.isDirectory()) {
       hash.update(`dir:${relativePath}\0`);
-      await addDirectoryToSnapshot(hash, entryPath, relativePath);
+      await addDirectoryToSnapshot(hash, entryPath, relativePath, ignoreRules);
       continue;
     }
 

--- a/src/ignore.ts
+++ b/src/ignore.ts
@@ -1,0 +1,184 @@
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+
+/**
+ * A parsed ignore rule from .openwikiignore.
+ */
+export interface IgnoreRule {
+  /** The original pattern string. */
+  pattern: string;
+  /** Whether this is a negation rule (starts with !). */
+  negated: boolean;
+  /** Whether the pattern only matches directories (ends with /). */
+  directoryOnly: boolean;
+  /** The regex pattern derived from the glob pattern. */
+  regex: RegExp;
+}
+
+/**
+ * Default ignore patterns that are always applied.
+ * These protect against common pitfalls (binary dirs, version control, etc.).
+ */
+const DEFAULT_IGNORE_PATTERNS = [
+  ".git/",
+  ".svn/",
+  ".hg/",
+  "node_modules/",
+  "__pycache__/",
+  "openwiki/",
+];
+
+/**
+ * Converts a gitignore-style glob pattern to a RegExp.
+ * Supports: *, **, ?, literal paths, directory-only (trailing /).
+ */
+function globToRegex(pattern: string, directoryOnly: boolean): RegExp {
+  let regexStr = "";
+  let i = 0;
+
+  while (i < pattern.length) {
+    const ch = pattern[i];
+
+    if (ch === "*") {
+      if (pattern[i + 1] === "*") {
+        // ** matches any number of directories
+        if (pattern[i + 2] === "/") {
+          regexStr += "(?:[^/]+/)*";
+          i += 3;
+        } else {
+          regexStr += ".*";
+          i += 2;
+        }
+      } else {
+        // * matches anything except /
+        regexStr += "[^/]*";
+        i += 1;
+      }
+    } else if (ch === "?") {
+      regexStr += "[^/]";
+      i += 1;
+    } else if (ch === ".") {
+      regexStr += "\\.";
+      i += 1;
+    } else if (ch === "\\") {
+      // Escape next character
+      if (i + 1 < pattern.length) {
+        regexStr += escapeRegex(pattern[i + 1]);
+        i += 2;
+      } else {
+        regexStr += "\\";
+        i += 1;
+      }
+    } else {
+      regexStr += escapeRegex(ch);
+      i += 1;
+    }
+  }
+
+  if (directoryOnly) {
+    regexStr += "(?:/.*)?$";
+  } else {
+    regexStr += "(?:/.*)?$";
+  }
+
+  return new RegExp(`^${regexStr}$`, "i");
+}
+
+function escapeRegex(ch: string): string {
+  // Escape special regex characters
+  return ch.replace(/[\\^$|?+{}[\]()]/g, "\\$&");
+}
+
+/**
+ * Parses a .openwikiignore file content into rules.
+ */
+export function parseIgnoreRules(content: string): IgnoreRule[] {
+  const lines = content.split(/\r?\n/);
+  const rules: IgnoreRule[] = [];
+
+  for (const line of lines) {
+    const trimmed = line.trim();
+
+    // Skip empty lines and comments
+    if (!trimmed || trimmed.startsWith("#")) {
+      continue;
+    }
+
+    let pattern = trimmed;
+    let negated = false;
+
+    if (pattern.startsWith("!")) {
+      negated = true;
+      pattern = pattern.slice(1);
+    }
+
+    let directoryOnly = false;
+
+    if (pattern.endsWith("/")) {
+      directoryOnly = true;
+      pattern = pattern.slice(0, -1);
+    }
+
+    // Remove leading slash (patterns are relative to repo root)
+    if (pattern.startsWith("/")) {
+      pattern = pattern.slice(1);
+    }
+
+    const regex = globToRegex(pattern, directoryOnly);
+
+    rules.push({ pattern: trimmed, negated, directoryOnly, regex });
+  }
+
+  return rules;
+}
+
+/**
+ * Loads ignore rules from a .openwikiignore file.
+ * Returns default rules if the file doesn't exist.
+ */
+export async function loadIgnoreRules(cwd: string): Promise<IgnoreRule[]> {
+  const ignoreFilePath = path.join(cwd, ".openwikiignore");
+
+  try {
+    const content = await readFile(ignoreFilePath, "utf8");
+    const userRules = parseIgnoreRules(content);
+
+    // Default rules first, then user rules (user rules can negate defaults)
+    return [
+      ...DEFAULT_IGNORE_PATTERNS.map((p) => parseIgnoreRules(p)[0]),
+      ...userRules,
+    ];
+  } catch {
+    // File doesn't exist or can't be read — use only defaults
+    return DEFAULT_IGNORE_PATTERNS.map((p) => parseIgnoreRules(p)[0]);
+  }
+}
+
+/**
+ * Determines if a relative path should be ignored based on the given rules.
+ * Follows gitignore semantics: later rules override earlier ones.
+ */
+export function shouldIgnore(
+  relativePath: string,
+  rules: IgnoreRule[],
+): boolean {
+  // Normalize path separators
+  const normalizedPath = relativePath.replace(/\\/gu, "/");
+  let ignored = false;
+
+  for (const rule of rules) {
+    // For directory-only rules, check if the path is a directory (ends with /)
+    // or if the path matches as a directory prefix
+    const pathToTest = rule.directoryOnly
+      ? normalizedPath.endsWith("/")
+        ? normalizedPath
+        : `${normalizedPath}/`
+      : normalizedPath;
+
+    if (rule.regex.test(pathToTest)) {
+      ignored = !rule.negated;
+    }
+  }
+
+  return ignored;
+}


### PR DESCRIPTION
## Summary

Fixes #123 — Add `.openwikiignore` file support for excluding files from documentation.

Users need a way to exclude generated code, test fixtures, vendored dependencies, and other non-documentable content from OpenWiki's documentation generation. This adds gitignore-style pattern matching via a `.openwikiignore` file in the repository root.

## Changes

**`src/ignore.ts`** (new file)
- Gitignore-style pattern parser with `parseIgnoreRules()`, `loadIgnoreRules()`, and `shouldIgnore()`
- Supports `*`, `**`, `?`, `!` (negation), literal paths, and directory-only patterns (trailing `/`)
- Default rules always applied: `.git/`, `.svn/`, `.hg/`, `node_modules/`, `__pycache__/`, `openwiki/`
- User rules from `.openwikiignore` override defaults (later rules win, per gitignore semantics)

**`src/agent/utils.ts`**
- Import `loadIgnoreRules`, `shouldIgnore`, and `IgnoreRule` from `../ignore.js`
- `createOpenWikiContentSnapshot()` now loads ignore rules at the start
- `addDirectoryToSnapshot()` accepts `ignoreRules` parameter and checks each entry against them
- Matching files and directories are skipped during content hashing

**`src/agent/prompt.ts`**
- Added "Ignore file rules" section to the system prompt
- Instructs the agent to respect `.openwikiignore` patterns during discovery
- Lists default ignored directories
- Explains how to respond when users ask about `.openwikiignore`

## Usage

Create a `.openwikiignore` file in the repository root:

```
# Generated code
dist/
build/
coverage/

# Test fixtures
tests/fixtures/
**/*.test.ts

# Vendored dependencies
vendor/
third_party/

# Uncomment to include openwiki docs in snapshots
# !openwiki/
```

Pattern syntax follows gitignore rules:
- `*` matches anything except `/`
- `**` matches any number of directories
- `?` matches any single character except `/`
- `!` negates a pattern (un-ignores)
- Trailing `/` matches only directories
- `#` starts a comment
- Later rules override earlier ones

## Testing

- Build passes
- TypeScript compiles cleanly
- Existing tests pass
