### PR TITLE
feat(cli): support local Codex runner

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,12 @@ Run a single command and exit:
 openwiki -p "Summarize what you can do"
 ```
 
+Run through the local Codex CLI instead of model provider API credentials:
+
+```sh
+openwiki --codex --update --print
+```
+
 Initialize OpenWiki:
 
 ```sh
@@ -68,6 +74,17 @@ openwiki --help
 On the first interactive run, OpenWiki will have you configure your inference provider, API key, and LLM. You will also be able to set a LangSmith API key to trace your OpenWiki runs to a LangSmith tracing project named "openwiki" (optional).
 
 These configuration options and secrets will be saved to `~/.openwiki/.env` on your local machine.
+
+### Codex runner
+
+Use `--codex` to run OpenWiki through `codex exec` with your local Codex CLI authentication instead of provider API keys. This is useful when Codex is already authenticated with ChatGPT-managed access:
+
+```sh
+openwiki --codex --init --print
+openwiki --codex --update --print
+```
+
+The Codex runner uses `codex --cd <repo> --sandbox workspace-write --ask-for-approval never exec --ephemeral` and writes only inside the target repository. If you also pass `--modelId`, OpenWiki forwards it to Codex as `--model`.
 
 ## Customizing
 

--- a/src/cli.tsx
+++ b/src/cli.tsx
@@ -21,6 +21,7 @@ import {
   type CredentialDiagnostic,
 } from "./env.js";
 import { createOpenWikiThreadId, runOpenWikiAgent } from "./agent/index.js";
