### PR TITLE
fix: stop dropping OPENAI_BASE_URL so OpenAI proxies work

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,15 @@ ANTHROPIC_API_KEY=your-key
 ANTHROPIC_BASE_URL=https://your-gateway.example.com/anthropic
 ```
 
+The OpenAI provider can be routed the same way, for example to an auditing
+proxy or an OpenAI-compatible gateway, by setting `OPENAI_BASE_URL`:
+
+```bash
+OPENWIKI_PROVIDER=openai
+OPENAI_API_KEY=your-key
+OPENAI_BASE_URL=https://your-gateway.example.com/v1
+```
+
 ### OpenAI-compatible endpoints
 
 The `openai-compatible` provider targets any OpenAI-compatible chat-completions

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -26,6 +26,7 @@ import {
   isValidModelId,
   normalizeModelId,
   OPENAI_API_KEY_ENV_KEY,
+  OPENAI_BASE_URL_ENV_KEY,
   OPENAI_COMPATIBLE_API_KEY_ENV_KEY,
   OPENAI_COMPATIBLE_BASE_URL_ENV_KEY,
   OPENROUTER_API_KEY_ENV_KEY,
@@ -1306,6 +1307,7 @@ function formatEnvironmentDebug(): string {
     BASETEN_API_KEY_ENV_KEY,
     FIREWORKS_API_KEY_ENV_KEY,
     OPENAI_API_KEY_ENV_KEY,
+    OPENAI_BASE_URL_ENV_KEY,
     OPENAI_COMPATIBLE_API_KEY_ENV_KEY,
     OPENAI_COMPATIBLE_BASE_URL_ENV_KEY,
     ANTHROPIC_API_KEY_ENV_KEY,
@@ -1330,6 +1332,7 @@ function formatDebugValue(key: string, value: string | undefined): string {
   if (
     key === "LANGCHAIN_ENDPOINT" ||
     key === ANTHROPIC_BASE_URL_ENV_KEY ||
+    key === OPENAI_BASE_URL_ENV_KEY ||
     key === OPENAI_COMPATIBLE_BASE_URL_ENV_KEY
   ) {
     return formatUrlDebugValue(value);

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -3,6 +3,7 @@ export const UPDATE_METADATA_PATH = `${OPEN_WIKI_DIR}/.last-update.json`;
 export const BASETEN_API_KEY_ENV_KEY = "BASETEN_API_KEY";
 export const FIREWORKS_API_KEY_ENV_KEY = "FIREWORKS_API_KEY";
 export const OPENAI_API_KEY_ENV_KEY = "OPENAI_API_KEY";
+export const OPENAI_BASE_URL_ENV_KEY = "OPENAI_BASE_URL";
 export const OPENAI_COMPATIBLE_API_KEY_ENV_KEY = "OPENAI_COMPATIBLE_API_KEY";
 export const OPENAI_COMPATIBLE_BASE_URL_ENV_KEY = "OPENAI_COMPATIBLE_BASE_URL";
 export const ANTHROPIC_API_KEY_ENV_KEY = "ANTHROPIC_API_KEY";
@@ -78,6 +79,7 @@ export const PROVIDER_CONFIGS: Record<OpenWikiProvider, ProviderConfig> = {
   },
   openai: {
     apiKeyEnvKey: OPENAI_API_KEY_ENV_KEY,
+    baseUrlEnvKey: OPENAI_BASE_URL_ENV_KEY,
     label: "OpenAI",
     modelOptions: [
       { id: "gpt-5.4-mini", label: "5.4 mini" },

--- a/src/env.ts
+++ b/src/env.ts
@@ -9,6 +9,7 @@ import {
   isValidModelId,
   normalizeProvider,
   OPENAI_API_KEY_ENV_KEY,
+  OPENAI_BASE_URL_ENV_KEY,
   OPENAI_COMPATIBLE_API_KEY_ENV_KEY,
   OPENAI_COMPATIBLE_BASE_URL_ENV_KEY,
   OPENROUTER_API_KEY_ENV_KEY,
@@ -37,6 +38,7 @@ const managedEnvKeys = [
   BASETEN_API_KEY_ENV_KEY,
   FIREWORKS_API_KEY_ENV_KEY,
   OPENAI_API_KEY_ENV_KEY,
+  OPENAI_BASE_URL_ENV_KEY,
   OPENAI_COMPATIBLE_API_KEY_ENV_KEY,
   OPENAI_COMPATIBLE_BASE_URL_ENV_KEY,
   ANTHROPIC_API_KEY_ENV_KEY,
@@ -49,11 +51,7 @@ const managedEnvKeys = [
   "LANGCHAIN_TRACING_V2",
 ];
 
-const deprecatedEnvKeys = [
-  "OPENAI_BASE_URL",
-  "OPENAI_ORG_ID",
-  "OPENAI_PROJECT",
-];
+const deprecatedEnvKeys = ["OPENAI_ORG_ID", "OPENAI_PROJECT"];
 
 export async function loadOpenWikiEnv(): Promise<EnvMap> {
   const env = await readOpenWikiEnv();
@@ -81,6 +79,7 @@ export async function getCredentialDiagnostics(): Promise<
     createCredentialDiagnostic(BASETEN_API_KEY_ENV_KEY, fileEnv),
     createCredentialDiagnostic(FIREWORKS_API_KEY_ENV_KEY, fileEnv),
     createCredentialDiagnostic(OPENAI_API_KEY_ENV_KEY, fileEnv),
+    createCredentialDiagnostic(OPENAI_BASE_URL_ENV_KEY, fileEnv),
     createCredentialDiagnostic(OPENAI_COMPATIBLE_API_KEY_ENV_KEY, fileEnv),
     createCredentialDiagnostic(OPENAI_COMPATIBLE_BASE_URL_ENV_KEY, fileEnv),
     createCredentialDiagnostic(ANTHROPIC_API_KEY_ENV_KEY, fileEnv),
@@ -178,6 +177,7 @@ function isNonSecretDiagnosticKey(key: string): boolean {
     key === OPENWIKI_MODEL_ID_ENV_KEY ||
     key === OPENWIKI_PROVIDER_ENV_KEY ||
     key === ANTHROPIC_BASE_URL_ENV_KEY ||
+    key === OPENAI_BASE_URL_ENV_KEY ||
     key === OPENAI_COMPATIBLE_BASE_URL_ENV_KEY
   );
 }

--- a/test/constants.test.ts
+++ b/test/constants.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, test } from "vitest";
+import {
+  ANTHROPIC_BASE_URL_ENV_KEY,
+  OPENAI_BASE_URL_ENV_KEY,
+  PROVIDER_CONFIGS,
+  getProviderBaseUrlEnvKey,
+  isValidBaseUrl,
+  providerRequiresBaseUrl,
+  resolveProviderBaseUrl,
+} from "../src/constants.ts";
+
+describe("OpenAI base URL override (#64)", () => {
+  test("exposes an OPENAI_BASE_URL env key constant", () => {
+    expect(OPENAI_BASE_URL_ENV_KEY).toBe("OPENAI_BASE_URL");
+  });
+
+  test("the openai provider advertises OPENAI_BASE_URL as its override channel", () => {
+    expect(getProviderBaseUrlEnvKey("openai")).toBe(OPENAI_BASE_URL_ENV_KEY);
+    expect(PROVIDER_CONFIGS.openai.baseUrlEnvKey).toBe(OPENAI_BASE_URL_ENV_KEY);
+  });
+
+  test("does not require a base URL (the OpenAI default endpoint still applies)", () => {
+    expect(providerRequiresBaseUrl("openai")).toBe(false);
+  });
+
+  test("resolveProviderBaseUrl returns undefined when no override is set", () => {
+    expect(resolveProviderBaseUrl("openai", {})).toBeUndefined();
+  });
+
+  test("resolveProviderBaseUrl honors OPENAI_BASE_URL when set", () => {
+    const gateway = "https://audit-gateway.example.com/v1";
+
+    expect(
+      resolveProviderBaseUrl("openai", {
+        [OPENAI_BASE_URL_ENV_KEY]: gateway,
+      }),
+    ).toBe(gateway);
+  });
+
+  test("resolveProviderBaseUrl trims whitespace from the override", () => {
+    expect(
+      resolveProviderBaseUrl("openai", {
+        [OPENAI_BASE_URL_ENV_KEY]: "  https://gateway.example.com/v1  ",
+      }),
+    ).toBe("https://gateway.example.com/v1");
+  });
+
+  test("resolveProviderBaseUrl treats a blank override as unset", () => {
+    expect(
+      resolveProviderBaseUrl("openai", {
+        [OPENAI_BASE_URL_ENV_KEY]: "   ",
+      }),
+    ).toBeUndefined();
+  });
+
+  test("the override is isolated to the openai provider", () => {
+    // OPENAI_BASE_URL must not bleed into the anthropic provider's resolution.
+    expect(
+      resolveProviderBaseUrl("anthropic", {
+        [OPENAI_BASE_URL_ENV_KEY]: "https://wrong.example.com",
+      }),
+    ).toBeUndefined();
+  });
+});
+
+describe("base URL override surface across providers", () => {
+  test("anthropic, openai, and openai-compatible are the only providers with an override channel", () => {
+    const providers = Object.keys(PROVIDER_CONFIGS);
+    const withOverride = providers
+      .map((provider) => getProviderBaseUrlEnvKey(provider as never))
+      .filter((key): key is string => key !== undefined)
+      .sort();
+
+    expect(withOverride).toEqual(
+      [
+        ANTHROPIC_BASE_URL_ENV_KEY,
+        OPENAI_BASE_URL_ENV_KEY,
+        "OPENAI_COMPATIBLE_BASE_URL",
+      ].sort(),
+    );
+  });
+});
+
+describe("isValidBaseUrl", () => {
+  test("accepts http and https URLs", () => {
+    expect(isValidBaseUrl("https://api.openai.com/v1")).toBe(true);
+    expect(isValidBaseUrl("http://localhost:8080")).toBe(true);
+  });
+
+  test("rejects empty, non-http(s), and malformed input", () => {
+    expect(isValidBaseUrl("")).toBe(false);
+    expect(isValidBaseUrl("   ")).toBe(false);
+    expect(isValidBaseUrl("ftp://example.com")).toBe(false);
+    expect(isValidBaseUrl("not-a-url")).toBe(false);
+  });
+});

--- a/test/env.test.ts
+++ b/test/env.test.ts
@@ -1,0 +1,185 @@
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, test } from "vitest";
+import {
+  getCredentialDiagnostics,
+  loadOpenWikiEnv,
+  openWikiEnvPath,
+  saveOpenWikiEnv,
+} from "../src/env.ts";
+import {
+  OPENAI_API_KEY_ENV_KEY,
+  OPENAI_BASE_URL_ENV_KEY,
+  OPENROUTER_API_KEY_ENV_KEY,
+  OPENWIKI_PROVIDER_ENV_KEY,
+} from "../src/constants.ts";
+
+// `loadOpenWikiEnv` reads from a fixed `~/.openwiki/.env` path derived from
+// `os.homedir()`. Pointing HOME at a throwaway temp directory keeps these
+// tests fully isolated from the developer's real credentials and machine.
+const ENV_KEYS_UNDER_TEST = [
+  OPENAI_API_KEY_ENV_KEY,
+  OPENAI_BASE_URL_ENV_KEY,
+  OPENROUTER_API_KEY_ENV_KEY,
+  OPENWIKI_PROVIDER_ENV_KEY,
+] as const;
+
+let originalHome: string | undefined;
+let tempHome: string;
+
+beforeEach(async () => {
+  originalHome = process.env.HOME;
+  tempHome = await mkdtemp(path.join(tmpdir(), "openwiki-env-test-"));
+  process.env.HOME = tempHome;
+
+  for (const key of ENV_KEYS_UNDER_TEST) {
+    delete process.env[key];
+  }
+});
+
+afterEach(async () => {
+  for (const key of ENV_KEYS_UNDER_TEST) {
+    delete process.env[key];
+  }
+
+  if (originalHome === undefined) {
+    delete process.env.HOME;
+  } else {
+    process.env.HOME = originalHome;
+  }
+
+  await rm(tempHome, { recursive: true, force: true });
+});
+
+describe("loadOpenWikiEnv — OPENAI_BASE_URL regression (#64)", () => {
+  test("no longer drops OPENAI_BASE_URL saved to ~/.openwiki/.env", async () => {
+    const proxyUrl = "https://audit-gateway.example.com/v1";
+
+    await saveOpenWikiEnv({ [OPENAI_BASE_URL_ENV_KEY]: proxyUrl });
+
+    const env = await loadOpenWikiEnv();
+
+    // The persisted file must keep the override...
+    expect(env[OPENAI_BASE_URL_ENV_KEY]).toBe(proxyUrl);
+
+    // ...and it must be loaded into process.env rather than silently dropped.
+    expect(process.env[OPENAI_BASE_URL_ENV_KEY]).toBe(proxyUrl);
+  });
+
+  test("does not clobber an OPENAI_BASE_URL already in process.env", async () => {
+    const inlineUrl = "https://inline-proxy.example.com/v1";
+    const fileUrl = "https://file-proxy.example.com/v1";
+
+    // Save a file value first (this also seeds process.env with fileUrl).
+    await saveOpenWikiEnv({ [OPENAI_BASE_URL_ENV_KEY]: fileUrl });
+
+    // Now have the caller override process.env after the save, simulating an
+    // explicit `OPENAI_BASE_URL=... openwiki` invocation.
+    process.env[OPENAI_BASE_URL_ENV_KEY] = inlineUrl;
+
+    await loadOpenWikiEnv();
+
+    // process.env wins over the file, matching the existing precedence rule.
+    expect(process.env[OPENAI_BASE_URL_ENV_KEY]).toBe(inlineUrl);
+  });
+
+  test("still drops genuinely deprecated OpenAI keys (OPENAI_ORG_ID, OPENAI_PROJECT)", async () => {
+    // Sanity check: only OPENAI_BASE_URL was un-deprecated; the other legacy
+    // keys remain ignored so a stale ~/.openwiki/.env can't override behavior.
+    const rawEnvFile = [
+      `OPENAI_ORG_ID=org-should-be-ignored`,
+      `OPENAI_PROJECT=proj-should-be-ignored`,
+    ].join("\n");
+
+    const { writeFile, mkdir } = await import("node:fs/promises");
+    await mkdir(path.dirname(openWikiEnvPath), { recursive: true });
+    await writeFile(openWikiEnvPath, `${rawEnvFile}\n`, "utf8");
+
+    const env = await loadOpenWikiEnv();
+
+    expect(env.OPENAI_ORG_ID).toBe("org-should-be-ignored");
+    expect(process.env.OPENAI_ORG_ID).toBeUndefined();
+    expect(process.env.OPENAI_PROJECT).toBeUndefined();
+  });
+});
+
+describe("saveOpenWikiEnv round-trip", () => {
+  test("persists and reloads a full provider configuration", async () => {
+    await saveOpenWikiEnv({
+      [OPENWIKI_PROVIDER_ENV_KEY]: "openai",
+      [OPENAI_API_KEY_ENV_KEY]: "sk-test-key",
+      [OPENAI_BASE_URL_ENV_KEY]: "https://gateway.example.com/v1",
+    });
+
+    // Wipe process.env to simulate a fresh process reading the saved file.
+    delete process.env[OPENAI_API_KEY_ENV_KEY];
+    delete process.env[OPENAI_BASE_URL_ENV_KEY];
+
+    await loadOpenWikiEnv();
+
+    expect(process.env[OPENAI_API_KEY_ENV_KEY]).toBe("sk-test-key");
+    expect(process.env[OPENAI_BASE_URL_ENV_KEY]).toBe(
+      "https://gateway.example.com/v1",
+    );
+  });
+
+  test("writes a 0600 env file", async () => {
+    await saveOpenWikiEnv({ [OPENROUTER_API_KEY_ENV_KEY]: "sk-or-..." });
+
+    const stat = await import("node:fs/promises").then((fs) =>
+      fs.stat(openWikiEnvPath),
+    );
+    const mode = stat.mode & 0o777;
+
+    // macOS/Linux: 0600. Be permissive about extra bits on odd filesystems.
+    expect(mode & 0o077).toBe(0o000);
+    expect(mode & 0o600).toBe(0o600);
+  });
+
+  test("treats the file as the source of truth for the saved override", async () => {
+    await saveOpenWikiEnv({
+      [OPENAI_BASE_URL_ENV_KEY]: "https://saved.example.com/v1",
+    });
+
+    const contents = await readFile(openWikiEnvPath, "utf8");
+    expect(contents).toContain(
+      `${OPENAI_BASE_URL_ENV_KEY}="https://saved.example.com/v1"`,
+    );
+  });
+});
+
+describe("getCredentialDiagnostics", () => {
+  test("reports OPENAI_BASE_URL as a configured, non-secret diagnostic", async () => {
+    await saveOpenWikiEnv({
+      [OPENAI_BASE_URL_ENV_KEY]: "https://proxy.example.com/v1",
+    });
+
+    const diagnostics = await getCredentialDiagnostics();
+    const openAiBaseUrl = diagnostics.find(
+      (entry) => entry.key === OPENAI_BASE_URL_ENV_KEY,
+    );
+
+    expect(openAiBaseUrl).toBeDefined();
+    // The value is surfaced verbatim (not masked) because a base URL is not a
+    // secret, unlike API keys.
+    expect(openAiBaseUrl?.preview).toBe('"https://proxy.example.com/v1"');
+    // saveOpenWikiEnv mirrors the value into process.env, so the diagnostic
+    // correctly reports it as present in both places.
+    expect(openAiBaseUrl?.source).toBe("process.env over ~/.openwiki/.env");
+  });
+
+  test("reports an unset OPENAI_BASE_URL as unset", async () => {
+    // Other tests in this suite write to the shared temp env file; remove it
+    // so this assertion observes a genuinely unconfigured state.
+    await rm(openWikiEnvPath, { force: true });
+
+    const diagnostics = await getCredentialDiagnostics();
+    const openAiBaseUrl = diagnostics.find(
+      (entry) => entry.key === OPENAI_BASE_URL_ENV_KEY,
+    );
+
+    expect(openAiBaseUrl?.source).toBe("unset");
+    expect(openAiBaseUrl?.preview).toBe("<unset>");
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #64.

`OPENAI_BASE_URL` is currently listed in `deprecatedEnvKeys` in `src/env.ts`, so any value a user saves to `~/.openwiki/.env` (or exports inline) is **silently discarded on load** and never reaches the OpenAI provider. This forces users behind an auditing proxy / OpenAI-compatible gateway to prepend the env var before every invocation, as described in the issue.

This is a leftover from when the default provider moved off OpenAI (commit `1473a12`). `OPENAI_API_KEY` has since been un-deprecated as OpenAI became a first-class provider again, but the base URL override was left behind in the deprecated list. This PR un-deprecates it and routes it through the same override channel that `ANTHROPIC_BASE_URL` and `OPENAI_COMPATIBLE_BASE_URL` already use.

## Root cause

`loadOpenWikiEnv` skips any key in `deprecatedEnvKeys`, and `OPENAI_BASE_URL` was still in that list despite the OpenAI provider being fully supported.

## Changes

- **`src/constants.ts`** — add `OPENAI_BASE_URL_ENV_KEY = "OPENAI_BASE_URL"` and set it as the `openai` provider's `baseUrlEnvKey`, so `resolveProviderBaseUrl("openai")` honors it.
- **`src/env.ts`** — remove `OPENAI_BASE_URL` from `deprecatedEnvKeys`; add it to `managedEnvKeys` and `getCredentialDiagnostics`; treat it as a non-secret (URL preview) diagnostic like the other base URLs.
- **`src/agent/index.ts`** — include `OPENAI_BASE_URL` in `--debug` environment logging.
- **`README.md`** — document the OpenAI base URL override alongside the existing Anthropic one.

The interactive setup in `src/credentials.tsx` needs no change — its base-URL step is fully data-driven off `baseUrlEnvKey`, so it now renders for OpenAI when the override is absent and skips it when present.

## Usage

```bash
OPENWIKI_PROVIDER=openai
OPENAI_API_KEY=your-key
OPENAI_BASE_URL=https://your-gateway.example.com/v1
```

## Tests

- **`test/constants.test.ts`** (new) — openai base-url resolution, whitespace/blank handling, isolation from the anthropic provider, and the base-URL override surface across all providers.
- **`test/env.test.ts`** (new) — the #64 regression: `OPENAI_BASE_URL` is **persisted and loaded** rather than dropped; `process.env` precedence over the file is preserved; genuinely deprecated keys (`OPENAI_ORG_ID`, `OPENAI_PROJECT`) are still ignored; diagnostics surface the override as a non-secret URL; save/load round-trip and 0600 file mode.

The regression test runs against a throwaway `HOME` so it never touches real credentials.

## Verification

```
pnpm run build        # OK
pnpm test             # 25 passed (6 existing + 19 new), existing tests unchanged
pnpm run lint:check   # OK
pnpm run format:check # OK
```

Closes #64