### PR TITLE
Feat: Add custom model header configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,18 @@ OPENWIKI_MODEL_ID=your-gateway-model-name
 
 Base URLs (and all credentials) can be set in your environment or stored in `~/.openwiki/.env`.
 
+### Custom model request headers
+
+If your model gateway requires additional request headers, set
+`OPENWIKI_MODEL_HEADERS` to a JSON object whose values are strings:
+
+```bash
+OPENWIKI_MODEL_HEADERS='{"X-Tenant-ID":"tenant-a","x-api-key":"gateway-secret"}'
+```
+
+OpenWiki passes these headers to OpenAI-compatible, OpenAI, Anthropic, and
+OpenRouter model calls. Header values are treated as sensitive in diagnostics.
+
 If there's an inference provider or model you'd like to see added, please open a PR!
 
 ## Contributing

--- a/openwiki/agent/workflow.md
+++ b/openwiki/agent/workflow.md
@@ -23,11 +23,15 @@ Chat runs skip metadata writes entirely.
 
 `createModel()` in `src/agent/index.ts` branches by provider:
 
-- **anthropic**: `new ChatAnthropic(modelId, { apiKey, anthropicApiUrl? })` — uses `@langchain/anthropic` directly. When `ANTHROPIC_BASE_URL` is set, the resolved alternative base URL is passed as `anthropicApiUrl` so requests can be routed to a self-hosted or proxied Anthropic-compatible endpoint instead of the default API.
-- **openrouter**: `new ChatOpenRouter({ apiKey, baseURL, model, models, route: "fallback", siteName: "OpenWiki" })` — passes a fallback model list so OpenRouter can route around server-side failures.
-- **baseten / fireworks / openai / openai-compatible**: `new ChatOpenAI({ apiKey, configuration: { baseURL? }, model })` — OpenAI-compatible clients using the provider's base URL when configured. The `openai-compatible` provider has no default endpoint; its base URL is user-supplied via `OPENAI_COMPATIBLE_BASE_URL` and required (`requiresBaseUrl: true`), which lets OpenWiki target any OpenAI-compatible gateway (for example a LiteLLM gateway fronting upstream providers).
+- **anthropic**: `new ChatAnthropic(modelId, { apiKey, anthropicApiUrl?, clientOptions: { defaultHeaders? } })` — uses `@langchain/anthropic` directly. When `ANTHROPIC_BASE_URL` is set, the resolved alternative base URL is passed as `anthropicApiUrl` so requests can be routed to a self-hosted or proxied Anthropic-compatible endpoint instead of the default API.
+- **openrouter**: `new ChatOpenRouter({ apiKey, baseURL, model, models, route: "fallback", siteName: "OpenWiki" })` — passes a fallback model list so OpenRouter can route around server-side failures. Extra headers from `OPENWIKI_MODEL_HEADERS` are merged into the OpenRouter request headers after construction.
+- **baseten / fireworks / openai / openai-compatible**: `new ChatOpenAI({ apiKey, configuration: { baseURL?, defaultHeaders? }, model })` — OpenAI-compatible clients using the provider's base URL when configured. The `openai-compatible` provider has no default endpoint; its base URL is user-supplied via `OPENAI_COMPATIBLE_BASE_URL` and required (`requiresBaseUrl: true`), which lets OpenWiki target any OpenAI-compatible gateway (for example a LiteLLM gateway fronting upstream providers).
 
 Base URLs are resolved through `resolveProviderBaseUrl()` in `src/constants.ts`, which prefers a provider's alternative base URL environment variable (`baseUrlEnvKey`) over the built-in default before falling back to the SDK's own default endpoint. Providers marked `requiresBaseUrl` are validated at startup by `ensureProviderBaseUrl()`.
+
+Extra model request headers are resolved through `resolveModelHeaders()` from the
+optional `OPENWIKI_MODEL_HEADERS` JSON object. Invalid JSON or non-string header
+values fail fast before the model client is invoked.
 
 ## Prompting strategy
 

