### PR TITLE
fix: normalize quoted provider values from environment configuration

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -205,7 +205,16 @@ export function normalizeProvider(
     return null;
   }
 
-  const provider = value.trim().toLowerCase();
+  let provider = value.trim();
+  
+  if (
+    (provider.startsWith('"') && provider.endsWith('"')) ||
+    (provider.startsWith("'") && provider.endsWith("'"))
+  ) {
+    provider = provider.slice(1, -1).trim();
+  }
+  
+  provider = provider.toLowerCase();
 
   return isValidProvider(provider) ? provider : null;
 }


### PR DESCRIPTION
## Description

Related to #157

This PR resolves an issue where non-interactive runs (`openwiki -p ...`) incorrectly require `OPENROUTER_API_KEY` when a different provider is configured via an environment variable or `.env` file that includes surrounding quotes.

### Expected Behavior
When `OPENWIKI_PROVIDER` is set to a valid provider (e.g., `"openai-compatible"`) and the appropriate provider-specific API key is set, the CLI should bypass the `OPENROUTER_API_KEY` check and use the configured provider.

### Actual Behavior
When `OPENWIKI_PROVIDER` contains surrounding quotes (common in `.env` files and containerized environments), the CLI fails the provider validation check, falls back to the default provider (`openrouter`), and incorrectly demands `OPENROUTER_API_KEY`.

### Root Cause
In `src/constants.ts`, the `normalizeProvider()` function trims whitespace and lowercases the provider string but does not strip surrounding quotes. Consequently, if `OPENWIKI_PROVIDER` evaluates to `"\"openai-compatible\""`, `isValidProvider()` returns `false`, causing `resolveConfiguredProvider()` to fall back to `openrouter`.

*(Note: The exact state of the issue reporter's bash shell could not be reproduced. When `export OPENWIKI_PROVIDER=openai-compatible` is executed natively without quotes, the bug does not occur. The bug exclusively triggers when quotes are passed to the Node process, such as via the `.env` file provided in the issue description).*

### Fix
Updated `normalizeProvider()` in `src/constants.ts` to actively detect and strip surrounding single (`'`) and double (`"`) quotes from the evaluated provider string before performing the validation check.

### Verification Steps
1. Configured `.env` to include quotes:
   ```env
   OPENWIKI_PROVIDER="openai-compatible"
   OPENAI_COMPATIBLE_API_KEY="sk-test"
   OPENAI_COMPATIBLE_BASE_URL="http://localhost:8080/v1"
