### PR TITLE
fix: html tokens have incomplete multi-character sanitization

### DIFF
--- a/src/cli.tsx
+++ b/src/cli.tsx
@@ -22,6 +22,7 @@ import {
 } from "./env.js";
 import { createOpenWikiThreadId, runOpenWikiAgent } from "./agent/index.js";
 import { getErrorMessage, sanitizeDiagnosticText } from "./diagnostics.js";
+import { stripHtmlTags } from "./utils.js";
 import {
   type OpenWikiRunEvent,
   type OpenWikiRunResult,
@@ -1172,7 +1173,7 @@ function renderHtmlToken(token: Token): React.ReactNode {
     return <Text underline>{underlineMatch[1]}</Text>;
   }
 
-  return text.replace(/<[^>]*>/gu, "");
+  return stripHtmlTags(text);
 }
 
 function ChatHistory({ runs }: { runs: CompletedRun[] }) {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,11 +1,18 @@
 /**
  * Removes HTML tags from a string and returns the remaining plain text.
  *
- * Strips both complete tags (e.g. `<div>`, `</u>`) and a trailing unterminated
- * tag start (e.g. `<script` with no closing `>`).
+ * Applies the tag-removal replacement repeatedly until the string stops
+ * changing, so removing one tag cannot reveal another that a single pass would
+ * miss.
  */
 export function stripHtmlTags(input: string): string {
-  return input
-    .replace(/<[^>]*>/gu, "") // complete tags: <div>, </u>, <br/>, ...
-    .replace(/<[^>]*$/u, ""); // unterminated trailing tag start: "<script"
+  let previous: string;
+  let output = input;
+
+  do {
+    previous = output;
+    output = output.replace(/<[^>]*>/gu, "");
+  } while (output !== previous);
+
+  return output;
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,0 +1,11 @@
+/**
+ * Removes HTML tags from a string and returns the remaining plain text.
+ *
+ * Strips both complete tags (e.g. `<div>`, `</u>`) and a trailing unterminated
+ * tag start (e.g. `<script` with no closing `>`).
+ */
+export function stripHtmlTags(input: string): string {
+  return input
+    .replace(/<[^>]*>/gu, "") // complete tags: <div>, </u>, <br/>, ...
+    .replace(/<[^>]*$/u, ""); // unterminated trailing tag start: "<script"
+}

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,9 +1,9 @@
 /**
  * Removes HTML tags from a string and returns the remaining plain text.
  *
- * Applies the tag-removal replacement repeatedly until the string stops
- * changing, so removing one tag cannot reveal another that a single pass would
- * miss.
+ * Well-formed tags are removed by stripping `<...>` spans repeatedly until the
+ * string stops changing. Any leftover angle brackets are then removed individually,
+ * so neither a complete nor a partial tag can survive.
  */
 export function stripHtmlTags(input: string): string {
   let previous: string;
@@ -14,5 +14,5 @@ export function stripHtmlTags(input: string): string {
     output = output.replace(/<[^>]*>/gu, "");
   } while (output !== previous);
 
-  return output;
+  return output.replace(/[<>]/gu, "");
 }

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -11,16 +11,18 @@ describe("stripHtmlTags", () => {
     expect(stripHtmlTags("a<br/>b<hr>c")).toBe("abc");
   });
 
-  test("removes an unterminated trailing tag start", () => {
-    // The reported gap: a single-pass /<[^>]*>/ leaves "<script" (no closing >).
-    expect(stripHtmlTags("text <script")).toBe("text ");
-    expect(stripHtmlTags("<script")).toBe("");
-    expect(stripHtmlTags("ok <div class=")).toBe("ok ");
+  test("removes HTML comments", () => {
+    expect(stripHtmlTags("before<!-- secret -->after")).toBe("beforeafter");
   });
 
-  test("does not reintroduce a tag from surrounding text", () => {
+  test("does not leave a tag reassembled from surrounding brackets", () => {
     expect(stripHtmlTags("<scr<script>ipt>")).not.toContain("<script");
     expect(stripHtmlTags("<<script>>")).not.toContain("<script");
+  });
+
+  test("leaves an unterminated tag fragment as literal text", () => {
+    // No closing ">", so it isn't a tag; harmless as terminal text.
+    expect(stripHtmlTags("text <script")).toBe("text <script");
   });
 
   test("leaves plain text untouched", () => {

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, test } from "vitest";
+import { stripHtmlTags } from "../src/utils.ts";
+
+describe("stripHtmlTags", () => {
+  test("removes a complete tag pair", () => {
+    expect(stripHtmlTags("<div>hello</div>")).toBe("hello");
+  });
+
+  test("removes adjacent and nested tags", () => {
+    expect(stripHtmlTags("<b><i>hi</i></b>")).toBe("hi");
+    expect(stripHtmlTags("a<br/>b<hr>c")).toBe("abc");
+  });
+
+  test("removes an unterminated trailing tag start", () => {
+    // The reported gap: a single-pass /<[^>]*>/ leaves "<script" (no closing >).
+    expect(stripHtmlTags("text <script")).toBe("text ");
+    expect(stripHtmlTags("<script")).toBe("");
+    expect(stripHtmlTags("ok <div class=")).toBe("ok ");
+  });
+
+  test("does not reintroduce a tag from surrounding text", () => {
+    expect(stripHtmlTags("<scr<script>ipt>")).not.toContain("<script");
+    expect(stripHtmlTags("<<script>>")).not.toContain("<script");
+  });
+
+  test("leaves plain text untouched", () => {
+    expect(stripHtmlTags("just plain text")).toBe("just plain text");
+    expect(stripHtmlTags("")).toBe("");
+  });
+});

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -15,14 +15,23 @@ describe("stripHtmlTags", () => {
     expect(stripHtmlTags("before<!-- secret -->after")).toBe("beforeafter");
   });
 
-  test("does not leave a tag reassembled from surrounding brackets", () => {
-    expect(stripHtmlTags("<scr<script>ipt>")).not.toContain("<script");
-    expect(stripHtmlTags("<<script>>")).not.toContain("<script");
+  test("strips an unterminated tag fragment, leaving no angle brackets", () => {
+    expect(stripHtmlTags("text <script")).toBe("text script");
+    expect(stripHtmlTags("<script")).toBe("script");
   });
 
-  test("leaves an unterminated tag fragment as literal text", () => {
-    // No closing ">", so it isn't a tag; harmless as terminal text.
-    expect(stripHtmlTags("text <script")).toBe("text <script");
+  test("never leaves an angle bracket in the output", () => {
+    for (const input of [
+      "<div>hi</div>",
+      "text <script",
+      "<scr<script>ipt>",
+      "<<script>>",
+      "a < b > c",
+    ]) {
+      const output = stripHtmlTags(input);
+      expect(output).not.toContain("<");
+      expect(output).not.toContain(">");
+    }
   });
 
   test("leaves plain text untouched", () => {


### PR DESCRIPTION
### Summary

Fixes a CodeQL high-sev alert (`js/incomplete-multi-character-sanitization`) in the markdown renderer. `renderHtmlToken` was stripping HTML tags with a single-pass regex is flagged as being unreliable. Specifically,

```
Incomplete multi-character sanitization
This string may still contain <script, which may cause an HTML element injection vulnerability.
```

Since this only renders tokens to plain text in the terminal there's no HTML/DOM sink and so there is no real XSS path. As a result, I kept it dependency-free for now and used CodeQL's recommended fixpoint-loop approach instead of pulling in a sanitizer library. Recommended from CodeQL:
```ts
Consider the following JavaScript code that aims to remove all HTML comment start and end tags:

str.replace(/<!--|--!?>/g, "");   
Given the input string "<!<!--- comment --->>", the output will be "<!-- comment -->", which still contains an HTML comment.

One possible fix for this issue is to apply the regular expression replacement repeatedly until no more replacements can be performed. This ensures that the unsafe text does not re-appear in the sanitized input, effectively removing all instances of the targeted pattern:

function removeHtmlComments(input) {  
  let previous;  
  do {  
    previous = input;  
    input = input.replace(/<!--|--!?>/g, "");  
  } while (input !== previous);  
  return input;  
}  
```

I moved the logic into a small `stripHtmlTags` helper in src/utils.ts so it's testable on its own.

### Tests

Added `test/utils.test.ts` covering complete, nested, and adjacent tags plus HTML comments. Tests also assert that no angle bracket ever survives, so a fragment like `<script` can't slip through.
