### PR TITLE
feat: exclude paths from doc runs via `.openwikiignore`

### DIFF
--- a/.changeset/thin-mirrors-add.md
+++ b/.changeset/thin-mirrors-add.md
@@ -1,0 +1,5 @@
+---
+"openwiki": patch
+---
+
+feat: exclude paths from doc runs via .openwikiignore

--- a/README.md
+++ b/README.md
@@ -239,6 +239,18 @@ OPENWIKI_MODEL_ID="gpt-5.5"
 
 In CI (such as the scheduled GitHub Actions workflow), set the `COPILOT_API_KEY` repository secret and export `OPENWIKI_PROVIDER=copilot` in the workflow environment.
 
+### Ignoring paths
+
+Create a `.openwikiignore` file in the repository root to keep generated docs from reading or describing private, generated, or irrelevant paths. The syntax supports comments, blank lines, `*` and `**` globs, directory rules, and `!` negation:
+
+```gitignore
+secrets/
+*.log
+!logs/keep.log
+```
+
+When `.openwikiignore` has active rules, OpenWiki filters filesystem discovery and restricts shell execute so ignored paths stay out of the run.
+
 ### Alternative base URLs
 
 To route the Anthropic provider at an alternative, Anthropic-compatible endpoint

--- a/README.md
+++ b/README.md
@@ -251,6 +251,8 @@ secrets/
 
 When `.openwikiignore` has active rules, OpenWiki filters filesystem discovery and restricts shell execute so ignored paths stay out of the run.
 
+This is a read boundary: ignored paths are never read, scanned, or reproduced in the generated docs. It does not guarantee a topic will never be mentioned, since the agent may still infer an ignored area from other allowed evidence such as tests, the README, commit messages, or the existing wiki.
+
 ### Alternative base URLs
 
 To route the Anthropic provider at an alternative, Anthropic-compatible endpoint

--- a/src/agent/docs-only-backend.ts
+++ b/src/agent/docs-only-backend.ts
@@ -330,7 +330,7 @@ export class OpenWikiLocalShellBackend extends LocalShellBackend {
     ) {
       return {
         exitCode: 1,
-        output: `Shell execute is restricted while ${OPENWIKI_IGNORE_FILE} is active. Use filesystem tools so ignored paths stay excluded.`,
+        output: `Shell execute is restricted while ${OPENWIKI_IGNORE_FILE} is active. Use the file tools instead (read_file, ls, glob, grep) so ignored paths stay excluded.`,
         truncated: false,
       };
     }

