### PR TITLE
chore: engineering-hygiene pass with CI safety net, tests, de-duplication

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -51,3 +51,60 @@ jobs:
 
       - name: Check lint
         run: pnpm run lint:check
+
+  build:
+    name: Build & Typecheck
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: ["20", "22"]
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          run_install: false
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Typecheck
+        run: pnpm run typecheck
+
+      - name: Build
+        run: pnpm run build
+
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: ["20", "22"]
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          run_install: false
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Run tests
+        run: pnpm test

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 node_modules/
 dist/
+coverage/
 
 *.log
+*.tgz
 .DS_Store

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -18,7 +18,7 @@ Restart your shell, or source the profile file that `pnpm setup` changed. Then
 set up and link this package:
 
 ```sh
-cd /Users/bracesproul/code/lang-chain-ai/projects/agent-docs
+cd /path/to/openwiki
 pnpm install
 pnpm run build
 pnpm link --global
@@ -47,7 +47,7 @@ avoids typing the path to `dist/cli.js`.
 If you do not want to configure pnpm globals, use a shell alias instead:
 
 ```sh
-alias openwiki='node /Users/bracesproul/code/lang-chain-ai/projects/agent-docs/dist/cli.js'
+alias openwiki='node /path/to/openwiki/dist/cli.js'
 ```
 
 That alias can go in `~/.zshrc` if you want it to persist.

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,6 +1,8 @@
 import js from "@eslint/js";
 import tseslint from "typescript-eslint";
 
+const TS_FILES = ["src/**/*.{ts,tsx}", "test/**/*.{ts,tsx}"];
+
 export default tseslint.config(
   {
     ignores: [
@@ -12,12 +14,22 @@ export default tseslint.config(
     ],
   },
   js.configs.recommended,
-  ...tseslint.configs.recommended,
+  // Type-checked linting for the TypeScript sources and tests.
   {
-    files: ["src/**/*.{ts,tsx}"],
+    extends: [...tseslint.configs.recommendedTypeChecked],
+    files: TS_FILES,
     languageOptions: {
       ecmaVersion: "latest",
       sourceType: "module",
+      parserOptions: {
+        project: "./tsconfig.eslint.json",
+        tsconfigRootDir: import.meta.dirname,
+      },
     },
+  },
+  // Non-TypeScript files (e.g. this config) can't use type-aware rules.
+  {
+    files: ["**/*.js"],
+    extends: [tseslint.configs.disableTypeChecked],
   },
 );

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "openwiki": "node dist/cli.js",
     "build": "tsc -p tsconfig.json",
     "clean": "rm -rf dist",
+    "coverage": "vitest run --coverage",
     "dev": "tsx src/cli.tsx",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
@@ -36,7 +37,8 @@
     "prebuild": "pnpm run clean",
     "prepack": "pnpm run build",
     "start": "node dist/cli.js",
-    "test": "vitest run"
+    "test": "vitest run",
+    "typecheck": "tsc --noEmit -p tsconfig.json"
   },
   "dependencies": {
     "@langchain/anthropic": "^1.5.1",
@@ -54,12 +56,13 @@
     "@eslint/js": "^10.0.1",
     "@types/node": "^22.10.2",
     "@types/react": "^18.3.17",
+    "@vitest/coverage-v8": "^4.1.10",
     "eslint": "^10.5.0",
     "prettier": "^3.8.4",
     "tsx": "^4.19.2",
     "typescript": "^5.7.2",
     "typescript-eslint": "^8.62.0",
-    "vitest": "^4.1.9"
+    "vitest": "^4.1.10"
   },
   "pnpm": {
     "onlyBuiltDependencies": [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -48,6 +48,9 @@ importers:
       '@types/react':
         specifier: ^18.3.17
         version: 18.3.31
+      '@vitest/coverage-v8':
+        specifier: ^4.1.10
+        version: 4.1.10(vitest@4.1.10)
       eslint:
         specifier: ^10.5.0
         version: 10.5.0
@@ -64,8 +67,8 @@ importers:
         specifier: ^8.62.0
         version: 8.62.0(eslint@10.5.0)(typescript@5.9.3)
       vitest:
-        specifier: ^4.1.9
-        version: 4.1.9(@types/node@22.19.21)(vite@8.1.3(@types/node@22.19.21)(esbuild@0.28.1)(tsx@4.22.4)(yaml@2.9.0))
+        specifier: ^4.1.10
+        version: 4.1.10(@types/node@22.19.21)(@vitest/coverage-v8@4.1.10)(vite@8.1.3(@types/node@22.19.21)(esbuild@0.28.1)(tsx@4.22.4)(yaml@2.9.0))
 
 packages:
 
@@ -82,9 +85,30 @@ packages:
       zod:
         optional: true
 
+  '@babel/helper-string-parser@7.29.7':
+    resolution: {integrity: sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-validator-identifier@7.29.7':
+    resolution: {integrity: sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/parser@7.29.7':
+    resolution: {integrity: sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+
   '@babel/runtime@7.29.7':
     resolution: {integrity: sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==}
     engines: {node: '>=6.9.0'}
+
+  '@babel/types@7.29.7':
+    resolution: {integrity: sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==}
+    engines: {node: '>=6.9.0'}
+
+  '@bcoe/v8-coverage@1.0.2':
+    resolution: {integrity: sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==}
+    engines: {node: '>=18'}
 
   '@cfworker/json-schema@4.1.1':
     resolution: {integrity: sha512-gAmrUZSGtKc3AiBL71iNWxDsyUC5uMaKKGdvzYsBoTW/xi42JQHl7eKV2OYzCUqvc+D2RCcf7EXY2iCyFIk6og==}
@@ -313,8 +337,15 @@ packages:
     resolution: {integrity: sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==}
     engines: {node: '>=18.18'}
 
+  '@jridgewell/resolve-uri@3.1.2':
+    resolution: {integrity: sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==}
+    engines: {node: '>=6.0.0'}
+
   '@jridgewell/sourcemap-codec@1.5.5':
     resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
+
+  '@jridgewell/trace-mapping@0.3.31':
+    resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
 
   '@langchain/anthropic@1.5.1':
     resolution: {integrity: sha512-j92zCCd5BFH3rHMRzc2wBmSKDoVpinof1oh8aFiAz9TWbSOc4tGU4n6bqwy/wP0GH1uO96zZHLGCHBMPgrxTNw==}
@@ -594,11 +625,20 @@ packages:
     resolution: {integrity: sha512-CY3uyFSRbcQv3nnSv8S0+lDftMVz6P963PoRlxrV7ew/Md564g9ut60PYzdLM5qW4jFn93GBF+Soi90ISAN+GQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
-  '@vitest/expect@4.1.9':
-    resolution: {integrity: sha512-vl/rYsUKcBr3SnQn166+XR5ZQcgMx3DQhFWdfli/cWpLnLUmbxZvyrJZotLFUryib+LtArYMSTJ5RbQ57ZqrlA==}
+  '@vitest/coverage-v8@4.1.10':
+    resolution: {integrity: sha512-IM49HmthevbgAO4anp1hwtoT9wYe59w0LR00gr+eagHE+ZJ5lK4sLPeO0ubgoJcwLk6dehU3R24N+FbEEKDc8g==}
+    peerDependencies:
+      '@vitest/browser': 4.1.10
+      vitest: 4.1.10
+    peerDependenciesMeta:
+      '@vitest/browser':
+        optional: true
 
-  '@vitest/mocker@4.1.9':
-    resolution: {integrity: sha512-EVkXzBjrPGM+cK8/ANWgBrkUCfJfb38/EfTSO8h7pWvKkyPkpWxvR7BkD2MyItMF62C97zAEoqdpUixwR/e+Rw==}
+  '@vitest/expect@4.1.10':
+    resolution: {integrity: sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA==}
+
+  '@vitest/mocker@4.1.10':
+    resolution: {integrity: sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow==}
     peerDependencies:
       msw: ^2.4.9
       vite: ^6.0.0 || ^7.0.0 || ^8.0.0
@@ -608,20 +648,20 @@ packages:
       vite:
         optional: true
 
-  '@vitest/pretty-format@4.1.9':
-    resolution: {integrity: sha512-s0iufns3iIFitdgm+YR7g1whCAaGtXz459VS9/PqyKDEEFgYIhsHOQmXgIgDuYCt7DeQmiZT0Qe2OA2p4ZPu5A==}
+  '@vitest/pretty-format@4.1.10':
+    resolution: {integrity: sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q==}
 
-  '@vitest/runner@4.1.9':
-    resolution: {integrity: sha512-KXLMDtc7oe70+3mJfGrPUWPesswH+3sTxAMAMl8DG7I8IUQT4XW718dY5ID3vPUcmlu27CcKfY4P3h3I29SLJg==}
+  '@vitest/runner@4.1.10':
+    resolution: {integrity: sha512-IKI6kpIH+LmpROplyLwBBaCfMgOZOMsygVa6BARD6ahA04VRuJSa6OaVG7kRvSEMD870Vd91rSSw0eegtWyLGg==}
 
-  '@vitest/snapshot@4.1.9':
-    resolution: {integrity: sha512-Jc7RKGNBo8Z28WYIm0Niej4xdSPByRf6mU58VpHQkd6Zh05rlnA+twjbK5HyeIGHxrzsc3mJgS43uM0CZKzaIA==}
+  '@vitest/snapshot@4.1.10':
+    resolution: {integrity: sha512-xRkfOT1qpTAi/Ti4Y1LtfRc3kEuqxGw59eN2jN9pRWMtS/XDevekhcFSqvQqjUNGksfjMJu3Y+oJ+4Ypn2OaJw==}
 
-  '@vitest/spy@4.1.9':
-    resolution: {integrity: sha512-fHpsS6mIi+PiEW+vcRVOMkX1oSaPKne3VOclSFICPcGOmfKgXPU5iAah+wcNcj2xPrCCmfq99IDGf+EojhhvhA==}
+  '@vitest/spy@4.1.10':
+    resolution: {integrity: sha512-PLf/Ugvoq5wO/b4rwYCR1h2PSIdXz7wnkQFMiUpLdtM7l6pqVFcQIBEHyT1+l+cj7mNwAfZHzqXqDyjvOuwbDw==}
 
-  '@vitest/utils@4.1.9':
-    resolution: {integrity: sha512-A51o8ymO5PpqlWNnBP9ZHPXDIpuMtTLlGSjN7la4US+LJzoUMyhwjA5QXlm39JexgwHKW4Xjs8Z2d3dLCXOeuA==}
+  '@vitest/utils@4.1.10':
+    resolution: {integrity: sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==}
 
   acorn-jsx@5.3.2:
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
@@ -651,6 +691,9 @@ packages:
   assertion-error@2.0.1:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
     engines: {node: '>=12'}
+
+  ast-v8-to-istanbul@1.0.4:
+    resolution: {integrity: sha512-0bC0/4bTSrnwdhU3IsZDwEdojvuPrSg59OYZfKsLRtJZ0u8VBx9DebfqqG8bRdCC0I7vjgxmPi41P0lpkhJHtA==}
 
   auto-bind@5.0.1:
     resolution: {integrity: sha512-ooviqdwwgfIfNmDwo94wlshcdzfO64XV0Cg6oDsDYBJfITDz1EngD2z7DkbvCWn+XIMsIqW27sEVF6qcpJrRcg==}
@@ -919,6 +962,13 @@ packages:
     resolution: {integrity: sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==}
     engines: {node: '>=10.13.0'}
 
+  has-flag@4.0.0:
+    resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
+    engines: {node: '>=8'}
+
+  html-escaper@2.0.2:
+    resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
+
   ieee754@1.2.1:
     resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
 
@@ -989,8 +1039,23 @@ packages:
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
 
+  istanbul-lib-coverage@3.2.2:
+    resolution: {integrity: sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==}
+    engines: {node: '>=8'}
+
+  istanbul-lib-report@3.0.1:
+    resolution: {integrity: sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==}
+    engines: {node: '>=10'}
+
+  istanbul-reports@3.2.0:
+    resolution: {integrity: sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==}
+    engines: {node: '>=8'}
+
   js-tiktoken@1.0.21:
     resolution: {integrity: sha512-biOj/6M5qdgx5TKjDnFT1ymSpM5tbd3ylwDtrQvFQSu0Z7bBYko2dF+W/aUkXUPuk6IVpRxk/3Q2sHOzGlS36g==}
+
+  js-tokens@10.0.0:
+    resolution: {integrity: sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==}
 
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
@@ -1125,6 +1190,13 @@ packages:
 
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
+
+  magicast@0.5.3:
+    resolution: {integrity: sha512-pVKE4UdSQ7DvHzivsCIFx2BJn1mHG6KsyrFcaxFx6tONdneEuThrDx0Cj3AMg58KyN4pzYT+LHOotxDQDjNvkw==}
+
+  make-dir@4.0.0:
+    resolution: {integrity: sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==}
+    engines: {node: '>=10'}
 
   marked@18.0.5:
     resolution: {integrity: sha512-S6GcvALHg6K4ohtu4E7x0a1AqhAjp6cV8KhLSyN9qVapnzJkusVBxZRcIU9AeYsbe6P1hKDusSbEOzGyyuce6w==}
@@ -1397,6 +1469,10 @@ packages:
     resolution: {integrity: sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==}
     engines: {node: '>=0.10.0'}
 
+  supports-color@7.2.0:
+    resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
+    engines: {node: '>=8'}
+
   tar-fs@2.1.4:
     resolution: {integrity: sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==}
 
@@ -1515,20 +1591,20 @@ packages:
       yaml:
         optional: true
 
-  vitest@4.1.9:
-    resolution: {integrity: sha512-nE3/LEyc0z87uHYLZebqCUOaJr2hdtuPp7BQ4BosVFnfltxgAvMG08NyrSGlPpOUWvR27c5flSmYFTNr78L9GQ==}
+  vitest@4.1.10:
+    resolution: {integrity: sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw==}
     engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
     hasBin: true
     peerDependencies:
       '@edge-runtime/vm': '*'
       '@opentelemetry/api': ^1.9.0
       '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
-      '@vitest/browser-playwright': 4.1.9
-      '@vitest/browser-preview': 4.1.9
-      '@vitest/browser-webdriverio': 4.1.9
-      '@vitest/coverage-istanbul': 4.1.9
-      '@vitest/coverage-v8': 4.1.9
-      '@vitest/ui': 4.1.9
+      '@vitest/browser-playwright': 4.1.10
+      '@vitest/browser-preview': 4.1.10
+      '@vitest/browser-webdriverio': 4.1.10
+      '@vitest/coverage-istanbul': 4.1.10
+      '@vitest/coverage-v8': 4.1.10
+      '@vitest/ui': 4.1.10
       happy-dom: '*'
       jsdom: '*'
       vite: ^6.0.0 || ^7.0.0 || ^8.0.0
@@ -1622,7 +1698,22 @@ snapshots:
     optionalDependencies:
       zod: 4.4.3
 
+  '@babel/helper-string-parser@7.29.7': {}
+
+  '@babel/helper-validator-identifier@7.29.7': {}
+
+  '@babel/parser@7.29.7':
+    dependencies:
+      '@babel/types': 7.29.7
+
   '@babel/runtime@7.29.7': {}
+
+  '@babel/types@7.29.7':
+    dependencies:
+      '@babel/helper-string-parser': 7.29.7
+      '@babel/helper-validator-identifier': 7.29.7
+
+  '@bcoe/v8-coverage@1.0.2': {}
 
   '@cfworker/json-schema@4.1.1': {}
 
@@ -1770,7 +1861,14 @@ snapshots:
 
   '@humanwhocodes/retry@0.4.3': {}
 
+  '@jridgewell/resolve-uri@3.1.2': {}
+
   '@jridgewell/sourcemap-codec@1.5.5': {}
+
+  '@jridgewell/trace-mapping@0.3.31':
+    dependencies:
+      '@jridgewell/resolve-uri': 3.1.2
+      '@jridgewell/sourcemap-codec': 1.5.5
 
   '@langchain/anthropic@1.5.1(@langchain/core@1.2.1(openai@6.44.0(ws@8.21.0)(zod@4.4.3))(ws@8.21.0))':
     dependencies:
@@ -2045,44 +2143,58 @@ snapshots:
       '@typescript-eslint/types': 8.62.0
       eslint-visitor-keys: 5.0.1
 
-  '@vitest/expect@4.1.9':
+  '@vitest/coverage-v8@4.1.10(vitest@4.1.10)':
+    dependencies:
+      '@bcoe/v8-coverage': 1.0.2
+      '@vitest/utils': 4.1.10
+      ast-v8-to-istanbul: 1.0.4
+      istanbul-lib-coverage: 3.2.2
+      istanbul-lib-report: 3.0.1
+      istanbul-reports: 3.2.0
+      magicast: 0.5.3
+      obug: 2.1.3
+      std-env: 4.1.0
+      tinyrainbow: 3.1.0
+      vitest: 4.1.10(@types/node@22.19.21)(@vitest/coverage-v8@4.1.10)(vite@8.1.3(@types/node@22.19.21)(esbuild@0.28.1)(tsx@4.22.4)(yaml@2.9.0))
+
+  '@vitest/expect@4.1.10':
     dependencies:
       '@standard-schema/spec': 1.1.0
       '@types/chai': 5.2.3
-      '@vitest/spy': 4.1.9
-      '@vitest/utils': 4.1.9
+      '@vitest/spy': 4.1.10
+      '@vitest/utils': 4.1.10
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
-  '@vitest/mocker@4.1.9(vite@8.1.3(@types/node@22.19.21)(esbuild@0.28.1)(tsx@4.22.4)(yaml@2.9.0))':
+  '@vitest/mocker@4.1.10(vite@8.1.3(@types/node@22.19.21)(esbuild@0.28.1)(tsx@4.22.4)(yaml@2.9.0))':
     dependencies:
-      '@vitest/spy': 4.1.9
+      '@vitest/spy': 4.1.10
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
       vite: 8.1.3(@types/node@22.19.21)(esbuild@0.28.1)(tsx@4.22.4)(yaml@2.9.0)
 
-  '@vitest/pretty-format@4.1.9':
+  '@vitest/pretty-format@4.1.10':
     dependencies:
       tinyrainbow: 3.1.0
 
-  '@vitest/runner@4.1.9':
+  '@vitest/runner@4.1.10':
     dependencies:
-      '@vitest/utils': 4.1.9
+      '@vitest/utils': 4.1.10
       pathe: 2.0.3
 
-  '@vitest/snapshot@4.1.9':
+  '@vitest/snapshot@4.1.10':
     dependencies:
-      '@vitest/pretty-format': 4.1.9
-      '@vitest/utils': 4.1.9
+      '@vitest/pretty-format': 4.1.10
+      '@vitest/utils': 4.1.10
       magic-string: 0.30.21
       pathe: 2.0.3
 
-  '@vitest/spy@4.1.9': {}
+  '@vitest/spy@4.1.10': {}
 
-  '@vitest/utils@4.1.9':
+  '@vitest/utils@4.1.10':
     dependencies:
-      '@vitest/pretty-format': 4.1.9
+      '@vitest/pretty-format': 4.1.10
       convert-source-map: 2.0.0
       tinyrainbow: 3.1.0
 
@@ -2108,6 +2220,12 @@ snapshots:
   ansi-styles@6.2.3: {}
 
   assertion-error@2.0.1: {}
+
+  ast-v8-to-istanbul@1.0.4:
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.31
+      estree-walker: 3.0.3
+      js-tokens: 10.0.0
 
   auto-bind@5.0.1: {}
 
@@ -2399,6 +2517,10 @@ snapshots:
     dependencies:
       is-glob: 4.0.3
 
+  has-flag@4.0.0: {}
+
+  html-escaper@2.0.2: {}
+
   ieee754@1.2.1: {}
 
   ignore@5.3.2: {}
@@ -2466,9 +2588,24 @@ snapshots:
 
   isexe@2.0.0: {}
 
+  istanbul-lib-coverage@3.2.2: {}
+
+  istanbul-lib-report@3.0.1:
+    dependencies:
+      istanbul-lib-coverage: 3.2.2
+      make-dir: 4.0.0
+      supports-color: 7.2.0
+
+  istanbul-reports@3.2.0:
+    dependencies:
+      html-escaper: 2.0.2
+      istanbul-lib-report: 3.0.1
+
   js-tiktoken@1.0.21:
     dependencies:
       base64-js: 1.5.1
+
+  js-tokens@10.0.0: {}
 
   js-tokens@4.0.0: {}
 
@@ -2578,6 +2715,16 @@ snapshots:
   magic-string@0.30.21:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
+
+  magicast@0.5.3:
+    dependencies:
+      '@babel/parser': 7.29.7
+      '@babel/types': 7.29.7
+      source-map-js: 1.2.1
+
+  make-dir@4.0.0:
+    dependencies:
+      semver: 7.8.5
 
   marked@18.0.5: {}
 
@@ -2838,6 +2985,10 @@ snapshots:
 
   strip-json-comments@2.0.1: {}
 
+  supports-color@7.2.0:
+    dependencies:
+      has-flag: 4.0.0
+
   tar-fs@2.1.4:
     dependencies:
       chownr: 1.1.4
@@ -2928,15 +3079,15 @@ snapshots:
       tsx: 4.22.4
       yaml: 2.9.0
 
-  vitest@4.1.9(@types/node@22.19.21)(vite@8.1.3(@types/node@22.19.21)(esbuild@0.28.1)(tsx@4.22.4)(yaml@2.9.0)):
+  vitest@4.1.10(@types/node@22.19.21)(@vitest/coverage-v8@4.1.10)(vite@8.1.3(@types/node@22.19.21)(esbuild@0.28.1)(tsx@4.22.4)(yaml@2.9.0)):
     dependencies:
-      '@vitest/expect': 4.1.9
-      '@vitest/mocker': 4.1.9(vite@8.1.3(@types/node@22.19.21)(esbuild@0.28.1)(tsx@4.22.4)(yaml@2.9.0))
-      '@vitest/pretty-format': 4.1.9
-      '@vitest/runner': 4.1.9
-      '@vitest/snapshot': 4.1.9
-      '@vitest/spy': 4.1.9
-      '@vitest/utils': 4.1.9
+      '@vitest/expect': 4.1.10
+      '@vitest/mocker': 4.1.10(vite@8.1.3(@types/node@22.19.21)(esbuild@0.28.1)(tsx@4.22.4)(yaml@2.9.0))
+      '@vitest/pretty-format': 4.1.10
+      '@vitest/runner': 4.1.10
+      '@vitest/snapshot': 4.1.10
+      '@vitest/spy': 4.1.10
+      '@vitest/utils': 4.1.10
       es-module-lexer: 2.3.0
       expect-type: 1.4.0
       magic-string: 0.30.21
@@ -2952,6 +3103,7 @@ snapshots:
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 22.19.21
+      '@vitest/coverage-v8': 4.1.10(vitest@4.1.10)
     transitivePeerDependencies:
       - msw
 

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -6,7 +6,8 @@ import { SqliteSaver } from "@langchain/langgraph-checkpoint-sqlite";
 import { ChatOpenAI } from "@langchain/openai";
 import { ChatOpenRouter } from "@langchain/openrouter";
 import { createDeepAgent, LocalShellBackend } from "deepagents";
-import { loadOpenWikiEnv, openWikiEnvDir } from "../env.js";
+import { DEBUG_ENV_KEYS, loadOpenWikiEnv, openWikiEnvDir } from "../env.js";
+import { isFileNotFoundError } from "../fs-errors.js";
 import { createSystemPrompt, createUserPrompt } from "./prompt.js";
 import type {
   OpenWikiCommand,
@@ -15,18 +16,13 @@ import type {
   OpenWikiRunResult,
 } from "./types.js";
 import {
-  ANTHROPIC_API_KEY_ENV_KEY,
   ANTHROPIC_BASE_URL_ENV_KEY,
-  BASETEN_API_KEY_ENV_KEY,
-  FIREWORKS_API_KEY_ENV_KEY,
   getDefaultModelId,
   getProviderApiKeyEnvKey,
   getProviderBaseUrlEnvKey,
   getProviderLabel,
   isValidModelId,
   normalizeModelId,
-  OPENAI_API_KEY_ENV_KEY,
-  OPENAI_COMPATIBLE_API_KEY_ENV_KEY,
   OPENAI_COMPATIBLE_BASE_URL_ENV_KEY,
   OPENROUTER_API_KEY_ENV_KEY,
   OPENROUTER_BASE_URL,
@@ -189,7 +185,7 @@ async function runOpenWikiAgentCore(
   const openWikiSnapshotBefore =
     command === "chat" ? null : await createOpenWikiContentSnapshot(cwd);
   emitDebug(options, "openwiki.snapshot=created");
-  const model = await createModel(provider, modelId);
+  const model = createModel(provider, modelId);
   emitDebug(options, `model.provider=${provider}`);
   if (provider === "openrouter") {
     emitDebug(
@@ -367,14 +363,6 @@ function emitDebug(options: OpenWikiRunOptions, message: string): void {
   });
 }
 
-function isFileNotFoundError(error: unknown): boolean {
-  return (
-    error instanceof Error &&
-    "code" in error &&
-    (error as NodeJS.ErrnoException).code === "ENOENT"
-  );
-}
-
 function ensureProviderKey(provider: OpenWikiProvider): void {
   const apiKeyEnvKey = getProviderApiKeyEnvKey(provider);
 
@@ -418,7 +406,7 @@ function resolveModelId(
   return modelId;
 }
 
-async function createModel(provider: OpenWikiProvider, modelId: string) {
+function createModel(provider: OpenWikiProvider, modelId: string) {
   if (provider === "anthropic") {
     const baseURL = resolveProviderBaseUrl(provider);
 
@@ -840,7 +828,7 @@ function getMessageRole(value: Record<string, unknown>): string | null {
   }
 
   try {
-    const role = getType.call(value);
+    const role: unknown = getType.call(value);
 
     return isMessageRole(role) ? role : null;
   } catch {
@@ -1215,7 +1203,7 @@ function getOpenRouterMessageChars(messages: unknown): number | undefined {
     return undefined;
   }
 
-  return messages.reduce((total, message) => {
+  return messages.reduce<number>((total, message) => {
     if (!isRecord(message)) {
       return total;
     }
@@ -1230,7 +1218,7 @@ function countMessageContentChars(content: unknown): number {
   }
 
   if (Array.isArray(content)) {
-    return content.reduce(
+    return content.reduce<number>(
       (total, block) => total + countMessageContentChars(block),
       0,
     );
@@ -1264,7 +1252,7 @@ async function readResponseBodyPreview(response: Response): Promise<string> {
   }
 }
 
-function sanitizeOpenRouterResponseBody(body: string): string {
+export function sanitizeOpenRouterResponseBody(body: string): string {
   return body.replace(
     /"([^"]*(?:api[-_]?key|authorization|bearer|password|secret|token|user_id)[^"]*)"\s*:\s*"[^"]*"/giu,
     (_, key: string) => `${JSON.stringify(key)}:"[REDACTED]"`,
@@ -1301,25 +1289,9 @@ function formatOpenRouterDebugUrl(value: string): string {
 }
 
 function formatEnvironmentDebug(): string {
-  const keys = [
-    OPENWIKI_PROVIDER_ENV_KEY,
-    BASETEN_API_KEY_ENV_KEY,
-    FIREWORKS_API_KEY_ENV_KEY,
-    OPENAI_API_KEY_ENV_KEY,
-    OPENAI_COMPATIBLE_API_KEY_ENV_KEY,
-    OPENAI_COMPATIBLE_BASE_URL_ENV_KEY,
-    ANTHROPIC_API_KEY_ENV_KEY,
-    ANTHROPIC_BASE_URL_ENV_KEY,
-    OPENROUTER_API_KEY_ENV_KEY,
-    OPENWIKI_MODEL_ID_ENV_KEY,
-    "LANGCHAIN_TRACING_V2",
-    "LANGCHAIN_PROJECT",
-    "LANGCHAIN_ENDPOINT",
-  ];
-
-  return keys
-    .map((key) => `${key}:${formatDebugValue(key, process.env[key])}`)
-    .join(" ");
+  return DEBUG_ENV_KEYS.map(
+    (key) => `${key}:${formatDebugValue(key, process.env[key])}`,
+  ).join(" ");
 }
 
 function formatDebugValue(key: string, value: string | undefined): string {

--- a/src/agent/utils.ts
+++ b/src/agent/utils.ts
@@ -4,6 +4,10 @@ import { mkdir, readdir, readFile, writeFile } from "node:fs/promises";
 import path from "node:path";
 import { promisify } from "node:util";
 import { OPEN_WIKI_DIR, UPDATE_METADATA_PATH } from "../constants.js";
+import {
+  isExpectedSnapshotRaceError,
+  isFileNotFoundError,
+} from "../fs-errors.js";
 import type {
   OpenWikiCommand,
   OpenWikiRunOptions,
@@ -385,24 +389,6 @@ function isOpenWikiPath(changedPath: string): boolean {
 
 function normalizeGitPath(value: string): string {
   return value.trim().replace(/\\/gu, "/");
-}
-
-function isFileNotFoundError(error: unknown): boolean {
-  return (
-    error instanceof Error &&
-    "code" in error &&
-    (error as NodeJS.ErrnoException).code === "ENOENT"
-  );
-}
-
-function isExpectedSnapshotRaceError(error: unknown): boolean {
-  if (!(error instanceof Error) || !("code" in error)) {
-    return false;
-  }
-
-  return ["EISDIR", "ENOENT", "ENOTDIR"].includes(
-    (error as NodeJS.ErrnoException).code ?? "",
-  );
 }
 
 function isExecError(

--- a/src/cli.tsx
+++ b/src/cli.tsx
@@ -21,14 +21,12 @@ import {
   type CredentialDiagnostic,
 } from "./env.js";
 import { createOpenWikiThreadId, runOpenWikiAgent } from "./agent/index.js";
+import { getErrorMessage, sanitizeDiagnosticText } from "./diagnostics.js";
 import {
   type OpenWikiRunEvent,
   type OpenWikiRunResult,
 } from "./agent/types.js";
 import {
-  ANTHROPIC_API_KEY_ENV_KEY,
-  BASETEN_API_KEY_ENV_KEY,
-  FIREWORKS_API_KEY_ENV_KEY,
   getDefaultModelId,
   getProviderApiKeyEnvKey,
   getProviderLabel,
@@ -36,10 +34,8 @@ import {
   isValidModelId,
   normalizeModelId,
   normalizeProvider,
-  OPENAI_API_KEY_ENV_KEY,
   OPENWIKI_PROVIDER_ENV_KEY,
   OPENWIKI_MODEL_ID_ENV_KEY,
-  OPENROUTER_API_KEY_ENV_KEY,
   OPEN_WIKI_DIR,
   resolveConfiguredProvider,
   SELECTABLE_OPENWIKI_PROVIDERS,
@@ -2885,65 +2881,6 @@ function isDiagnosticValue(value: unknown): value is string | number | boolean {
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null;
-}
-
-function getErrorMessage(error: unknown): string {
-  const message =
-    error instanceof Error ? error.message : "OpenWiki agent run failed.";
-
-  if (isOpenRouterServerError(error, message)) {
-    return "OpenRouter/provider returned 500 Internal Server Error. Try retrying or switching models with /model. Run with OPENWIKI_DEBUG=1 to show provider metadata.";
-  }
-
-  return sanitizeDiagnosticText(message);
-}
-
-function isOpenRouterServerError(error: unknown, message: string): boolean {
-  if (isRecord(error)) {
-    const status = error.statusCode ?? error.status;
-    const name = error instanceof Error ? error.name : null;
-
-    if (
-      (status === 500 || status === "500") &&
-      (name === "OpenRouterError" || "metadata" in error)
-    ) {
-      return true;
-    }
-  }
-
-  return /OpenRouterError/iu.test(String(error)) ||
-    /Internal Server Error/iu.test(message)
-    ? /\b500\b|Internal Server Error/iu.test(message)
-    : false;
-}
-
-function sanitizeDiagnosticText(value: string): string {
-  let sanitized = value;
-
-  for (const key of [
-    BASETEN_API_KEY_ENV_KEY,
-    FIREWORKS_API_KEY_ENV_KEY,
-    OPENAI_API_KEY_ENV_KEY,
-    ANTHROPIC_API_KEY_ENV_KEY,
-    OPENROUTER_API_KEY_ENV_KEY,
-    "LANGSMITH_API_KEY",
-  ]) {
-    const secret = process.env[key];
-
-    if (secret && secret.length > 0) {
-      sanitized = sanitized.split(secret).join(`[REDACTED:${key}]`);
-    }
-  }
-
-  return sanitized
-    .replace(
-      /(Incorrect API key provided:\s*)([^\s.]+)/giu,
-      "$1[REDACTED:API_KEY]",
-    )
-    .replace(/\bBearer\s+[A-Za-z0-9._~+/=-]+/gu, "Bearer [REDACTED]")
-    .replace(/\bsk-or-v1-[A-Za-z0-9_-]+/gu, "[REDACTED:OPENROUTER_API_KEY]")
-    .replace(/\bsk-[A-Za-z0-9_-]+/gu, "[REDACTED:API_KEY]")
-    .replace(/\bls[v_][A-Za-z0-9_-]+/gu, "[REDACTED:LANGSMITH_API_KEY]");
 }
 
 function sanitizeHeaderValue(value: string, maxLength = 80): string {

--- a/src/credentials.tsx
+++ b/src/credentials.tsx
@@ -867,7 +867,7 @@ function getSelectedModelId(
   selectedIndex: number,
   input: string,
   isCustomInput: boolean,
-): string | "custom" | null {
+): string | null {
   if (!isCustomInput) {
     const selectedOption = getModelSelectionOptions(provider)[selectedIndex];
 

--- a/src/diagnostics.ts
+++ b/src/diagnostics.ts
@@ -1,0 +1,90 @@
+import {
+  ANTHROPIC_API_KEY_ENV_KEY,
+  BASETEN_API_KEY_ENV_KEY,
+  FIREWORKS_API_KEY_ENV_KEY,
+  OPENAI_API_KEY_ENV_KEY,
+  OPENROUTER_API_KEY_ENV_KEY,
+} from "./constants.js";
+
+/**
+ * Redacts secrets from text before it is shown to the user or written to a log.
+ *
+ * This is a security boundary: any error message, header value, or provider
+ * response body that could contain a credential must pass through here first.
+ * It removes (1) the exact values of secrets currently set in the environment
+ * and (2) anything matching known key/token shapes (OpenAI/OpenRouter `sk-…`,
+ * `Bearer …`, LangSmith `ls…`, and "Incorrect API key provided: …" phrasing).
+ */
+export function sanitizeDiagnosticText(value: string): string {
+  let sanitized = value;
+
+  for (const key of [
+    BASETEN_API_KEY_ENV_KEY,
+    FIREWORKS_API_KEY_ENV_KEY,
+    OPENAI_API_KEY_ENV_KEY,
+    ANTHROPIC_API_KEY_ENV_KEY,
+    OPENROUTER_API_KEY_ENV_KEY,
+    "LANGSMITH_API_KEY",
+  ]) {
+    const secret = process.env[key];
+
+    if (secret && secret.length > 0) {
+      sanitized = sanitized.split(secret).join(`[REDACTED:${key}]`);
+    }
+  }
+
+  return sanitized
+    .replace(
+      /(Incorrect API key provided:\s*)([^\s.]+)/giu,
+      "$1[REDACTED:API_KEY]",
+    )
+    .replace(/\bBearer\s+[A-Za-z0-9._~+/=-]+/gu, "Bearer [REDACTED]")
+    .replace(/\bsk-or-v1-[A-Za-z0-9_-]+/gu, "[REDACTED:OPENROUTER_API_KEY]")
+    .replace(/\bsk-[A-Za-z0-9_-]+/gu, "[REDACTED:API_KEY]")
+    .replace(/\bls[v_][A-Za-z0-9_-]+/gu, "[REDACTED:LANGSMITH_API_KEY]");
+}
+
+/**
+ * Recognizes an OpenRouter/provider 500 response so a friendlier, actionable
+ * message can be shown instead of a raw stack trace.
+ */
+export function isOpenRouterServerError(
+  error: unknown,
+  message: string,
+): boolean {
+  if (isRecord(error)) {
+    const status = error.statusCode ?? error.status;
+    const name = error instanceof Error ? error.name : null;
+
+    if (
+      (status === 500 || status === "500") &&
+      (name === "OpenRouterError" || "metadata" in error)
+    ) {
+      return true;
+    }
+  }
+
+  return /OpenRouterError/iu.test(String(error)) ||
+    /Internal Server Error/iu.test(message)
+    ? /\b500\b|Internal Server Error/iu.test(message)
+    : false;
+}
+
+/**
+ * Produces a user-facing error message: a friendly note for provider 500s,
+ * otherwise the error's own message with any secrets redacted.
+ */
+export function getErrorMessage(error: unknown): string {
+  const message =
+    error instanceof Error ? error.message : "OpenWiki agent run failed.";
+
+  if (isOpenRouterServerError(error, message)) {
+    return "OpenRouter/provider returned 500 Internal Server Error. Try retrying or switching models with /model. Run with OPENWIKI_DEBUG=1 to show provider metadata.";
+  }
+
+  return sanitizeDiagnosticText(message);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}

--- a/src/env.ts
+++ b/src/env.ts
@@ -15,6 +15,7 @@ import {
   OPENWIKI_MODEL_ID_ENV_KEY,
   OPENWIKI_PROVIDER_ENV_KEY,
 } from "./constants.js";
+import { isFileNotFoundError } from "./fs-errors.js";
 
 export const openWikiEnvDir = path.join(os.homedir(), ".openwiki");
 export const openWikiEnvPath = path.join(openWikiEnvDir, ".env");
@@ -33,7 +34,15 @@ export type CredentialDiagnostic = {
   warnings: string[];
 };
 
-const managedEnvKeys = [
+/**
+ * Every environment variable OpenWiki reads or persists, in the order they are
+ * written to `~/.openwiki/.env`. This is the single source of truth: the
+ * credential diagnostics list and the agent's debug-dump key list are both
+ * derived from it (see {@link CREDENTIAL_DIAGNOSTIC_ENV_KEYS} and
+ * {@link DEBUG_ENV_KEYS}), so they cannot silently drift out of sync when a new
+ * managed key is added.
+ */
+export const MANAGED_ENV_KEYS = [
   BASETEN_API_KEY_ENV_KEY,
   FIREWORKS_API_KEY_ENV_KEY,
   OPENAI_API_KEY_ENV_KEY,
@@ -47,7 +56,40 @@ const managedEnvKeys = [
   "LANGSMITH_API_KEY",
   "LANGCHAIN_PROJECT",
   "LANGCHAIN_TRACING_V2",
+] as const;
+
+// LangChain project/tracing settings are managed but are not credentials, so
+// they are excluded from the diagnostics panel.
+const NON_CREDENTIAL_ENV_KEYS = new Set<string>([
+  "LANGCHAIN_PROJECT",
+  "LANGCHAIN_TRACING_V2",
+]);
+
+/**
+ * Managed keys surfaced (in display order) in the credential diagnostics panel:
+ * the provider/model settings and every credential, but not the LangChain
+ * project/tracing settings. Derived from {@link MANAGED_ENV_KEYS} so a new
+ * credential key automatically appears in diagnostics.
+ */
+export const CREDENTIAL_DIAGNOSTIC_ENV_KEYS: readonly string[] = [
+  OPENWIKI_PROVIDER_ENV_KEY,
+  ...MANAGED_ENV_KEYS.filter(
+    (key) =>
+      key !== OPENWIKI_PROVIDER_ENV_KEY && !NON_CREDENTIAL_ENV_KEYS.has(key),
+  ),
 ];
+
+/**
+ * Keys dumped in the agent's environment debug line: every managed key plus the
+ * LangChain endpoint override that OpenWiki reads but never persists. Derived
+ * from {@link MANAGED_ENV_KEYS} so it cannot drift.
+ */
+export const DEBUG_ENV_KEYS: readonly string[] = [
+  ...MANAGED_ENV_KEYS,
+  "LANGCHAIN_ENDPOINT",
+];
+
+const managedEnvKeys: readonly string[] = MANAGED_ENV_KEYS;
 
 const deprecatedEnvKeys = [
   "OPENAI_BASE_URL",
@@ -76,19 +118,9 @@ export async function getCredentialDiagnostics(): Promise<
 > {
   const fileEnv = await readOpenWikiEnv();
 
-  return [
-    createCredentialDiagnostic(OPENWIKI_PROVIDER_ENV_KEY, fileEnv),
-    createCredentialDiagnostic(BASETEN_API_KEY_ENV_KEY, fileEnv),
-    createCredentialDiagnostic(FIREWORKS_API_KEY_ENV_KEY, fileEnv),
-    createCredentialDiagnostic(OPENAI_API_KEY_ENV_KEY, fileEnv),
-    createCredentialDiagnostic(OPENAI_COMPATIBLE_API_KEY_ENV_KEY, fileEnv),
-    createCredentialDiagnostic(OPENAI_COMPATIBLE_BASE_URL_ENV_KEY, fileEnv),
-    createCredentialDiagnostic(ANTHROPIC_API_KEY_ENV_KEY, fileEnv),
-    createCredentialDiagnostic(ANTHROPIC_BASE_URL_ENV_KEY, fileEnv),
-    createCredentialDiagnostic(OPENROUTER_API_KEY_ENV_KEY, fileEnv),
-    createCredentialDiagnostic(OPENWIKI_MODEL_ID_ENV_KEY, fileEnv),
-    createCredentialDiagnostic("LANGSMITH_API_KEY", fileEnv),
-  ];
+  return CREDENTIAL_DIAGNOSTIC_ENV_KEYS.map((key) =>
+    createCredentialDiagnostic(key, fileEnv),
+  );
 }
 
 export async function saveOpenWikiEnv(updates: EnvMap): Promise<void> {
@@ -232,7 +264,7 @@ async function readOpenWikiEnv(): Promise<EnvMap> {
   }
 }
 
-function parseEnv(content: string): EnvMap {
+export function parseEnv(content: string): EnvMap {
   const env: EnvMap = {};
 
   for (const rawLine of content.split(/\r?\n/u)) {
@@ -273,7 +305,7 @@ function parseEnvValue(value: string): string {
   return value;
 }
 
-function formatEnv(env: EnvMap): string {
+export function formatEnv(env: EnvMap): string {
   const keys = [
     ...managedEnvKeys.filter((key) => env[key] !== undefined),
     ...Object.keys(env)
@@ -289,12 +321,4 @@ function formatEnvValue(value: string): string {
     .replace(/\\/gu, "\\\\")
     .replace(/"/gu, '\\"')
     .replace(/\n/gu, "\\n")}"`;
