### PR TITLE
fix: sniff text files with unmapped extensions

### DIFF
--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -5,10 +5,11 @@ import { ChatAnthropic } from "@langchain/anthropic";
 import { SqliteSaver } from "@langchain/langgraph-checkpoint-sqlite";
 import { ChatOpenAI } from "@langchain/openai";
 import { ChatOpenRouter } from "@langchain/openrouter";
-import { createDeepAgent, LocalShellBackend } from "deepagents";
+import { createDeepAgent } from "deepagents";
 import { DEBUG_ENV_KEYS, loadOpenWikiEnv, openWikiEnvDir } from "../env.js";
 import { isFileNotFoundError } from "../fs-errors.js";
 import { createSystemPrompt, createUserPrompt } from "./prompt.js";
+import { TextSniffingLocalShellBackend } from "./text-backend.js";
 import type {
   OpenWikiCommand,
   OpenWikiRunEvent,
@@ -204,7 +205,7 @@ async function runOpenWikiAgentCore(
     model,
     tools: [],
     checkpointer,
-    backend: new LocalShellBackend({
+    backend: new TextSniffingLocalShellBackend({
       maxOutputBytes: 100_000,
       rootDir: cwd,
       timeout: 120,

--- a/src/agent/text-backend.ts
+++ b/src/agent/text-backend.ts
@@ -1,0 +1,75 @@
+import { LocalShellBackend } from "deepagents";
+
+type BackendReadResult = Awaited<ReturnType<LocalShellBackend["read"]>>;
+
+/**
+ * LocalShellBackend classifies text/binary by MIME type, which can mark
+ * extensionless or unmapped text files as binary. This wrapper keeps genuine
+ * binary files untouched, but reclassifies valid UTF-8 byte results as text.
+ */
+export class TextSniffingLocalShellBackend extends LocalShellBackend {
+  override async read(
+    filePath: string,
+    offset = 0,
+    limit = 500,
+  ): Promise<BackendReadResult> {
+    const result = await super.read(filePath, offset, limit);
+
+    return sniffBinaryReadResultAsText(result, offset, limit) ?? result;
+  }
+}
+
+export function sniffBinaryReadResultAsText<T extends { content?: unknown }>(
+  result: T,
+  offset = 0,
+  limit = 500,
+): (T & { content: string; mimeType: "text/plain" }) | null {
+  const bytes = getByteContent(result.content);
+
+  if (!bytes) {
+    return null;
+  }
+
+  const text = decodeUtf8Text(bytes);
+
+  if (text === null || text.includes("\0")) {
+    return null;
+  }
+
+  return {
+    ...result,
+    content: applyLineWindow(text, offset, limit),
+    mimeType: "text/plain",
+  };
+}
+
+function getByteContent(content: unknown): Uint8Array | null {
+  if (content instanceof Uint8Array) {
+    return content;
+  }
+
+  if (content instanceof ArrayBuffer) {
+    return new Uint8Array(content);
+  }
+
+  return null;
+}
+
+function decodeUtf8Text(bytes: Uint8Array): string | null {
+  try {
+    return new TextDecoder("utf-8", { fatal: true }).decode(bytes);
+  } catch {
+    return null;
+  }
+}
+
+export function applyLineWindow(
+  text: string,
+  offset = 0,
+  limit = 500,
+): string {
+  const start = Math.max(0, offset);
+  const count = Math.max(0, limit);
+
+  return text.split("\n").slice(start, start + count).join("\n");
+}

--- a/test/text-backend.test.ts
+++ b/test/text-backend.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, test } from "vitest";
+import {
+  applyLineWindow,
+  sniffBinaryReadResultAsText,
+} from "../src/agent/text-backend.ts";
+
+const encoder = new TextEncoder();
+
+describe("sniffBinaryReadResultAsText", () => {
+  test("converts valid UTF-8 byte content to text/plain", () => {
+    const result = sniffBinaryReadResultAsText({
+      content: encoder.encode('region = "us-east-1"\n'),
+      mimeType: "application/octet-stream",
+    });
+
+    expect(result).toEqual({
+      content: 'region = "us-east-1"\n',
+      mimeType: "text/plain",
+    });
+  });
+
+  test("applies line offset and limit to sniffed text", () => {
+    const result = sniffBinaryReadResultAsText(
+      {
+        content: encoder.encode("first\nsecond\nthird\nfourth"),
+        mimeType: "application/octet-stream",
+      },
+      1,
+      2,
+    );
+
+    expect(result?.content).toBe("second\nthird");
+  });
+
+  test("leaves invalid UTF-8 byte content unchanged", () => {
+    const result = sniffBinaryReadResultAsText({
+      content: new Uint8Array([0xff, 0xfe, 0xfd]),
+      mimeType: "application/octet-stream",
+    });
+
+    expect(result).toBeNull();
+  });
+
+  test("leaves NUL-containing byte content unchanged", () => {
+    const result = sniffBinaryReadResultAsText({
+      content: new Uint8Array([0x61, 0x00, 0x62]),
+      mimeType: "application/octet-stream",
+    });
+
+    expect(result).toBeNull();
+  });
+
+  test("ignores already-text read results", () => {
+    const result = sniffBinaryReadResultAsText({
+      content: "already text",
+      mimeType: "text/plain",
+    });
+
+    expect(result).toBeNull();
+  });
+});
+
+describe("applyLineWindow", () => {
+  test("normalizes negative offset and limit", () => {
+    expect(applyLineWindow("first\nsecond", -1, -1)).toBe("");
+  });
+
+  test("keeps the default 500-line window", () => {
+    const text = Array.from({ length: 501 }, (_, index) => String(index)).join(
+      "\n",
+    );
+
+    expect(applyLineWindow(text).split("\n")).toHaveLength(500);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #168.

  - Add an OpenWiki-side `TextSniffingLocalShellBackend` wrapper around DeepAgents `LocalShellBackend`.
  - Reclassify binary-looking read results as `text/plain` when the bytes decode as valid UTF-8 and contain no NUL bytes.
  - Preserve existing binary behavior for invalid UTF-8 or NUL-containing files.
  - Apply the same line `offset`/`limit` windowing when sniffed content is returned as text.
  - Add focused tests for Terraform-style text content, invalid UTF-8, NUL-containing binary data, and pagination behavior.

## Motivation

DeepAgents currently decides text-vs-binary from MIME/extension metadata. Plain-text files with unmapped extensions, such as `terraform.tfvars`, `.tf`, `.hcl`, `.conf`, `.lock`, or `.env.example`, can be returned as binary data instead of readable text. That prevents the OpenWiki agent from documenting important repository files even though their contents are normal UTF-8 text. This wrapper unblocks OpenWiki users while keeping genuine binary files on the existing binary path.