### PR TITLE
fix: require custom model for openai-compatible provider

### DIFF
--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -395,6 +395,15 @@ function resolveModelId(
     options.modelId ??
     process.env[OPENWIKI_MODEL_ID_ENV_KEY] ??
     getDefaultModelId(provider);
+
+  if (!rawModelId) {
+    throw new Error(
+      `${OPENWIKI_MODEL_ID_ENV_KEY} is required to run OpenWiki with ${getProviderLabel(
+        provider,
+      )}. Use --modelId <id> or set ${OPENWIKI_MODEL_ID_ENV_KEY}.`,
+    );
+  }
+
   const modelId = normalizeModelId(rawModelId);
 
   if (!isValidModelId(modelId)) {

--- a/src/cli.tsx
+++ b/src/cli.tsx
@@ -628,7 +628,8 @@ function DryRunView({
           label="Model"
           value={
             modelId ??
-            `saved setting or ${getDefaultModelId(resolveConfiguredProvider())}`
+            process.env[OPENWIKI_MODEL_ID_ENV_KEY] ??
+            `saved setting or ${getDefaultModelLabel(resolveConfiguredProvider())}`
           }
         />
         <StatusLine tone="muted" label="Agent" value="not invoked" />
@@ -711,7 +712,8 @@ function Header({
   const displayModelId = sanitizeHeaderValue(
     modelId ??
       process.env[OPENWIKI_MODEL_ID_ENV_KEY] ??
-      getDefaultModelId(resolveConfiguredProvider()),
+      getDefaultModelId(resolveConfiguredProvider()) ??
+      "custom model ID required",
     Math.max(8, terminalColumns - 12),
   );
   const displayProvider = getProviderLabel(resolveConfiguredProvider());
@@ -1504,7 +1506,7 @@ function ChatInput({
 
     if (provider === null) {
       setError(
-        "Enter a valid provider: openrouter, baseten, fireworks, openai, or anthropic.",
+        "Enter a valid provider: openrouter, baseten, fireworks, openai, openai-compatible, or anthropic.",
       );
       return;
     }
@@ -1516,10 +1518,19 @@ function ChatInput({
     try {
       await onProviderSelect(provider);
       resetInput();
+      const defaultModelId = getDefaultModelId(provider);
       setNotice(
-        `Provider switched to ${getProviderLabel(provider)} with model ${getDefaultModelId(
-          provider,
-        )}. Ensure ${getProviderApiKeyEnvKey(provider)} is set.`,
+        defaultModelId
+          ? `Provider switched to ${getProviderLabel(
+              provider,
+            )} with model ${defaultModelId}. Ensure ${getProviderApiKeyEnvKey(
+              provider,
+            )} is set.`
+          : `Provider switched to ${getProviderLabel(
+              provider,
+            )}. Set a custom model with /model <model-id> and ensure ${getProviderApiKeyEnvKey(
+              provider,
+            )} is set.`,
       );
     } catch (saveError) {
       setError(
@@ -1712,7 +1723,7 @@ function SlashMenu({
             description={
               provider === currentProvider
                 ? "current"
-                : `default model ${getDefaultModelId(provider)}`
+                : getProviderModelMenuDescription(provider)
             }
             isSelected={index === menuState.selectedIndex}
             key={provider}
@@ -2587,8 +2598,21 @@ function getDisplayModelId(modelId: string | null): string {
   return (
     modelId ??
     process.env[OPENWIKI_MODEL_ID_ENV_KEY] ??
-    getDefaultModelId(resolveConfiguredProvider())
+    getDefaultModelId(resolveConfiguredProvider()) ??
+    "custom model ID required"
   );
+}
+
+function getDefaultModelLabel(provider: OpenWikiProvider): string {
+  return getDefaultModelId(provider) ?? "custom model ID required";
+}
+
+function getProviderModelMenuDescription(provider: OpenWikiProvider): string {
+  const defaultModelId = getDefaultModelId(provider);
+
+  return defaultModelId
+    ? `default model ${defaultModelId}`
+    : "custom model ID required";
 }
 
 function getErrorDiagnostics(error: unknown): ErrorDiagnostic[] {

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -194,8 +194,8 @@ export function getProviderModelOptions(
   return getProviderConfig(provider).modelOptions;
 }
 
-export function getDefaultModelId(provider: OpenWikiProvider): string {
-  return getProviderModelOptions(provider)[0]?.id ?? DEFAULT_MODEL_ID;
+export function getDefaultModelId(provider: OpenWikiProvider): string | null {
+  return getProviderModelOptions(provider)[0]?.id ?? null;
 }
 
 export function normalizeProvider(

--- a/src/credentials.tsx
+++ b/src/credentials.tsx
@@ -88,7 +88,8 @@ export function InitSetup({
       initialProvider,
       modelIdOverride ??
         process.env[OPENWIKI_MODEL_ID_ENV_KEY] ??
-        getDefaultModelId(initialProvider),
+        getDefaultModelId(initialProvider) ??
+        "",
     ),
   );
   const [isCustomModelInput, setIsCustomModelInput] = useState(false);
@@ -119,7 +120,8 @@ export function InitSetup({
         initialProvider,
         modelIdOverride ??
           process.env[OPENWIKI_MODEL_ID_ENV_KEY] ??
-          getDefaultModelId(initialProvider),
+          getDefaultModelId(initialProvider) ??
+          "",
       ),
     );
     setIsCustomModelInput(
@@ -204,7 +206,7 @@ export function InitSetup({
       setModelSelectionIndex(
         getModelSelectionIndex(
           selectedProvider,
-          getDefaultModelId(selectedProvider),
+          getDefaultModelId(selectedProvider) ?? "",
         ),
       );
       setInput("");
@@ -832,7 +834,11 @@ function getModelSetupDetail(
     return process.env[OPENWIKI_MODEL_ID_ENV_KEY] ?? "";
   }
 
-  return `default ${getDefaultModelId(provider)}`;
+  const defaultModelId = getDefaultModelId(provider);
+
+  return defaultModelId
+    ? `default ${defaultModelId}`
+    : "custom model ID required";
 }
 
 type ModelSelectionOption =

--- a/src/env.ts
+++ b/src/env.ts
@@ -21,6 +21,7 @@ export const openWikiEnvDir = path.join(os.homedir(), ".openwiki");
 export const openWikiEnvPath = path.join(openWikiEnvDir, ".env");
 
 type EnvMap = Record<string, string>;
+type EnvUpdates = Record<string, string | null | undefined>;
 
 export type CredentialDiagnostic = {
   key: string;
@@ -123,12 +124,17 @@ export async function getCredentialDiagnostics(): Promise<
   );
 }
 
-export async function saveOpenWikiEnv(updates: EnvMap): Promise<void> {
+export async function saveOpenWikiEnv(updates: EnvUpdates): Promise<void> {
   const currentEnv = await readOpenWikiEnv();
-  const nextEnv = {
-    ...currentEnv,
-    ...updates,
-  };
+  const nextEnv = { ...currentEnv };
+
+  for (const [key, value] of Object.entries(updates)) {
+    if (value === null || value === undefined) {
+      delete nextEnv[key];
+    } else {
+      nextEnv[key] = value;
+    }
+  }
 
   for (const key of deprecatedEnvKeys) {
     delete nextEnv[key];
@@ -147,7 +153,11 @@ export async function saveOpenWikiEnv(updates: EnvMap): Promise<void> {
   await chmod(openWikiEnvPath, 0o600);
 
   for (const [key, value] of Object.entries(updates)) {
-    process.env[key] = value;
+    if (value === null || value === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = value;
+    }
   }
 }
 

--- a/test/constants.test.ts
+++ b/test/constants.test.ts
@@ -131,14 +131,7 @@ describe("getDefaultModelId", () => {
     expect(getDefaultModelId(DEFAULT_PROVIDER)).toBe(DEFAULT_MODEL_ID);
   });
 
-  test(
-    "openai-compatible has no presets, so it falls back to the global " +
-      "DEFAULT_MODEL_ID (a known cross-provider quirk documented here)",
-    () => {
-      // This asserts CURRENT behavior: openai-compatible has an empty
-      // modelOptions list, so getDefaultModelId yields an OpenRouter id.
-      // If this ever changes intentionally, update this test.
-      expect(getDefaultModelId("openai-compatible")).toBe(DEFAULT_MODEL_ID);
-    },
-  );
+  test("returns null when a provider has no preset default model", () => {
+    expect(getDefaultModelId("openai-compatible")).toBeNull();
+  });
 });


### PR DESCRIPTION
## Motivation

`openai-compatible` endpoints do not have a universal default model name. The previous behavior allowed OpenWiki to fall back to the global OpenRouter default model when no `OPENWIKI_MODEL_ID` was configured, which could send an invalid model ID to an OpenAI-compatible gateway or make the active provider/model pairing misleading. This change makes the configuration contract explicit: providers without preset model options require the user to provide a model ID.

 ## Summary

  - Require an explicit model ID for providers that do not define preset model options, including `openai-compatible`.
  - Prevent `openai-compatible` from silently falling back to the OpenRouter default model.
  - Clear stale saved model IDs when switching to a custom-only provider.
  - Update CLI/setup messaging so users are told when a custom model ID is required.
  - Update constants coverage for the corrected default-model behavior.