### PR TITLE
fix: read text files with unmapped extensions as text

### DIFF
--- a/openwiki/agent/workflow.md
+++ b/openwiki/agent/workflow.md
@@ -13,7 +13,7 @@ The documentation agent is implemented in `src/agent/`. It takes a command (`cha
 5. Snapshot the current `openwiki/` content hash (before the run).
 6. Build the system prompt and user prompt.
 7. Create the provider-specific model client (`ChatAnthropic`, `ChatOpenRouter`, or `ChatOpenAI`).
-8. Create a DeepAgents `LocalShellBackend` rooted at the repository with a SQLite checkpointer.
+8. Create a DeepAgents backend rooted at the repository with a SQLite checkpointer. OpenWiki uses `TextSniffingLocalShellBackend` (`src/agent/text-sniffing-backend.ts`), a `LocalShellBackend` subclass that content-sniffs files the extension-based MIME lookup would treat as binary — valid UTF-8 files with unmapped extensions (terraform.tfvars, .tf, .hcl, .lock, ...) are returned as readable text instead of base64 blocks.
 9. Stream messages and tool events back to the CLI.
 10. For `init` and `update`, compare the post-run content snapshot to the pre-run snapshot. Write `openwiki/.last-update.json` **only if the content changed**.
 

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -5,8 +5,9 @@ import { ChatAnthropic } from "@langchain/anthropic";
 import { SqliteSaver } from "@langchain/langgraph-checkpoint-sqlite";
 import { ChatOpenAI } from "@langchain/openai";
 import { ChatOpenRouter } from "@langchain/openrouter";
-import { createDeepAgent, LocalShellBackend } from "deepagents";
+import { createDeepAgent } from "deepagents";
 import { DEBUG_ENV_KEYS, loadOpenWikiEnv, openWikiEnvDir } from "../env.js";
+import { TextSniffingLocalShellBackend } from "./text-sniffing-backend.js";
 import { isFileNotFoundError } from "../fs-errors.js";
 import { createSystemPrompt, createUserPrompt } from "./prompt.js";
 import type {
@@ -204,7 +205,7 @@ async function runOpenWikiAgentCore(
     model,
     tools: [],
     checkpointer,
-    backend: new LocalShellBackend({
+    backend: new TextSniffingLocalShellBackend({
       maxOutputBytes: 100_000,
       rootDir: cwd,
       timeout: 120,

--- a/src/agent/text-sniffing-backend.ts
+++ b/src/agent/text-sniffing-backend.ts
@@ -1,0 +1,76 @@
+import { LocalShellBackend, type ReadResult } from "deepagents";
+
+/**
+ * A {@link LocalShellBackend} that recognizes plain-text files regardless of
+ * their extension.
+ *
+ * The base backend decides text-vs-binary purely from the file extension, so
+ * text files with unmapped extensions (terraform.tfvars, .tf, .hcl, .lock,
+ * .conf, extensionless configs, ...) come back as binary `Uint8Array` content.
+ * The read_file tool then wraps them in a base64 block the model cannot read
+ * (and that the Anthropic API rejects outright). When the base class returns
+ * binary content, this subclass sniffs the bytes and, if they are valid UTF-8
+ * without NUL bytes, returns them as text with the same offset/limit line
+ * semantics as the base class's text path.
+ */
+export class TextSniffingLocalShellBackend extends LocalShellBackend {
+  override async read(
+    filePath: string,
+    offset = 0,
+    limit = 500,
+  ): Promise<ReadResult> {
+    const result = await super.read(filePath, offset, limit);
+
+    if (result.error !== undefined || typeof result.content === "string") {
+      return result;
+    }
+
+    const text =
+      result.content === undefined ? null : decodeUtf8Text(result.content);
+
+    if (text === null) {
+      return result;
+    }
+
+    return {
+      content: sliceLines(text, offset, limit),
+      mimeType: "text/plain",
+    };
+  }
+}
+
+/**
+ * Decodes bytes as UTF-8 text, returning `null` for content that is not
+ * plain text (invalid UTF-8 sequences, or NUL bytes — which valid text files
+ * do not contain but nearly all binary formats do).
+ */
+export function decodeUtf8Text(bytes: Uint8Array): string | null {
+  if (bytes.includes(0)) {
+    return null;
+  }
+
+  try {
+    return new TextDecoder("utf-8", { fatal: true }).decode(bytes);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Mirrors the base class's text-path semantics: `offset` is a 0-indexed
+ * starting line and `limit` the maximum number of lines returned.
+ */
+export function sliceLines(
+  text: string,
+  offset: number,
+  limit: number,
+): string {
+  if (limit === 0) {
+    return "";
+  }
+
+  return text
+    .split("\n")
+    .slice(offset, offset + limit)
+    .join("\n");
+}

--- a/test/text-sniffing-backend.test.ts
+++ b/test/text-sniffing-backend.test.ts
@@ -1,0 +1,110 @@
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterAll, beforeAll, describe, expect, test } from "vitest";
+import {
+  decodeUtf8Text,
+  sliceLines,
+  TextSniffingLocalShellBackend,
+} from "../src/agent/text-sniffing-backend.ts";
+
+describe("decodeUtf8Text", () => {
+  test("decodes plain UTF-8 text", () => {
+    const bytes = new TextEncoder().encode('region = "us-east-1"\n');
+
+    expect(decodeUtf8Text(bytes)).toBe('region = "us-east-1"\n');
+  });
+
+  test("decodes multi-byte UTF-8 (accents, CJK, emoji)", () => {
+    const bytes = new TextEncoder().encode("café 東京 ✅\n");
+
+    expect(decodeUtf8Text(bytes)).toBe("café 東京 ✅\n");
+  });
+
+  test("rejects content containing NUL bytes", () => {
+    expect(decodeUtf8Text(new Uint8Array([0x68, 0x69, 0x00, 0x68]))).toBeNull();
+  });
+
+  test("rejects invalid UTF-8 sequences", () => {
+    // 0xff is never valid in UTF-8.
+    expect(decodeUtf8Text(new Uint8Array([0xff, 0xfe, 0x00, 0x01]))).toBeNull();
+  });
+});
+
+describe("sliceLines", () => {
+  const text = ["l1", "l2", "l3", "l4"].join("\n");
+
+  test("applies 0-indexed offset and line limit", () => {
+    expect(sliceLines(text, 1, 2)).toBe("l2\nl3");
+  });
+
+  test("returns empty string for limit 0", () => {
+    expect(sliceLines(text, 0, 0)).toBe("");
+  });
+
+  test("returns everything within a large limit", () => {
+    expect(sliceLines(text, 0, 500)).toBe(text);
+  });
+});
+
+describe("TextSniffingLocalShellBackend", () => {
+  let rootDir: string;
+  let backend: TextSniffingLocalShellBackend;
+
+  beforeAll(async () => {
+    rootDir = await mkdtemp(path.join(os.tmpdir(), "openwiki-sniff-"));
+    await writeFile(
+      path.join(rootDir, "terraform.tfvars"),
+      'region = "us-east-1"\ninstance_type = "t3.micro"\n',
+    );
+    await writeFile(
+      path.join(rootDir, "notes.txt"),
+      "first line\nsecond line\n",
+    );
+    // PNG magic bytes followed by NULs: genuinely binary.
+    await writeFile(
+      path.join(rootDir, "image.png"),
+      Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0x00, 0x00]),
+    );
+    backend = new TextSniffingLocalShellBackend({
+      rootDir,
+      timeout: 30,
+      virtualMode: true,
+    });
+    await backend.initialize();
+  });
+
+  afterAll(async () => {
+    await backend.close();
+    await rm(rootDir, { force: true, recursive: true });
+  });
+
+  test("returns tfvars content as text despite the unmapped extension", async () => {
+    const result = await backend.read("/terraform.tfvars");
+
+    expect(result.error).toBeUndefined();
+    expect(result.mimeType).toBe("text/plain");
+    expect(result.content).toContain('region = "us-east-1"');
+  });
+
+  test("applies offset/limit line semantics to sniffed text", async () => {
+    const result = await backend.read("/terraform.tfvars", 1, 1);
+
+    expect(result.content).toBe('instance_type = "t3.micro"');
+  });
+
+  test("keeps the base class's text path for known text extensions", async () => {
+    const result = await backend.read("/notes.txt");
+
+    expect(result.error).toBeUndefined();
+    expect(typeof result.content).toBe("string");
+    expect(result.content).toContain("first line");
+  });
+
+  test("still returns genuinely binary files as binary", async () => {
+    const result = await backend.read("/image.png");
+
+    expect(result.error).toBeUndefined();
+    expect(typeof result.content).not.toBe("string");
+  });
+});


### PR DESCRIPTION
## What

Makes the agent able to read plain-text files whose extensions aren't in the MIME map — `terraform.tfvars`, `.tf`, `.hcl`, `.lock`, `.conf`, and similar. Today those files are classified as binary by extension lookup alone, wrapped in a base64 block the model cannot read, and (on the Anthropic provider) rejected by the API.

Fixes #168.

## Why

`LocalShellBackend.read()` (deepagents) decides text-vs-binary purely from `getMimeType(filePath)`. Any unmapped extension falls back to a non-text MIME type, so the backend returns the whole file as a `Uint8Array` without ever looking at the bytes. For a Terraform repository this means the variable definitions at the core of the codebase can't be documented at all. Related earlier reports (#33, #65, #134, #114) focused on the crash this caused on Anthropic — #164 stopped the crash, but the files remained unreadable; this PR fixes the readability itself, for **every provider**.

## How

- **`src/agent/text-sniffing-backend.ts`** (new) — `TextSniffingLocalShellBackend`, a `LocalShellBackend` subclass. When the base class's `read()` returns binary content, it sniffs the bytes: valid UTF-8 with no NUL bytes → returned as text (`mimeType: "text/plain"`), applying the same 0-indexed `offset` / `limit` line semantics as the base class's text path. Anything that fails the sniff (NUL bytes, invalid UTF-8 sequences) keeps the existing binary behavior, so images/archives/bytecode are unaffected.
- **`src/agent/index.ts`** — `createDeepAgent` now uses the subclass in place of `LocalShellBackend`. No other behavior changes.

The base class already downloads the full file on its binary path, so the sniff adds no extra I/O. A longer-term fix belongs upstream in `deepagents` (content sniffing inside `LocalShellBackend`, or an extended MIME map); this wrapper unblocks OpenWiki users now without forking upstream behavior for known file types.

## How I tested it

- New tests in `test/text-sniffing-backend.test.ts` (11 tests): UTF-8 decode incl. multi-byte (accents/CJK/emoji), NUL-byte and invalid-sequence rejection, offset/limit slicing — plus behavioral tests against a real `TextSniffingLocalShellBackend` on a temp directory: a `terraform.tfvars` reads back as text with correct content, offset/limit works on sniffed files, known text extensions still use the base text path, and a PNG still comes back binary.
- `pnpm run format`, `pnpm run lint`, `pnpm test` (97 tests), `tsc --noEmit` — all green.

## Notes

- Scope: one concern — text-file readability at the backend boundary. Complements #164 (Anthropic 400 guard) but is independent of it; either merges cleanly without the other.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