-}
-
-function isFileNotFoundError(error: unknown): boolean {
-  return (
-    error instanceof Error &&
-    "code" in error &&
-    (error as NodeJS.ErrnoException).code === "ENOENT"
-  );
 }

--- a/src/fs-errors.ts
+++ b/src/fs-errors.ts
@@ -1,0 +1,34 @@
+/**
+ * Shared helpers for classifying Node.js filesystem errors.
+ *
+ * These were previously duplicated verbatim across several modules. Keeping a
+ * single source of truth avoids drift when the set of tolerated error codes
+ * changes.
+ */
+
+/**
+ * True when the error is a "file or directory does not exist" (ENOENT) error.
+ */
+export function isFileNotFoundError(error: unknown): boolean {
+  return (
+    error instanceof Error &&
+    "code" in error &&
+    (error as NodeJS.ErrnoException).code === "ENOENT"
+  );
+}
+
+/**
+ * True when the error is one that can normally occur if a file or directory
+ * changes shape while a directory tree is being scanned (removed, replaced by a
+ * directory, or replaced by a non-directory). Callers treat these as "skip this
+ * entry" rather than as fatal.
+ */
+export function isExpectedSnapshotRaceError(error: unknown): boolean {
+  if (!(error instanceof Error) || !("code" in error)) {
+    return false;
+  }
+
+  return ["EISDIR", "ENOENT", "ENOTDIR"].includes(
+    (error as NodeJS.ErrnoException).code ?? "",
+  );
+}

