### PR TITLE
feat: add LiteLLM as a supported provider

### DIFF
--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -24,6 +24,8 @@ import {
   getProviderBaseUrlEnvKey,
   getProviderLabel,
   isValidModelId,
+  LITELLM_API_KEY_ENV_KEY,
+  LITELLM_BASE_URL_ENV_KEY,
   normalizeModelId,
   OPENAI_API_KEY_ENV_KEY,
   OPENAI_COMPATIBLE_API_KEY_ENV_KEY,
@@ -1305,6 +1307,8 @@ function formatEnvironmentDebug(): string {
     OPENWIKI_PROVIDER_ENV_KEY,
     BASETEN_API_KEY_ENV_KEY,
     FIREWORKS_API_KEY_ENV_KEY,
+    LITELLM_API_KEY_ENV_KEY,
+    LITELLM_BASE_URL_ENV_KEY,
     OPENAI_API_KEY_ENV_KEY,
     OPENAI_COMPATIBLE_API_KEY_ENV_KEY,
     OPENAI_COMPATIBLE_BASE_URL_ENV_KEY,
@@ -1330,6 +1334,7 @@ function formatDebugValue(key: string, value: string | undefined): string {
   if (
     key === "LANGCHAIN_ENDPOINT" ||
     key === ANTHROPIC_BASE_URL_ENV_KEY ||
+    key === LITELLM_BASE_URL_ENV_KEY ||
     key === OPENAI_COMPATIBLE_BASE_URL_ENV_KEY
   ) {
     return formatUrlDebugValue(value);

--- a/src/cli.tsx
+++ b/src/cli.tsx
@@ -31,6 +31,7 @@ import {
   FIREWORKS_API_KEY_ENV_KEY,
   getDefaultModelId,
   getProviderApiKeyEnvKey,
+  LITELLM_API_KEY_ENV_KEY,
   getProviderLabel,
   getProviderModelOptions,
   isValidModelId,
@@ -1507,7 +1508,7 @@ function ChatInput({
 
     if (provider === null) {
       setError(
-        "Enter a valid provider: openrouter, baseten, fireworks, openai, or anthropic.",
+        "Enter a valid provider: openrouter, baseten, fireworks, litellm, openai, openai-compatible, or anthropic.",
       );
       return;
     }
@@ -2923,6 +2924,7 @@ function sanitizeDiagnosticText(value: string): string {
   for (const key of [
     BASETEN_API_KEY_ENV_KEY,
     FIREWORKS_API_KEY_ENV_KEY,
+    LITELLM_API_KEY_ENV_KEY,
     OPENAI_API_KEY_ENV_KEY,
     ANTHROPIC_API_KEY_ENV_KEY,
     OPENROUTER_API_KEY_ENV_KEY,

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -2,6 +2,8 @@ export const OPEN_WIKI_DIR = "openwiki";
 export const UPDATE_METADATA_PATH = `${OPEN_WIKI_DIR}/.last-update.json`;
 export const BASETEN_API_KEY_ENV_KEY = "BASETEN_API_KEY";
 export const FIREWORKS_API_KEY_ENV_KEY = "FIREWORKS_API_KEY";
+export const LITELLM_API_KEY_ENV_KEY = "LITELLM_API_KEY";
+export const LITELLM_BASE_URL_ENV_KEY = "LITELLM_BASE_URL";
 export const OPENAI_API_KEY_ENV_KEY = "OPENAI_API_KEY";
 export const OPENAI_COMPATIBLE_API_KEY_ENV_KEY = "OPENAI_COMPATIBLE_API_KEY";
 export const OPENAI_COMPATIBLE_BASE_URL_ENV_KEY = "OPENAI_COMPATIBLE_BASE_URL";
@@ -17,6 +19,7 @@ export type OpenWikiProvider =
   | "anthropic"
   | "baseten"
   | "fireworks"
+  | "litellm"
   | "openai"
   | "openai-compatible"
   | "openrouter";
@@ -49,6 +52,7 @@ export const SELECTABLE_OPENWIKI_PROVIDERS = [
   "openrouter",
   "baseten",
   "fireworks",
+  "litellm",
   "openai",
   "openai-compatible",
   "anthropic",
@@ -83,6 +87,13 @@ export const PROVIDER_CONFIGS: Record<OpenWikiProvider, ProviderConfig> = {
       { id: "gpt-5.4-mini", label: "5.4 mini" },
       { id: "gpt-5.5", label: "5.5" },
     ],
+  },
+  litellm: {
+    apiKeyEnvKey: LITELLM_API_KEY_ENV_KEY,
+    baseUrlEnvKey: LITELLM_BASE_URL_ENV_KEY,
+    requiresBaseUrl: true,
+    label: "LiteLLM",
+    modelOptions: [],
   },
   "openai-compatible": {
     apiKeyEnvKey: OPENAI_COMPATIBLE_API_KEY_ENV_KEY,

--- a/src/credentials.tsx
+++ b/src/credentials.tsx
@@ -915,7 +915,11 @@ function moveSelectionIndex(
 }
 
 function getProviderArticle(provider: OpenWikiProvider): "a" | "an" {
-  return provider === "baseten" || provider === "fireworks" ? "a" : "an";
+  return provider === "baseten" ||
+    provider === "fireworks" ||
+    provider === "litellm"
+    ? "a"
+    : "an";
 }
 
 function sanitizeInputChunk(value: string): string {

--- a/src/env.ts
+++ b/src/env.ts
@@ -7,6 +7,8 @@ import {
   BASETEN_API_KEY_ENV_KEY,
   FIREWORKS_API_KEY_ENV_KEY,
   isValidModelId,
+  LITELLM_API_KEY_ENV_KEY,
+  LITELLM_BASE_URL_ENV_KEY,
   normalizeProvider,
   OPENAI_API_KEY_ENV_KEY,
   OPENAI_COMPATIBLE_API_KEY_ENV_KEY,
@@ -36,6 +38,8 @@ export type CredentialDiagnostic = {
 const managedEnvKeys = [
   BASETEN_API_KEY_ENV_KEY,
   FIREWORKS_API_KEY_ENV_KEY,
+  LITELLM_API_KEY_ENV_KEY,
+  LITELLM_BASE_URL_ENV_KEY,
   OPENAI_API_KEY_ENV_KEY,
   OPENAI_COMPATIBLE_API_KEY_ENV_KEY,
   OPENAI_COMPATIBLE_BASE_URL_ENV_KEY,
@@ -80,6 +84,8 @@ export async function getCredentialDiagnostics(): Promise<
     createCredentialDiagnostic(OPENWIKI_PROVIDER_ENV_KEY, fileEnv),
     createCredentialDiagnostic(BASETEN_API_KEY_ENV_KEY, fileEnv),
     createCredentialDiagnostic(FIREWORKS_API_KEY_ENV_KEY, fileEnv),
+    createCredentialDiagnostic(LITELLM_API_KEY_ENV_KEY, fileEnv),
+    createCredentialDiagnostic(LITELLM_BASE_URL_ENV_KEY, fileEnv),
     createCredentialDiagnostic(OPENAI_API_KEY_ENV_KEY, fileEnv),
     createCredentialDiagnostic(OPENAI_COMPATIBLE_API_KEY_ENV_KEY, fileEnv),
     createCredentialDiagnostic(OPENAI_COMPATIBLE_BASE_URL_ENV_KEY, fileEnv),
@@ -178,6 +184,7 @@ function isNonSecretDiagnosticKey(key: string): boolean {
     key === OPENWIKI_MODEL_ID_ENV_KEY ||
     key === OPENWIKI_PROVIDER_ENV_KEY ||
     key === ANTHROPIC_BASE_URL_ENV_KEY ||
+    key === LITELLM_BASE_URL_ENV_KEY ||
     key === OPENAI_COMPATIBLE_BASE_URL_ENV_KEY
   );
 }


### PR DESCRIPTION
## Summary

- Adds **LiteLLM** as a first-class provider alongside OpenRouter, Anthropic, OpenAI, Baseten, Fireworks, and OpenAI-compatible
- LiteLLM exposes an OpenAI-compatible proxy API, so it reuses the existing `ChatOpenAI` code path with a user-supplied `baseURL` — **no new dependency required**
- `requiresBaseUrl: true` ensures the credential wizard prompts for `LITELLM_BASE_URL`

## Changes

| File | Change |
|------|--------|
| `src/constants.ts` | `LITELLM_API_KEY_ENV_KEY` / `LITELLM_BASE_URL_ENV_KEY` constants; `"litellm"` added to `OpenWikiProvider` union, `SELECTABLE_OPENWIKI_PROVIDERS`, and `PROVIDER_CONFIGS` |
| `src/env.ts` | LiteLLM keys added to `managedEnvKeys`, `getCredentialDiagnostics`, and `isNonSecretDiagnosticKey` (URL shown unmasked) |
| `src/agent/index.ts` | LiteLLM keys included in `formatEnvironmentDebug` / `formatDebugValue` with URL formatting |
| `src/credentials.tsx` | `getProviderArticle` returns `"a"` for `"litellm"` |
| `src/cli.tsx` | `LITELLM_API_KEY_ENV_KEY` added to `sanitizeDiagnosticText` redaction list; `"litellm"` added to the provider validation error message |

## Motivation

LiteLLM is a widely-used unified LLM proxy that supports 100+ models (AWS Bedrock, Azure, Vertex AI, Ollama, etc.) through a single OpenAI-compatible interface. Adding it as a provider allows OpenWiki users to route through any model supported by LiteLLM without needing separate provider integrations.