--- a/src/agent/docs-only-backend.ts
+++ b/src/agent/docs-only-backend.ts
@@ -4,10 +4,8 @@ import {
   type EditResult,
   type ExecuteResponse,
   type FileDownloadResponse,
-  type FileInfo,
   type FileUploadResponse,
   type GlobResult,
-  type GrepMatch,
   type GrepResult,
   type LocalShellBackendOptions,
   type LsResult,
@@ -16,10 +14,7 @@ import {
   type WriteResult,
 } from "deepagents";
 import { OPEN_WIKI_DIR } from "../constants.js";
-import {
-  OPENWIKI_IGNORE_FILE,
-  OpenWikiIgnoreRules,
-} from "./openwiki-ignore.js";
+import { OPENWIKI_IGNORE_FILE, OpenWikiIgnore } from "./openwiki-ignore.js";
 import type { OpenWikiOutputMode } from "./types.js";
 
 /**
@@ -43,7 +38,7 @@ type OpenWikiBackendOptions = LocalShellBackendOptions & {
    *
    * @default an inactive ruleset (no exclusions)
    */
-  ignoreRules?: OpenWikiIgnoreRules;
+  openWikiIgnore?: OpenWikiIgnore;
 
   /**
    * The doc-generation output target, which relaxes the docs-only write check
@@ -99,7 +94,7 @@ export class OpenWikiLocalShellBackend extends LocalShellBackend {
   /**
    * The active `.openwikiignore` ruleset gating every path this backend touches.
    */
-  private readonly ignoreRules: OpenWikiIgnoreRules;
+  private readonly openWikiIgnore: OpenWikiIgnore;
 
   /**
    * The doc-generation output target; `local-wiki` relaxes the docs-only write check.
@@ -109,7 +104,7 @@ export class OpenWikiLocalShellBackend extends LocalShellBackend {
   constructor(options: OpenWikiBackendOptions) {
     super(options);
     this.docsOnly = options.docsOnly === true;
-    this.ignoreRules = options.ignoreRules ?? new OpenWikiIgnoreRules([]);
+    this.openWikiIgnore = options.openWikiIgnore ?? new OpenWikiIgnore([]);
     this.outputMode = options.outputMode ?? "repository";
   }
 
@@ -202,7 +197,9 @@ export class OpenWikiLocalShellBackend extends LocalShellBackend {
 
     return {
       ...result,
-      files: result.files?.filter((file) => !this.isIgnoredFile(file)),
+      files: result.files?.filter(
+        (file) => !this.openWikiIgnore.ignores(file.path, file.is_dir === true),
+      ),
     };
   }
 
@@ -215,7 +212,7 @@ export class OpenWikiLocalShellBackend extends LocalShellBackend {
     dirPath?: string | null,
     glob?: string | null,
   ): Promise<GrepResult> {
-    if (dirPath && this.ignoreRules.ignores(dirPath, true)) {
+    if (dirPath && this.openWikiIgnore.ignores(dirPath, true)) {
       return { matches: [] };
     }
 
@@ -223,7 +220,9 @@ export class OpenWikiLocalShellBackend extends LocalShellBackend {
 
     return {
       ...result,
-      matches: result.matches?.filter((match) => !this.isIgnoredMatch(match)),
+      matches: result.matches?.filter(
+        (match) => !this.openWikiIgnore.ignores(match.path),
+      ),
     };
   }
 
@@ -235,7 +234,7 @@ export class OpenWikiLocalShellBackend extends LocalShellBackend {
     pattern: string,
     searchPath?: string,
   ): Promise<GlobResult> {
-    if (searchPath && this.ignoreRules.ignores(searchPath, true)) {
+    if (searchPath && this.openWikiIgnore.ignores(searchPath, true)) {
       return { files: [] };
     }
 
@@ -243,7 +242,9 @@ export class OpenWikiLocalShellBackend extends LocalShellBackend {
 
     return {
       ...result,
-      files: result.files?.filter((file) => !this.isIgnoredFile(file)),
+      files: result.files?.filter(
+        (file) => !this.openWikiIgnore.ignores(file.path, file.is_dir === true),
+      ),
     };
   }
 
@@ -289,7 +290,7 @@ export class OpenWikiLocalShellBackend extends LocalShellBackend {
     paths: string[],
   ): Promise<FileDownloadResponse[]> {
     const allowedPaths = paths.filter(
-      (filePath) => !this.ignoreRules.ignores(filePath),
+      (filePath) => !this.openWikiIgnore.ignores(filePath),
     );
 
     if (allowedPaths.length === paths.length) {
@@ -302,7 +303,7 @@ export class OpenWikiLocalShellBackend extends LocalShellBackend {
     );
 
     return paths.map((filePath) => {
-      if (this.ignoreRules.ignores(filePath)) {
+      if (this.openWikiIgnore.ignores(filePath)) {
         return { content: null, error: "permission_denied", path: filePath };
       }
 
@@ -324,7 +325,7 @@ export class OpenWikiLocalShellBackend extends LocalShellBackend {
    */
   override async execute(command: string): Promise<ExecuteResponse> {
     if (
-      this.ignoreRules.isActive &&
+      this.openWikiIgnore.isActive &&
       !isAllowedShellCommandWithIgnore(command)
     ) {
       return {
@@ -362,7 +363,7 @@ export class OpenWikiLocalShellBackend extends LocalShellBackend {
     filePath: string,
     isDirectory = false,
   ): string | null {
-    if (!this.ignoreRules.ignores(filePath, isDirectory)) {
+    if (!this.openWikiIgnore.ignores(filePath, isDirectory)) {
       return null;
     }
 
@@ -377,23 +378,9 @@ export class OpenWikiLocalShellBackend extends LocalShellBackend {
    */
   private isWriteBlocked(filePath: string): boolean {
     return (
-      this.ignoreRules.ignores(filePath) ||
+      this.openWikiIgnore.ignores(filePath) ||
       this.getDocsOnlyWriteError(filePath) !== null
     );
-  }
-
-  /**
-   * Whether a directory entry should be filtered out of discovery results.
-   */
-  private isIgnoredFile(file: FileInfo): boolean {
-    return this.ignoreRules.ignores(file.path, file.is_dir === true);
-  }
-
-  /**
-   * Whether a grep hit should be filtered out because its file is ignored.
-   */
-  private isIgnoredMatch(match: GrepMatch): boolean {
-    return this.ignoreRules.ignores(match.path);
   }
 }
 

--- a/src/agent/docs-only-backend.ts
+++ b/src/agent/docs-only-backend.ts
@@ -248,14 +248,17 @@ export class OpenWikiLocalShellBackend extends LocalShellBackend {
   }
 
   /**
-   * Upload files, returning `permission_denied` for any ignored path while still
-   * uploading the allowed ones. Results are returned in the original input order.
+   * Upload files, returning `permission_denied` for any path that is excluded by
+   * `.openwikiignore` or (in docs-only mode) falls outside the `openwiki/` tree,
+   * while still uploading the allowed ones. As a write path, this enforces the
+   * same docs-only confinement as {@link write}/{@link edit}. Results are
+   * returned in the original input order.
    */
   override async uploadFiles(
     files: Array<[string, Uint8Array]>,
   ): Promise<FileUploadResponse[]> {
     const allowedFiles = files.filter(
-      ([filePath]) => !this.ignoreRules.ignores(filePath),
+      ([filePath]) => !this.isWriteBlocked(filePath),
     );
 
     if (allowedFiles.length === files.length) {
@@ -268,7 +271,7 @@ export class OpenWikiLocalShellBackend extends LocalShellBackend {
     );
 
     return files.map(([filePath]) => {
-      if (this.ignoreRules.ignores(filePath)) {
+      if (this.isWriteBlocked(filePath)) {
         return { error: "permission_denied", path: filePath };
       }
 
@@ -364,6 +367,19 @@ export class OpenWikiLocalShellBackend extends LocalShellBackend {
     }
 
     return `Path is excluded by ${OPENWIKI_IGNORE_FILE}: ${filePath}`;
+  }
+
+  /**
+   * Whether writing to a path is disallowed, combining the `.openwikiignore`
+   * exclusion and the docs-only confinement checks that {@link write} and
+   * {@link edit} apply. Used by batch write paths that cannot short-circuit on a
+   * single error message.
+   */
+  private isWriteBlocked(filePath: string): boolean {
+    return (
+      this.ignoreRules.ignores(filePath) ||
+      this.getDocsOnlyWriteError(filePath) !== null
+    );
   }
 
   /**

--- a/src/agent/docs-only-backend.ts
+++ b/src/agent/docs-only-backend.ts
@@ -2,34 +2,84 @@ import path from "node:path";
 import {
   LocalShellBackend,
   type EditResult,
+  type ExecuteResponse,
+  type FileDownloadResponse,
+  type FileInfo,
+  type FileUploadResponse,
+  type GlobResult,
+  type GrepMatch,
+  type GrepResult,
   type LocalShellBackendOptions,
+  type LsResult,
+  type ReadRawResult,
+  type ReadResult,
   type WriteResult,
 } from "deepagents";
 import { OPEN_WIKI_DIR } from "../constants.js";
+import {
+  OPENWIKI_IGNORE_FILE,
+  OpenWikiIgnoreRules,
+} from "./openwiki-ignore.js";
 import type { OpenWikiOutputMode } from "./types.js";
 
 export const MUTATION_PATH_METADATA_KEY = "openwikiMutationPath";
 
 type OpenWikiBackendOptions = LocalShellBackendOptions & {
   docsOnly?: boolean;
+  ignoreRules?: OpenWikiIgnoreRules;
   outputMode?: OpenWikiOutputMode;
 };
 
+const allowedIgnoredShellCommands = [
+  /^pwd$/u,
+  /^git\s+(?:--no-pager\s+)?rev-parse\s+HEAD$/u,
+  /^rm\s+-f\s+(?:\.\/)?openwiki\/_plan\.md$/u,
+];
+
 export class OpenWikiLocalShellBackend extends LocalShellBackend {
   private readonly docsOnly: boolean;
+  private readonly ignoreRules: OpenWikiIgnoreRules;
   private readonly outputMode: OpenWikiOutputMode;
 
   constructor(options: OpenWikiBackendOptions) {
     super(options);
     this.docsOnly = options.docsOnly === true;
+    this.ignoreRules = options.ignoreRules ?? new OpenWikiIgnoreRules([]);
     this.outputMode = options.outputMode ?? "repository";
+  }
+
+  override async read(
+    filePath: string,
+    offset?: number,
+    limit?: number,
+  ): Promise<ReadResult> {
+    const error = this.getIgnoredPathError(filePath);
+
+    if (error) {
+      return { error };
+    }
+
+    return super.read(filePath, offset, limit);
+  }
+
+  override async readRaw(filePath: string): Promise<ReadRawResult> {
+    const error = this.getIgnoredPathError(filePath);
+
+    if (error) {
+      return { error };
+    }
+
+    return super.readRaw(filePath);
   }
 
   override async write(
     filePath: string,
     content: string,
   ): Promise<WriteResult> {
-    const error = this.getDocsOnlyWriteError(filePath);
+    const error =
+      this.getIgnoredPathError(filePath) ??
+      this.getDocsOnlyWriteError(filePath);
+
     if (error) {
       return { error };
     }
@@ -43,7 +93,10 @@ export class OpenWikiLocalShellBackend extends LocalShellBackend {
     newString: string,
     replaceAll?: boolean,
   ): Promise<EditResult> {
-    const error = this.getDocsOnlyWriteError(filePath);
+    const error =
+      this.getIgnoredPathError(filePath) ??
+      this.getDocsOnlyWriteError(filePath);
+
     if (error) {
       return { error };
     }
@@ -52,6 +105,127 @@ export class OpenWikiLocalShellBackend extends LocalShellBackend {
       await super.edit(filePath, oldString, newString, replaceAll),
       filePath,
     );
+  }
+
+  override async ls(dirPath: string): Promise<LsResult> {
+    const error = this.getIgnoredPathError(dirPath, true);
+
+    if (error) {
+      return { error };
+    }
+
+    const result = await super.ls(dirPath);
+
+    return {
+      ...result,
+      files: result.files?.filter((file) => !this.isIgnoredFile(file)),
+    };
+  }
+
+  override async grep(
+    pattern: string,
+    dirPath?: string | null,
+    glob?: string | null,
+  ): Promise<GrepResult> {
+    if (dirPath && this.ignoreRules.ignores(dirPath, true)) {
+      return { matches: [] };
+    }
+
+    const result = await super.grep(pattern, dirPath ?? undefined, glob);
+
+    return {
+      ...result,
+      matches: result.matches?.filter((match) => !this.isIgnoredMatch(match)),
+    };
+  }
+
+  override async glob(
+    pattern: string,
+    searchPath?: string,
+  ): Promise<GlobResult> {
+    if (searchPath && this.ignoreRules.ignores(searchPath, true)) {
+      return { files: [] };
+    }
+
+    const result = await super.glob(pattern, searchPath);
+
+    return {
+      ...result,
+      files: result.files?.filter((file) => !this.isIgnoredFile(file)),
+    };
+  }
+
+  override async uploadFiles(
+    files: Array<[string, Uint8Array]>,
+  ): Promise<FileUploadResponse[]> {
+    const allowedFiles = files.filter(
+      ([filePath]) => !this.ignoreRules.ignores(filePath),
+    );
+
+    if (allowedFiles.length === files.length) {
+      return super.uploadFiles(files);
+    }
+
+    const allowedResults = await super.uploadFiles(allowedFiles);
+    const resultsByPath = new Map(
+      allowedResults.map((result) => [result.path, result]),
+    );
+
+    return files.map(([filePath]) => {
+      if (this.ignoreRules.ignores(filePath)) {
+        return { error: "permission_denied", path: filePath };
+      }
+
+      return (
+        resultsByPath.get(filePath) ?? { error: "invalid_path", path: filePath }
+      );
+    });
+  }
+
+  override async downloadFiles(
+    paths: string[],
+  ): Promise<FileDownloadResponse[]> {
+    const allowedPaths = paths.filter(
+      (filePath) => !this.ignoreRules.ignores(filePath),
+    );
+
+    if (allowedPaths.length === paths.length) {
+      return super.downloadFiles(paths);
+    }
+
+    const allowedResults = await super.downloadFiles(allowedPaths);
+    const resultsByPath = new Map(
+      allowedResults.map((result) => [result.path, result]),
+    );
+
+    return paths.map((filePath) => {
+      if (this.ignoreRules.ignores(filePath)) {
+        return { content: null, error: "permission_denied", path: filePath };
+      }
+
+      return (
+        resultsByPath.get(filePath) ?? {
+          content: null,
+          error: "invalid_path",
+          path: filePath,
+        }
+      );
+    });
+  }
+
+  override async execute(command: string): Promise<ExecuteResponse> {
+    if (
+      this.ignoreRules.isActive &&
+      !isAllowedShellCommandWithIgnore(command)
+    ) {
+      return {
+        exitCode: 1,
+        output: `Shell execute is restricted while ${OPENWIKI_IGNORE_FILE} is active. Use filesystem tools so ignored paths stay excluded.`,
+        truncated: false,
+      };
+    }
+
+    return super.execute(command);
   }
 
   private getDocsOnlyWriteError(filePath: string): string | null {
@@ -64,6 +238,25 @@ export class OpenWikiLocalShellBackend extends LocalShellBackend {
     }
 
     return `OpenWiki repository init/update runs may only write under /${OPEN_WIKI_DIR}/. Refused path: ${filePath}`;
+  }
+
+  private getIgnoredPathError(
+    filePath: string,
+    isDirectory = false,
+  ): string | null {
+    if (!this.ignoreRules.ignores(filePath, isDirectory)) {
+      return null;
+    }
+
+    return `Path is excluded by ${OPENWIKI_IGNORE_FILE}: ${filePath}`;
+  }
+
+  private isIgnoredFile(file: FileInfo): boolean {
+    return this.ignoreRules.ignores(file.path, file.is_dir === true);
+  }
+
+  private isIgnoredMatch(match: GrepMatch): boolean {
+    return this.ignoreRules.ignores(match.path);
   }
 }
 
@@ -90,5 +283,13 @@ export function isOpenWikiDocsPath(filePath: string): boolean {
 
   return (
     virtualPath === OPEN_WIKI_DIR || virtualPath.startsWith(`${OPEN_WIKI_DIR}/`)
+  );
+}
+
+function isAllowedShellCommandWithIgnore(command: string): boolean {
+  const trimmedCommand = command.trim();
+
+  return allowedIgnoredShellCommands.some((allowedCommand) =>
+    allowedCommand.test(trimmedCommand),
   );
 }

--- a/src/agent/docs-only-backend.ts
+++ b/src/agent/docs-only-backend.ts
@@ -22,23 +22,88 @@ import {
 } from "./openwiki-ignore.js";
 import type { OpenWikiOutputMode } from "./types.js";
 
+/**
+ * ToolMessage metadata key under which a successful mutation records the path it wrote.
+ */
 export const MUTATION_PATH_METADATA_KEY = "openwikiMutationPath";
 
+/**
+ * Options for {@link OpenWikiLocalShellBackend}, extending the deepagents shell backend options.
+ */
 type OpenWikiBackendOptions = LocalShellBackendOptions & {
+  /**
+   * Confine writes to the `openwiki/` docs tree.
+   *
+   * @default false
+   */
   docsOnly?: boolean;
+
+  /**
+   * Rules that exclude paths from all agent filesystem/shell access.
+   *
+   * @default an inactive ruleset (no exclusions)
+   */
   ignoreRules?: OpenWikiIgnoreRules;
+
+  /**
+   * The doc-generation output target, which relaxes the docs-only write check
+   * for `local-wiki` runs.
+   *
+   * @default "repository"
+   */
   outputMode?: OpenWikiOutputMode;
 };
 
+/**
+ * Shell commands the agent may still run while `.openwikiignore` rules are active.
+ *
+ * This is a deliberate allowlist, not a denylist. While rules are active we
+ * cannot statically prove what an arbitrary shell command reads (variable
+ * expansion, command substitution, `find -exec`, `cd` + relative paths,
+ * `git show HEAD:<path>`, and so on all defeat naive command scanning), so the
+ * safe default is to deny shell and permit only these few commands that the
+ * agent workflow needs and that cannot exfiltrate an ignored path. Each entry
+ * is fully anchored (`^...$`) so it cannot be prefixed or chained with a second
+ * command. Discovery and reads must instead go through the gated filesystem
+ * tools. See {@link isAllowedShellCommandWithIgnore}.
+ */
 const allowedIgnoredShellCommands = [
   /^pwd$/u,
   /^git\s+(?:--no-pager\s+)?rev-parse\s+HEAD$/u,
   /^rm\s+-f\s+(?:\.\/)?openwiki\/_plan\.md$/u,
 ];
 
+/**
+ * Filesystem/shell backend that enforces OpenWiki's access boundaries for the
+ * doc-generation agent.
+ *
+ * It wraps the deepagents `LocalShellBackend` and layers on two independent
+ * constraints:
+ *
+ * 1. `.openwikiignore` exclusion: reads/writes/edits of an ignored path are hard
+ *    denied with an error; discovery tools (`ls`/`glob`/`grep`) silently drop
+ *    ignored entries; uploads/downloads reject ignored paths; and shell
+ *    `execute` is restricted to a small allowlist while any rule is active.
+ * 2. Docs-only confinement (`docsOnly`): in repository mode, writes are limited
+ *    to the `openwiki/` tree via {@link isOpenWikiDocsPath}.
+ *
+ * Both are security boundaries against an agent that may be prompt-injected via
+ * untrusted repository content, so path checks canonicalize before matching.
+ */
 export class OpenWikiLocalShellBackend extends LocalShellBackend {
+  /**
+   * Whether writes are confined to the `openwiki/` docs tree (repository mode).
+   */
   private readonly docsOnly: boolean;
+
+  /**
+   * The active `.openwikiignore` ruleset gating every path this backend touches.
+   */
   private readonly ignoreRules: OpenWikiIgnoreRules;
+
+  /**
+   * The doc-generation output target; `local-wiki` relaxes the docs-only write check.
+   */
   private readonly outputMode: OpenWikiOutputMode;
 
   constructor(options: OpenWikiBackendOptions) {
@@ -48,6 +113,9 @@ export class OpenWikiLocalShellBackend extends LocalShellBackend {
     this.outputMode = options.outputMode ?? "repository";
   }
 
+  /**
+   * Read a file, hard-denying the read if the path is excluded by `.openwikiignore`.
+   */
   override async read(
     filePath: string,
     offset?: number,
@@ -62,6 +130,9 @@ export class OpenWikiLocalShellBackend extends LocalShellBackend {
     return super.read(filePath, offset, limit);
   }
 
+  /**
+   * Read raw bytes, hard-denying the read if the path is excluded by `.openwikiignore`.
+   */
   override async readRaw(filePath: string): Promise<ReadRawResult> {
     const error = this.getIgnoredPathError(filePath);
 
@@ -72,6 +143,11 @@ export class OpenWikiLocalShellBackend extends LocalShellBackend {
     return super.readRaw(filePath);
   }
 
+  /**
+   * Write a file, denying if the path is excluded by `.openwikiignore` or falls
+   * outside the docs tree in docs-only mode. On success, records the mutated
+   * path in the result metadata for the validator.
+   */
   override async write(
     filePath: string,
     content: string,
@@ -87,6 +163,10 @@ export class OpenWikiLocalShellBackend extends LocalShellBackend {
     return markMutation(await super.write(filePath, content), filePath);
   }
 
+  /**
+   * Edit a file in place, applying the same `.openwikiignore` and docs-only
+   * checks as {@link write} and recording the mutated path on success.
+   */
   override async edit(
     filePath: string,
     oldString: string,
@@ -107,6 +187,10 @@ export class OpenWikiLocalShellBackend extends LocalShellBackend {
     );
   }
 
+  /**
+   * List a directory, denying if the directory itself is excluded and otherwise
+   * filtering out any ignored entries so they never surface to the agent.
+   */
   override async ls(dirPath: string): Promise<LsResult> {
     const error = this.getIgnoredPathError(dirPath, true);
 
@@ -122,6 +206,10 @@ export class OpenWikiLocalShellBackend extends LocalShellBackend {
     };
   }
 
+  /**
+   * Search file contents, short-circuiting to no matches if the search root is
+   * an ignored directory and filtering out matches under any ignored path.
+   */
   override async grep(
     pattern: string,
     dirPath?: string | null,
@@ -139,6 +227,10 @@ export class OpenWikiLocalShellBackend extends LocalShellBackend {
     };
   }
 
+  /**
+   * Expand a glob, short-circuiting to no results if the search root is an
+   * ignored directory and filtering out any ignored files from the results.
+   */
   override async glob(
     pattern: string,
     searchPath?: string,
@@ -155,6 +247,10 @@ export class OpenWikiLocalShellBackend extends LocalShellBackend {
     };
   }
 
+  /**
+   * Upload files, returning `permission_denied` for any ignored path while still
+   * uploading the allowed ones. Results are returned in the original input order.
+   */
   override async uploadFiles(
     files: Array<[string, Uint8Array]>,
   ): Promise<FileUploadResponse[]> {
@@ -182,6 +278,10 @@ export class OpenWikiLocalShellBackend extends LocalShellBackend {
     });
   }
 
+  /**
+   * Download files, returning `permission_denied` for any ignored path while
+   * still downloading the allowed ones. Results preserve the input order.
+   */
   override async downloadFiles(
     paths: string[],
   ): Promise<FileDownloadResponse[]> {
@@ -213,6 +313,12 @@ export class OpenWikiLocalShellBackend extends LocalShellBackend {
     });
   }
 
+  /**
+   * Run a shell command. While any `.openwikiignore` rule is active, only the
+   * {@link allowedIgnoredShellCommands} allowlist may run; anything else is
+   * refused (exit code 1) with guidance to use the gated filesystem tools,
+   * since arbitrary shell cannot be proven not to read an ignored path.
+   */
   override async execute(command: string): Promise<ExecuteResponse> {
     if (
       this.ignoreRules.isActive &&
@@ -228,6 +334,11 @@ export class OpenWikiLocalShellBackend extends LocalShellBackend {
     return super.execute(command);
   }
 
+  /**
+   * Return a refusal message when a write escapes the docs tree in docs-only
+   * mode, or `null` if the write is allowed. Always allows in `local-wiki` mode
+   * or when the path is under `openwiki/`.
+   */
   private getDocsOnlyWriteError(filePath: string): string | null {
     if (
       !this.docsOnly ||
@@ -240,6 +351,10 @@ export class OpenWikiLocalShellBackend extends LocalShellBackend {
     return `OpenWiki repository init/update runs may only write under /${OPEN_WIKI_DIR}/. Refused path: ${filePath}`;
   }
 
+  /**
+   * Return a refusal message when a path is excluded by `.openwikiignore`, or
+   * `null` if it is allowed.
+   */
   private getIgnoredPathError(
     filePath: string,
     isDirectory = false,
@@ -251,16 +366,24 @@ export class OpenWikiLocalShellBackend extends LocalShellBackend {
     return `Path is excluded by ${OPENWIKI_IGNORE_FILE}: ${filePath}`;
   }
 
+  /**
+   * Whether a directory entry should be filtered out of discovery results.
+   */
   private isIgnoredFile(file: FileInfo): boolean {
     return this.ignoreRules.ignores(file.path, file.is_dir === true);
   }
 
+  /**
+   * Whether a grep hit should be filtered out because its file is ignored.
+   */
   private isIgnoredMatch(match: GrepMatch): boolean {
     return this.ignoreRules.ignores(match.path);
   }
 }
 
-/** Carries a successful mutation's file path into the ToolMessage metadata used by the validator. */
+/**
+ * Carries a successful mutation's file path into the ToolMessage metadata used by the validator.
+ */
 function markMutation<Result extends WriteResult | EditResult>(
   result: Result,
   filePath: string,
@@ -274,6 +397,13 @@ function markMutation<Result extends WriteResult | EditResult>(
   return result;
 }
 
+/**
+ * Whether a path resolves to somewhere inside the `openwiki/` docs tree.
+ *
+ * The path is canonicalized (backslashes, leading slashes, and `.`/`..`
+ * segments collapsed) before the prefix check so a path such as
+ * `/openwiki/../AGENTS.md` cannot escape the confinement.
+ */
 export function isOpenWikiDocsPath(filePath: string): boolean {
   const slashed = filePath.trim().replace(/\\/gu, "/");
   // Collapse `..`/`.` segments before the prefix check so a path like
@@ -286,6 +416,10 @@ export function isOpenWikiDocsPath(filePath: string): boolean {
   );
 }
 
+/**
+ * Whether a shell command is on the {@link allowedIgnoredShellCommands} allowlist
+ * and may therefore run while `.openwikiignore` rules are active.
+ */
 function isAllowedShellCommandWithIgnore(command: string): boolean {
   const trimmedCommand = command.trim();
 

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -121,7 +121,7 @@ import {
   shouldCheckUpdateNoop,
 } from "./utils.js";
 import { classifyError, recordRunSafe } from "../telemetry/index.js";
-import { loadOpenWikiIgnore, OpenWikiIgnoreRules } from "./openwiki-ignore.js";
+import { OpenWikiIgnore } from "./openwiki-ignore.js";
 
 export async function runOpenWikiAgent(
   command: OpenWikiCommand,
@@ -145,14 +145,17 @@ export async function runOpenWikiAgent(
   emitDebug(options, "env=loaded ~/.openwiki/.env");
   emitDebug(options, `env.afterLoad ${formatEnvironmentDebug()}`);
 
-  const ignoreRules =
+  const openWikiIgnore =
     outputMode === "repository"
-      ? await loadOpenWikiIgnore(runtimeCwd)
-      : new OpenWikiIgnoreRules([]);
-  emitDebug(options, `openwikiignore.patterns=${ignoreRules.patterns.length}`);
+      ? await OpenWikiIgnore.load(runtimeCwd)
+      : new OpenWikiIgnore([]);
+  emitDebug(
+    options,
+    `openwikiignore.patterns=${openWikiIgnore.patterns.length}`,
+  );
 
   if (command === "update" && shouldCheckUpdateNoop(options)) {
-    const noopStatus = await getUpdateNoopStatus(cwd, ignoreRules);
+    const noopStatus = await getUpdateNoopStatus(cwd, openWikiIgnore);
 
     if (noopStatus.shouldSkip) {
       const message =
@@ -229,7 +232,7 @@ export async function runOpenWikiAgent(
       provider,
       modelId,
       providerRetryAttempts,
-      ignoreRules,
+      openWikiIgnore,
     );
 
     await recordRunSafe(command, options, {
@@ -260,7 +263,7 @@ async function runOpenWikiAgentCore(
   provider: OpenWikiProvider,
   modelId: string,
   providerRetryAttempts: number,
-  ignoreRules: OpenWikiIgnoreRules,
+  openWikiIgnore: OpenWikiIgnore,
 ): Promise<OpenWikiRunResult> {
   const outputMode = options.outputMode ?? "local-wiki";
   const context = await createRunContext(
@@ -268,7 +271,7 @@ async function runOpenWikiAgentCore(
     cwd,
     outputMode,
     options.language,
-    ignoreRules,
+    openWikiIgnore,
   );
   emitDebug(options, "context=created");
   const openWikiSnapshotBefore =
@@ -291,7 +294,7 @@ async function runOpenWikiAgentCore(
   );
   const wikiBackend = new OpenWikiLocalShellBackend({
     docsOnly: command !== "chat",
-    ignoreRules,
+    openWikiIgnore,
     maxOutputBytes: 100_000,
     outputMode,
     rootDir: cwd,
@@ -372,7 +375,7 @@ async function runOpenWikiAgentCore(
       command,
       outputMode,
       context.language,
-      ignoreRules,
+      openWikiIgnore,
     ),
   });
   emitDebug(options, "agent=created");

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -121,12 +121,14 @@ import {
   shouldCheckUpdateNoop,
 } from "./utils.js";
 import { classifyError, recordRunSafe } from "../telemetry/index.js";
+import { loadOpenWikiIgnore, OpenWikiIgnoreRules } from "./openwiki-ignore.js";
 
 export async function runOpenWikiAgent(
   command: OpenWikiCommand,
   cwd = openWikiLocalWikiDir,
   options: OpenWikiRunOptions = {},
 ): Promise<OpenWikiRunResult> {
+  const outputMode = options.outputMode ?? "local-wiki";
   const runtimeCwd = options.outputMode ? cwd : openWikiLocalWikiDir;
 
   emitDebug(options, `command=${command}`);
@@ -143,8 +145,14 @@ export async function runOpenWikiAgent(
   emitDebug(options, "env=loaded ~/.openwiki/.env");
   emitDebug(options, `env.afterLoad ${formatEnvironmentDebug()}`);
 
+  const ignoreRules =
+    outputMode === "repository"
+      ? await loadOpenWikiIgnore(runtimeCwd)
+      : new OpenWikiIgnoreRules([]);
+  emitDebug(options, `openwikiignore.patterns=${ignoreRules.patterns.length}`);
+
   if (command === "update" && shouldCheckUpdateNoop(options)) {
-    const noopStatus = await getUpdateNoopStatus(cwd);
+    const noopStatus = await getUpdateNoopStatus(cwd, ignoreRules);
 
     if (noopStatus.shouldSkip) {
       const message =
@@ -221,6 +229,7 @@ export async function runOpenWikiAgent(
       provider,
       modelId,
       providerRetryAttempts,
+      ignoreRules,
     );
 
     await recordRunSafe(command, options, {
@@ -251,6 +260,7 @@ async function runOpenWikiAgentCore(
   provider: OpenWikiProvider,
   modelId: string,
   providerRetryAttempts: number,
+  ignoreRules: OpenWikiIgnoreRules,
 ): Promise<OpenWikiRunResult> {
   const outputMode = options.outputMode ?? "local-wiki";
   const context = await createRunContext(
@@ -258,6 +268,7 @@ async function runOpenWikiAgentCore(
     cwd,
     outputMode,
     options.language,
+    ignoreRules,
   );
   emitDebug(options, "context=created");
   const openWikiSnapshotBefore =
@@ -280,6 +291,7 @@ async function runOpenWikiAgentCore(
   );
   const wikiBackend = new OpenWikiLocalShellBackend({
     docsOnly: command !== "chat",
+    ignoreRules,
     maxOutputBytes: 100_000,
     outputMode,
     rootDir: cwd,
@@ -356,7 +368,12 @@ async function runOpenWikiAgentCore(
     permissions: [
       { operations: ["write"], paths: ["/skills/**"], mode: "deny" },
     ],
-    systemPrompt: createSystemPrompt(command, outputMode, context.language),
+    systemPrompt: createSystemPrompt(
+      command,
+      outputMode,
+      context.language,
+      ignoreRules,
+    ),
   });
   emitDebug(options, "agent=created");
 

--- a/src/agent/openwiki-ignore.ts
+++ b/src/agent/openwiki-ignore.ts
@@ -1,0 +1,187 @@
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import { isFileNotFoundError } from "../fs-errors.js";
+
+export const OPENWIKI_IGNORE_FILE = ".openwikiignore";
+
+type IgnoreRule = {
+  directoryOnly: boolean;
+  matcher: RegExp;
+  negated: boolean;
+};
+
+export class OpenWikiIgnoreRules {
+  readonly patterns: string[];
+  private readonly rules: IgnoreRule[];
+
+  constructor(patterns: string[]) {
+    this.patterns = patterns;
+    this.rules = patterns.map(createRule).filter((rule) => rule !== null);
+  }
+
+  get isActive(): boolean {
+    return this.rules.length > 0;
+  }
+
+  ignores(filePath: string, isDirectory = false): boolean {
+    const normalizedPath = normalizeIgnorePath(filePath);
+
+    if (normalizedPath.length === 0) {
+      return false;
+    }
+
+    let ignored = false;
+
+    for (const rule of this.rules) {
+      if (matchesRule(rule, normalizedPath, isDirectory)) {
+        ignored = !rule.negated;
+      }
+    }
+
+    return ignored;
+  }
+}
+
+export async function loadOpenWikiIgnore(
+  cwd: string,
+): Promise<OpenWikiIgnoreRules> {
+  try {
+    const contents = await readFile(
+      path.join(cwd, OPENWIKI_IGNORE_FILE),
+      "utf8",
+    );
+
+    return createOpenWikiIgnoreRules(contents);
+  } catch (error) {
+    if (isFileNotFoundError(error)) {
+      return createOpenWikiIgnoreRules("");
+    }
+
+    throw error;
+  }
+}
+
+export function createOpenWikiIgnoreRules(
+  contents: string,
+): OpenWikiIgnoreRules {
+  return new OpenWikiIgnoreRules(
+    contents
+      .split(/\r?\n/u)
+      .map(parseIgnoreLine)
+      .filter((line) => line !== null),
+  );
+}
+
+export function normalizeIgnorePath(filePath: string): string {
+  return filePath
+    .replace(/\\/gu, "/")
+    .replace(/^\/+/u, "")
+    .replace(/\/+$/u, "");
+}
+
+function parseIgnoreLine(line: string): string | null {
+  const trimmedLine = line.trim();
+
+  if (trimmedLine.length === 0 || trimmedLine.startsWith("#")) {
+    return null;
+  }
+
+  return trimmedLine;
+}
+
+function createRule(pattern: string): IgnoreRule | null {
+  let normalizedPattern = pattern.replace(/\\/gu, "/");
+  const negated = normalizedPattern.startsWith("!");
+
+  if (negated) {
+    normalizedPattern = normalizedPattern.slice(1);
+  }
+
+  normalizedPattern = normalizedPattern
+    .replace(/^\.\/+/u, "")
+    .replace(/\/+/gu, "/");
+
+  const anchored = normalizedPattern.startsWith("/");
+  const directoryOnly = normalizedPattern.endsWith("/");
+  normalizedPattern = normalizedPattern
+    .replace(/^\/+/u, "")
+    .replace(/\/+$/u, "");
+
+  if (normalizedPattern.length === 0) {
+    return null;
+  }
+
+  return {
+    directoryOnly,
+    matcher: createPatternMatcher(normalizedPattern, anchored),
+    negated,
+  };
+}
+
+function createPatternMatcher(pattern: string, anchored: boolean): RegExp {
+  const containsSlash = pattern.includes("/");
+  const source = globToRegexSource(pattern);
+
+  if (anchored || containsSlash) {
+    return new RegExp(`^${source}(?:/.*)?$`, "u");
+  }
+
+  return new RegExp(`(^|/)${source}(/.*)?$`, "u");
+}
+
+function matchesRule(
+  rule: IgnoreRule,
+  filePath: string,
+  isDirectory: boolean,
+): boolean {
+  if (!rule.matcher.test(filePath)) {
+    return false;
+  }
+
+  if (!rule.directoryOnly) {
+    return true;
+  }
+
+  return isDirectory || filePath.includes("/");
+}
+
+function globToRegexSource(pattern: string): string {
+  let source = "";
+
+  for (let index = 0; index < pattern.length; index += 1) {
+    const character = pattern[index];
+    const nextCharacter = pattern[index + 1];
+
+    if (character === "*" && nextCharacter === "*") {
+      const characterAfterGlobstar = pattern[index + 2];
+
+      if (characterAfterGlobstar === "/") {
+        source += "(?:.*/)?";
+        index += 2;
+      } else {
+        source += ".*";
+        index += 1;
+      }
+
+      continue;
+    }
+
+    if (character === "*") {
+      source += "[^/]*";
+      continue;
+    }
+
+    if (character === "?") {
+      source += "[^/]";
+      continue;
+    }
+
+    source += escapeRegex(character);
+  }
+
+  return source;
+}
+
+function escapeRegex(value: string): string {
+  return value.replace(/[|\\{}()[\]^$+*?.]/gu, "\\$&");
+}

--- a/src/agent/openwiki-ignore.ts
+++ b/src/agent/openwiki-ignore.ts
@@ -60,16 +60,24 @@ export class OpenWikiIgnoreRule {
    * matched from the start of the path; a trailing `(?:/.*)?` lets a directory
    * pattern also match everything nested beneath it. Unanchored, slash-free
    * patterns (e.g. `*.log`) match at any path segment via the `(^|/)` prefix.
+   *
+   * The `i` flag is deliberate and security-relevant: on case-insensitive
+   * filesystems (macOS APFS/HFS+, Windows NTFS) `Secrets/token.txt` and
+   * `secrets/token.txt` resolve to the same file, so a case-sensitive rule
+   * would let an alternate-cased spelling slip past an exclusion. Matching
+   * case-insensitively everywhere closes that bypass; the worst case on a
+   * genuinely case-sensitive filesystem is over-excluding a case variant,
+   * which is the safe direction for an access gate.
    */
   private static createMatcher(pattern: string, anchored: boolean): RegExp {
     const containsSlash = pattern.includes("/");
     const source = OpenWikiIgnoreRule.globToRegexSource(pattern);
 
     if (anchored || containsSlash) {
-      return new RegExp(`^${source}(?:/.*)?$`, "u");
+      return new RegExp(`^${source}(?:/.*)?$`, "iu");
     }
 
-    return new RegExp(`(^|/)${source}(/.*)?$`, "u");
+    return new RegExp(`(^|/)${source}(/.*)?$`, "iu");
   }
 
   /**

--- a/src/agent/openwiki-ignore.ts
+++ b/src/agent/openwiki-ignore.ts
@@ -8,44 +8,222 @@ import { isFileNotFoundError } from "../fs-errors.js";
 export const OPENWIKI_IGNORE_FILE = ".openwikiignore";
 
 /**
- * A single compiled `.openwikiignore` line.
+ * One compiled `.openwikiignore` pattern.
  *
- * One source pattern becomes one rule. Evaluation order matters: rules are
- * applied in file order with last-match-wins semantics (see {@link OpenWikiIgnoreRules.ignores}),
- * which is what lets a later `!negated` rule re-include a path an earlier rule excluded.
+ * A rule owns both the compiled matcher and the decision of whether a given
+ * path matches it. Rules are never evaluated alone: {@link OpenWikiIgnore}
+ * applies them in file order with last-match-wins semantics, which is what lets
+ * a later negated (`!`) rule re-include a path an earlier rule excluded.
  */
-type IgnoreRule = {
+export class OpenWikiIgnoreRule {
+  /**
+   * Compile one `.openwikiignore` pattern into a rule.
+   *
+   * Peels off the gitignore modifiers before building the matcher: a leading `!`
+   * marks negation, a leading `/` (or embedded slash) anchors the pattern to the
+   * repo root, and a trailing `/` scopes it to directories. Returns `undefined`
+   * if the pattern is empty after stripping those markers.
+   */
+  static compile(pattern: string): OpenWikiIgnoreRule | undefined {
+    let normalizedPattern = pattern.replace(/\\/gu, "/");
+    const negated = normalizedPattern.startsWith("!");
+
+    if (negated) {
+      normalizedPattern = normalizedPattern.slice(1);
+    }
+
+    normalizedPattern = normalizedPattern
+      .replace(/^\.\/+/u, "")
+      .replace(/\/+/gu, "/");
+
+    const anchored = normalizedPattern.startsWith("/");
+    const directoryOnly = normalizedPattern.endsWith("/");
+    normalizedPattern = normalizedPattern
+      .replace(/^\/+/u, "")
+      .replace(/\/+$/u, "");
+
+    if (normalizedPattern.length === 0) {
+      return undefined;
+    }
+
+    return new OpenWikiIgnoreRule(
+      directoryOnly,
+      OpenWikiIgnoreRule.createMatcher(normalizedPattern, anchored),
+      negated,
+    );
+  }
+
+  /**
+   * Build the regex that tests a normalized path against one pattern.
+   *
+   * Anchored patterns (leading `/`) and patterns that contain a slash are
+   * matched from the start of the path; a trailing `(?:/.*)?` lets a directory
+   * pattern also match everything nested beneath it. Unanchored, slash-free
+   * patterns (e.g. `*.log`) match at any path segment via the `(^|/)` prefix.
+   */
+  private static createMatcher(pattern: string, anchored: boolean): RegExp {
+    const containsSlash = pattern.includes("/");
+    const source = OpenWikiIgnoreRule.globToRegexSource(pattern);
+
+    if (anchored || containsSlash) {
+      return new RegExp(`^${source}(?:/.*)?$`, "u");
+    }
+
+    return new RegExp(`(^|/)${source}(/.*)?$`, "u");
+  }
+
+  /**
+   * Translate a gitignore-style glob into a regex source fragment.
+   *
+   * Supported wildcards: `**\/` spans zero or more directories, a bare `**`
+   * spans anything, `*` matches within a single path segment, and `?` matches
+   * one non-slash character. All other characters are escaped as literals.
+   */
+  private static globToRegexSource(pattern: string): string {
+    let source = "";
+
+    for (let index = 0; index < pattern.length; index += 1) {
+      const character = pattern[index];
+      const nextCharacter = pattern[index + 1];
+
+      if (character === "*" && nextCharacter === "*") {
+        const characterAfterGlobstar = pattern[index + 2];
+
+        if (characterAfterGlobstar === "/") {
+          source += "(?:.*/)?";
+          index += 2;
+        } else {
+          source += ".*";
+          index += 1;
+        }
+
+        continue;
+      }
+
+      if (character === "*") {
+        source += "[^/]*";
+        continue;
+      }
+
+      if (character === "?") {
+        source += "[^/]";
+        continue;
+      }
+
+      source += OpenWikiIgnoreRule.escapeRegex(character);
+    }
+
+    return source;
+  }
+
+  /**
+   * Escape a single character so it is treated literally inside a regex.
+   */
+  private static escapeRegex(value: string): string {
+    return value.replace(/[|\\{}()[\]^$+*?.]/gu, "\\$&");
+  }
+
   /**
    * Whether the pattern only matches directories (trailing `/` in the source,
    * e.g. `build/`). Directory-only rules still match files nested under the
-   * directory; see {@link matchesRule}.
+   * directory; see {@link matches}.
    */
-  directoryOnly: boolean;
+  private readonly directoryOnly: boolean;
 
   /**
    * Compiled matcher for the glob, tested against a normalized repo-relative path.
    */
-  matcher: RegExp;
+  private readonly matcher: RegExp;
 
   /**
    * Whether the source line began with `!`, re-including a previously excluded path.
    */
-  negated: boolean;
-};
+  readonly negated: boolean;
+
+  private constructor(
+    directoryOnly: boolean,
+    matcher: RegExp,
+    negated: boolean,
+  ) {
+    this.directoryOnly = directoryOnly;
+    this.matcher = matcher;
+    this.negated = negated;
+  }
+
+  /**
+   * Test whether this rule matches a normalized path.
+   *
+   * A directory-only rule matches only when the target is itself a directory or
+   * sits under one (the path contains a `/`), so `build/` never excludes a
+   * top-level file literally named `build`.
+   */
+  matches(filePath: string, isDirectory: boolean): boolean {
+    if (!this.matcher.test(filePath)) {
+      return false;
+    }
+
+    if (!this.directoryOnly) {
+      return true;
+    }
+
+    return isDirectory || filePath.includes("/");
+  }
+}
 
 /**
  * The full, ordered set of `.openwikiignore` rules for one run.
  *
- * This is the aggregate matcher, not a single rule: {@link ignores} can only
- * answer "is this path excluded?" by walking every rule in file order, because
- * negation (`!`) is only meaningful relative to the rules that precede it. It is
- * threaded through the agent backend, prompt, and run context as one cohesive
- * object so the matching semantics live in exactly one place.
+ * This is the aggregate matcher over every rule, not a single rule:
+ * {@link ignores} can only answer "is this path excluded?" by walking the rules
+ * in file order, because negation (`!`) is only meaningful relative to the rules
+ * that precede it. It is threaded through the agent backend, prompt, and run
+ * context as one cohesive object so the matching semantics live in exactly one
+ * place.
  *
  * Matching aims to be gitignore-compatible: last-match-wins, `*`/`**`/`?` globs,
  * leading-`/` anchoring to the repo root, and trailing-`/` directory scoping.
  */
-export class OpenWikiIgnoreRules {
+export class OpenWikiIgnore {
+  /**
+   * Parse raw `.openwikiignore` file contents into an aggregate matcher.
+   *
+   * Splits on newlines, drops blank lines and `#` comments, and keeps the
+   * remaining lines as patterns.
+   */
+  static parse(contents: string): OpenWikiIgnore {
+    return new OpenWikiIgnore(
+      contents
+        .split(/\r?\n/u)
+        .map(parseIgnoreLine)
+        .filter((line) => line !== undefined),
+    );
+  }
+
+  /**
+   * Load and parse `.openwikiignore` from a repo root.
+   *
+   * A missing file is treated as "no rules" (an inactive matcher), not an error;
+   * any other read failure is rethrown.
+   *
+   * @param cwd - Absolute path to the repository root to read the file from.
+   */
+  static async load(cwd: string): Promise<OpenWikiIgnore> {
+    try {
+      const contents = await readFile(
+        path.join(cwd, OPENWIKI_IGNORE_FILE),
+        "utf8",
+      );
+
+      return OpenWikiIgnore.parse(contents);
+    } catch (error) {
+      if (isFileNotFoundError(error)) {
+        return OpenWikiIgnore.parse("");
+      }
+
+      throw error;
+    }
+  }
+
   /**
    * The raw, non-comment pattern lines, preserved for prompt/display purposes.
    */
@@ -54,11 +232,13 @@ export class OpenWikiIgnoreRules {
   /**
    * The compiled rules, in file order; invalid/empty patterns are dropped.
    */
-  private readonly rules: IgnoreRule[];
+  private readonly rules: OpenWikiIgnoreRule[];
 
   constructor(patterns: string[]) {
     this.patterns = patterns;
-    this.rules = patterns.map(createRule).filter((rule) => rule !== null);
+    this.rules = patterns
+      .map((pattern) => OpenWikiIgnoreRule.compile(pattern))
+      .filter((rule) => rule !== undefined);
   }
 
   /**
@@ -90,59 +270,13 @@ export class OpenWikiIgnoreRules {
     let ignored = false;
 
     for (const rule of this.rules) {
-      if (matchesRule(rule, normalizedPath, isDirectory)) {
+      if (rule.matches(normalizedPath, isDirectory)) {
         ignored = !rule.negated;
       }
     }
 
     return ignored;
   }
-}
-
-/**
- * Load and parse `.openwikiignore` from a repo root.
- *
- * A missing file is treated as "no rules" (an inactive {@link OpenWikiIgnoreRules}),
- * not an error; any other read failure is rethrown.
- *
- * @param cwd - Absolute path to the repository root to read the file from.
- */
-export async function loadOpenWikiIgnore(
-  cwd: string,
-): Promise<OpenWikiIgnoreRules> {
-  try {
-    const contents = await readFile(
-      path.join(cwd, OPENWIKI_IGNORE_FILE),
-      "utf8",
-    );
-
-    return createOpenWikiIgnoreRules(contents);
-  } catch (error) {
-    if (isFileNotFoundError(error)) {
-      return createOpenWikiIgnoreRules("");
-    }
-
-    throw error;
-  }
-}
-
-/**
- * Build an {@link OpenWikiIgnoreRules} from raw file contents.
- *
- * Splits on newlines, drops blank lines and `#` comments, and keeps the
- * remaining lines as patterns.
- *
- * @param contents - The full text of a `.openwikiignore` file.
- */
-export function createOpenWikiIgnoreRules(
-  contents: string,
-): OpenWikiIgnoreRules {
-  return new OpenWikiIgnoreRules(
-    contents
-      .split(/\r?\n/u)
-      .map(parseIgnoreLine)
-      .filter((line) => line !== null),
-  );
 }
 
 /**
@@ -161,7 +295,7 @@ export function createOpenWikiIgnoreRules(
  *
  * @param filePath - A path in any spelling (backslashes, leading `/`, `.`/`..`).
  */
-export function normalizeIgnorePath(filePath: string): string {
+function normalizeIgnorePath(filePath: string): string {
   const slashed = filePath.replace(/\\/gu, "/");
   const normalized = path.posix.normalize(`/${slashed.replace(/^\/+/u, "")}`);
 
@@ -171,147 +305,14 @@ export function normalizeIgnorePath(filePath: string): string {
 /**
  * Trim one raw line and decide whether it is a usable pattern.
  *
- * Returns the trimmed pattern, or `null` for blank lines and `#` comments.
+ * Returns the trimmed pattern, or `undefined` for blank lines and `#` comments.
  */
-function parseIgnoreLine(line: string): string | null {
+function parseIgnoreLine(line: string): string | undefined {
   const trimmedLine = line.trim();
 
   if (trimmedLine.length === 0 || trimmedLine.startsWith("#")) {
-    return null;
+    return undefined;
   }
 
   return trimmedLine;
-}
-
-/**
- * Compile one `.openwikiignore` pattern into an {@link IgnoreRule}.
- *
- * Peels off the gitignore modifiers before building the matcher: a leading `!`
- * marks negation, a leading `/` (or embedded slash) anchors the pattern to the
- * repo root, and a trailing `/` scopes it to directories. Returns `null` if the
- * pattern is empty after stripping those markers.
- */
-function createRule(pattern: string): IgnoreRule | null {
-  let normalizedPattern = pattern.replace(/\\/gu, "/");
-  const negated = normalizedPattern.startsWith("!");
-
-  if (negated) {
-    normalizedPattern = normalizedPattern.slice(1);
-  }
-
-  normalizedPattern = normalizedPattern
-    .replace(/^\.\/+/u, "")
-    .replace(/\/+/gu, "/");
-
-  const anchored = normalizedPattern.startsWith("/");
-  const directoryOnly = normalizedPattern.endsWith("/");
-  normalizedPattern = normalizedPattern
-    .replace(/^\/+/u, "")
-    .replace(/\/+$/u, "");
-
-  if (normalizedPattern.length === 0) {
-    return null;
-  }
-
-  return {
-    directoryOnly,
-    matcher: createPatternMatcher(normalizedPattern, anchored),
-    negated,
-  };
-}
-
-/**
- * Build the regex that tests a normalized path against one pattern.
- *
- * Anchored patterns (leading `/`) and patterns that contain a slash are matched
- * from the start of the path; a trailing `(?:/.*)?` lets a directory pattern
- * also match everything nested beneath it. Unanchored, slash-free patterns
- * (e.g. `*.log`) match at any path segment via the `(^|/)` prefix.
- *
- * @param pattern - The pattern with `!`, leading/trailing `/` already stripped.
- * @param anchored - Whether the source pattern was root-anchored.
- */
-function createPatternMatcher(pattern: string, anchored: boolean): RegExp {
-  const containsSlash = pattern.includes("/");
-  const source = globToRegexSource(pattern);
-
-  if (anchored || containsSlash) {
-    return new RegExp(`^${source}(?:/.*)?$`, "u");
-  }
-
-  return new RegExp(`(^|/)${source}(/.*)?$`, "u");
-}
-
-/**
- * Test whether a compiled rule matches a normalized path.
- *
- * A directory-only rule matches only when the target is itself a directory or
- * sits under one (the path contains a `/`), so `build/` never excludes a
- * top-level file literally named `build`.
- */
-function matchesRule(
-  rule: IgnoreRule,
-  filePath: string,
-  isDirectory: boolean,
-): boolean {
-  if (!rule.matcher.test(filePath)) {
-    return false;
-  }
-
-  if (!rule.directoryOnly) {
-    return true;
-  }
-
-  return isDirectory || filePath.includes("/");
-}
-
-/**
- * Translate a gitignore-style glob into a regex source fragment.
- *
- * Supported wildcards: `**\/` spans zero or more directories, a bare `**` spans
- * anything, `*` matches within a single path segment, and `?` matches one
- * non-slash character. All other characters are escaped as literals.
- */
-function globToRegexSource(pattern: string): string {
-  let source = "";
-
-  for (let index = 0; index < pattern.length; index += 1) {
-    const character = pattern[index];
-    const nextCharacter = pattern[index + 1];
-
-    if (character === "*" && nextCharacter === "*") {
-      const characterAfterGlobstar = pattern[index + 2];
-
-      if (characterAfterGlobstar === "/") {
-        source += "(?:.*/)?";
-        index += 2;
-      } else {
-        source += ".*";
-        index += 1;
-      }
-
-      continue;
-    }
-
-    if (character === "*") {
-      source += "[^/]*";
-      continue;
-    }
-
-    if (character === "?") {
-      source += "[^/]";
-      continue;
-    }
-
-    source += escapeRegex(character);
-  }
-
-  return source;
-}
-
-/**
- * Escape a single character so it is treated literally inside a regex.
- */
-function escapeRegex(value: string): string {
-  return value.replace(/[|\\{}()[\]^$+*?.]/gu, "\\$&");
 }

--- a/src/agent/openwiki-ignore.ts
+++ b/src/agent/openwiki-ignore.ts
@@ -2,16 +2,58 @@ import { readFile } from "node:fs/promises";
 import path from "node:path";
 import { isFileNotFoundError } from "../fs-errors.js";
 
+/**
+ * Name of the gitignore-style file that lists paths the doc agent must not touch.
+ */
 export const OPENWIKI_IGNORE_FILE = ".openwikiignore";
 
+/**
+ * A single compiled `.openwikiignore` line.
+ *
+ * One source pattern becomes one rule. Evaluation order matters: rules are
+ * applied in file order with last-match-wins semantics (see {@link OpenWikiIgnoreRules.ignores}),
+ * which is what lets a later `!negated` rule re-include a path an earlier rule excluded.
+ */
 type IgnoreRule = {
+  /**
+   * Whether the pattern only matches directories (trailing `/` in the source,
+   * e.g. `build/`). Directory-only rules still match files nested under the
+   * directory; see {@link matchesRule}.
+   */
   directoryOnly: boolean;
+
+  /**
+   * Compiled matcher for the glob, tested against a normalized repo-relative path.
+   */
   matcher: RegExp;
+
+  /**
+   * Whether the source line began with `!`, re-including a previously excluded path.
+   */
   negated: boolean;
 };
 
+/**
+ * The full, ordered set of `.openwikiignore` rules for one run.
+ *
+ * This is the aggregate matcher, not a single rule: {@link ignores} can only
+ * answer "is this path excluded?" by walking every rule in file order, because
+ * negation (`!`) is only meaningful relative to the rules that precede it. It is
+ * threaded through the agent backend, prompt, and run context as one cohesive
+ * object so the matching semantics live in exactly one place.
+ *
+ * Matching aims to be gitignore-compatible: last-match-wins, `*`/`**`/`?` globs,
+ * leading-`/` anchoring to the repo root, and trailing-`/` directory scoping.
+ */
 export class OpenWikiIgnoreRules {
+  /**
+   * The raw, non-comment pattern lines, preserved for prompt/display purposes.
+   */
   readonly patterns: string[];
+
+  /**
+   * The compiled rules, in file order; invalid/empty patterns are dropped.
+   */
   private readonly rules: IgnoreRule[];
 
   constructor(patterns: string[]) {
@@ -19,10 +61,25 @@ export class OpenWikiIgnoreRules {
     this.rules = patterns.map(createRule).filter((rule) => rule !== null);
   }
 
+  /**
+   * Whether any usable rule was parsed. Enforcement is a no-op when this is false.
+   */
   get isActive(): boolean {
     return this.rules.length > 0;
   }
 
+  /**
+   * Report whether `filePath` is excluded by the ruleset.
+   *
+   * The path is first canonicalized by {@link normalizeIgnorePath} so that
+   * equivalent spellings (`./secrets/x`, `secrets/../secrets/x`, `/secrets/x`)
+   * cannot slip past an anchored rule. Rules are then applied in file order and
+   * the last matching rule wins, so a trailing `!pattern` can re-include a path.
+   *
+   * @param filePath - A repo-relative (or root-anchored) path to test.
+   * @param isDirectory - Whether the path refers to a directory; lets
+   *   directory-only rules match the directory entry itself. Defaults to false.
+   */
   ignores(filePath: string, isDirectory = false): boolean {
     const normalizedPath = normalizeIgnorePath(filePath);
 
@@ -42,6 +99,14 @@ export class OpenWikiIgnoreRules {
   }
 }
 
+/**
+ * Load and parse `.openwikiignore` from a repo root.
+ *
+ * A missing file is treated as "no rules" (an inactive {@link OpenWikiIgnoreRules}),
+ * not an error; any other read failure is rethrown.
+ *
+ * @param cwd - Absolute path to the repository root to read the file from.
+ */
 export async function loadOpenWikiIgnore(
   cwd: string,
 ): Promise<OpenWikiIgnoreRules> {
@@ -61,6 +126,14 @@ export async function loadOpenWikiIgnore(
   }
 }
 
+/**
+ * Build an {@link OpenWikiIgnoreRules} from raw file contents.
+ *
+ * Splits on newlines, drops blank lines and `#` comments, and keeps the
+ * remaining lines as patterns.
+ *
+ * @param contents - The full text of a `.openwikiignore` file.
+ */
 export function createOpenWikiIgnoreRules(
   contents: string,
 ): OpenWikiIgnoreRules {
@@ -72,13 +145,34 @@ export function createOpenWikiIgnoreRules(
   );
 }
 
+/**
+ * Canonicalize a path into the repo-relative form that rule matchers expect.
+ *
+ * This is a security boundary, not cosmetic cleanup: naive string stripping
+ * would let equivalent spellings dodge an anchored rule. For example, with the
+ * rule `/secrets`, the path `./secrets/token.txt` would fail to match once the
+ * leading `./` was present, and `secrets/../secrets/token.txt` would not match
+ * either, leaking an excluded file. So we normalize `.`/`..` segments with
+ * `path.posix.normalize`, mirroring the confinement check in `isOpenWikiDocsPath`.
+ *
+ * The path is anchored to `/` before normalizing so that any `..` cannot escape
+ * above the repo root (`../foo` collapses to `foo`); the leading and trailing
+ * slashes are then stripped back off to yield a bare repo-relative path.
+ *
+ * @param filePath - A path in any spelling (backslashes, leading `/`, `.`/`..`).
+ */
 export function normalizeIgnorePath(filePath: string): string {
-  return filePath
-    .replace(/\\/gu, "/")
-    .replace(/^\/+/u, "")
-    .replace(/\/+$/u, "");
+  const slashed = filePath.replace(/\\/gu, "/");
+  const normalized = path.posix.normalize(`/${slashed.replace(/^\/+/u, "")}`);
+
+  return normalized.replace(/^\/+/u, "").replace(/\/+$/u, "");
 }
 
+/**
+ * Trim one raw line and decide whether it is a usable pattern.
+ *
+ * Returns the trimmed pattern, or `null` for blank lines and `#` comments.
+ */
 function parseIgnoreLine(line: string): string | null {
   const trimmedLine = line.trim();
 
@@ -89,6 +183,14 @@ function parseIgnoreLine(line: string): string | null {
   return trimmedLine;
 }
 
+/**
+ * Compile one `.openwikiignore` pattern into an {@link IgnoreRule}.
+ *
+ * Peels off the gitignore modifiers before building the matcher: a leading `!`
+ * marks negation, a leading `/` (or embedded slash) anchors the pattern to the
+ * repo root, and a trailing `/` scopes it to directories. Returns `null` if the
+ * pattern is empty after stripping those markers.
+ */
 function createRule(pattern: string): IgnoreRule | null {
   let normalizedPattern = pattern.replace(/\\/gu, "/");
   const negated = normalizedPattern.startsWith("!");
@@ -118,6 +220,17 @@ function createRule(pattern: string): IgnoreRule | null {
   };
 }
 
+/**
+ * Build the regex that tests a normalized path against one pattern.
+ *
+ * Anchored patterns (leading `/`) and patterns that contain a slash are matched
+ * from the start of the path; a trailing `(?:/.*)?` lets a directory pattern
+ * also match everything nested beneath it. Unanchored, slash-free patterns
+ * (e.g. `*.log`) match at any path segment via the `(^|/)` prefix.
+ *
+ * @param pattern - The pattern with `!`, leading/trailing `/` already stripped.
+ * @param anchored - Whether the source pattern was root-anchored.
+ */
 function createPatternMatcher(pattern: string, anchored: boolean): RegExp {
   const containsSlash = pattern.includes("/");
   const source = globToRegexSource(pattern);
@@ -129,6 +242,13 @@ function createPatternMatcher(pattern: string, anchored: boolean): RegExp {
   return new RegExp(`(^|/)${source}(/.*)?$`, "u");
 }
 
+/**
+ * Test whether a compiled rule matches a normalized path.
+ *
+ * A directory-only rule matches only when the target is itself a directory or
+ * sits under one (the path contains a `/`), so `build/` never excludes a
+ * top-level file literally named `build`.
+ */
 function matchesRule(
   rule: IgnoreRule,
   filePath: string,
@@ -145,6 +265,13 @@ function matchesRule(
   return isDirectory || filePath.includes("/");
 }
 
+/**
+ * Translate a gitignore-style glob into a regex source fragment.
+ *
+ * Supported wildcards: `**\/` spans zero or more directories, a bare `**` spans
+ * anything, `*` matches within a single path segment, and `?` matches one
+ * non-slash character. All other characters are escaped as literals.
+ */
 function globToRegexSource(pattern: string): string {
   let source = "";
 
@@ -182,6 +309,9 @@ function globToRegexSource(pattern: string): string {
   return source;
 }
 
+/**
+ * Escape a single character so it is treated literally inside a regex.
+ */
 function escapeRegex(value: string): string {
   return value.replace(/[|\\{}()[\]^$+*?.]/gu, "\\$&");
 }

--- a/src/agent/prompt.ts
+++ b/src/agent/prompt.ts
@@ -4,7 +4,7 @@ import {
   RunContext,
   UpdateMetadata,
 } from "./types.js";
-import type { OpenWikiIgnoreRules } from "./openwiki-ignore.js";
+import type { OpenWikiIgnore } from "./openwiki-ignore.js";
 
 function formatLastUpdate(lastUpdate: UpdateMetadata | null): string {
   if (lastUpdate === null) {
@@ -18,7 +18,7 @@ export function createSystemPrompt(
   command: OpenWikiCommand,
   outputMode: OpenWikiOutputMode = "local-wiki",
   language?: string,
-  ignoreRules?: OpenWikiIgnoreRules,
+  openWikiIgnore?: OpenWikiIgnore,
 ): string {
   const output = getOutputPromptConfig(outputMode);
   const languageInstructions = createLanguageInstructions(language);
@@ -42,7 +42,7 @@ Run discipline:
 - Create a strong first-pass wiki that is accurate and navigable, then stop. The wiki can be refined in later update runs.
 - Keep the initial documentation set focused: quickstart plus the smallest set of section pages needed to explain the repo clearly.
 - ${output.searchBoundaryInstruction}
-${createOpenWikiIgnoreInstructions(ignoreRules)}
+${createOpenWikiIgnoreInstructions(openWikiIgnore)}
 
 Connector ingestion discipline:
 - OpenWiki has built-in local connectors for git-repo, notion, x, google, web-search, hackernews, and slack. Use openwiki_list_connectors to inspect connector capabilities, config paths, required env var names, and raw data paths.
@@ -233,13 +233,13 @@ Diagram discipline:
 }
 
 function createOpenWikiIgnoreInstructions(
-  ignoreRules?: OpenWikiIgnoreRules,
+  openWikiIgnore?: OpenWikiIgnore,
 ): string {
-  if (!ignoreRules?.isActive) {
+  if (!openWikiIgnore?.isActive) {
     return "";
   }
 
-  const patterns = ignoreRules.patterns
+  const patterns = openWikiIgnore.patterns
     .map((pattern) => `  - ${JSON.stringify(pattern)}`)
     .join("\n");
 

--- a/src/agent/prompt.ts
+++ b/src/agent/prompt.ts
@@ -22,6 +22,28 @@ export function createSystemPrompt(
 ): string {
   const output = getOutputPromptConfig(outputMode);
   const languageInstructions = createLanguageInstructions(language);
+  const ignoreActive = openWikiIgnore?.isActive === true;
+
+  // When .openwikiignore is active the execute allowlist refuses shell-based
+  // discovery, so the prompt must steer to the file tools and the provided git
+  // summary instead of git/rg. When inactive these keep today's wording exactly,
+  // so the common no-ignore run is unchanged.
+  const gitHistoryHint = ignoreActive
+    ? "Use the provided git summary for repository history. "
+    : "Use git through shell execute when it provides useful history. ";
+  const discoveryHint = ignoreActive
+    ? "- Do not call glob with **/* from the root. Use targeted ls, glob, and grep by directory and extension, skipping .git, node_modules, dist, build, cache directories, and existing generated wiki output."
+    : "- Do not call glob with **/* from the root. Use targeted discovery by directory and extension. Prefer shell commands like rg --files with excludes for .git, node_modules, dist, build, cache directories, and existing generated wiki output.";
+  const gitDiscipline = ignoreActive
+    ? `Git discipline:
+- A filtered git summary of repository history is provided in your context. Use it to explain why code exists, not just what it does, focusing on recent, high-signal changes.
+- The summary already excludes .openwikiignore paths. Do not run git or other shell commands to reconstruct history; shell discovery is unavailable while .openwikiignore is active.`
+    : `Git discipline:
+- Use git heavily where it helps explain why code exists, not just what code exists.
+- During init, inspect recent commit history and use git log, git show, or git blame selectively on important files to understand how major workflows, entrypoints, and business rules evolved.
+- ${output.gitDisciplineInstruction}
+- Use git status and git diff to account for uncommitted local changes, especially if they touch existing docs or important source files.
+- Do not over-index on ancient history. Focus on recent commits and high-signal history for important files.`;
 
   return `
 You are OpenWiki, an expert technical writer, software architect, and product analyst.
@@ -30,14 +52,14 @@ Your job is to inspect the relevant source evidence and local OpenWiki knowledge
 
 ${output.canonicalLocationInstruction}
 
-Use only the tools available to you. Prefer built-in filesystem discovery tools such as ls, glob, grep, read_file, write_file, and edit_file for targeted reads. Use git through shell execute when it provides useful history. Do not invent files, modules, APIs, business rules, or behavior. Ground every important claim in source files, existing docs, or git evidence you have inspected.
+Use only the tools available to you. Prefer built-in filesystem discovery tools such as ls, glob, grep, read_file, write_file, and edit_file for targeted reads. ${gitHistoryHint}Do not invent files, modules, APIs, business rules, or behavior. Ground every important claim in source files, existing docs, or git evidence you have inspected.
 
 Run discipline:
 - ${output.filesystemRootInstruction}
 - Never pass host absolute paths like /Users/... to filesystem tools; that creates nested paths inside the repo instead of touching the intended file.
 - Shell execute commands run on the host. If you use execute, run commands from the current runtime root unless a source-specific instruction explicitly tells you to inspect a connector raw file or configured local repository path.
 - Do not exhaustively read every file. For a local knowledge wiki, inspect the existing wiki structure and only the relevant connector evidence or configured local repository paths. For an explicit repository source, inspect the repository tree, package/config files, README-style files, entrypoints, routing files, database/schema files, and representative files for each major domain.
-- Do not call glob with **/* from the root. Use targeted discovery by directory and extension. Prefer shell commands like rg --files with excludes for .git, node_modules, dist, build, cache directories, and existing generated wiki output.
+${discoveryHint}
 - Prefer grep/glob and short targeted reads over full-file reads when files are large.
 - Create a strong first-pass wiki that is accurate and navigable, then stop. The wiki can be refined in later update runs.
 - Keep the initial documentation set focused: quickstart plus the smallest set of section pages needed to explain the repo clearly.
@@ -83,18 +105,12 @@ Planning discipline:
 - After discovery and before writing final documentation, create a temporary ${output.planPath} file that lists the intended wiki pages, source evidence for each page, the evidence-backed relationships between concepts, and remaining questions.
 - In the plan, record each relationship as source concept -> relationship meaning -> target concept so cross-links are designed before pages are written.
 - Use ${output.planPath} when writing this temporary plan with filesystem tools.
-- Before completing the run, delete ${output.planPath}. If there is no filesystem delete tool, use shell execute from the runtime root, for example ${output.removePlanCommand}.
-- Do not leave ${output.planPath} in the final wiki.
+- The temporary ${output.planPath} is removed automatically after the run, so you do not need to delete it. Do not treat it as a wiki concept or link to it from other pages.
 
 Index discipline:
 - Directory index.md files are generated deterministically after the run. Do not create or edit them yourself.
 
-Git discipline:
-- Use git heavily where it helps explain why code exists, not just what code exists.
-- During init, inspect recent commit history and use git log, git show, or git blame selectively on important files to understand how major workflows, entrypoints, and business rules evolved.
-- ${output.gitDisciplineInstruction}
-- Use git status and git diff to account for uncommitted local changes, especially if they touch existing docs or important source files.
-- Do not over-index on ancient history. Focus on recent commits and high-signal history for important files.
+${gitDiscipline}
 
 Existing documentation discipline:
 - Treat existing README files, docs/ trees, root documentation files, runbooks, and SKILL.md files as primary source material.
@@ -197,7 +213,6 @@ Required documentation structure:
 Coverage self-check:
 - Before finishing, verify that every identified area is either documented or backlogged.
 - Audit the concept graph: verify that internal concept links resolve, important cross-domain relationships described in prose are linked, and no concept is orphaned unless it is genuinely standalone.
-- Verify that ${output.planPath} has been deleted. Do not finish while the temporary plan remains in the wiki as a concept.
 - Keep deferred areas in a concise \`## Backlog\` section at the end of ${output.quickstartPath}; do not create a separate backlog page.
 - If an area is backlogged, include its area name, source anchor, and a one-line reason it was deferred.
 ${createDiagramInstructions()}
@@ -248,7 +263,7 @@ function createOpenWikiIgnoreInstructions(
 .openwikiignore discipline:
 - This repository has .openwikiignore rules. Treat matching paths as out of scope.
 - Filesystem tools enforce these rules; if a tool reports an excluded path, do not retry through shell execute.
-- Shell execute is restricted while .openwikiignore is active. Use the provided Git summary plus ls, read_file, glob, and grep for repository discovery so exclusions remain enforced.
+- For repository discovery use the provided git summary plus ls, read_file, glob, and grep; these keep exclusions enforced. Shell execute is limited to a few maintenance commands while .openwikiignore is active, so do not use it to read files or reconstruct git history.
 - Do not document excluded paths or infer details about their contents.
 - Active patterns:
 ${patterns}`;
@@ -375,7 +390,6 @@ type OutputPromptConfig = {
   metadataPath: string;
   planPath: string;
   quickstartPath: string;
-  removePlanCommand: string;
   rootAgentInstructions: string;
   searchBoundaryInstruction: string;
   sectionDirectoryInstruction: string;
@@ -470,7 +484,6 @@ function getOutputPromptConfig(
       metadataPath: "/.last-update.json",
       planPath: "/_plan.md",
       quickstartPath: "/quickstart.md",
-      removePlanCommand: "rm -f ./_plan.md",
       rootAgentInstructions:
         "Root agent instruction files:\n- Repository /AGENTS.md and /CLAUDE.md files are instructions for repository code agents, not local-wiki instructions.\n- When inspecting a configured local repository as evidence, do not read or follow those files unless the user explicitly asks about their contents.\n- Local wiki mode does not manage repository /AGENTS.md or /CLAUDE.md files.\n- Do not create or edit agent instruction files unless the user explicitly asks for that as a separate repository documentation task.",
       searchBoundaryInstruction:
@@ -511,7 +524,6 @@ function getOutputPromptConfig(
     metadataPath: "/openwiki/.last-update.json",
     planPath: "/openwiki/_plan.md",
     quickstartPath: "/openwiki/quickstart.md",
-    removePlanCommand: "rm -f ./openwiki/_plan.md",
     rootAgentInstructions: `Root agent instruction files:
 - Do not create or update repository /AGENTS.md or /CLAUDE.md files during normal code wiki runs.
 - Keep generated wiki content under the repository /openwiki directory.

--- a/src/agent/prompt.ts
+++ b/src/agent/prompt.ts
@@ -4,6 +4,7 @@ import {
   RunContext,
   UpdateMetadata,
 } from "./types.js";
+import type { OpenWikiIgnoreRules } from "./openwiki-ignore.js";
 
 function formatLastUpdate(lastUpdate: UpdateMetadata | null): string {
   if (lastUpdate === null) {
@@ -17,6 +18,7 @@ export function createSystemPrompt(
   command: OpenWikiCommand,
   outputMode: OpenWikiOutputMode = "local-wiki",
   language?: string,
+  ignoreRules?: OpenWikiIgnoreRules,
 ): string {
   const output = getOutputPromptConfig(outputMode);
   const languageInstructions = createLanguageInstructions(language);
@@ -40,6 +42,7 @@ Run discipline:
 - Create a strong first-pass wiki that is accurate and navigable, then stop. The wiki can be refined in later update runs.
 - Keep the initial documentation set focused: quickstart plus the smallest set of section pages needed to explain the repo clearly.
 - ${output.searchBoundaryInstruction}
+${createOpenWikiIgnoreInstructions(ignoreRules)}
 
 Connector ingestion discipline:
 - OpenWiki has built-in local connectors for git-repo, notion, x, google, web-search, hackernews, and slack. Use openwiki_list_connectors to inspect connector capabilities, config paths, required env var names, and raw data paths.
@@ -227,6 +230,28 @@ Diagram discipline:
 - Add a diagram wherever a page documents a request or runtime flow, a call sequence, a lifecycle or state machine, or a data model. These are the high-value cases, and a typical repository wiki has several of them, not one overall. Skip pages that are navigation, reference tables, or configuration. Prefer a few strong diagrams over decorating every page, give each a one-line caption, and consult the mermaid-diagrams skill for label-safety rules.
 - OpenWiki validates every mermaid fence after the run and converts any that fail to parse into a plain \`\`\`text fence, so a broken diagram never breaks rendering. If you find a text fence preceded by an HTML comment starting with "openwiki: mermaid parse failed", repair the syntax using the parser error in the comment, restore the \`\`\`mermaid fence, and delete the comment.
 `;
+}
+
+function createOpenWikiIgnoreInstructions(
+  ignoreRules?: OpenWikiIgnoreRules,
+): string {
+  if (!ignoreRules?.isActive) {
+    return "";
+  }
+
+  const patterns = ignoreRules.patterns
+    .map((pattern) => `  - ${JSON.stringify(pattern)}`)
+    .join("\n");
+
+  return `
+
+.openwikiignore discipline:
+- This repository has .openwikiignore rules. Treat matching paths as out of scope.
+- Filesystem tools enforce these rules; if a tool reports an excluded path, do not retry through shell execute.
+- Shell execute is restricted while .openwikiignore is active. Use the provided Git summary plus ls, read_file, glob, and grep for repository discovery so exclusions remain enforced.
+- Do not document excluded paths or infer details about their contents.
+- Active patterns:
+${patterns}`;
 }
 
 export function createModeInstructions(

--- a/src/agent/utils.ts
+++ b/src/agent/utils.ts
@@ -13,6 +13,7 @@ import {
   readOpenWikiOnboardingConfig,
   readRepositoryWikiInstructions,
 } from "../onboarding.js";
+import { OpenWikiIgnoreRules } from "./openwiki-ignore.js";
 import type {
   OpenWikiCommand,
   OpenWikiOutputMode,
@@ -48,6 +49,7 @@ export async function createRunContext(
   cwd: string,
   outputMode: OpenWikiOutputMode = "repository",
   language?: string | null,
+  ignoreRules = new OpenWikiIgnoreRules([]),
 ): Promise<RunContext> {
   const lastUpdate = await readLastUpdate(cwd, outputMode);
   // A validated flag wins; otherwise inherit the wiki's persisted language so an
@@ -82,7 +84,7 @@ export async function createRunContext(
 
   return {
     lastUpdate,
-    gitSummary: await createGitSummary(command, cwd, lastUpdate),
+    gitSummary: await createGitSummary(command, cwd, lastUpdate, ignoreRules),
     ...languageContext,
     wikiGoal,
   };
@@ -101,6 +103,7 @@ async function readRunWikiGoal(
 
 export async function getUpdateNoopStatus(
   cwd: string,
+  ignoreRules = new OpenWikiIgnoreRules([]),
 ): Promise<UpdateNoopStatus> {
   const lastUpdate = await readLastUpdate(cwd, "repository");
 
@@ -127,7 +130,8 @@ export async function getUpdateNoopStatus(
     .split("\n")
     .map((line) => line.trimEnd())
     .filter(Boolean)
-    .filter((line) => !isUpdateMetadataStatusLine(line));
+    .filter((line) => !isUpdateMetadataStatusLine(line))
+    .filter((line) => !lineReferencesIgnoredPath(line, ignoreRules));
 
   if (meaningfulStatus.length > 0) {
     return { shouldSkip: false, reason: "worktree has changes" };
@@ -141,7 +145,10 @@ export async function getUpdateNoopStatus(
 
     if (
       committedPaths.length === 0 ||
-      committedPaths.some((changedPath) => !isOpenWikiPath(changedPath))
+      committedPaths.some(
+        (changedPath) =>
+          !isOpenWikiPath(changedPath) && !ignoreRules.ignores(changedPath),
+      )
     ) {
       return { shouldSkip: false, reason: "git head changed" };
     }
@@ -419,21 +426,28 @@ async function createGitSummary(
   command: OpenWikiCommand,
   cwd: string,
   lastUpdate: UpdateMetadata | null,
+  ignoreRules: OpenWikiIgnoreRules,
 ): Promise<string> {
   const sections: string[] = [];
-  const status = await runGit(cwd, ["status", "--short"]);
+  const status = filterGitOutputForIgnore(
+    await runGit(cwd, ["status", "--short"]),
+    ignoreRules,
+  );
   const head = await getGitHead(cwd);
 
   sections.push(formatGitSection("git status --short", status));
   sections.push(formatGitSection("git rev-parse HEAD", head ?? "(unknown)"));
 
   if (command === "update" && lastUpdate?.gitHead) {
-    const logSinceLastHead = await runGit(cwd, [
-      "log",
-      `${lastUpdate.gitHead}..HEAD`,
-      "--name-status",
-      "--oneline",
-    ]);
+    const logSinceLastHead = filterGitOutputForIgnore(
+      await runGit(cwd, [
+        "log",
+        `${lastUpdate.gitHead}..HEAD`,
+        "--name-status",
+        "--oneline",
+      ]),
+      ignoreRules,
+    );
 
     sections.push(
       formatGitSection(
@@ -442,13 +456,16 @@ async function createGitSummary(
       ),
     );
   } else if (command === "update" && lastUpdate?.updatedAt) {
-    const logSinceLastUpdate = await runGit(cwd, [
-      "log",
-      "--since",
-      lastUpdate.updatedAt,
-      "--name-status",
-      "--oneline",
-    ]);
+    const logSinceLastUpdate = filterGitOutputForIgnore(
+      await runGit(cwd, [
+        "log",
+        "--since",
+        lastUpdate.updatedAt,
+        "--name-status",
+        "--oneline",
+      ]),
+      ignoreRules,
+    );
 
     sections.push(
       formatGitSection(
@@ -457,12 +474,15 @@ async function createGitSummary(
       ),
     );
   } else {
-    const recentLog = await runGit(cwd, [
-      "log",
-      "--max-count=20",
-      "--name-status",
-      "--oneline",
-    ]);
+    const recentLog = filterGitOutputForIgnore(
+      await runGit(cwd, [
+        "log",
+        "--max-count=20",
+        "--name-status",
+        "--oneline",
+      ]),
+      ignoreRules,
+    );
 
     if (command === "update") {
       sections.push("No prior OpenWiki update timestamp was found.");
@@ -476,7 +496,10 @@ async function createGitSummary(
     );
   }
 
-  const diff = await runGit(cwd, ["diff", "--name-status", "HEAD"]);
+  const diff = filterGitOutputForIgnore(
+    await runGit(cwd, ["diff", "--name-status", "HEAD"]),
+    ignoreRules,
+  );
   sections.push(formatGitSection("git diff --name-status HEAD", diff));
 
   return sections.join("\n\n");
@@ -559,6 +582,58 @@ function isOpenWikiPath(changedPath: string): boolean {
 
 function normalizeGitPath(value: string): string {
   return value.trim().replace(/\\/gu, "/");
+}
+
+function filterGitOutputForIgnore(
+  output: string,
+  ignoreRules: OpenWikiIgnoreRules,
+): string {
+  if (!ignoreRules.isActive || output.length === 0) {
+    return output;
+  }
+
+  const filteredOutput = output
+    .split("\n")
+    .filter((line) => !lineReferencesIgnoredPath(line, ignoreRules))
+    .join("\n")
+    .trim();
+
+  return filteredOutput.length > 0
+    ? filteredOutput
+    : "(all matching paths are excluded by .openwikiignore)";
+}
+
+function lineReferencesIgnoredPath(
+  line: string,
+  ignoreRules: OpenWikiIgnoreRules,
+): boolean {
+  return extractGitPaths(line).some((changedPath) =>
+    ignoreRules.ignores(changedPath),
+  );
+}
+
+function extractGitPaths(line: string): string[] {
+  const shortStatusMatch = /^(?:[ MARCUD?!]{2})\s+(.+)$/u.exec(line);
+  const nameStatusMatch = /^(?:[ACDMRTUXB]\d*)\s+(.+)$/u.exec(line.trim());
+  const pathsText = shortStatusMatch?.[1] ?? nameStatusMatch?.[1];
+
+  if (!pathsText) {
+    return [];
+  }
+
+  return splitGitPaths(pathsText).map(normalizeGitPath).filter(Boolean);
+}
+
+function splitGitPaths(pathsText: string): string[] {
+  if (pathsText.includes("\t")) {
+    return pathsText.split("\t");
+  }
+
+  if (pathsText.includes(" -> ")) {
+    return pathsText.split(" -> ");
+  }
+
+  return [pathsText];
 }
 
 function isExecError(

--- a/src/agent/utils.ts
+++ b/src/agent/utils.ts
@@ -13,7 +13,7 @@ import {
   readOpenWikiOnboardingConfig,
   readRepositoryWikiInstructions,
 } from "../onboarding.js";
-import { OpenWikiIgnoreRules } from "./openwiki-ignore.js";
+import { OpenWikiIgnore } from "./openwiki-ignore.js";
 import type {
   OpenWikiCommand,
   OpenWikiOutputMode,
@@ -44,7 +44,7 @@ export type UpdateNoopStatus =
 /**
  * Builds the per-run context the prompt uses to reason about prior docs and git changes.
  *
- * Paths excluded by `ignoreRules` are stripped from the git evidence so the
+ * Paths excluded by `openWikiIgnore` are stripped from the git evidence so the
  * agent never sees changes under an ignored path.
  */
 export async function createRunContext(
@@ -52,7 +52,7 @@ export async function createRunContext(
   cwd: string,
   outputMode: OpenWikiOutputMode = "repository",
   language?: string | null,
-  ignoreRules = new OpenWikiIgnoreRules([]),
+  openWikiIgnore = new OpenWikiIgnore([]),
 ): Promise<RunContext> {
   const lastUpdate = await readLastUpdate(cwd, outputMode);
   // A validated flag wins; otherwise inherit the wiki's persisted language so an
@@ -87,7 +87,12 @@ export async function createRunContext(
 
   return {
     lastUpdate,
-    gitSummary: await createGitSummary(command, cwd, lastUpdate, ignoreRules),
+    gitSummary: await createGitSummary(
+      command,
+      cwd,
+      lastUpdate,
+      openWikiIgnore,
+    ),
     ...languageContext,
     wikiGoal,
   };
@@ -108,12 +113,12 @@ async function readRunWikiGoal(
  * Decides whether an `update` run can be skipped because nothing meaningful changed.
  *
  * Working-tree and committed changes that only touch `openwiki/` or paths
- * excluded by `ignoreRules` do not count as meaningful, so an ignored path
+ * excluded by `openWikiIgnore` do not count as meaningful, so an ignored path
  * changing on its own never forces a rebuild.
  */
 export async function getUpdateNoopStatus(
   cwd: string,
-  ignoreRules = new OpenWikiIgnoreRules([]),
+  openWikiIgnore = new OpenWikiIgnore([]),
 ): Promise<UpdateNoopStatus> {
   const lastUpdate = await readLastUpdate(cwd, "repository");
 
@@ -141,7 +146,7 @@ export async function getUpdateNoopStatus(
     .map((line) => line.trimEnd())
     .filter(Boolean)
     .filter((line) => !isUpdateMetadataStatusLine(line))
-    .filter((line) => !lineReferencesIgnoredPath(line, ignoreRules));
+    .filter((line) => !lineReferencesIgnoredPath(line, openWikiIgnore));
 
   if (meaningfulStatus.length > 0) {
     return { shouldSkip: false, reason: "worktree has changes" };
@@ -157,7 +162,7 @@ export async function getUpdateNoopStatus(
       committedPaths.length === 0 ||
       committedPaths.some(
         (changedPath) =>
-          !isOpenWikiPath(changedPath) && !ignoreRules.ignores(changedPath),
+          !isOpenWikiPath(changedPath) && !openWikiIgnore.ignores(changedPath),
       )
     ) {
       return { shouldSkip: false, reason: "git head changed" };
@@ -432,19 +437,19 @@ async function readSnapshotFile(filePath: string): Promise<Buffer | null> {
 /**
  * Produces the git evidence block passed to init/update prompts.
  *
- * Lines that reference a path excluded by `ignoreRules` are filtered out of
+ * Lines that reference a path excluded by `openWikiIgnore` are filtered out of
  * every git section (status, log, diff) before the block is assembled.
  */
 async function createGitSummary(
   command: OpenWikiCommand,
   cwd: string,
   lastUpdate: UpdateMetadata | null,
-  ignoreRules: OpenWikiIgnoreRules,
+  openWikiIgnore: OpenWikiIgnore,
 ): Promise<string> {
   const sections: string[] = [];
   const status = filterGitOutputForIgnore(
     await runGit(cwd, ["status", "--short"]),
-    ignoreRules,
+    openWikiIgnore,
   );
   const head = await getGitHead(cwd);
 
@@ -459,7 +464,7 @@ async function createGitSummary(
         "--name-status",
         "--oneline",
       ]),
-      ignoreRules,
+      openWikiIgnore,
     );
 
     sections.push(
@@ -477,7 +482,7 @@ async function createGitSummary(
         "--name-status",
         "--oneline",
       ]),
-      ignoreRules,
+      openWikiIgnore,
     );
 
     sections.push(
@@ -494,7 +499,7 @@ async function createGitSummary(
         "--name-status",
         "--oneline",
       ]),
-      ignoreRules,
+      openWikiIgnore,
     );
 
     if (command === "update") {
@@ -511,7 +516,7 @@ async function createGitSummary(
 
   const diff = filterGitOutputForIgnore(
     await runGit(cwd, ["diff", "--name-status", "HEAD"]),
-    ignoreRules,
+    openWikiIgnore,
   );
   sections.push(formatGitSection("git diff --name-status HEAD", diff));
 
@@ -606,15 +611,15 @@ function normalizeGitPath(value: string): string {
  */
 function filterGitOutputForIgnore(
   output: string,
-  ignoreRules: OpenWikiIgnoreRules,
+  openWikiIgnore: OpenWikiIgnore,
 ): string {
-  if (!ignoreRules.isActive || output.length === 0) {
+  if (!openWikiIgnore.isActive || output.length === 0) {
     return output;
   }
 
   const filteredOutput = output
     .split("\n")
-    .filter((line) => !lineReferencesIgnoredPath(line, ignoreRules))
+    .filter((line) => !lineReferencesIgnoredPath(line, openWikiIgnore))
     .join("\n")
     .trim();
 
@@ -628,10 +633,10 @@ function filterGitOutputForIgnore(
  */
 function lineReferencesIgnoredPath(
   line: string,
-  ignoreRules: OpenWikiIgnoreRules,
+  openWikiIgnore: OpenWikiIgnore,
 ): boolean {
   return extractGitPaths(line).some((changedPath) =>
-    ignoreRules.ignores(changedPath),
+    openWikiIgnore.ignores(changedPath),
   );
 }
 

--- a/src/agent/utils.ts
+++ b/src/agent/utils.ts
@@ -43,6 +43,9 @@ export type UpdateNoopStatus =
 
 /**
  * Builds the per-run context the prompt uses to reason about prior docs and git changes.
+ *
+ * Paths excluded by `ignoreRules` are stripped from the git evidence so the
+ * agent never sees changes under an ignored path.
  */
 export async function createRunContext(
   command: OpenWikiCommand,
@@ -101,6 +104,13 @@ async function readRunWikiGoal(
   return (await readOpenWikiOnboardingConfig()).wikiGoal;
 }
 
+/**
+ * Decides whether an `update` run can be skipped because nothing meaningful changed.
+ *
+ * Working-tree and committed changes that only touch `openwiki/` or paths
+ * excluded by `ignoreRules` do not count as meaningful, so an ignored path
+ * changing on its own never forces a rebuild.
+ */
 export async function getUpdateNoopStatus(
   cwd: string,
   ignoreRules = new OpenWikiIgnoreRules([]),
@@ -421,6 +431,9 @@ async function readSnapshotFile(filePath: string): Promise<Buffer | null> {
 
 /**
  * Produces the git evidence block passed to init/update prompts.
+ *
+ * Lines that reference a path excluded by `ignoreRules` are filtered out of
+ * every git section (status, log, diff) before the block is assembled.
  */
 async function createGitSummary(
   command: OpenWikiCommand,
@@ -584,6 +597,13 @@ function normalizeGitPath(value: string): string {
   return value.trim().replace(/\\/gu, "/");
 }
 
+/**
+ * Strips lines that reference an ignored path from a block of git output.
+ *
+ * Returns the input unchanged when no rules are active. When filtering removes
+ * every line, returns a placeholder so the prompt records that matching paths
+ * existed but were excluded, rather than showing a misleadingly empty section.
+ */
 function filterGitOutputForIgnore(
   output: string,
   ignoreRules: OpenWikiIgnoreRules,
@@ -603,6 +623,9 @@ function filterGitOutputForIgnore(
     : "(all matching paths are excluded by .openwikiignore)";
 }
 
+/**
+ * Whether a single line of git output names at least one ignored path.
+ */
 function lineReferencesIgnoredPath(
   line: string,
   ignoreRules: OpenWikiIgnoreRules,
@@ -612,6 +635,15 @@ function lineReferencesIgnoredPath(
   );
 }
 
+/**
+ * Pulls the file path(s) out of one line of `git status --short` or
+ * `--name-status` output.
+ *
+ * Handles both the two-column short-status format and the letter-prefixed
+ * name-status format, and returns an empty array for lines that carry no path
+ * (such as `--oneline` commit headers). Rename lines yield both the old and new
+ * paths so that either side matching a rule excludes the line.
+ */
 function extractGitPaths(line: string): string[] {
   const shortStatusMatch = /^(?:[ MARCUD?!]{2})\s+(.+)$/u.exec(line);
   const nameStatusMatch = /^(?:[ACDMRTUXB]\d*)\s+(.+)$/u.exec(line.trim());
@@ -624,6 +656,12 @@ function extractGitPaths(line: string): string[] {
   return splitGitPaths(pathsText).map(normalizeGitPath).filter(Boolean);
 }
 
+/**
+ * Splits the path portion of a git line into individual paths.
+ *
+ * `--name-status` separates a rename's source and target with a tab, while
+ * `git status --short` uses ` -> `; a plain single path is returned as-is.
+ */
 function splitGitPaths(pathsText: string): string[] {
   if (pathsText.includes("\t")) {
     return pathsText.split("\t");

--- a/test/openwiki-ignore.test.ts
+++ b/test/openwiki-ignore.test.ts
@@ -1,0 +1,104 @@
+import { mkdir, mkdtemp, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { describe, expect, test } from "vitest";
+import { OpenWikiLocalShellBackend } from "../src/agent/docs-only-backend.ts";
+import { createOpenWikiIgnoreRules } from "../src/agent/openwiki-ignore.ts";
+
+async function createIgnoredRepo(): Promise<{
+  backend: OpenWikiLocalShellBackend;
+  repo: string;
+}> {
+  const repo = await mkdtemp(path.join(tmpdir(), "openwiki-ignore-"));
+
+  await mkdir(path.join(repo, "logs"));
+  await mkdir(path.join(repo, "secrets"));
+  await writeFile(path.join(repo, "public.txt"), "visible\n", "utf8");
+  await writeFile(path.join(repo, "logs", "debug.log"), "debug\n", "utf8");
+  await writeFile(path.join(repo, "logs", "keep.log"), "keep\n", "utf8");
+  await writeFile(
+    path.join(repo, "secrets", "token.txt"),
+    "hidden-token\n",
+    "utf8",
+  );
+
+  const ignoreRules = createOpenWikiIgnoreRules(`
+secrets/
+*.log
+!logs/keep.log
+`);
+  const backend = new OpenWikiLocalShellBackend({
+    ignoreRules,
+    maxOutputBytes: 100_000,
+    rootDir: repo,
+    timeout: 120,
+    virtualMode: true,
+  });
+
+  await backend.initialize();
+
+  return { backend, repo };
+}
+
+describe(".openwikiignore rules", () => {
+  test("matches comments, directory rules, globs, negation, and root anchoring", () => {
+    const rules = createOpenWikiIgnoreRules(`
+# ignored paths
+secrets/
+*.log
+!logs/keep.log
+/build
+`);
+
+    expect(rules.isActive).toBe(true);
+    expect(rules.ignores("secrets/token.txt")).toBe(true);
+    expect(rules.ignores("src/secrets/token.txt")).toBe(true);
+    expect(rules.ignores("logs/debug.log")).toBe(true);
+    expect(rules.ignores("logs/keep.log")).toBe(false);
+    expect(rules.ignores("build/index.js")).toBe(true);
+    expect(rules.ignores("src/build/index.js")).toBe(false);
+    expect(rules.ignores("src/index.ts")).toBe(false);
+  });
+});
+
+describe("OpenWikiLocalShellBackend", () => {
+  test("blocks direct reads and filters discovery results for ignored paths", async () => {
+    const { backend } = await createIgnoredRepo();
+
+    const publicRead = await backend.read("/public.txt");
+    expect(publicRead.content).toContain("visible");
+
+    const ignoredRead = await backend.read("/secrets/token.txt");
+    expect(ignoredRead.error).toContain(".openwikiignore");
+
+    const listing = await backend.ls("/");
+    expect(listing.files?.map((file) => file.path).join("\n")).not.toContain(
+      "secrets",
+    );
+
+    const glob = await backend.glob("**/*", "/");
+    expect(glob.files?.map((file) => file.path).join("\n")).not.toContain(
+      "secrets/token.txt",
+    );
+    expect(glob.files?.map((file) => file.path).join("\n")).not.toContain(
+      "logs/debug.log",
+    );
+    expect(glob.files?.map((file) => file.path).join("\n")).toContain(
+      "logs/keep.log",
+    );
+
+    const grep = await backend.grep("hidden-token", "/");
+    expect(grep.matches).toEqual([]);
+  });
+
+  test("restricts shell execute while ignore rules are active", async () => {
+    const { backend } = await createIgnoredRepo();
+
+    const blocked = await backend.execute("cat secrets/token.txt");
+    expect(blocked.exitCode).toBe(1);
+    expect(blocked.output).toContain(".openwikiignore");
+
+    const allowed = await backend.execute("pwd");
+    expect(allowed.exitCode).toBe(0);
+  });
+});

--- a/test/openwiki-ignore.test.ts
+++ b/test/openwiki-ignore.test.ts
@@ -77,6 +77,21 @@ secrets/
     // A path that genuinely resolves elsewhere stays allowed.
     expect(rules.ignores("secrets/../public.txt")).toBe(false);
   });
+
+  test("matches case-insensitively so alternate casing cannot bypass a rule", () => {
+    const rules = OpenWikiIgnore.parse(`
+secrets/
+*.log
+`);
+
+    // On case-insensitive filesystems (macOS, Windows) these spellings all
+    // resolve to the same excluded files, so they must all be ignored.
+    expect(rules.ignores("secrets/token.txt")).toBe(true);
+    expect(rules.ignores("Secrets/token.txt")).toBe(true);
+    expect(rules.ignores("SECRETS/token.txt")).toBe(true);
+    expect(rules.ignores("secrets/Token.TXT")).toBe(true);
+    expect(rules.ignores("app/DEBUG.LOG")).toBe(true);
+  });
 });
 
 describe("OpenWikiLocalShellBackend", () => {
@@ -119,6 +134,21 @@ describe("OpenWikiLocalShellBackend", () => {
     const traversalRead = await backend.read("/secrets/../secrets/token.txt");
     expect(traversalRead.error).toContain(".openwikiignore");
     expect(traversalRead.content).toBeUndefined();
+  });
+
+  test("blocks reads of ignored paths spelled with different casing", async () => {
+    const { backend } = await createIgnoredRepo();
+
+    // On a case-insensitive filesystem /Secrets/token.txt resolves to the same
+    // file as the excluded /secrets/token.txt, so the gate must reject it. The
+    // check runs before any filesystem access, so this holds on every platform.
+    const upperDirRead = await backend.read("/Secrets/token.txt");
+    expect(upperDirRead.error).toContain(".openwikiignore");
+    expect(upperDirRead.content).toBeUndefined();
+
+    const upperAllRead = await backend.read("/SECRETS/TOKEN.txt");
+    expect(upperAllRead.error).toContain(".openwikiignore");
+    expect(upperAllRead.content).toBeUndefined();
   });
 
   test("refuses writes and edits to ignored paths", async () => {

--- a/test/openwiki-ignore.test.ts
+++ b/test/openwiki-ignore.test.ts
@@ -3,7 +3,7 @@ import { tmpdir } from "node:os";
 import path from "node:path";
 import { describe, expect, test } from "vitest";
 import { OpenWikiLocalShellBackend } from "../src/agent/docs-only-backend.ts";
-import { createOpenWikiIgnoreRules } from "../src/agent/openwiki-ignore.ts";
+import { OpenWikiIgnore } from "../src/agent/openwiki-ignore.ts";
 
 async function createIgnoredRepo(): Promise<{
   backend: OpenWikiLocalShellBackend;
@@ -22,13 +22,13 @@ async function createIgnoredRepo(): Promise<{
     "utf8",
   );
 
-  const ignoreRules = createOpenWikiIgnoreRules(`
+  const openWikiIgnore = OpenWikiIgnore.parse(`
 secrets/
 *.log
 !logs/keep.log
 `);
   const backend = new OpenWikiLocalShellBackend({
-    ignoreRules,
+    openWikiIgnore,
     maxOutputBytes: 100_000,
     rootDir: repo,
     timeout: 120,
@@ -42,7 +42,7 @@ secrets/
 
 describe(".openwikiignore rules", () => {
   test("matches comments, directory rules, globs, negation, and root anchoring", () => {
-    const rules = createOpenWikiIgnoreRules(`
+    const rules = OpenWikiIgnore.parse(`
 # ignored paths
 secrets/
 *.log
@@ -61,7 +61,7 @@ secrets/
   });
 
   test("canonicalizes ./ and ../ so anchored rules cannot be bypassed", () => {
-    const rules = createOpenWikiIgnoreRules(`
+    const rules = OpenWikiIgnore.parse(`
 /secrets
 `);
 

--- a/test/openwiki-ignore.test.ts
+++ b/test/openwiki-ignore.test.ts
@@ -165,6 +165,35 @@ describe("OpenWikiLocalShellBackend", () => {
     );
   });
 
+  test("refuses uploads outside the docs tree in docs-only mode", async () => {
+    const repo = await mkdtemp(path.join(tmpdir(), "openwiki-docsonly-"));
+    const backend = new OpenWikiLocalShellBackend({
+      docsOnly: true,
+      maxOutputBytes: 100_000,
+      outputMode: "repository",
+      rootDir: repo,
+      timeout: 120,
+      virtualMode: true,
+    });
+
+    await backend.initialize();
+
+    const uploads = await backend.uploadFiles([
+      ["AGENTS.md", new TextEncoder().encode("x")],
+      ["openwiki/notes.md", new TextEncoder().encode("y")],
+    ]);
+    const uploadByPath = new Map(
+      uploads.map((result) => [result.path, result]),
+    );
+
+    // A write outside openwiki/ must be refused even though no .openwikiignore
+    // rule matches it, mirroring the docs-only guard on write()/edit().
+    expect(uploadByPath.get("AGENTS.md")?.error).toBe("permission_denied");
+    expect(uploadByPath.get("openwiki/notes.md")?.error).not.toBe(
+      "permission_denied",
+    );
+  });
+
   test("restricts shell execute while ignore rules are active", async () => {
     const { backend } = await createIgnoredRepo();
 

--- a/test/openwiki-ignore.test.ts
+++ b/test/openwiki-ignore.test.ts
@@ -59,6 +59,24 @@ secrets/
     expect(rules.ignores("src/build/index.js")).toBe(false);
     expect(rules.ignores("src/index.ts")).toBe(false);
   });
+
+  test("canonicalizes ./ and ../ so anchored rules cannot be bypassed", () => {
+    const rules = createOpenWikiIgnoreRules(`
+/secrets
+`);
+
+    // Baseline: the plainly-spelled path is excluded.
+    expect(rules.ignores("secrets/token.txt")).toBe(true);
+    expect(rules.ignores("/secrets/token.txt")).toBe(true);
+
+    // Equivalent spellings that must resolve to the same excluded path.
+    expect(rules.ignores("./secrets/token.txt")).toBe(true);
+    expect(rules.ignores("secrets/../secrets/token.txt")).toBe(true);
+    expect(rules.ignores("./secrets/../secrets/token.txt")).toBe(true);
+
+    // A path that genuinely resolves elsewhere stays allowed.
+    expect(rules.ignores("secrets/../public.txt")).toBe(false);
+  });
 });
 
 describe("OpenWikiLocalShellBackend", () => {
@@ -89,6 +107,62 @@ describe("OpenWikiLocalShellBackend", () => {
 
     const grep = await backend.grep("hidden-token", "/");
     expect(grep.matches).toEqual([]);
+  });
+
+  test("blocks reads of ignored paths spelled with ./ or ../", async () => {
+    const { backend } = await createIgnoredRepo();
+
+    const dotSlashRead = await backend.read("/./secrets/token.txt");
+    expect(dotSlashRead.error).toContain(".openwikiignore");
+    expect(dotSlashRead.content).toBeUndefined();
+
+    const traversalRead = await backend.read("/secrets/../secrets/token.txt");
+    expect(traversalRead.error).toContain(".openwikiignore");
+    expect(traversalRead.content).toBeUndefined();
+  });
+
+  test("refuses writes and edits to ignored paths", async () => {
+    const { backend } = await createIgnoredRepo();
+
+    const write = await backend.write("/secrets/token.txt", "overwrite\n");
+    expect(write.error).toContain(".openwikiignore");
+
+    const edit = await backend.edit(
+      "/secrets/token.txt",
+      "hidden-token",
+      "leaked",
+    );
+    expect(edit.error).toContain(".openwikiignore");
+  });
+
+  test("denies uploads and downloads of ignored paths while allowing others", async () => {
+    const { backend } = await createIgnoredRepo();
+
+    const uploads = await backend.uploadFiles([
+      ["secrets/token.txt", new TextEncoder().encode("x")],
+      ["public.txt", new TextEncoder().encode("y")],
+    ]);
+    const uploadByPath = new Map(
+      uploads.map((result) => [result.path, result]),
+    );
+    expect(uploadByPath.get("secrets/token.txt")?.error).toBe(
+      "permission_denied",
+    );
+    expect(uploadByPath.get("public.txt")?.error).not.toBe("permission_denied");
+
+    const downloads = await backend.downloadFiles([
+      "secrets/token.txt",
+      "public.txt",
+    ]);
+    const downloadByPath = new Map(
+      downloads.map((result) => [result.path, result]),
+    );
+    expect(downloadByPath.get("secrets/token.txt")?.error).toBe(
+      "permission_denied",
+    );
+    expect(downloadByPath.get("public.txt")?.error).not.toBe(
+      "permission_denied",
+    );
   });
 
   test("restricts shell execute while ignore rules are active", async () => {

--- a/test/update-noop.test.ts
+++ b/test/update-noop.test.ts
@@ -4,7 +4,7 @@ import path from "node:path";
 import { execFile } from "node:child_process";
 import { promisify } from "node:util";
 import { describe, expect, test } from "vitest";
-import { createOpenWikiIgnoreRules } from "../src/agent/openwiki-ignore.ts";
+import { OpenWikiIgnore } from "../src/agent/openwiki-ignore.ts";
 import {
   getUpdateNoopStatus,
   shouldCheckUpdateNoop,
@@ -106,7 +106,7 @@ describe("getUpdateNoopStatus", () => {
 
     const status = await getUpdateNoopStatus(
       repo,
-      createOpenWikiIgnoreRules("private/\n"),
+      OpenWikiIgnore.parse("private/\n"),
     );
 
     expect(status.shouldSkip).toBe(true);

--- a/test/update-noop.test.ts
+++ b/test/update-noop.test.ts
@@ -4,6 +4,7 @@ import path from "node:path";
 import { execFile } from "node:child_process";
 import { promisify } from "node:util";
 import { describe, expect, test } from "vitest";
+import { createOpenWikiIgnoreRules } from "../src/agent/openwiki-ignore.ts";
 import {
   getUpdateNoopStatus,
   shouldCheckUpdateNoop,
@@ -90,6 +91,25 @@ describe("getUpdateNoopStatus", () => {
     const status = await getUpdateNoopStatus(repo);
 
     expect(status.shouldSkip).toBe(false);
+  });
+
+  test("skips update when worktree changes only touch ignored paths", async () => {
+    const repo = await createRepoWithOpenWiki();
+    const head = await git(repo, ["rev-parse", "HEAD"]);
+    await writeLastUpdate(repo, head);
+    await mkdir(path.join(repo, "private"));
+    await writeFile(
+      path.join(repo, "private", "notes.md"),
+      "Ignored\n",
+      "utf8",
+    );
+
+    const status = await getUpdateNoopStatus(
+      repo,
+      createOpenWikiIgnoreRules("private/\n"),
+    );
+
+    expect(status.shouldSkip).toBe(true);
   });
 
   test("skips update when commits since the last run only touch OpenWiki files", async () => {


### PR DESCRIPTION
## What it is

Adds `.openwikiignore` support so OpenWiki excludes private, generated, and irrelevant paths from documentation runs. Unlike a cosmetic filter, this is enforced as a hard boundary: even a prompt-injected doc agent cannot read or reproduce ignored paths.

## How it works

At repository-mode startup OpenWiki loads `.openwikiignore` and threads the rules through the docs-only backend, the agent prompt, the git summary, and the update no-op check.

- **Backend enforcement.** The backend filters filesystem discovery (`ls`, `glob`, `grep`) and hard-denies reads, writes, and file transfers to ignored paths.
- **Shell execute.** While rules are active, `execute` is limited to a small allowlist of maintenance commands. This is an allowlist, not a denylist, by design: a command string cannot be statically proven safe (variable expansion, `$(...)`, globs, `git show HEAD:path` object-DB reads, `git -c` aliasing into arbitrary RCE, output redirection), so anything outside the allowlist is refused.
- **Git evidence.** The injected git summary is filtered so lines referencing ignored paths are dropped, keeping ignored content out of the prompt itself.
- **Prompt.** The prompt adapts to whether ignore is active, so it never directs the agent toward commands the backend will refuse.

The ignore syntax supports comments, blank lines, `*`, `**`, directory rules, root-anchored rules, and `!` negation (case-insensitive matching, last-match-wins).

## Scope

`.openwikiignore` is a read boundary: ignored bytes are never read, scanned, or reproduced. It does not suppress topics. The agent may still mention an ignored area if it infers it from other allowed evidence (tests, README, commit messages, existing wiki). This is documented in the README.

## Verification

- **Unit/integration suite** covering pattern semantics, read/write/transfer denial, discovery filtering, the execute allowlist, and update no-op handling.
- **Deterministic adversarial probe:** a scripted attacker model driving the real backend through every evasion above (git-as-reader, `-c` alias RCE, var-expansion, path traversal, chaining past an allowed prefix). Zero leaks.
- **Live-LLM smoke:** one real-model run against a prompt-injection fixture (`README.md` instructing the agent to exfiltrate `secrets/` and `*.log`). The agent refused, documented the injection defensively, and the generated wiki contained zero secret markers.
- **Compiled top-hat:** built `dist`, created a temp fixture repo (`secrets/`, `*.log`, `!logs/keep.log`) and verified compiled backend behavior for direct reads, `ls`, `glob`, `grep`, restricted shell execute, and allowed `pwd`.

## Checks

```
npx --yes pnpm@10.33.2 exec vitest run                          182 tests passed
npx --yes pnpm@10.33.2 exec eslint .                            passed
npx --yes pnpm@10.33.2 exec prettier --check .                  passed
npx --yes pnpm@10.33.2 exec tsc --noEmit -p tsconfig.json       passed
npx --yes pnpm@10.33.2 run build                                passed
```

## Authorship

Co-authored by @n33levo and @colifran

---

Closes #123.
