### PR TITLE
fix: report tool-error runs as failed

### DIFF
--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -233,12 +233,17 @@ async function runOpenWikiAgentCore(
   });
   emitDebug(options, "stream=started modes=messages,tools subgraphs=true");
 
+  let hadToolError = false;
   let unhandledChunkCount = 0;
 
   for await (const chunk of stream) {
     const event = parseStreamEvent(chunk);
 
     if (event) {
+      if (event.type === "tool_end" && event.status === "error") {
+        hadToolError = true;
+      }
+
       options.onEvent?.(event);
     } else if (options.debug && unhandledChunkCount < 3) {
       emitDebug(
@@ -253,6 +258,7 @@ async function runOpenWikiAgentCore(
 
   if (
     command !== "chat" &&
+    !hadToolError &&
     openWikiSnapshotBefore !== (await createOpenWikiContentSnapshot(cwd))
   ) {
     await writeLastUpdateMetadata(command, cwd, modelId);
@@ -262,12 +268,15 @@ async function runOpenWikiAgentCore(
       options,
       command === "chat"
         ? "metadata=skipped command=chat"
-        : "metadata=skipped openwiki=unchanged",
+        : hadToolError
+          ? "metadata=skipped tool_error=true"
+          : "metadata=skipped openwiki=unchanged",
     );
   }
 
   return {
     command,
+    ...(hadToolError ? { hadToolError } : {}),
     model: modelId,
   };
 }

--- a/src/agent/result.ts
+++ b/src/agent/result.ts
@@ -1,0 +1,5 @@
+import type { OpenWikiRunResult } from "./types.js";
+
+export function getRunExitCode(result: OpenWikiRunResult): 0 | 1 {
+  return result.hadToolError ? 1 : 0;
+}

--- a/src/agent/types.ts
+++ b/src/agent/types.ts
@@ -2,6 +2,7 @@ export type OpenWikiCommand = "chat" | "init" | "update";
 
 export type OpenWikiRunResult = {
   command: OpenWikiCommand;
+  hadToolError?: boolean;
   model: string;
   skipped?: boolean;
 };

--- a/src/cli.tsx
+++ b/src/cli.tsx
@@ -21,6 +21,7 @@ import {
   type CredentialDiagnostic,
 } from "./env.js";
 import { createOpenWikiThreadId, runOpenWikiAgent } from "./agent/index.js";
+import { getRunExitCode } from "./agent/result.js";
 import { getErrorMessage, sanitizeDiagnosticText } from "./diagnostics.js";
 import {
   type OpenWikiRunEvent,
@@ -380,7 +381,7 @@ function App({ command }: AppProps) {
     }
 
     if (runState.status === "success" && autoExitOnSuccess) {
-      process.exitCode = 0;
+      process.exitCode = getRunExitCode(runState.result);
       app.exit();
     }
   }, [app, autoExitOnSuccess, runState.status]);
@@ -3008,7 +3009,7 @@ async function runPrintCommand(
   try {
     const output: string[] = [];
 
-    await runOpenWikiAgent(command.command, process.cwd(), {
+    const result = await runOpenWikiAgent(command.command, process.cwd(), {
       debug: isDebugMode(),
       isFollowup: command.command === "chat",
       modelId: command.modelId,
@@ -3027,7 +3028,7 @@ async function runPrintCommand(
       process.stdout.write(`${text}\n`);
     }
 
-    process.exitCode = 0;
+    process.exitCode = getRunExitCode(result);
   } catch (error) {
     process.stderr.write(`${getErrorMessage(error)}\n`);
     writePrintErrorDiagnostics(error);

--- a/test/agent-tool-error-result.test.ts
+++ b/test/agent-tool-error-result.test.ts
@@ -1,0 +1,222 @@
+import { execFile } from "node:child_process";
+import { mkdtemp, mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { promisify } from "node:util";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import {
+  OPENROUTER_API_KEY_ENV_KEY,
+  OPENWIKI_MODEL_ID_ENV_KEY,
+  OPENWIKI_PROVIDER_ENV_KEY,
+  UPDATE_METADATA_PATH,
+} from "../src/constants.ts";
+import type { OpenWikiRunEvent } from "../src/agent/types.ts";
+
+const execFileAsync = promisify(execFile);
+const envKeys = [
+  "HOME",
+  OPENROUTER_API_KEY_ENV_KEY,
+  OPENWIKI_MODEL_ID_ENV_KEY,
+  OPENWIKI_PROVIDER_ENV_KEY,
+] as const;
+const originalEnv = new Map(
+  envKeys.map((key) => [key, process.env[key]] as const),
+);
+
+let activeRepo: string | null = null;
+let streamScenario: "success" | "tool-error" = "success";
+let tempRoots: string[] = [];
+
+beforeEach(() => {
+  vi.resetModules();
+  restoreEnv();
+  activeRepo = null;
+  streamScenario = "success";
+  tempRoots = [];
+});
+
+afterEach(async () => {
+  vi.resetModules();
+  vi.restoreAllMocks();
+  restoreEnv();
+
+  await Promise.all(
+    tempRoots.map((tempRoot) => rm(tempRoot, { force: true, recursive: true })),
+  );
+});
+
+describe("runOpenWikiAgent tool-error result tracking", () => {
+  test("records tool-error stream events and skips successful-update metadata", async () => {
+    const { repo, home } = await createTestContext();
+    const { runOpenWikiAgent } = await importAgentWithMockedDependencies(home);
+    const events: OpenWikiRunEvent[] = [];
+
+    activeRepo = repo;
+    streamScenario = "tool-error";
+
+    const result = await runOpenWikiAgent("init", repo, {
+      onEvent: (event) => events.push(event),
+    });
+
+    expect(result).toMatchObject({
+      command: "init",
+      model: "z-ai/glm-5.2",
+      hadToolError: true,
+    });
+    expect(events).toEqual([
+      expect.objectContaining({
+        type: "tool_start",
+        id: "tool-1",
+        name: "write_file",
+      }),
+      expect.objectContaining({
+        type: "tool_end",
+        id: "tool-1",
+        name: "write_file",
+        status: "error",
+      }),
+    ]);
+    await expect(
+      readFile(path.join(repo, UPDATE_METADATA_PATH), "utf8"),
+    ).rejects.toMatchObject({ code: "ENOENT" });
+  });
+
+  test("leaves clean runs unflagged and records update metadata", async () => {
+    const { repo, home } = await createTestContext();
+    const { runOpenWikiAgent } = await importAgentWithMockedDependencies(home);
+
+    activeRepo = repo;
+    streamScenario = "success";
+
+    const result = await runOpenWikiAgent("init", repo);
+
+    expect(result).toEqual({
+      command: "init",
+      model: "z-ai/glm-5.2",
+    });
+
+    const metadata = JSON.parse(
+      await readFile(path.join(repo, UPDATE_METADATA_PATH), "utf8"),
+    ) as Record<string, unknown>;
+    expect(metadata.command).toBe("init");
+    expect(metadata.model).toBe("z-ai/glm-5.2");
+  });
+});
+
+async function importAgentWithMockedDependencies(
+  home: string,
+): Promise<typeof import("../src/agent/index.ts")> {
+  installDependencyMocks();
+  process.env.HOME = home;
+  process.env[OPENROUTER_API_KEY_ENV_KEY] = "test-openrouter-key";
+  process.env[OPENWIKI_MODEL_ID_ENV_KEY] = "z-ai/glm-5.2";
+  process.env[OPENWIKI_PROVIDER_ENV_KEY] = "openrouter";
+
+  return import("../src/agent/index.ts");
+}
+
+function installDependencyMocks(): void {
+  vi.doMock("@langchain/anthropic", () => ({
+    ChatAnthropic: class ChatAnthropic {},
+  }));
+  vi.doMock("@langchain/openai", () => ({
+    ChatOpenAI: class ChatOpenAI {},
+  }));
+  vi.doMock("@langchain/openrouter", () => ({
+    ChatOpenRouter: class ChatOpenRouter {},
+  }));
+  vi.doMock("@langchain/langgraph-checkpoint-sqlite", () => ({
+    SqliteSaver: {
+      fromConnString: () => ({}),
+    },
+  }));
+  vi.doMock("deepagents", () => ({
+    LocalShellBackend: class LocalShellBackend {
+      readonly options: unknown;
+
+      constructor(options: unknown) {
+        this.options = options;
+      }
+    },
+    createDeepAgent: () => ({
+      stream: () => createMockStream(),
+    }),
+  }));
+}
+
+async function* createMockStream(): AsyncGenerator<unknown> {
+  if (!activeRepo) {
+    throw new Error("Test stream missing active repo.");
+  }
+
+  await writeFile(
+    path.join(activeRepo, "openwiki", "quickstart.md"),
+    streamScenario === "tool-error"
+      ? "# Quickstart\nPartial update\n"
+      : "# Quickstart\nSuccessful update\n",
+    "utf8",
+  );
+
+  yield [
+    "tools",
+    {
+      event: "on_tool_start",
+      input: { file_path: "/openwiki/quickstart.md" },
+      name: "write_file",
+      toolCallId: "tool-1",
+    },
+  ];
+  yield [
+    "tools",
+    {
+      event: streamScenario === "tool-error" ? "on_tool_error" : "on_tool_end",
+      input: { file_path: "/openwiki/quickstart.md" },
+      name: "write_file",
+      toolCallId: "tool-1",
+    },
+  ];
+}
+
+async function createTestContext(): Promise<{ home: string; repo: string }> {
+  const root = await mkdtemp(path.join(tmpdir(), "openwiki-tool-error-"));
+  const home = path.join(root, "home");
+  const repo = path.join(root, "repo");
+
+  tempRoots.push(root);
+  await mkdir(home, { recursive: true });
+  await mkdir(repo, { recursive: true });
+  await createRepoWithOpenWiki(repo);
+
+  return { home, repo };
+}
+
+async function createRepoWithOpenWiki(repo: string): Promise<void> {
+  await git(repo, ["init"]);
+  await git(repo, ["config", "user.email", "test@example.com"]);
+  await git(repo, ["config", "user.name", "OpenWiki Test"]);
+  await writeFile(path.join(repo, "README.md"), "# Test Repo\n", "utf8");
+  await mkdir(path.join(repo, "openwiki"));
+  await writeFile(
+    path.join(repo, "openwiki", "quickstart.md"),
+    "# Quickstart\n",
+    "utf8",
+  );
+  await git(repo, ["add", "."]);
+  await git(repo, ["commit", "-m", "initial"]);
+}
+
+async function git(cwd: string, args: string[]): Promise<void> {
+  await execFileAsync("git", args, { cwd });
+}
+
+function restoreEnv(): void {
+  for (const key of envKeys) {
+    const value = originalEnv.get(key);
+
+    if (value === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = value;
+    }
+  }
+}

--- a/test/run-result.test.ts
+++ b/test/run-result.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, test } from "vitest";
+import { getRunExitCode } from "../src/agent/result.ts";
+
+describe("getRunExitCode", () => {
+  test("returns success for a clean run result", () => {
+    expect(getRunExitCode({ command: "init", model: "test-model" })).toBe(0);
+  });
+
+  test("returns failure for a run result with tool errors", () => {
+    expect(
+      getRunExitCode({
+        command: "update",
+        hadToolError: true,
+        model: "test-model",
+      }),
+    ).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary
- Track whether an agent run observed a tool-error stream event.
- Avoid recording successful update metadata for `--init` / `--update` runs that saw a tool error.
- Return a non-zero exit code for `--print` and auto-exit `--init` / `--update` runs when the resolved run result contains tool errors.

## Why
Fixes #43

## Tests
- `pnpm exec vitest run test/agent-tool-error-result.test.ts test/run-result.test.ts`
- `pnpm test`
- `pnpm run typecheck`
- `pnpm run lint:check`
- `pnpm run format:check`
- `pnpm run build`
- `git diff --check`

## Scope
- This reports completed runs with observed tool errors as failed for automation.
- This does not change provider retry behavior, prompt wording, malformed tool-call generation, or LangChain/DeepAgents recovery semantics.