--- a/test/commands.test.ts
+++ b/test/commands.test.ts
@@ -1,0 +1,200 @@
+import { afterEach, beforeEach, describe, expect, test } from "vitest";
+import { parseCommand } from "../src/commands.ts";
+
+// parseCommand's --dry-run gate consults isDevelopmentMode(), which reads
+// NODE_ENV / OPENWIKI_DEV. Pin both to a non-development state per test and
+// restore afterward.
+const originalNodeEnv = process.env.NODE_ENV;
+const originalDevFlag = process.env.OPENWIKI_DEV;
+
+beforeEach(() => {
+  delete process.env.NODE_ENV;
+  delete process.env.OPENWIKI_DEV;
+});
+
+afterEach(() => {
+  if (originalNodeEnv === undefined) delete process.env.NODE_ENV;
+  else process.env.NODE_ENV = originalNodeEnv;
+  if (originalDevFlag === undefined) delete process.env.OPENWIKI_DEV;
+  else process.env.OPENWIKI_DEV = originalDevFlag;
+});
+
+describe("parseCommand — help", () => {
+  test("--help and -h return a help command", () => {
+    expect(parseCommand(["--help"])).toEqual({ kind: "help", exitCode: 0 });
+    expect(parseCommand(["-h"])).toEqual({ kind: "help", exitCode: 0 });
+  });
+
+  test("--help anywhere in argv wins", () => {
+    expect(parseCommand(["--init", "--help"]).kind).toBe("help");
+  });
+});
+
+describe("parseCommand — chat default", () => {
+  test("no args is an interactive chat that should not auto-start", () => {
+    const result = parseCommand([]);
+
+    expect(result).toMatchObject({
+      kind: "run",
+      command: "chat",
+      shouldStart: false,
+      userMessage: null,
+      print: false,
+      dryRun: false,
+      modelId: null,
+    });
+  });
+
+  test("a positional message becomes the user message and starts", () => {
+    const result = parseCommand(["Document", "the", "API"]);
+
+    expect(result).toMatchObject({
+      kind: "run",
+      command: "chat",
+      userMessage: "Document the API",
+      shouldStart: true,
+    });
+  });
+});
+
+describe("parseCommand — init/update", () => {
+  test("--init selects the init command and starts", () => {
+    expect(parseCommand(["--init"])).toMatchObject({
+      kind: "run",
+      command: "init",
+      shouldStart: true,
+    });
+  });
+
+  test("--update selects the update command and starts", () => {
+    expect(parseCommand(["--update"])).toMatchObject({
+      kind: "run",
+      command: "update",
+      shouldStart: true,
+    });
+  });
+
+  test("--init and --update together is an error", () => {
+    const result = parseCommand(["--init", "--update"]);
+
+    expect(result.kind).toBe("error");
+    if (result.kind === "error") {
+      expect(result.exitCode).toBe(1);
+      expect(result.message).toMatch(/cannot be used together/u);
+    }
+  });
+
+  test("repeating the same command flag is allowed", () => {
+    expect(parseCommand(["--init", "--init"]).kind).toBe("run");
+  });
+});
+
+describe("parseCommand — print", () => {
+  test("--print with a message runs and prints", () => {
+    expect(parseCommand(["-p", "hello"])).toMatchObject({
+      kind: "run",
+      print: true,
+      userMessage: "hello",
+      shouldStart: true,
+    });
+  });
+
+  test("--print with --init is valid", () => {
+    expect(parseCommand(["--print", "--init"])).toMatchObject({
+      kind: "run",
+      print: true,
+      command: "init",
+    });
+  });
+
+  test("--print with nothing to run is an error", () => {
+    const result = parseCommand(["-p"]);
+
+    expect(result.kind).toBe("error");
+    if (result.kind === "error") {
+      expect(result.message).toMatch(/requires a message/u);
+    }
+  });
+});
+
+describe("parseCommand — --modelId", () => {
+  test("space-separated valid model id", () => {
+    expect(parseCommand(["--modelId", "claude-opus-4-8"])).toMatchObject({
+      kind: "run",
+      modelId: "claude-opus-4-8",
+    });
+  });
+
+  test("--model-id alias works", () => {
+    expect(parseCommand(["--model-id", "gpt-5.5"])).toMatchObject({
+      modelId: "gpt-5.5",
+    });
+  });
+
+  test("equals form: --modelId=<id>", () => {
+    expect(parseCommand(["--modelId=z-ai/glm-5.2"])).toMatchObject({
+      modelId: "z-ai/glm-5.2",
+    });
+  });
+
+  test("missing value is an error", () => {
+    const result = parseCommand(["--modelId"]);
+
+    expect(result.kind).toBe("error");
+    if (result.kind === "error") {
+      expect(result.message).toMatch(/requires a model ID/u);
+    }
+  });
+
+  test("a following flag is treated as a missing value", () => {
+    const result = parseCommand(["--modelId", "--init"]);
+
+    expect(result.kind).toBe("error");
+    if (result.kind === "error") {
+      expect(result.message).toMatch(/requires a model ID/u);
+    }
+  });
+
+  test("invalid model id (contains ://) is an error", () => {
+    const result = parseCommand(["--modelId", "http://evil"]);
+
+    expect(result.kind).toBe("error");
+    if (result.kind === "error") {
+      expect(result.message).toMatch(/Invalid model ID/u);
+    }
+  });
+
+  test("invalid model id via equals form is an error", () => {
+    expect(parseCommand(["--modelId="]).kind).toBe("error");
+  });
+});
+
+describe("parseCommand — unknown options and dry-run gating", () => {
+  test("an unknown --flag is an error", () => {
+    const result = parseCommand(["--nope"]);
+
+    expect(result.kind).toBe("error");
+    if (result.kind === "error") {
+      expect(result.message).toMatch(/Unknown option/u);
+    }
+  });
+
+  test("--dry-run is rejected outside development mode", () => {
+    const result = parseCommand(["--dry-run"]);
+
+    expect(result.kind).toBe("error");
+    if (result.kind === "error") {
+      expect(result.message).toMatch(/Unknown option/u);
+    }
+  });
+
+  test("--dry-run is accepted in development mode", () => {
+    process.env.OPENWIKI_DEV = "1";
+
+    expect(parseCommand(["--dry-run", "--init"])).toMatchObject({
+      kind: "run",
+      dryRun: true,
+      command: "init",
+    });
+  });
+});

