### PR TITLE
fix: read unknown-extension UTF-8 files as text

### DIFF
--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -5,10 +5,11 @@ import { ChatAnthropic } from "@langchain/anthropic";
 import { SqliteSaver } from "@langchain/langgraph-checkpoint-sqlite";
 import { ChatOpenAI } from "@langchain/openai";
 import { ChatOpenRouter } from "@langchain/openrouter";
-import { createDeepAgent, LocalShellBackend } from "deepagents";
+import { createDeepAgent } from "deepagents";
 import { DEBUG_ENV_KEYS, loadOpenWikiEnv, openWikiEnvDir } from "../env.js";
 import { isFileNotFoundError } from "../fs-errors.js";
 import { createSystemPrompt, createUserPrompt } from "./prompt.js";
+import { TextSniffingLocalShellBackend } from "./text-sniffing-backend.js";
 import type {
   OpenWikiCommand,
   OpenWikiRunEvent,
@@ -204,7 +205,7 @@ async function runOpenWikiAgentCore(
     model,
     tools: [],
     checkpointer,
-    backend: new LocalShellBackend({
+    backend: new TextSniffingLocalShellBackend({
       maxOutputBytes: 100_000,
       rootDir: cwd,
       timeout: 120,

--- a/src/agent/text-sniffing-backend.ts
+++ b/src/agent/text-sniffing-backend.ts
@@ -1,0 +1,86 @@
+import { LocalShellBackend } from "deepagents";
+
+/**
+ * Result shape returned by {@link LocalShellBackend.read}. Derived from the
+ * backend method itself so we don't depend on the type being re-exported.
+ */
+type ReadResult = Awaited<ReturnType<LocalShellBackend["read"]>>;
+
+/**
+ * Decode bytes as UTF-8 text, returning `null` when the bytes are not
+ * plausibly text — i.e. they contain a NUL byte or are not valid UTF-8. This
+ * is the same cheap heuristic Git uses to distinguish text from binary.
+ */
+export function decodeUtf8Text(bytes: Uint8Array): string | null {
+  if (bytes.includes(0)) {
+    return null;
+  }
+  try {
+    return new TextDecoder("utf-8", { fatal: true }).decode(bytes);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Re-apply the line-window semantics of the native text read path, so a
+ * sniffed-text file behaves identically to a natively recognized text file.
+ */
+function sliceLines(text: string, offset: number, limit: number): ReadResult {
+  const lines = text.split("\n");
+  if (offset >= lines.length) {
+    return {
+      error: `Line offset ${offset} exceeds file length (${lines.length} lines)`,
+    };
+  }
+  const endIdx = Math.min(offset + limit, lines.length);
+  return {
+    content: lines.slice(offset, endIdx).join("\n"),
+    mimeType: "text/plain",
+  };
+}
+
+/**
+ * Reinterpret a binary {@link ReadResult} as text when its bytes decode
+ * cleanly as UTF-8. Error results and results that are already text (string
+ * content) pass through unchanged.
+ */
+export function reinterpretBinaryAsText(
+  result: ReadResult,
+  offset: number,
+  limit: number,
+): ReadResult {
+  if (result.error !== undefined || !(result.content instanceof Uint8Array)) {
+    return result;
+  }
+  const text = decodeUtf8Text(result.content);
+  if (text === null) {
+    return result;
+  }
+  return sliceLines(text, offset, limit);
+}
+
+/**
+ * A {@link LocalShellBackend} that treats files with unrecognized extensions
+ * as text when their bytes are valid UTF-8.
+ *
+ * deepagents' `getMimeType()` maps any unknown extension to
+ * `application/octet-stream`, which `read_file` then sends to the model as a
+ * base64 `document`/`file` content block. On the Anthropic provider that
+ * fails hard with `400 ... media_type: Input should be 'application/pdf'`, and
+ * on every provider the model never sees the file's real contents. Many common
+ * text files trip this: `.properties`, `.scss`, `.tf`, `.tfvars`, `.hcl`,
+ * `.lock`, and extension-less files such as `mvnw` or `Dockerfile`.
+ *
+ * See https://github.com/langchain-ai/openwiki/issues/168 and #134.
+ */
+export class TextSniffingLocalShellBackend extends LocalShellBackend {
+  override async read(
+    filePath: string,
+    offset = 0,
+    limit = 500,
+  ): Promise<ReadResult> {
+    const result = await super.read(filePath, offset, limit);
+    return reinterpretBinaryAsText(result, offset, limit);
+  }
+}

--- a/test/text-sniffing-backend.test.ts
+++ b/test/text-sniffing-backend.test.ts
@@ -1,0 +1,122 @@
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterAll, beforeAll, describe, expect, test } from "vitest";
+import {
+  TextSniffingLocalShellBackend,
+  decodeUtf8Text,
+  reinterpretBinaryAsText,
+} from "../src/agent/text-sniffing-backend.ts";
+
+describe("decodeUtf8Text", () => {
+  test("decodes valid UTF-8 bytes", () => {
+    const bytes = new TextEncoder().encode("server.port=8080\n# café");
+    expect(decodeUtf8Text(bytes)).toBe("server.port=8080\n# café");
+  });
+
+  test("returns null when bytes contain a NUL byte", () => {
+    const bytes = new Uint8Array([0x68, 0x69, 0x00, 0x21]);
+    expect(decodeUtf8Text(bytes)).toBeNull();
+  });
+
+  test("returns null for invalid UTF-8", () => {
+    // 0xff is never valid as a standalone UTF-8 byte.
+    const bytes = new Uint8Array([0xff, 0xfe, 0x00, 0x01]);
+    expect(decodeUtf8Text(bytes)).toBeNull();
+  });
+
+  test("decodes empty input to an empty string", () => {
+    expect(decodeUtf8Text(new Uint8Array())).toBe("");
+  });
+});
+
+describe("reinterpretBinaryAsText", () => {
+  const bytesOf = (s: string) => new TextEncoder().encode(s);
+
+  test("passes error results through unchanged", () => {
+    const result = { error: "File 'x' not found" };
+    expect(reinterpretBinaryAsText(result, 0, 500)).toBe(result);
+  });
+
+  test("passes text (string) results through unchanged", () => {
+    const result = { content: "already text", mimeType: "text/plain" };
+    expect(reinterpretBinaryAsText(result, 0, 500)).toBe(result);
+  });
+
+  test("converts valid-UTF-8 binary content to text/plain", () => {
+    const result = {
+      content: bytesOf("a=1\nb=2\n"),
+      mimeType: "application/octet-stream",
+    };
+    const out = reinterpretBinaryAsText(result, 0, 500);
+    expect(out.mimeType).toBe("text/plain");
+    expect(out.content).toBe("a=1\nb=2\n");
+  });
+
+  test("leaves genuinely binary content untouched", () => {
+    const bytes = new Uint8Array([0x00, 0x01, 0x02, 0xff]);
+    const result = { content: bytes, mimeType: "application/octet-stream" };
+    const out = reinterpretBinaryAsText(result, 0, 500);
+    expect(out.content).toBe(bytes);
+    expect(out.mimeType).toBe("application/octet-stream");
+  });
+
+  test("applies offset/limit line windowing", () => {
+    const result = {
+      content: bytesOf("l1\nl2\nl3\nl4\nl5"),
+      mimeType: "application/octet-stream",
+    };
+    expect(reinterpretBinaryAsText(result, 1, 2).content).toBe("l2\nl3");
+  });
+
+  test("reports an out-of-range offset as an error", () => {
+    const result = {
+      content: bytesOf("only\ntwo"),
+      mimeType: "application/octet-stream",
+    };
+    expect(reinterpretBinaryAsText(result, 10, 500).error).toMatch(
+      /exceeds file length/,
+    );
+  });
+});
+
+describe("TextSniffingLocalShellBackend (integration)", () => {
+  let root: string;
+
+  beforeAll(async () => {
+    root = await mkdtemp(path.join(tmpdir(), "openwiki-sniff-"));
+    await writeFile(
+      path.join(root, "application.properties"),
+      "server.port=8080\nspring.datasource.url=jdbc:postgresql://db\n",
+    );
+    await writeFile(
+      path.join(root, "styles.scss"),
+      "$primary: #FF6B35;\n.button { color: $primary; }\n",
+    );
+  });
+
+  afterAll(async () => {
+    await rm(root, { recursive: true, force: true });
+  });
+
+  test("reads an unknown-extension text file as readable text", async () => {
+    const backend = new TextSniffingLocalShellBackend({
+      rootDir: root,
+      virtualMode: true,
+    });
+    const result = await backend.read("/application.properties");
+    expect(result.error).toBeUndefined();
+    expect(typeof result.content).toBe("string");
+    expect(result.content).toContain("server.port=8080");
+  });
+
+  test("reads a .scss file as readable text", async () => {
+    const backend = new TextSniffingLocalShellBackend({
+      rootDir: root,
+      virtualMode: true,
+    });
+    const result = await backend.read("/styles.scss");
+    expect(typeof result.content).toBe("string");
+    expect(result.content).toContain("$primary");
+  });
+});


### PR DESCRIPTION
## What & why

`read_file` can't read many common text files, and on the Anthropic provider it crashes the whole run.

deepagents' `getMimeType()` maps any **unrecognized extension** to `application/octet-stream`, and `isTextMimeType()` only accepts `text/*`, `application/json`, `application/javascript`, and `image/svg+xml`. Everything else is treated as binary, so `read_file` base64-encodes it into a `document`/`file` content block. Two consequences:

1. **Anthropic hard-fails the run** with `400 ... tool_result...document.source.base64.media_type: Input should be 'application/pdf'` (see #134, #171).
2. **On every provider**, the model never sees the file's real contents.

This hits ordinary source files with extensions not in deepagents' map — e.g. `.properties` (Spring config), `.scss` (Angular/Sass), `.tf` / `.tfvars` / `.hcl` (Terraform), `.lock`, and extension-less files like `mvnw` or `Dockerfile`. On a typical Spring Boot + Angular monorepo, generation dies within the first few file reads.

## The fix

A small `TextSniffingLocalShellBackend` wraps `LocalShellBackend.read()`: when the base read returns **binary** content whose bytes are **valid UTF-8 with no NUL byte** (the same cheap heuristic Git uses), it's returned as `text/plain`, re-applying the same `offset`/`limit` line-window semantics as the native text path. Genuinely binary files (images, archives, invalid UTF-8) pass through unchanged, so image handling is unaffected.

This is the content-sniffing approach suggested by the maintainer in #168, implemented as a backend wrapper in `src/agent/`. It's complementary to #164: that PR rewrites already-unsupported blocks into placeholders to avoid the 400; this one lets the model actually read these files as text in the first place.

## Changes

- `src/agent/text-sniffing-backend.ts` — new backend subclass + pure helpers (`decodeUtf8Text`, `reinterpretBinaryAsText`).
- `src/agent/index.ts` — use it for the agent's backend.
- `test/text-sniffing-backend.test.ts` — unit tests for the helpers (valid/invalid UTF-8, NUL detection, offset/limit windowing, binary pass-through) plus an integration test reading a real `.properties`/`.scss` file from a temp dir.

## Testing

`pnpm run format`, `pnpm run lint:check`, `pnpm run typecheck`, and `pnpm test` all pass locally (98 tests, 12 new).

Fixes #168. Also resolves the Anthropic 400 in #134 for text files with unknown extensions.
