### PR TITLE
fix: run --init/--update non-interactively when stdin is not a TTY

### DIFF
--- a/src/cli.tsx
+++ b/src/cli.tsx
@@ -3055,6 +3055,20 @@ function resolveStartupCommand(command: CliCommand): CliCommand {
   if (
     command.kind === "run" &&
     !command.dryRun &&
+    !command.shouldStart &&
+    !process.stdin.isTTY
+  ) {
+    return {
+      kind: "error",
+      exitCode: 1,
+      message:
+        "Interactive chat requires a terminal. Pass a message or use --init or --update for non-interactive runs.",
+    };
+  }
+
+  if (
+    command.kind === "run" &&
+    !command.dryRun &&
     command.shouldStart &&
     (command.print || !process.stdin.isTTY)
   ) {

--- a/src/cli.tsx
+++ b/src/cli.tsx
@@ -6,6 +6,7 @@ import {
   helpContent,
   isDevelopmentMode,
   parseCommand,
+  shouldRunNonInteractively,
   type CliCommand,
   type HelpRow,
 } from "./commands.js";
@@ -2970,7 +2971,7 @@ const command = resolveStartupCommand(parsedCommand);
 if (shouldPrintStartupError(argv, parsedCommand, command)) {
   process.stderr.write(`${command.message}\n`);
   process.exitCode = command.exitCode;
-} else if (command.kind === "run" && command.print && !command.dryRun) {
+} else if (shouldRunNonInteractively(command, process.stdin.isTTY === true)) {
   await runPrintCommand(command);
 } else {
   render(<App command={command} />);

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -163,6 +163,24 @@ export function parseCommand(argv: string[]): CliCommand {
   };
 }
 
+/**
+ * True when a run must bypass the Ink UI and use the non-interactive path:
+ * either the user asked for print mode, or stdin is not a TTY (CI, cron,
+ * pipes), where Ink's raw-mode input is unavailable and rendering the UI
+ * fails. Interactive chat without a message still requires a TTY, so it is
+ * excluded.
+ */
+export function shouldRunNonInteractively(
+  command: CliCommand,
+  stdinIsTTY: boolean,
+): command is Extract<CliCommand, { kind: "run" }> {
+  return (
+    command.kind === "run" &&
+    !command.dryRun &&
+    (command.print || (!stdinIsTTY && command.shouldStart))
+  );
+}
+
 export function isDevelopmentMode(): boolean {
   return (
     process.env.NODE_ENV === "development" || process.env.OPENWIKI_DEV === "1"

--- a/test/commands.test.ts
+++ b/test/commands.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, test } from "vitest";
-import { parseCommand } from "../src/commands.ts";
+import { parseCommand, shouldRunNonInteractively } from "../src/commands.ts";
 
 // parseCommand's --dry-run gate consults isDevelopmentMode(), which reads
 // NODE_ENV / OPENWIKI_DEV. Pin both to a non-development state per test and
@@ -196,5 +196,55 @@ describe("parseCommand — unknown options and dry-run gating", () => {
       dryRun: true,
       command: "init",
     });
+  });
+});
+
+describe("shouldRunNonInteractively", () => {
+  test("--init and --update without --print bypass the UI when stdin is not a TTY", () => {
+    expect(shouldRunNonInteractively(parseCommand(["--init"]), false)).toBe(
+      true,
+    );
+    expect(shouldRunNonInteractively(parseCommand(["--update"]), false)).toBe(
+      true,
+    );
+  });
+
+  test("a one-shot chat message bypasses the UI when stdin is not a TTY", () => {
+    expect(
+      shouldRunNonInteractively(parseCommand(["Document the API"]), false),
+    ).toBe(true);
+  });
+
+  test("--init on a TTY keeps the interactive UI", () => {
+    expect(shouldRunNonInteractively(parseCommand(["--init"]), true)).toBe(
+      false,
+    );
+  });
+
+  test("--print bypasses the UI regardless of TTY", () => {
+    expect(
+      shouldRunNonInteractively(parseCommand(["--init", "--print"]), true),
+    ).toBe(true);
+    expect(
+      shouldRunNonInteractively(parseCommand(["--init", "--print"]), false),
+    ).toBe(true);
+  });
+
+  test("interactive chat without a message still uses the UI path", () => {
+    expect(shouldRunNonInteractively(parseCommand([]), false)).toBe(false);
+    expect(shouldRunNonInteractively(parseCommand([]), true)).toBe(false);
+  });
+
+  test("dry-run, help, and error commands never run non-interactively", () => {
+    process.env.OPENWIKI_DEV = "1";
+    expect(
+      shouldRunNonInteractively(parseCommand(["--dry-run", "--init"]), false),
+    ).toBe(false);
+    expect(shouldRunNonInteractively(parseCommand(["--help"]), false)).toBe(
+      false,
+    );
+    expect(shouldRunNonInteractively(parseCommand(["--nope"]), false)).toBe(
+      false,
+    );
   });
 });


### PR DESCRIPTION
## Problem

Running `openwiki --init` or `--update` with stdin that is not a TTY (CI, cron, piped shells) renders the Ink UI, which requires raw-mode stdin. The run prints `ERROR Raw mode is not supported on the current process.stdin` and then **hangs without exiting** — even with valid credentials in `~/.openwiki/.env`. The GitHub Actions / GitLab examples avoid this with `--print`, but the plain commands are broken in any non-interactive context.

Fixes #149.

## Fix

Treat non-TTY runs the same as `--print`:

- Non-TTY `--init` / `--update` / one-shot messages now go through the existing
  `--print` path: run the agent, write output to stdout, exit 0 or 1.
- TTY behavior is unchanged; plain `openwiki` (interactive chat) still needs a terminal.
- The check lives in `src/commands.ts` so it can be unit-tested.


## Verification

- `pnpm run format:check`, `lint:check`, `test` — 92 passing, including 6 new tests covering the TTY × `--print` × `--dry-run` matrix (TTY `--init` keeps the UI; bare `openwiki`, help, error, and dry-run are unchanged).
- End-to-end in a scratch repo: before, `echo "" | openwiki --init` prints the raw-mode error and never exits; after, the same command runs the agent, writes errors to stderr, and exits 1 on failure.