--- a/test/constants.test.ts
+++ b/test/constants.test.ts
@@ -1,0 +1,144 @@
+import { describe, expect, test } from "vitest";
+import {
+  DEFAULT_MODEL_ID,
+  DEFAULT_PROVIDER,
+  getDefaultModelId,
+  isValidBaseUrl,
+  isValidModelId,
+  isValidProvider,
+  normalizeModelId,
+  normalizeProvider,
+  resolveConfiguredProvider,
+  resolveProviderBaseUrl,
+} from "../src/constants.ts";
+
+describe("isValidModelId", () => {
+  test("accepts normal provider/model ids", () => {
+    expect(isValidModelId("claude-opus-4-8")).toBe(true);
+    expect(isValidModelId("z-ai/glm-5.2")).toBe(true);
+    expect(isValidModelId("accounts/fireworks/models/glm-5p2")).toBe(true);
+    expect(isValidModelId("gpt-5.4-mini")).toBe(true);
+  });
+
+  test("rejects empty, whitespace-only, and over-long ids", () => {
+    expect(isValidModelId("")).toBe(false);
+    expect(isValidModelId("   ")).toBe(false);
+    expect(isValidModelId("a".repeat(121))).toBe(false);
+    expect(isValidModelId("a".repeat(120))).toBe(true);
+  });
+
+  test("rejects ids containing a scheme (://)", () => {
+    expect(isValidModelId("http://evil.example/model")).toBe(false);
+  });
+
+  test("rejects ids starting with a non-alphanumeric character", () => {
+    expect(isValidModelId("-leading-dash")).toBe(false);
+    expect(isValidModelId("/leading-slash")).toBe(false);
+  });
+
+  test("normalizeModelId trims surrounding whitespace", () => {
+    expect(normalizeModelId("  claude-opus-4-8  ")).toBe("claude-opus-4-8");
+  });
+});
+
+describe("normalizeProvider / isValidProvider", () => {
+  test("normalizes case and whitespace to a known provider", () => {
+    expect(normalizeProvider("  Anthropic ")).toBe("anthropic");
+    expect(normalizeProvider("OPENROUTER")).toBe("openrouter");
+  });
+
+  test("returns null for unknown or nullish providers", () => {
+    expect(normalizeProvider("bogus")).toBeNull();
+    expect(normalizeProvider(null)).toBeNull();
+    expect(normalizeProvider(undefined)).toBeNull();
+  });
+
+  test("isValidProvider is a type guard over the known set", () => {
+    expect(isValidProvider("anthropic")).toBe(true);
+    expect(isValidProvider("openai-compatible")).toBe(true);
+    expect(isValidProvider("nope")).toBe(false);
+  });
+});
+
+describe("resolveConfiguredProvider", () => {
+  test("honors an explicit OPENWIKI_PROVIDER", () => {
+    expect(resolveConfiguredProvider({ OPENWIKI_PROVIDER: "anthropic" })).toBe(
+      "anthropic",
+    );
+  });
+
+  test("falls back to openrouter when only an OpenRouter key is present", () => {
+    expect(resolveConfiguredProvider({ OPENROUTER_API_KEY: "x" })).toBe(
+      "openrouter",
+    );
+  });
+
+  test("falls back to the default provider when nothing is configured", () => {
+    expect(resolveConfiguredProvider({})).toBe(DEFAULT_PROVIDER);
+  });
+
+  test("ignores an invalid OPENWIKI_PROVIDER value", () => {
+    expect(resolveConfiguredProvider({ OPENWIKI_PROVIDER: "bogus" })).toBe(
+      DEFAULT_PROVIDER,
+    );
+  });
+});
+
+describe("resolveProviderBaseUrl", () => {
+  test("returns the built-in default when no override is set", () => {
+    expect(resolveProviderBaseUrl("openrouter", {})).toBe(
+      "https://openrouter.ai/api/v1",
+    );
+  });
+
+  test("prefers a non-empty env override over the default", () => {
+    expect(
+      resolveProviderBaseUrl("anthropic", {
+        ANTHROPIC_BASE_URL: "https://gateway.example/anthropic",
+      }),
+    ).toBe("https://gateway.example/anthropic");
+  });
+
+  test("ignores a whitespace-only override", () => {
+    // anthropic has no built-in default, so a blank override resolves to undefined.
+    expect(
+      resolveProviderBaseUrl("anthropic", { ANTHROPIC_BASE_URL: "   " }),
+    ).toBeUndefined();
+  });
+
+  test("returns undefined for a provider with no default and no override", () => {
+    expect(resolveProviderBaseUrl("openai", {})).toBeUndefined();
+  });
+});
+
+describe("isValidBaseUrl", () => {
+  test("accepts http and https URLs", () => {
+    expect(isValidBaseUrl("https://api.example.com/v1")).toBe(true);
+    expect(isValidBaseUrl("http://localhost:8080")).toBe(true);
+  });
+
+  test("rejects blank, non-URL, and non-http(s) schemes", () => {
+    expect(isValidBaseUrl("")).toBe(false);
+    expect(isValidBaseUrl("   ")).toBe(false);
+    expect(isValidBaseUrl("not a url")).toBe(false);
+    expect(isValidBaseUrl("ftp://example.com")).toBe(false);
+  });
+});
+
+describe("getDefaultModelId", () => {
+  test("returns the first model option for a provider", () => {
+    expect(getDefaultModelId("anthropic")).toBe("claude-haiku-4-5");
+    expect(getDefaultModelId(DEFAULT_PROVIDER)).toBe(DEFAULT_MODEL_ID);
+  });
+
+  test(
+    "openai-compatible has no presets, so it falls back to the global " +
+      "DEFAULT_MODEL_ID (a known cross-provider quirk documented here)",
+    () => {
+      // This asserts CURRENT behavior: openai-compatible has an empty
+      // modelOptions list, so getDefaultModelId yields an OpenRouter id.
+      // If this ever changes intentionally, update this test.
+      expect(getDefaultModelId("openai-compatible")).toBe(DEFAULT_MODEL_ID);
+    },
+  );
+});