--- a/openwiki/architecture/overview.md
+++ b/openwiki/architecture/overview.md
@@ -40,9 +40,9 @@ The agent runtime resolves the provider via `resolveConfiguredProvider()` in `sr
 
 Model creation branches by provider in `src/agent/index.ts` (`createModel`):
 
-- **anthropic** → `ChatAnthropic` with the Anthropic API key.
-- **openrouter** → `ChatOpenRouter` with `route: "fallback"` and a list of fallback models.
-- **baseten / fireworks / openai** → `ChatOpenAI` with the provider's API key and optional custom `baseURL` from `PROVIDER_CONFIGS`.
+- **anthropic** → `ChatAnthropic` with the Anthropic API key, optional alternative base URL, and optional request headers from `OPENWIKI_MODEL_HEADERS`.
+- **openrouter** → `ChatOpenRouter` with `route: "fallback"`, a list of fallback models, and optional request headers from `OPENWIKI_MODEL_HEADERS`.
+- **baseten / fireworks / openai / openai-compatible** → `ChatOpenAI` with the provider's API key, optional custom `baseURL`, and optional request headers from `OPENWIKI_MODEL_HEADERS`.
 
 ### DeepAgents backend
 

--- a/openwiki/cli/usage.md
+++ b/openwiki/cli/usage.md
@@ -98,6 +98,20 @@ OPENWIKI_MODEL_ID=<model name the gateway exposes>
 Base URLs are resolved by `resolveProviderBaseUrl()` in `src/constants.ts`, which
 prefers a provider's `baseUrlEnvKey` override over the built-in default.
 
+### Custom model request headers
+
+Set `OPENWIKI_MODEL_HEADERS` to a JSON object when a gateway needs extra HTTP
+headers on model calls:
+
+```bash
+OPENWIKI_MODEL_HEADERS='{"X-Tenant-ID":"tenant-a","x-api-key":"gateway-secret"}'
+```
+
+`resolveModelHeaders()` validates the JSON shape and requires every header value
+to be a string. The parsed headers are passed to OpenAI-compatible, OpenAI,
+Anthropic, and OpenRouter model clients. Diagnostics treat the full value and
+individual header values as sensitive.
+
 ## Help text and validation
 
 The help content is centralized in `src/commands.ts` and is used by the CLI UI. Model validation is intentionally strict:

--- a/openwiki/operations/credentials-and-updates.md
+++ b/openwiki/operations/credentials-and-updates.md
@@ -20,6 +20,7 @@ The file stores provider configuration and API keys:
 - `OPENWIKI_MODEL_ID` — the default model ID
 - Provider API keys: `OPENROUTER_API_KEY`, `OPENAI_API_KEY`, `OPENAI_COMPATIBLE_API_KEY`, `ANTHROPIC_API_KEY`, `BASETEN_API_KEY`, `FIREWORKS_API_KEY`
 - Base URLs: `ANTHROPIC_BASE_URL` (optional — routes the anthropic provider at an Anthropic-compatible endpoint other than the default API) and `OPENAI_COMPATIBLE_BASE_URL` (required by the openai-compatible provider, which has no default endpoint)
+- `OPENWIKI_MODEL_HEADERS` — optional JSON object of extra string-valued HTTP headers to attach to model calls
 - Optional LangSmith settings: `LANGSMITH_API_KEY`, `LANGCHAIN_PROJECT`, `LANGCHAIN_TRACING_V2`
 
 The loader merges those values into `process.env`, while preferring existing process-level values over file values. Deprecated keys (`OPENAI_BASE_URL`, `OPENAI_ORG_ID`, `OPENAI_PROJECT`) are skipped on load and removed on save.
@@ -55,9 +56,10 @@ The env layer also produces diagnostics for the CLI UI. Those diagnostics report
 - a masked preview,
 - warnings for suspicious formatting such as whitespace, newlines, quotes, or bracketed suffixes,
 - invalid model IDs,
-- invalid provider values.
+- invalid provider values,
+- invalid `OPENWIKI_MODEL_HEADERS` JSON or non-string header values.
 
-Diagnostics cover all six provider keys plus `OPENWIKI_PROVIDER`, `OPENWIKI_MODEL_ID`, the base URLs (`ANTHROPIC_BASE_URL`, `OPENAI_COMPATIBLE_BASE_URL`), and `LANGSMITH_API_KEY`. This makes startup problems easier to diagnose without exposing secret values (non-secret values such as the provider, model ID, and base URLs are shown in full).
+Diagnostics cover all six provider keys plus `OPENWIKI_PROVIDER`, `OPENWIKI_MODEL_ID`, `OPENWIKI_MODEL_HEADERS`, the base URLs (`ANTHROPIC_BASE_URL`, `OPENAI_COMPATIBLE_BASE_URL`), and `LANGSMITH_API_KEY`. This makes startup problems easier to diagnose without exposing secret values (non-secret values such as the provider, model ID, and base URLs are shown in full).
 
 ## Update metadata
 

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -27,10 +27,12 @@ import {
   OPENROUTER_API_KEY_ENV_KEY,
   OPENROUTER_BASE_URL,
   OPENROUTER_FALLBACK_MODEL_IDS,
+  OPENWIKI_MODEL_HEADERS_ENV_KEY,
   OPENWIKI_MODEL_ID_ENV_KEY,
   OPENWIKI_PROVIDER_ENV_KEY,
   providerRequiresBaseUrl,
   resolveConfiguredProvider,
+  resolveModelHeaders,
   resolveProviderBaseUrl,
   type OpenWikiProvider,
 } from "../constants.js";
@@ -406,40 +408,78 @@ function resolveModelId(
   return modelId;
 }
 
-function createModel(provider: OpenWikiProvider, modelId: string) {
+export function createModel(provider: OpenWikiProvider, modelId: string) {
+  const modelHeaders = resolveModelHeaders();
+
   if (provider === "anthropic") {
     const baseURL = resolveProviderBaseUrl(provider);
 
     return new ChatAnthropic(modelId, {
       apiKey: process.env[getProviderApiKeyEnvKey(provider)],
       ...(baseURL ? { anthropicApiUrl: baseURL } : {}),
+      ...(modelHeaders
+        ? { clientOptions: { defaultHeaders: modelHeaders } }
+        : {}),
     });
   }
 
   if (provider === "openrouter") {
     const models = createModelRoute(provider, modelId);
 
-    return new ChatOpenRouter({
-      apiKey: process.env[OPENROUTER_API_KEY_ENV_KEY],
-      baseURL: OPENROUTER_BASE_URL,
-      model: modelId,
-      models,
-      route: "fallback",
-      siteName: "OpenWiki",
-    });
+    return addOpenRouterModelHeaders(
+      new ChatOpenRouter({
+        apiKey: process.env[OPENROUTER_API_KEY_ENV_KEY],
+        baseURL: OPENROUTER_BASE_URL,
+        model: modelId,
+        models,
+        route: "fallback",
+        siteName: "OpenWiki",
+      }),
+      modelHeaders,
+    );
   }
 
   const baseURL = resolveProviderBaseUrl(provider);
+  const configuration =
+    baseURL || modelHeaders
+      ? {
+          ...(baseURL ? { baseURL } : {}),
+          ...(modelHeaders ? { defaultHeaders: modelHeaders } : {}),
+        }
+      : undefined;
 
   return new ChatOpenAI({
     apiKey: process.env[getProviderApiKeyEnvKey(provider)],
-    configuration: baseURL
-      ? {
-          baseURL,
-        }
-      : undefined,
+    ...(configuration ? { configuration } : {}),
     model: modelId,
   });
+}
+
+function addOpenRouterModelHeaders(
+  model: ChatOpenRouter,
+  modelHeaders: Record<string, string> | undefined,
+): ChatOpenRouter {
+  if (!modelHeaders) {
+    return model;
+  }
+
+  const modelWithHeaders = model as unknown as {
+    buildHeaders?: () => Record<string, string>;
+  };
+  const buildHeaders = modelWithHeaders.buildHeaders?.bind(model);
+
+  if (!buildHeaders) {
+    throw new Error(
+      "OPENWIKI_MODEL_HEADERS cannot be applied to this ChatOpenRouter version.",
+    );
+  }
+
+  modelWithHeaders.buildHeaders = () => ({
+    ...buildHeaders(),
+    ...modelHeaders,
+  });
+
+  return model;
 }
 
 function createModelRoute(
@@ -1308,6 +1348,10 @@ function formatDebugValue(key: string, value: string | undefined): string {
   }
 
   if (key.endsWith("_API_KEY")) {
+    return `set(length=${value.length})`;
+  }
+
+  if (key === OPENWIKI_MODEL_HEADERS_ENV_KEY) {
     return `set(length=${value.length})`;
   }
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -10,6 +10,7 @@ export const ANTHROPIC_BASE_URL_ENV_KEY = "ANTHROPIC_BASE_URL";
 export const OPENROUTER_API_KEY_ENV_KEY = "OPENROUTER_API_KEY";
 export const OPENWIKI_PROVIDER_ENV_KEY = "OPENWIKI_PROVIDER";
 export const OPENWIKI_MODEL_ID_ENV_KEY = "OPENWIKI_MODEL_ID";
+export const OPENWIKI_MODEL_HEADERS_ENV_KEY = "OPENWIKI_MODEL_HEADERS";
 export const DEFAULT_PROVIDER = "openrouter";
 export const OPENROUTER_BASE_URL = "https://openrouter.ai/api/v1";
 
@@ -160,6 +161,58 @@ export function resolveProviderBaseUrl(
   }
 
   return config.baseURL;
+}
+
+export function resolveModelHeaders(
+  env: NodeJS.ProcessEnv = process.env,
+): Record<string, string> | undefined {
+  const rawHeaders = env[OPENWIKI_MODEL_HEADERS_ENV_KEY]?.trim();
+
+  if (!rawHeaders) {
+    return undefined;
+  }
+
+  let parsedHeaders: unknown;
+
+  try {
+    parsedHeaders = JSON.parse(rawHeaders);
+  } catch {
+    throw new Error(
+      `${OPENWIKI_MODEL_HEADERS_ENV_KEY} must be a JSON object with string header values.`,
+    );
+  }
+
+  if (
+    typeof parsedHeaders !== "object" ||
+    parsedHeaders === null ||
+    Array.isArray(parsedHeaders)
+  ) {
+    throw new Error(
+      `${OPENWIKI_MODEL_HEADERS_ENV_KEY} must be a JSON object with string header values.`,
+    );
+  }
+
+  const headers: Record<string, string> = {};
+
+  for (const [key, value] of Object.entries(parsedHeaders)) {
+    const headerName = key.trim();
+
+    if (!headerName) {
+      throw new Error(
+        `${OPENWIKI_MODEL_HEADERS_ENV_KEY} contains an empty header name.`,
+      );
+    }
+
+    if (typeof value !== "string") {
+      throw new Error(
+        `${OPENWIKI_MODEL_HEADERS_ENV_KEY} must contain only string header values.`,
+      );
+    }
+
+    headers[headerName] = value;
+  }
+
+  return Object.keys(headers).length > 0 ? headers : undefined;
 }
 
 export function getProviderBaseUrlEnvKey(

--- a/src/diagnostics.ts
+++ b/src/diagnostics.ts
@@ -4,6 +4,8 @@ import {
   FIREWORKS_API_KEY_ENV_KEY,
   OPENAI_API_KEY_ENV_KEY,
   OPENROUTER_API_KEY_ENV_KEY,
+  OPENWIKI_MODEL_HEADERS_ENV_KEY,
+  resolveModelHeaders,
 } from "./constants.js";
 
 /**
@@ -24,6 +26,7 @@ export function sanitizeDiagnosticText(value: string): string {
     OPENAI_API_KEY_ENV_KEY,
     ANTHROPIC_API_KEY_ENV_KEY,
     OPENROUTER_API_KEY_ENV_KEY,
+    OPENWIKI_MODEL_HEADERS_ENV_KEY,
     "LANGSMITH_API_KEY",
   ]) {
     const secret = process.env[key];
@@ -31,6 +34,12 @@ export function sanitizeDiagnosticText(value: string): string {
     if (secret && secret.length > 0) {
       sanitized = sanitized.split(secret).join(`[REDACTED:${key}]`);
     }
+  }
+
+  for (const secret of getConfiguredModelHeaderValues()) {
+    sanitized = sanitized
+      .split(secret)
+      .join(`[REDACTED:${OPENWIKI_MODEL_HEADERS_ENV_KEY}]`);
   }
 
   return sanitized
@@ -42,6 +51,16 @@ export function sanitizeDiagnosticText(value: string): string {
     .replace(/\bsk-or-v1-[A-Za-z0-9_-]+/gu, "[REDACTED:OPENROUTER_API_KEY]")
     .replace(/\bsk-[A-Za-z0-9_-]+/gu, "[REDACTED:API_KEY]")
     .replace(/\bls[v_][A-Za-z0-9_-]+/gu, "[REDACTED:LANGSMITH_API_KEY]");
+}
+
+function getConfiguredModelHeaderValues(): string[] {
+  try {
+    return Object.values(resolveModelHeaders() ?? {}).filter(
+      (value) => value.length > 0,
+    );
+  } catch {
+    return [];
+  }
 }
 
 /**

--- a/src/env.ts
+++ b/src/env.ts
@@ -12,8 +12,10 @@ import {
   OPENAI_COMPATIBLE_API_KEY_ENV_KEY,
   OPENAI_COMPATIBLE_BASE_URL_ENV_KEY,
   OPENROUTER_API_KEY_ENV_KEY,
+  OPENWIKI_MODEL_HEADERS_ENV_KEY,
   OPENWIKI_MODEL_ID_ENV_KEY,
   OPENWIKI_PROVIDER_ENV_KEY,
+  resolveModelHeaders,
 } from "./constants.js";
 import { isFileNotFoundError } from "./fs-errors.js";
 
@@ -53,6 +55,7 @@ export const MANAGED_ENV_KEYS = [
   OPENROUTER_API_KEY_ENV_KEY,
   OPENWIKI_PROVIDER_ENV_KEY,
   OPENWIKI_MODEL_ID_ENV_KEY,
+  OPENWIKI_MODEL_HEADERS_ENV_KEY,
   "LANGSMITH_API_KEY",
   "LANGCHAIN_PROJECT",
   "LANGCHAIN_TRACING_V2",
@@ -174,15 +177,15 @@ function createCredentialDiagnostic(
     key,
     source,
     length: value.length,
-    preview: isNonSecretDiagnosticKey(key)
-      ? JSON.stringify(value)
-      : createCredentialPreview(value),
+    preview: createDiagnosticPreview(key, value),
     warnings:
       key === OPENWIKI_MODEL_ID_ENV_KEY
         ? getModelWarnings(value)
         : key === OPENWIKI_PROVIDER_ENV_KEY
           ? getProviderWarnings(value)
-          : getCredentialWarnings(value),
+          : key === OPENWIKI_MODEL_HEADERS_ENV_KEY
+            ? getModelHeadersWarnings(value)
+            : getCredentialWarnings(value),
   };
 }
 
@@ -212,6 +215,18 @@ function isNonSecretDiagnosticKey(key: string): boolean {
     key === ANTHROPIC_BASE_URL_ENV_KEY ||
     key === OPENAI_COMPATIBLE_BASE_URL_ENV_KEY
   );
+}
+
+function createDiagnosticPreview(key: string, value: string): string {
+  if (isNonSecretDiagnosticKey(key)) {
+    return JSON.stringify(value);
+  }
+
+  if (key === OPENWIKI_MODEL_HEADERS_ENV_KEY) {
+    return value.length === 0 ? '""' : "<set>";
+  }
+
+  return createCredentialPreview(value);
 }
 
 function createCredentialPreview(value: string): string {
@@ -250,6 +265,16 @@ function getModelWarnings(value: string): string[] {
 
 function getProviderWarnings(value: string): string[] {
   return normalizeProvider(value) === null ? ["invalid provider"] : [];
+}
+
+function getModelHeadersWarnings(value: string): string[] {
+  try {
+    resolveModelHeaders({ [OPENWIKI_MODEL_HEADERS_ENV_KEY]: value });
+
+    return [];
+  } catch (error) {
+    return [error instanceof Error ? error.message : "invalid model headers"];
+  }
 }
 
 async function readOpenWikiEnv(): Promise<EnvMap> {

--- a/test/agent-model-headers.test.ts
+++ b/test/agent-model-headers.test.ts
@@ -1,0 +1,113 @@
+import { afterEach, describe, expect, test, vi } from "vitest";
+
+vi.mock("@langchain/anthropic", () => ({
+  ChatAnthropic: vi.fn(function ChatAnthropic(
+    model: string,
+    fields: Record<string, unknown>,
+  ) {
+    return { fields, model };
+  }),
+}));
+
+vi.mock("@langchain/langgraph-checkpoint-sqlite", () => ({
+  SqliteSaver: vi.fn(),
+}));
+
+vi.mock("@langchain/openai", () => ({
+  ChatOpenAI: vi.fn(function ChatOpenAI(fields: Record<string, unknown>) {
+    return { fields };
+  }),
+}));
+
+vi.mock("@langchain/openrouter", () => ({
+  ChatOpenRouter: vi.fn(function ChatOpenRouter(
+    fields: Record<string, unknown>,
+  ) {
+    return {
+      buildHeaders() {
+        return {
+          Authorization: "Bearer original-openrouter-key",
+          "Content-Type": "application/json",
+        };
+      },
+      fields,
+    };
+  }),
+}));
+
+vi.mock("deepagents", () => ({
+  createDeepAgent: vi.fn(),
+  LocalShellBackend: vi.fn(),
+}));
+
+describe("createModel model headers", () => {
+  afterEach(() => {
+    delete process.env.ANTHROPIC_API_KEY;
+    delete process.env.OPENAI_COMPATIBLE_API_KEY;
+    delete process.env.OPENAI_COMPATIBLE_BASE_URL;
+    delete process.env.OPENROUTER_API_KEY;
+    delete process.env.OPENWIKI_MODEL_HEADERS;
+    vi.clearAllMocks();
+  });
+
+  test("passes configured headers to ChatOpenAI clients", async () => {
+    const { ChatOpenAI } = await import("@langchain/openai");
+    const { createModel } = await import("../src/agent/index.ts");
+
+    process.env.OPENAI_COMPATIBLE_API_KEY = "gateway-key";
+    process.env.OPENAI_COMPATIBLE_BASE_URL = "https://gateway.example/v1";
+    process.env.OPENWIKI_MODEL_HEADERS =
+      '{"X-Tenant-ID":"tenant-a","x-api-key":"secret"}';
+
+    createModel("openai-compatible", "gateway-model");
+
+    expect(ChatOpenAI).toHaveBeenCalledWith({
+      apiKey: "gateway-key",
+      configuration: {
+        baseURL: "https://gateway.example/v1",
+        defaultHeaders: {
+          "X-Tenant-ID": "tenant-a",
+          "x-api-key": "secret",
+        },
+      },
+      model: "gateway-model",
+    });
+  });
+
+  test("passes configured headers to ChatAnthropic clients", async () => {
+    const { ChatAnthropic } = await import("@langchain/anthropic");
+    const { createModel } = await import("../src/agent/index.ts");
+
+    process.env.ANTHROPIC_API_KEY = "anthropic-key";
+    process.env.OPENWIKI_MODEL_HEADERS = '{"X-Tenant-ID":"tenant-a"}';
+
+    createModel("anthropic", "claude-sonnet-5");
+
+    expect(ChatAnthropic).toHaveBeenCalledWith("claude-sonnet-5", {
+      apiKey: "anthropic-key",
+      clientOptions: {
+        defaultHeaders: {
+          "X-Tenant-ID": "tenant-a",
+        },
+      },
+    });
+  });
+
+  test("merges configured headers into ChatOpenRouter requests", async () => {
+    const { createModel } = await import("../src/agent/index.ts");
+
+    process.env.OPENROUTER_API_KEY = "openrouter-key";
+    process.env.OPENWIKI_MODEL_HEADERS =
+      '{"Authorization":"Bearer custom","X-Tenant-ID":"tenant-a"}';
+
+    const model = createModel("openrouter", "z-ai/glm-5.2") as unknown as {
+      buildHeaders(): Record<string, string>;
+    };
+
+    expect(model.buildHeaders()).toEqual({
+      Authorization: "Bearer custom",
+      "Content-Type": "application/json",
+      "X-Tenant-ID": "tenant-a",
+    });
+  });
+});

--- a/test/constants.test.ts
+++ b/test/constants.test.ts
@@ -8,7 +8,9 @@ import {
   isValidProvider,
   normalizeModelId,
   normalizeProvider,
+  OPENWIKI_MODEL_HEADERS_ENV_KEY,
   resolveConfiguredProvider,
+  resolveModelHeaders,
   resolveProviderBaseUrl,
 } from "../src/constants.ts";
 
@@ -108,6 +110,41 @@ describe("resolveProviderBaseUrl", () => {
 
   test("returns undefined for a provider with no default and no override", () => {
     expect(resolveProviderBaseUrl("openai", {})).toBeUndefined();
+  });
+});
+
+describe("resolveModelHeaders", () => {
+  test("returns undefined when no model headers are configured", () => {
+    expect(resolveModelHeaders({})).toBeUndefined();
+    expect(
+      resolveModelHeaders({ [OPENWIKI_MODEL_HEADERS_ENV_KEY]: "   " }),
+    ).toBeUndefined();
+  });
+
+  test("parses JSON object headers from the configured env var", () => {
+    expect(
+      resolveModelHeaders({
+        [OPENWIKI_MODEL_HEADERS_ENV_KEY]:
+          '{"X-Tenant-ID":"tenant-a","x-api-key":"secret"}',
+      }),
+    ).toEqual({
+      "X-Tenant-ID": "tenant-a",
+      "x-api-key": "secret",
+    });
+  });
+
+  test("rejects invalid or non-string model headers", () => {
+    expect(() =>
+      resolveModelHeaders({
+        [OPENWIKI_MODEL_HEADERS_ENV_KEY]: "not json",
+      }),
+    ).toThrow(/OPENWIKI_MODEL_HEADERS/u);
+
+    expect(() =>
+      resolveModelHeaders({
+        [OPENWIKI_MODEL_HEADERS_ENV_KEY]: '{"x-number":123}',
+      }),
+    ).toThrow(/string header values/u);
   });
 });
 

--- a/test/redaction.test.ts
+++ b/test/redaction.test.ts
@@ -4,13 +4,16 @@ import {
   isOpenRouterServerError,
   sanitizeDiagnosticText,
 } from "../src/diagnostics.ts";
+import { OPENWIKI_MODEL_HEADERS_ENV_KEY } from "../src/constants.ts";
 import { sanitizeOpenRouterResponseBody } from "../src/agent/index.ts";
 
 describe("sanitizeDiagnosticText", () => {
   const originalOpenAiKey = process.env.OPENAI_API_KEY;
+  const originalModelHeaders = process.env.OPENWIKI_MODEL_HEADERS;
 
   beforeEach(() => {
     delete process.env.OPENAI_API_KEY;
+    delete process.env.OPENWIKI_MODEL_HEADERS;
   });
 
   afterEach(() => {
@@ -18,6 +21,12 @@ describe("sanitizeDiagnosticText", () => {
       delete process.env.OPENAI_API_KEY;
     } else {
       process.env.OPENAI_API_KEY = originalOpenAiKey;
+    }
+
+    if (originalModelHeaders === undefined) {
+      delete process.env.OPENWIKI_MODEL_HEADERS;
+    } else {
+      process.env.OPENWIKI_MODEL_HEADERS = originalModelHeaders;
     }
   });
 
@@ -60,6 +69,19 @@ describe("sanitizeDiagnosticText", () => {
 
     expect(result).not.toContain("lsv_1234abcd");
     expect(result).toContain("[REDACTED:LANGSMITH_API_KEY]");
+  });
+
+  test("redacts configured model header values", () => {
+    process.env.OPENWIKI_MODEL_HEADERS =
+      '{"x-api-key":"gateway-secret","X-Tenant-ID":"tenant-a"}';
+
+    const result = sanitizeDiagnosticText(
+      "request failed for gateway-secret and tenant-a",
+    );
+
+    expect(result).not.toContain("gateway-secret");
+    expect(result).not.toContain("tenant-a");
+    expect(result).toContain(`[REDACTED:${OPENWIKI_MODEL_HEADERS_ENV_KEY}]`);
   });
 
   test('redacts "Incorrect API key provided: …" phrasing', () => {


### PR DESCRIPTION
## Summary

Adds `OPENWIKI_MODEL_HEADERS` so users can attach extra string-valued HTTP headers to model calls through environment configuration or `~/.openwiki/.env`.

## Details

- Parses and validates `OPENWIKI_MODEL_HEADERS` as a JSON object with string header values.
- Passes configured headers to OpenAI-compatible/OpenAI, Anthropic, and OpenRouter model clients.
- Treats model header configuration and individual header values as sensitive in diagnostics and debug output.
- Documents the new configuration option in the README and OpenWiki internal docs.

## Validation

- `pnpm format:check`
- `pnpm typecheck`
- `pnpm lint:check`
- `pnpm test`