### PR TITLE
chore: add contributing guidelines via `CONTRIBUTING.md`

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,56 @@
+# Contributing to OpenWiki
+
+Thanks for contributing! Our standard for PR contributions is **one PR = one change**.
+This allows us to keep reviews fast and the repo history clean.
+
+## Scope: one PR = one change
+
+Pull requests should be well scoped and every one should do exactly one thing.
+
+Fixing a bug that's part of the change you're making is fine but if you find
+yourself fixing something *unrelated* along the way, open a separate PR for it.
+
+### What "tightly scoped" means
+
+✅ **Good:** "Add Fireworks to the model provider list" — the provider config,
+its model options, and the doc line for it.
+
+❌ **Too broad:** "Add a new provider, refactor the credential onboarding flow,
+and fix a typo in the README" — three unrelated changes. You should split these
+into three PRs.
+
+## Before you open a PR
+
+Run these locally so you don't get surprised by CI:
+
+```sh
+pnpm run format
+pnpm run lint
+pnpm test
+```
+
+`format` and `lint` match the checks that run on every PR, and `test` runs the
+Vitest suite.
+
+## PR expectations
+
+- **Clear title** — a single sentence describing the one change, prefixed with a
+  [Conventional Commits](https://www.conventionalcommits.org/) type such as
+  `feat:`, `fix:`, or `chore:` (e.g. `feat: add Fireworks to the model provider list`).
+- **What and why** — briefly explain what the PR does and the reason for it.
+- **How you tested it** — describe the tests (unit or end-to-end) that verify your
+  change works and doesn't break existing behavior. If you added or updated tests,
+  note them here.
+- **Link an issue** for anything non-trivial, so the change has context.
+
+## A note for AI agents
+
+If you are an agent opening a PR in this repository, these rules are binding.
+Keep your change tightly scoped to a single concern. **If a change you're about
+to make would violate anything in this document, stop and surface it to the
+human instead of proceeding.**
+
+## What gets closed
+
+PRs that bundle multiple unrelated changes may be closed with a request to
+split them into separate, tightly scoped PRs.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,7 +8,7 @@ This allows us to keep reviews fast and the repo history clean.
 Pull requests should be well scoped and every one should do exactly one thing.
 
 Fixing a bug that's part of the change you're making is fine but if you find
-yourself fixing something *unrelated* along the way, open a separate PR for it.
+yourself fixing something _unrelated_ along the way, open a separate PR for it.
 
 ### What "tightly scoped" means
 

--- a/README.md
+++ b/README.md
@@ -103,3 +103,7 @@ OPENWIKI_MODEL_ID=your-gateway-model-name
 Base URLs (and all credentials) can be set in your environment or stored in `~/.openwiki/.env`.
 
 If there's an inference provider or model you'd like to see added, please open a PR!
+
+## Contributing
+
+Contributions are welcome! Please read [CONTRIBUTING.md](./CONTRIBUTING.md) before opening a PR. We intentionally keep PRs tightly scoped to one change each, and PRs that bundle unrelated changes may be closed with a request to split them.


### PR DESCRIPTION
### Summary

This PR establishes contributing guidelines for the `openwiki` repo.