--- a/test/env.test.ts
+++ b/test/env.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, test } from "vitest";
+import { formatEnv, parseEnv } from "../src/env.ts";
+
+describe("parseEnv", () => {
+  test("parses simple KEY=value lines", () => {
+    expect(parseEnv("OPENWIKI_PROVIDER=anthropic\n")).toEqual({
+      OPENWIKI_PROVIDER: "anthropic",
+    });
+  });
+
+  test("skips blank lines and comments", () => {
+    const content = ["# a comment", "", "OPENAI_API_KEY=abc", "   "].join("\n");
+
+    expect(parseEnv(content)).toEqual({ OPENAI_API_KEY: "abc" });
+  });
+
+  test("ignores lines with no '=' or an empty key", () => {
+    expect(parseEnv("noequalshere\n=value\n")).toEqual({});
+  });
+
+  test("rejects keys that are not UPPER_SNAKE_CASE", () => {
+    expect(parseEnv("lowercase=x\nMixed_Case=y\nOK_KEY=z\n")).toEqual({
+      OK_KEY: "z",
+    });
+  });
+
+  test("unquotes and unescapes double-quoted values", () => {
+    expect(parseEnv('ANTHROPIC_BASE_URL="https://a.example/v1"\n')).toEqual({
+      ANTHROPIC_BASE_URL: "https://a.example/v1",
+    });
+    expect(parseEnv('OPENAI_API_KEY="line1\\nline2"\n')).toEqual({
+      OPENAI_API_KEY: "line1\nline2",
+    });
+    expect(parseEnv('OPENAI_API_KEY="a\\"b\\\\c"\n')).toEqual({
+      OPENAI_API_KEY: 'a"b\\c',
+    });
+  });
+
+  test("leaves unquoted values as-is", () => {
+    expect(parseEnv("OPENWIKI_MODEL_ID=gpt-5.5\n")).toEqual({
+      OPENWIKI_MODEL_ID: "gpt-5.5",
+    });
+  });
+});
+
+describe("formatEnv", () => {
+  test("quotes and escapes values, terminating with a newline", () => {
+    expect(formatEnv({ OPENAI_API_KEY: "abc" })).toBe('OPENAI_API_KEY="abc"\n');
+    expect(formatEnv({ OPENAI_API_KEY: 'a"b\\c\nd' })).toBe(
+      'OPENAI_API_KEY="a\\"b\\\\c\\nd"\n',
+    );
+  });
+
+  test("orders managed keys first, then unknown keys sorted alphabetically", () => {
+    const formatted = formatEnv({
+      ZZZ_CUSTOM: "z",
+      AAA_CUSTOM: "a",
+      OPENWIKI_PROVIDER: "anthropic",
+      ANTHROPIC_API_KEY: "k",
+    });
+    const keys = formatted
+      .trimEnd()
+      .split("\n")
+      .map((line) => line.slice(0, line.indexOf("=")));
+
+    // Managed keys keep their MANAGED_ENV_KEYS relative order (ANTHROPIC before
+    // PROVIDER), and the two unknown keys follow, sorted.
+    expect(keys).toEqual([
+      "ANTHROPIC_API_KEY",
+      "OPENWIKI_PROVIDER",
+      "AAA_CUSTOM",
+      "ZZZ_CUSTOM",
+    ]);
+  });
+});
+
+describe("parseEnv <-> formatEnv round-trip", () => {
+  test("values survive a format -> parse round-trip", () => {
+    const original = {
+      OPENAI_API_KEY: 'weird "value" with\nnewline and \\ backslash',
+      ANTHROPIC_BASE_URL: "https://gateway.example/anthropic",
+      OPENWIKI_MODEL_ID: "claude-opus-4-8",
+    };
+
+    expect(parseEnv(formatEnv(original))).toEqual(original);
+  });
+});

