### PR TITLE
fix: validate configured provider before setup completes

### DIFF
--- a/openwiki/operations/credentials-and-updates.md
+++ b/openwiki/operations/credentials-and-updates.md
@@ -43,7 +43,7 @@ The setup flow runs for **all** interactive commands (chat, init, and update) wh
 2. Otherwise, if `OPENROUTER_API_KEY` is present, default to `openrouter`.
 3. Otherwise, fall back to `DEFAULT_PROVIDER` (`openrouter`).
 
-`needsCredentialSetup()` in `src/credentials.tsx` checks whether the provider env var, the provider's API key, a model ID (unless overridden), and a LangSmith key are all present. Any missing value triggers the interactive flow.
+`needsCredentialSetup()` in `src/credentials.tsx` checks whether the provider env var is valid and whether the provider's API key, a model ID (unless overridden), and a LangSmith key are all present. Any missing or invalid provider value triggers the interactive flow.
 
 ## Model and credential diagnostics
 

--- a/src/credentials.tsx
+++ b/src/credentials.tsx
@@ -9,6 +9,7 @@ import {
   getProviderModelOptions,
   isValidBaseUrl,
   isValidModelId,
+  normalizeProvider,
   normalizeModelId,
   OPENWIKI_MODEL_ID_ENV_KEY,
   OPENWIKI_PROVIDER_ENV_KEY,
@@ -44,7 +45,7 @@ export function needsCredentialSetup(
   const apiKeyEnvKey = getProviderApiKeyEnvKey(provider);
 
   return (
-    process.env[OPENWIKI_PROVIDER_ENV_KEY] === undefined ||
+    !hasValidConfiguredProvider() ||
     !process.env[apiKeyEnvKey] ||
     needsBaseUrlStep(provider) ||
     (modelIdOverride === null &&
@@ -446,7 +447,7 @@ export function InitSetup({
         <SetupStep
           label="Provider"
           state={
-            process.env[OPENWIKI_PROVIDER_ENV_KEY]
+            hasValidConfiguredProvider()
               ? "done"
               : step === "provider"
                 ? "current"
@@ -746,7 +747,7 @@ function getInitialStep(
   modelIdOverride: string | null,
   provider: OpenWikiProvider,
 ): PromptStep | null {
-  if (process.env[OPENWIKI_PROVIDER_ENV_KEY] === undefined) {
+  if (!hasValidConfiguredProvider()) {
     return "provider";
   }
 
@@ -813,11 +814,15 @@ function getNextStepAfterBaseUrl(
 }
 
 function getProviderSetupDetail(provider: OpenWikiProvider): string {
-  if (process.env[OPENWIKI_PROVIDER_ENV_KEY]) {
+  if (hasValidConfiguredProvider()) {
     return getProviderLabel(provider);
   }
 
   return `default ${getProviderLabel(DEFAULT_PROVIDER)}`;
+}
+
+function hasValidConfiguredProvider(): boolean {
+  return normalizeProvider(process.env[OPENWIKI_PROVIDER_ENV_KEY]) !== null;
 }
 
 function getModelSetupDetail(

--- a/test/credentials.test.ts
+++ b/test/credentials.test.ts
@@ -1,0 +1,36 @@
+import { afterEach, describe, expect, test } from "vitest";
+import { needsCredentialSetup } from "../src/credentials.tsx";
+
+const ENV_KEYS = [
+  "LANGSMITH_API_KEY",
+  "OPENROUTER_API_KEY",
+  "OPENWIKI_MODEL_ID",
+  "OPENWIKI_PROVIDER",
+] as const;
+
+const originalEnv = new Map<string, string | undefined>(
+  ENV_KEYS.map((key) => [key, process.env[key]]),
+);
+
+afterEach(() => {
+  for (const key of ENV_KEYS) {
+    const originalValue = originalEnv.get(key);
+
+    if (originalValue === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = originalValue;
+    }
+  }
+});
+
+describe("needsCredentialSetup", () => {
+  test("requires provider setup for an invalid configured provider", () => {
+    process.env.OPENWIKI_PROVIDER = "bogus";
+    process.env.OPENROUTER_API_KEY = "sk-or-v1-placeholder";
+    process.env.OPENWIKI_MODEL_ID = "z-ai/glm-5.2";
+    process.env.LANGSMITH_API_KEY = "lsv2_placeholder";
+
+    expect(needsCredentialSetup()).toBe(true);
+  });
+});


### PR DESCRIPTION
## What / Why / How

Fixes #176.

OpenWiki now treats an invalid `OPENWIKI_PROVIDER` as incomplete setup instead of accepting the variable because it exists and then silently falling back to OpenRouter. The setup UI also keeps the Provider step active for invalid values, so users can choose a valid provider before the API-key step.

I also updated the operations docs to state that invalid provider values trigger the interactive flow.

## Test verification (RED -> GREEN)

RED, with the production fix in `src/credentials.tsx` temporarily reverted while keeping the new regression test:

```text
pnpm exec vitest run test/credentials.test.ts

❯ test/credentials.test.ts (1 test | 1 failed)
  × requires provider setup for an invalid configured provider

Test Files  1 failed (1)
Tests  1 failed (1)
```

GREEN, with the fix applied:

```text
pnpm exec vitest run test/credentials.test.ts test/constants.test.ts test/env.test.ts test/commands.test.ts

✓ test/constants.test.ts (20 tests)
✓ test/commands.test.ts (21 tests)
✓ test/env.test.ts (9 tests)
✓ test/credentials.test.ts (1 test)

Test Files  4 passed (4)
Tests  51 passed (51)
```

Full local validation:

```text
pnpm test
Test Files  8 passed (8)
Tests  87 passed (87)

pnpm run typecheck
pnpm run format:check
pnpm run lint:check
pnpm run build
```

## Affected platforms

- [x] All platforms

## Test plan

- Added `test/credentials.test.ts` coverage for invalid `OPENWIKI_PROVIDER` values.
- Verified full test, typecheck, formatting, lint, and build commands locally.

## Checklist

- [x] Tests added/updated (TDD: red -> green)
- [x] `pnpm test` passes
- [x] `pnpm run typecheck` passes
- [x] Docs updated if needed (README, platform-support.md)
- [x] Targets `main` branch