+import { runOpenWikiWithCodex } from "./codex-runner.js";
 import { getErrorMessage, sanitizeDiagnosticText } from "./diagnostics.js";
 import { stripHtmlTags } from "./utils.js";
 import {
@@ -145,6 +146,7 @@ function App({ command }: AppProps) {
     );
   const shouldRunInteractiveCredentialSetup =
     command.kind === "run" &&
+    command.runner !== "codex" &&
     resolvedCommand !== null &&
     !command.dryRun &&
     process.stdin.isTTY &&
@@ -238,7 +240,11 @@ function App({ command }: AppProps) {
 
     const apiKeyEnvKey = getProviderApiKeyEnvKey(sessionProvider);
 
-    if (!process.env[apiKeyEnvKey] && !process.stdin.isTTY) {
+    if (
+      command.runner !== "codex" &&
+      !process.env[apiKeyEnvKey] &&
+      !process.stdin.isTTY
+    ) {
       setRunState({
         status: "error",
         message: `${apiKeyEnvKey} is required. Run openwiki in an interactive terminal to save credentials.`,
@@ -288,7 +294,10 @@ function App({ command }: AppProps) {
         });
     }
 
-    runOpenWikiAgent(resolvedCommand, process.cwd(), {
+    const runAgent =
+      command.runner === "codex" ? runOpenWikiWithCodex : runOpenWikiAgent;
+
+    runAgent(resolvedCommand, process.cwd(), {
       debug: isDebugMode(),
       isFollowup: activeMessageIsFollowup,
       modelId: sessionModelId,
@@ -405,6 +414,7 @@ function App({ command }: AppProps) {
       <DryRunView
         command={command.command}
         modelId={command.modelId}
+        runner={command.runner}
         shouldStart={command.shouldStart}
         userMessage={command.userMessage}
       />
@@ -600,11 +610,13 @@ function HelpView() {
 function DryRunView({
   command,
   modelId,
+  runner,
   shouldStart,
   userMessage,
 }: {
   command: OpenWikiCommand;
   modelId: string | null;
+  runner: "codex" | "deepagents";
   shouldStart: boolean;
   userMessage: string | null;
 }) {
@@ -617,6 +629,7 @@ function DryRunView({
           label="Command"
           value={`openwiki ${command}`}
         />
+        <StatusLine tone="muted" label="Runner" value={runner} />
         <StatusLine tone="muted" label="Mode" value={command} />
         <StatusLine
           tone="muted"
@@ -3008,8 +3021,10 @@ async function runPrintCommand(
 ): Promise<void> {
   try {
     const output: string[] = [];
+    const runAgent =
+      command.runner === "codex" ? runOpenWikiWithCodex : runOpenWikiAgent;
 
-    await runOpenWikiAgent(command.command, process.cwd(), {
+    await runAgent(command.command, process.cwd(), {
       debug: isDebugMode(),
       isFollowup: command.command === "chat",
       modelId: command.modelId,
@@ -3054,6 +3069,7 @@ function resolveStartupCommand(command: CliCommand): CliCommand {
   if (
     command.kind === "run" &&
     !command.dryRun &&
+    command.runner !== "codex" &&
     command.shouldStart &&
     (command.print || !process.stdin.isTTY)
   ) {

--- a/src/codex-runner.ts
+++ b/src/codex-runner.ts
@@ -1,0 +1,198 @@
+import { spawn } from "node:child_process";
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { createSystemPrompt, createUserPrompt } from "./agent/prompt.js";
+import type {
+  OpenWikiCommand,
+  OpenWikiRunOptions,
+  OpenWikiRunResult,
+} from "./agent/types.js";
+import {
+  createOpenWikiContentSnapshot,
+  createRunContext,
+  getUpdateNoopStatus,
+  shouldCheckUpdateNoop,
+  writeLastUpdateMetadata,
+} from "./agent/utils.js";
+
+const CODEX_RUNNER_MODEL = "codex";
+
+export async function runOpenWikiWithCodex(
+  command: OpenWikiCommand,
+  cwd = process.cwd(),
+  options: OpenWikiRunOptions = {},
+): Promise<OpenWikiRunResult> {
+  options.onEvent?.({
+    type: "debug",
+    message: "runner=codex",
+  });
+
+  if (command === "update" && shouldCheckUpdateNoop(options)) {
+    const noopStatus = await getUpdateNoopStatus(cwd);
+
+    if (noopStatus.shouldSkip) {
+      const message =
+        "No repository changes detected since the last OpenWiki update; skipping Codex run.";
+      options.onEvent?.({ type: "text", text: message });
+
+      return {
+        command,
+        model: noopStatus.model,
+        skipped: true,
+      };
+    }
+  }
+
+  const openWikiSnapshotBefore =
+    command === "chat" ? null : await createOpenWikiContentSnapshot(cwd);
+  const context = await createRunContext(command, cwd);
+  const prompt = createCodexPrompt(command, cwd, context, options);
+  const outputFile = await createOutputFilePath();
+
+  try {
+    options.onEvent?.({
+      type: "text",
+      text: "Starting local `codex exec` runner with saved Codex authentication.",
+    });
+
+    await runCodexExec(cwd, prompt, outputFile, options);
+
+    const finalMessage = await readFile(outputFile, "utf8").catch(() => "");
+    if (finalMessage.trim()) {
+      options.onEvent?.({ type: "text", text: finalMessage.trim() });
+    }
+
+    if (
+      command !== "chat" &&
+      openWikiSnapshotBefore !== (await createOpenWikiContentSnapshot(cwd))
+    ) {
+      await writeLastUpdateMetadata(command, cwd, CODEX_RUNNER_MODEL);
+      options.onEvent?.({
+        type: "debug",
+        message: "metadata=written runner=codex",
+      });
+    }
+
+    return {
+      command,
+      model: CODEX_RUNNER_MODEL,
+    };
+  } finally {
+    await rm(path.dirname(outputFile), { recursive: true, force: true });
+  }
+}
+
+function createCodexPrompt(
+  command: OpenWikiCommand,
+  cwd: string,
+  context: Awaited<ReturnType<typeof createRunContext>>,
+  options: OpenWikiRunOptions,
+): string {
+  const userPrompt =
+    options.isFollowup === true && options.userMessage?.trim()
+      ? options.userMessage.trim()
+      : createUserPrompt(command, context, options.userMessage ?? null);
+
+  return `
+${createSystemPrompt(command)}
+
+${userPrompt}
+
+Repository root:
+${cwd}
+
+Codex runner note:
+- You are running through OpenWiki's local Codex runner.
+- Operate only in the repository root above.
+- Use normal filesystem paths relative to that repository.
+- Keep all generated documentation under openwiki/.
+- Do not read .env files, credentials, private keys, tokens, or other secret-bearing files.
+- Before completing init/update, verify the openwiki/ tree and remove openwiki/_plan.md if it exists.
+`.trim();
+}
+
+async function createOutputFilePath(): Promise<string> {
+  const directory = await mkdtemp(path.join(tmpdir(), "openwiki-codex-"));
+  return path.join(directory, "last-message.md");
+}
+
+function runCodexExec(
+  cwd: string,
+  prompt: string,
+  outputFile: string,
+  options: OpenWikiRunOptions,
+): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const args = [
+      "--cd",
+      cwd,
+      "--sandbox",
+      "workspace-write",
+      "--ask-for-approval",
+      "never",
+    ];
+
+    if (options.modelId) {
+      args.push("--model", options.modelId);
+    }
+
+    args.push("exec", "--ephemeral", "--output-last-message", outputFile, "-");
+
+    const child = spawn("codex", args, {
+      cwd,
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+
+    let stderr = "";
+
+    child.stdout.setEncoding("utf8");
+    child.stdout.on("data", (chunk: string) => {
+      if (options.debug) {
+        options.onEvent?.({
+          type: "debug",
+          message: `codex.stdout ${chunk.trim()}`,
+        });
+      }
+    });
+
+    child.stderr.setEncoding("utf8");
+    child.stderr.on("data", (chunk: string) => {
+      stderr += chunk;
+      const trimmed = chunk.trim();
+      if (trimmed && options.debug) {
+        options.onEvent?.({
+          type: "debug",
+          message: `codex.stderr ${trimmed}`,
+        });
+      }
+    });
+
+    child.stdin.on("error", (error: NodeJS.ErrnoException) => {
+      if (error.code !== "EPIPE") {
+        reject(error);
+      }
+    });
+
+    child.on("error", (error) => {
+      reject(error);
+    });
+
+    child.on("close", (code) => {
+      if (code === 0) {
+        resolve();
+        return;
+      }
+
+      reject(
+        new Error(
+          `codex exec exited with code ${code ?? "unknown"}${
+            stderr.trim() ? `: ${stderr.trim()}` : ""
+          }`,
+        ),
+      );
+    });
+
+    child.stdin.end(prompt);
+  });
+}

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -26,6 +26,7 @@ export type CliCommand =
       dryRun: boolean;
       modelId: string | null;
       print: boolean;
+      runner: "codex" | "deepagents";
       shouldStart: boolean;
       userMessage: string | null;
     }
@@ -43,6 +44,7 @@ export function parseCommand(argv: string[]): CliCommand {
   let dryRun = false;
   let modelId: string | null = null;
   let print = false;
+  let runner: "codex" | "deepagents" = "deepagents";
   let command: OpenWikiCommand = "chat";
   const userMessageParts: string[] = [];
 
@@ -68,6 +70,11 @@ export function parseCommand(argv: string[]): CliCommand {
 
     if (arg === "--print" || arg === "-p") {
       print = true;
+      continue;
+    }
+
+    if (arg === "--codex") {
+      runner = "codex";
       continue;
     }
 
@@ -158,6 +165,7 @@ export function parseCommand(argv: string[]): CliCommand {
     dryRun,
     modelId,
     print,
+    runner,
     shouldStart,
     userMessage,
   };
@@ -178,6 +186,8 @@ export const helpContent: HelpContent = {
     "openwiki [--modelId <model>] [message]",
     "openwiki --init [message]",
     "openwiki --update [message]",
+    "openwiki --codex --init [message]",
+    "openwiki --codex --update [message]",
   ],
   commands: [
     {
@@ -202,6 +212,11 @@ export const helpContent: HelpContent = {
       label: "--modelId <id>",
       description: "Use a model ID for this run.",
     },
+    {
+      label: "--codex",
+      description:
+        "Run through local codex exec instead of provider API credentials.",
+    },
   ],
   developmentOptions: [
     {
@@ -217,6 +232,7 @@ export const helpContent: HelpContent = {
     'openwiki -p "Summarize what OpenWiki can do"',
     "openwiki --modelId gpt-5.5",
     'openwiki --update --modelId gpt-5.5 "Please document the API routes first"',
+    "openwiki --codex --update --print",
   ],
   developmentExamples: ["openwiki --dry-run"],
 };

--- a/test/commands.test.ts
+++ b/test/commands.test.ts
@@ -42,6 +42,7 @@ describe("parseCommand — chat default", () => {
       print: false,
       dryRun: false,
       modelId: null,
+      runner: "deepagents",
     });
   });
 
@@ -104,6 +105,16 @@ describe("parseCommand — print", () => {
       kind: "run",
       print: true,
       command: "init",
+    });
+  });
+
+  test("--codex selects the Codex runner", () => {
+    expect(parseCommand(["--codex", "--update", "--print"])).toMatchObject({
+      kind: "run",
+      command: "update",
+      print: true,
+      runner: "codex",
+      shouldStart: true,
     });
   });
 


### PR DESCRIPTION
## What changed

Adds an explicit `--codex` runner mode that routes OpenWiki init/update/chat runs through local `codex exec` instead of requiring provider API credentials. The existing DeepAgents/provider-backed runner remains the default.

## Why

Some users have ChatGPT-managed Codex access rather than separate provider API keys. Codex exposes that supported auth path through the local CLI, not as an OpenAI API key. This runner lets OpenWiki reuse saved Codex CLI authentication without touching private ChatGPT session internals.

## User impact

Users can run:

```sh
openwiki --codex --update --print
```

The runner uses `codex --cd <repo> --sandbox workspace-write --ask-for-approval never exec --ephemeral`. Passing `--modelId` forwards to Codex as `--model`.

## Migration needed?

N/A

### Migration steps

N/A

## Release notes draft

OpenWiki can now opt into a local Codex CLI runner with `--codex`, allowing documentation updates through saved Codex authentication instead of provider API keys.

## Verification

- `pnpm format:check`
- `pnpm lint:check`
- `pnpm test`
- `pnpm typecheck`
- `pnpm build`
- Smoke tested `node dist/cli.js --codex --update --print` against a local AGNC fixture