--- a/test/fs-errors.test.ts
+++ b/test/fs-errors.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, test } from "vitest";
+import {
+  isExpectedSnapshotRaceError,
+  isFileNotFoundError,
+} from "../src/fs-errors.ts";
+
+function errnoError(code: string): NodeJS.ErrnoException {
+  const error = new Error(code) as NodeJS.ErrnoException;
+  error.code = code;
+  return error;
+}
+
+describe("isFileNotFoundError", () => {
+  test("is true for an ENOENT error", () => {
+    expect(isFileNotFoundError(errnoError("ENOENT"))).toBe(true);
+  });
+
+  test("is false for other error codes", () => {
+    expect(isFileNotFoundError(errnoError("EACCES"))).toBe(false);
+    expect(isFileNotFoundError(errnoError("EISDIR"))).toBe(false);
+  });
+
+  test("is false for an Error with no code", () => {
+    expect(isFileNotFoundError(new Error("boom"))).toBe(false);
+  });
+
+  test("is false for non-error values", () => {
+    expect(isFileNotFoundError(null)).toBe(false);
+    expect(isFileNotFoundError("ENOENT")).toBe(false);
+    expect(isFileNotFoundError({ code: "ENOENT" })).toBe(false);
+  });
+});
+
+describe("isExpectedSnapshotRaceError", () => {
+  test("is true for the tolerated snapshot race codes", () => {
+    for (const code of ["EISDIR", "ENOENT", "ENOTDIR"]) {
+      expect(isExpectedSnapshotRaceError(errnoError(code))).toBe(true);
+    }
+  });
+
+  test("is false for unrelated error codes", () => {
+    expect(isExpectedSnapshotRaceError(errnoError("EACCES"))).toBe(false);
+  });
+
+  test("is false for an Error with no code", () => {
+    expect(isExpectedSnapshotRaceError(new Error("boom"))).toBe(false);
+  });
+
+  test("is false for non-error values", () => {
+    expect(isExpectedSnapshotRaceError(null)).toBe(false);
+    expect(isExpectedSnapshotRaceError({ code: "ENOENT" })).toBe(false);
+  });
+});

--- a/test/redaction.test.ts
+++ b/test/redaction.test.ts
@@ -1,0 +1,155 @@
+import { afterEach, beforeEach, describe, expect, test } from "vitest";
+import {
+  getErrorMessage,
+  isOpenRouterServerError,
+  sanitizeDiagnosticText,
+} from "../src/diagnostics.ts";
+import { sanitizeOpenRouterResponseBody } from "../src/agent/index.ts";
+
+describe("sanitizeDiagnosticText", () => {
+  const originalOpenAiKey = process.env.OPENAI_API_KEY;
+
+  beforeEach(() => {
+    delete process.env.OPENAI_API_KEY;
+  });
+
+  afterEach(() => {
+    if (originalOpenAiKey === undefined) {
+      delete process.env.OPENAI_API_KEY;
+    } else {
+      process.env.OPENAI_API_KEY = originalOpenAiKey;
+    }
+  });
+
+  test("redacts the exact value of a secret set in the environment", () => {
+    process.env.OPENAI_API_KEY = "super-secret-value-12345";
+
+    const result = sanitizeDiagnosticText(
+      "request failed with key super-secret-value-12345 attached",
+    );
+
+    expect(result).not.toContain("super-secret-value-12345");
+    expect(result).toContain("[REDACTED:OPENAI_API_KEY]");
+  });
+
+  test("redacts OpenAI-style sk- tokens", () => {
+    const result = sanitizeDiagnosticText("token sk-abcDEF123_456 rejected");
+
+    expect(result).not.toContain("sk-abcDEF123_456");
+    expect(result).toContain("[REDACTED:API_KEY]");
+  });
+
+  test("redacts OpenRouter sk-or-v1- tokens with the OpenRouter label", () => {
+    const result = sanitizeDiagnosticText("using sk-or-v1-deadbeef00 now");
+
+    expect(result).not.toContain("sk-or-v1-deadbeef00");
+    expect(result).toContain("[REDACTED:OPENROUTER_API_KEY]");
+  });
+
+  test("redacts Bearer tokens", () => {
+    const result = sanitizeDiagnosticText(
+      "Authorization: Bearer eyJhbGciOi.J9.abc-123",
+    );
+
+    expect(result).not.toContain("eyJhbGciOi.J9.abc-123");
+    expect(result).toContain("Bearer [REDACTED]");
+  });
+
+  test("redacts LangSmith ls_/lsv_ keys", () => {
+    const result = sanitizeDiagnosticText("langsmith lsv_1234abcd tracing");
+
+    expect(result).not.toContain("lsv_1234abcd");
+    expect(result).toContain("[REDACTED:LANGSMITH_API_KEY]");
+  });
+
+  test('redacts "Incorrect API key provided: …" phrasing', () => {
+    const result = sanitizeDiagnosticText(
+      "Incorrect API key provided: myLeakedKey. Check your account.",
+    );
+
+    expect(result).not.toContain("myLeakedKey");
+    expect(result).toContain("[REDACTED:API_KEY]");
+  });
+
+  test("leaves non-secret text untouched", () => {
+    const message = "Repository has 12 files and the wiki is already current.";
+
+    expect(sanitizeDiagnosticText(message)).toBe(message);
+  });
+});
+
+describe("isOpenRouterServerError", () => {
+  test("detects a 500 OpenRouterError object", () => {
+    const error = Object.assign(new Error("boom"), {
+      name: "OpenRouterError",
+      status: 500,
+    });
+
+    expect(isOpenRouterServerError(error, "boom")).toBe(true);
+  });
+
+  test("detects a provider 500 from the message text", () => {
+    expect(
+      isOpenRouterServerError(
+        new Error("OpenRouterError: 500 Internal Server Error"),
+        "OpenRouterError: 500 Internal Server Error",
+      ),
+    ).toBe(true);
+  });
+
+  test("is false for a normal error", () => {
+    expect(
+      isOpenRouterServerError(new Error("bad request"), "bad request"),
+    ).toBe(false);
+  });
+});
+
+describe("getErrorMessage", () => {
+  test("returns a friendly, actionable message for provider 500s", () => {
+    const error = Object.assign(new Error("500"), {
+      name: "OpenRouterError",
+      status: 500,
+    });
+
+    expect(getErrorMessage(error)).toMatch(/500 Internal Server Error/u);
+    expect(getErrorMessage(error)).toMatch(/\/model/u);
+  });
+
+  test("falls back to a generic message for non-Error values", () => {
+    expect(getErrorMessage("just a string")).toBe("OpenWiki agent run failed.");
+  });
+
+  test("redacts secrets in the underlying error message", () => {
+    expect(getErrorMessage(new Error("bad token sk-abcDEF123"))).toContain(
+      "[REDACTED:API_KEY]",
+    );
+  });
+});
+
+describe("sanitizeOpenRouterResponseBody", () => {
+  test("redacts secret-bearing JSON values while keeping the key name", () => {
+    const body = JSON.stringify({ api_key: "secret123", model: "glm-5.2" });
+    const result = sanitizeOpenRouterResponseBody(body);
+
+    expect(result).not.toContain("secret123");
+    expect(result).toContain('"api_key":"[REDACTED]"');
+    expect(result).toContain("glm-5.2");
+  });
+
+  test("redacts authorization and token fields", () => {
+    const body = JSON.stringify({
+      authorization: "Bearer abc",
+      token: "tok_123",
+    });
+    const result = sanitizeOpenRouterResponseBody(body);
+
+    expect(result).not.toContain("Bearer abc");
+    expect(result).not.toContain("tok_123");
+  });
+
+  test("leaves a body with no secret-shaped keys untouched", () => {
+    const body = JSON.stringify({ error: "rate limited", status: 429 });
+
+    expect(sanitizeOpenRouterResponseBody(body)).toBe(body);
+  });
+});

--- a/tsconfig.eslint.json
+++ b/tsconfig.eslint.json
@@ -1,0 +1,4 @@
+{
+  "extends": "./tsconfig.json",
+  "include": ["src/**/*.ts", "src/**/*.tsx", "test/**/*.ts", "test/**/*.tsx"]
+}


### PR DESCRIPTION
## Summary

Enforce and regression-proof the codebase's existing quality without changing agent or CLI behavior. Motivated by a review that found the source is well-disciplined (`strict` TS, no `any`/`@ts-ignore`/`!`) but the safety nets and test coverage are thin.

## Changes

**CI now verifies the code.** `checks.yml` previously ran only `format:check` and `lint:check`, so a PR could merge with a failing test suite or a broken compile. Added `build`+`typecheck` and `test` jobs on a **Node 20/22 matrix** (`engines` requires ≥20, but CI only tested 22). Added `typecheck` and `coverage` scripts.

**Tests: 6 → 80.** New suites for the untested, high-value surfaces:
- `parseCommand` — every flag, error path, and the dev-gated `--dry-run`
- `constants` validators/resolvers (`isValidModelId`, `normalizeProvider`, `resolveConfiguredProvider`, `resolveProviderBaseUrl`, `isValidBaseUrl`, `getDefaultModelId`)
- `.env` parse/format round-trip (quoting/escaping)
- shared fs-error helpers
- **security-critical secret redaction** (`sanitizeDiagnosticText`, `sanitizeOpenRouterResponseBody`, `getErrorMessage`)

Added `@vitest/coverage-v8`; bumped `vitest` to 4.1.10 to match.

**De-duplication.** Extracted `isFileNotFoundError` / `isExpectedSnapshotRaceError` into `src/fs-errors.ts` (were copied verbatim in 3 files); collapsed the 3 parallel env-key lists into one source of truth (`MANAGED_ENV_KEYS`) that derives the diagnostics and debug lists. Extracted the redaction helpers into `src/diagnostics.ts` so they're importable/testable without executing `cli.tsx`'s top-level render.

**Stricter lint.** ESLint → `recommendedTypeChecked`, now also lints `test/**` (via `tsconfig.eslint.json`). Fixed the findings it surfaced (a stray `async`, unsafe-`any` returns in the stream parser, a redundant union type). Deferred `noUncheckedIndexedAccess` — 17 errors concentrated in the untested `cli.tsx` monolith, out of proportion to this pass.

**Cleanups.** Removed a hard-coded personal path from `DEVELOPMENT.md`; added `coverage/` and `*.tgz` to `.gitignore`.

## Verification

- `pnpm run typecheck` / `build` / `lint:check` / `format:check` — all clean
- `pnpm test` — 80 passing (6 → 80)
- `pnpm run coverage` — new modules well covered (diagnostics 100%, fs-errors 100%, constants 92%, commands 80%)
- `OPENWIKI_DEV=1 openwiki --dry-run` — CLI behavior unchanged

No agent or CLI behavior was modified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)