### PR TITLE
feat: generate mermaid diagrams in the generated wiki

### DIFF
--- a/.github/workflows/openwiki-update.yml
+++ b/.github/workflows/openwiki-update.yml
@@ -23,7 +23,7 @@ jobs:
 
       - name: Install OpenWiki
         # mermaid + jsdom are optional; they add high-fidelity validation of Mermaid diagrams. Remove if your wiki has none.
-        run: npm install --global openwiki@0.2.1 mermaid@11.16.0 jsdom@29.1.1
+        run: npm install --global openwiki mermaid@11.16.0 jsdom@29.1.1
 
       - name: Run OpenWiki
         run: openwiki code --update --print

--- a/.github/workflows/openwiki-update.yml
+++ b/.github/workflows/openwiki-update.yml
@@ -23,7 +23,7 @@ jobs:
 
       - name: Install OpenWiki
         # mermaid + jsdom are optional; they add high-fidelity validation of Mermaid diagrams. Remove if your wiki has none.
-        run: npm install --global openwiki mermaid jsdom
+        run: npm install --global openwiki mermaid@11.16.0 jsdom@29.1.1
 
       - name: Run OpenWiki
         run: openwiki code --update --print

--- a/.github/workflows/openwiki-update.yml
+++ b/.github/workflows/openwiki-update.yml
@@ -23,7 +23,7 @@ jobs:
 
       - name: Install OpenWiki
         # mermaid + jsdom are optional; they add high-fidelity validation of Mermaid diagrams. Remove if your wiki has none.
-        run: npm install --global openwiki mermaid@11.16.0 jsdom@29.1.1
+        run: npm install --global openwiki@0.2.1 mermaid@11.16.0 jsdom@29.1.1
 
       - name: Run OpenWiki
         run: openwiki code --update --print

--- a/.github/workflows/openwiki-update.yml
+++ b/.github/workflows/openwiki-update.yml
@@ -22,7 +22,8 @@ jobs:
           node-version: "22"
 
       - name: Install OpenWiki
-        run: npm install --global openwiki
+        # mermaid + jsdom are optional; they add high-fidelity validation of Mermaid diagrams. Remove if your wiki has none.
+        run: npm install --global openwiki mermaid jsdom
 
       - name: Run OpenWiki
         run: openwiki code --update --print

--- a/README.md
+++ b/README.md
@@ -430,7 +430,36 @@ The value must be a positive integer. If the value is unset, OpenWiki defaults t
 
 ### Diagrams
 
-OpenWiki embeds **Mermaid** diagrams in the generated wiki where they aid understanding — sequence diagrams for runtime flows, ER diagrams for data models, state diagrams for lifecycles, and flowcharts for control flow. Diagrams are grounded in the source, kept in sync on `--update` runs, and follow Mermaid label-safety rules so the fenced blocks render on GitHub and other Mermaid-aware viewers. This is default behavior — no configuration required.
+OpenWiki embeds **Mermaid** diagrams in the generated wiki wherever they make a
+concept clearer than prose: sequence diagrams for runtime and request flows, ER
+diagrams for data models, state diagrams for lifecycles, and flowcharts for
+control flow. Diagrams are grounded in the inspected source, added where they
+add signal rather than on every page, and kept in sync on `--update` runs. This
+is default behavior; no configuration is required.
+
+**Validation and repair.** After each run, OpenWiki validates every `mermaid`
+fence. A diagram that fails validation is converted in place to a plain `text`
+fence, preceded by a short comment explaining why, so it degrades to readable
+text instead of a broken block. The next `--update` run finds that comment,
+repairs the diagram from the recorded error, and restores the `mermaid` fence,
+so quality recovers over successive runs.
+
+**Validation fidelity is optional.** By default OpenWiki runs a lightweight,
+zero-dependency check that catches the common syntax breakages. It is
+best-effort: a break it does not recognize can still render as an error on
+GitHub until a later run catches it. For authoritative validation that matches
+exactly what GitHub renders, catching every unrenderable diagram, install the
+Mermaid parser wherever you run OpenWiki (for example, in the scheduled GitHub
+Actions workflow that regenerates your wiki):
+
+```bash
+npm install mermaid jsdom
+```
+
+When the parser is present, OpenWiki uses it and no broken diagram ships; when
+it is absent, it falls back to the best-effort check. Diagram generation and the
+degrade-and-repair loop work the same either way, so the parser changes only how
+thoroughly diagrams are checked, never whether they are generated.
 
 If there's an inference provider or model you'd like to see added, please open a PR!
 

--- a/README.md
+++ b/README.md
@@ -428,6 +428,10 @@ OPENWIKI_PROVIDER_RETRY_ATTEMPTS=3
 
 The value must be a positive integer. If the value is unset, OpenWiki defaults to 3 retries.
 
+### Diagrams
+
+OpenWiki embeds **Mermaid** diagrams in the generated wiki where they aid understanding — sequence diagrams for runtime flows, ER diagrams for data models, state diagrams for lifecycles, and flowcharts for control flow. Diagrams are grounded in the source, kept in sync on `--update` runs, and follow Mermaid label-safety rules so the fenced blocks render on GitHub and other Mermaid-aware viewers. This is default behavior — no configuration required.
+
 If there's an inference provider or model you'd like to see added, please open a PR!
 
 ## Telemetry

--- a/examples/openwiki-update.bitbucket-pipelines.yml
+++ b/examples/openwiki-update.bitbucket-pipelines.yml
@@ -10,7 +10,7 @@ pipelines:
           script:
             - apt-get update && apt-get install -y git curl
             # mermaid + jsdom are optional; they add high-fidelity validation of Mermaid diagrams. Remove if your wiki has none.
-            - npm install --global openwiki mermaid jsdom
+            - npm install --global openwiki mermaid@11.16.0 jsdom@29.1.1
             - git config user.name "${BITBUCKET_USER_NAME:-OpenWiki Bot}"
             - git config user.email "${BITBUCKET_USER_EMAIL:-openwiki@example.com}"
             - openwiki code --update --print

--- a/examples/openwiki-update.bitbucket-pipelines.yml
+++ b/examples/openwiki-update.bitbucket-pipelines.yml
@@ -10,7 +10,7 @@ pipelines:
           script:
             - apt-get update && apt-get install -y git curl
             # mermaid + jsdom are optional; they add high-fidelity validation of Mermaid diagrams. Remove if your wiki has none.
-            - npm install --global openwiki@0.2.1 mermaid@11.16.0 jsdom@29.1.1
+            - npm install --global openwiki mermaid@11.16.0 jsdom@29.1.1
             - git config user.name "${BITBUCKET_USER_NAME:-OpenWiki Bot}"
             - git config user.email "${BITBUCKET_USER_EMAIL:-openwiki@example.com}"
             - openwiki code --update --print

--- a/examples/openwiki-update.bitbucket-pipelines.yml
+++ b/examples/openwiki-update.bitbucket-pipelines.yml
@@ -9,7 +9,8 @@ pipelines:
           name: Run OpenWiki update
           script:
             - apt-get update && apt-get install -y git curl
-            - npm install --global openwiki
+            # mermaid + jsdom are optional; they add high-fidelity validation of Mermaid diagrams. Remove if your wiki has none.
+            - npm install --global openwiki mermaid jsdom
             - git config user.name "${BITBUCKET_USER_NAME:-OpenWiki Bot}"
             - git config user.email "${BITBUCKET_USER_EMAIL:-openwiki@example.com}"
             - openwiki code --update --print

--- a/examples/openwiki-update.bitbucket-pipelines.yml
+++ b/examples/openwiki-update.bitbucket-pipelines.yml
@@ -10,7 +10,7 @@ pipelines:
           script:
             - apt-get update && apt-get install -y git curl
             # mermaid + jsdom are optional; they add high-fidelity validation of Mermaid diagrams. Remove if your wiki has none.
-            - npm install --global openwiki mermaid@11.16.0 jsdom@29.1.1
+            - npm install --global openwiki@0.2.1 mermaid@11.16.0 jsdom@29.1.1
             - git config user.name "${BITBUCKET_USER_NAME:-OpenWiki Bot}"
             - git config user.email "${BITBUCKET_USER_EMAIL:-openwiki@example.com}"
             - openwiki code --update --print

--- a/examples/openwiki-update.gitlab-ci.yml
+++ b/examples/openwiki-update.gitlab-ci.yml
@@ -6,7 +6,8 @@ openwiki_update:
     - if: '$CI_PIPELINE_SOURCE == "web"'
   before_script:
     - apt-get update && apt-get install -y git curl
-    - npm install --global openwiki
+    # mermaid + jsdom are optional; they add high-fidelity validation of Mermaid diagrams. Remove if your wiki has none.
+    - npm install --global openwiki mermaid jsdom
     - git config user.name "${GITLAB_USER_NAME:-OpenWiki Bot}"
     - git config user.email "${GITLAB_USER_EMAIL:-openwiki@example.com}"
   script:

--- a/examples/openwiki-update.gitlab-ci.yml
+++ b/examples/openwiki-update.gitlab-ci.yml
@@ -7,7 +7,7 @@ openwiki_update:
   before_script:
     - apt-get update && apt-get install -y git curl
     # mermaid + jsdom are optional; they add high-fidelity validation of Mermaid diagrams. Remove if your wiki has none.
-    - npm install --global openwiki mermaid@11.16.0 jsdom@29.1.1
+    - npm install --global openwiki@0.2.1 mermaid@11.16.0 jsdom@29.1.1
     - git config user.name "${GITLAB_USER_NAME:-OpenWiki Bot}"
     - git config user.email "${GITLAB_USER_EMAIL:-openwiki@example.com}"
   script:

--- a/examples/openwiki-update.gitlab-ci.yml
+++ b/examples/openwiki-update.gitlab-ci.yml
@@ -7,7 +7,7 @@ openwiki_update:
   before_script:
     - apt-get update && apt-get install -y git curl
     # mermaid + jsdom are optional; they add high-fidelity validation of Mermaid diagrams. Remove if your wiki has none.
-    - npm install --global openwiki@0.2.1 mermaid@11.16.0 jsdom@29.1.1
+    - npm install --global openwiki mermaid@11.16.0 jsdom@29.1.1
     - git config user.name "${GITLAB_USER_NAME:-OpenWiki Bot}"
     - git config user.email "${GITLAB_USER_EMAIL:-openwiki@example.com}"
   script:

--- a/examples/openwiki-update.gitlab-ci.yml
+++ b/examples/openwiki-update.gitlab-ci.yml
@@ -7,7 +7,7 @@ openwiki_update:
   before_script:
     - apt-get update && apt-get install -y git curl
     # mermaid + jsdom are optional; they add high-fidelity validation of Mermaid diagrams. Remove if your wiki has none.
-    - npm install --global openwiki mermaid jsdom
+    - npm install --global openwiki mermaid@11.16.0 jsdom@29.1.1
     - git config user.name "${GITLAB_USER_NAME:-OpenWiki Bot}"
     - git config user.email "${GITLAB_USER_EMAIL:-openwiki@example.com}"
   script:

--- a/examples/openwiki-update.yml
+++ b/examples/openwiki-update.yml
@@ -26,7 +26,7 @@ jobs:
 
       - name: Install OpenWiki
         # mermaid + jsdom are optional; they add high-fidelity validation of Mermaid diagrams. Remove if your wiki has none.
-        run: npm install --global openwiki@0.2.1 mermaid@11.16.0 jsdom@29.1.1
+        run: npm install --global openwiki mermaid@11.16.0 jsdom@29.1.1
 
       - name: Run OpenWiki
         # --update also handles the first run for code docs when env vars are set.

--- a/examples/openwiki-update.yml
+++ b/examples/openwiki-update.yml
@@ -26,7 +26,7 @@ jobs:
 
       - name: Install OpenWiki
         # mermaid + jsdom are optional; they add high-fidelity validation of Mermaid diagrams. Remove if your wiki has none.
-        run: npm install --global openwiki mermaid jsdom
+        run: npm install --global openwiki mermaid@11.16.0 jsdom@29.1.1
 
       - name: Run OpenWiki
         # --update also handles the first run for code docs when env vars are set.

--- a/examples/openwiki-update.yml
+++ b/examples/openwiki-update.yml
@@ -26,7 +26,7 @@ jobs:
 
       - name: Install OpenWiki
         # mermaid + jsdom are optional; they add high-fidelity validation of Mermaid diagrams. Remove if your wiki has none.
-        run: npm install --global openwiki mermaid@11.16.0 jsdom@29.1.1
+        run: npm install --global openwiki@0.2.1 mermaid@11.16.0 jsdom@29.1.1
 
       - name: Run OpenWiki
         # --update also handles the first run for code docs when env vars are set.

--- a/examples/openwiki-update.yml
+++ b/examples/openwiki-update.yml
@@ -25,7 +25,8 @@ jobs:
           node-version: "22"
 
       - name: Install OpenWiki
-        run: npm install --global openwiki
+        # mermaid + jsdom are optional; they add high-fidelity validation of Mermaid diagrams. Remove if your wiki has none.
+        run: npm install --global openwiki mermaid jsdom
 
       - name: Run OpenWiki
         # --update also handles the first run for code docs when env vars are set.

--- a/package.json
+++ b/package.json
@@ -59,8 +59,10 @@
     "deepagents": "^1.11.1",
     "google-auth-library": "^10.9.0",
     "ink": "^5.1.0",
+    "jsdom": "^29.1.1",
     "langchain": "^1.5.3",
     "marked": "^18.0.5",
+    "mermaid": "^11.16.0",
     "posthog-node": "^5.39.4",
     "react": "^18.3.1",
     "yaml": "^2.9.0",
@@ -68,6 +70,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",
+    "@types/jsdom": "^28.0.3",
     "@types/node": "^22.10.2",
     "@types/react": "^18.3.17",
     "@vitest/coverage-v8": "^4.1.10",

--- a/package.json
+++ b/package.json
@@ -59,14 +59,24 @@
     "deepagents": "^1.11.1",
     "google-auth-library": "^10.9.0",
     "ink": "^5.1.0",
-    "jsdom": "^29.1.1",
     "langchain": "^1.5.3",
     "marked": "^18.0.5",
-    "mermaid": "^11.16.0",
     "posthog-node": "^5.39.4",
     "react": "^18.3.1",
     "yaml": "^2.9.0",
     "zod": "^4.4.3"
+  },
+  "peerDependencies": {
+    "jsdom": "^29.1.1",
+    "mermaid": "^11.16.0"
+  },
+  "peerDependenciesMeta": {
+    "jsdom": {
+      "optional": true
+    },
+    "mermaid": {
+      "optional": true
+    }
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",
@@ -75,6 +85,8 @@
     "@types/react": "^18.3.17",
     "@vitest/coverage-v8": "^4.1.10",
     "eslint": "^10.5.0",
+    "jsdom": "^29.1.1",
+    "mermaid": "^11.16.0",
     "prettier": "^3.8.4",
     "tsx": "^4.19.2",
     "typescript": "^5.7.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -59,12 +59,18 @@ importers:
       ink:
         specifier: ^5.1.0
         version: 5.2.1(@types/react@18.3.31)(react@18.3.1)
+      jsdom:
+        specifier: ^29.1.1
+        version: 29.1.1
       langchain:
         specifier: ^1.5.3
         version: 1.5.3(@langchain/core@1.2.1(openai@6.45.0(@aws-sdk/credential-provider-node@3.972.63)(@smithy/signature-v4@5.6.2)(ws@8.21.0)(zod@4.4.3))(ws@8.21.0))(openai@6.45.0(@aws-sdk/credential-provider-node@3.972.63)(@smithy/signature-v4@5.6.2)(ws@8.21.0)(zod@4.4.3))(react@18.3.1)(ws@8.21.0)
       marked:
         specifier: ^18.0.5
         version: 18.0.5
+      mermaid:
+        specifier: ^11.16.0
+        version: 11.16.0
       posthog-node:
         specifier: ^5.39.4
         version: 5.40.0
@@ -81,6 +87,9 @@ importers:
       '@eslint/js':
         specifier: ^10.0.1
         version: 10.0.1(eslint@10.6.0)
+      '@types/jsdom':
+        specifier: ^28.0.3
+        version: 28.0.3
       '@types/node':
         specifier: ^22.10.2
         version: 22.20.0
@@ -107,13 +116,16 @@ importers:
         version: 8.62.1(eslint@10.6.0)(typescript@5.9.3)
       vitest:
         specifier: ^4.1.10
-        version: 4.1.10(@types/node@22.20.0)(@vitest/coverage-v8@4.1.10)(vite@8.1.3(@types/node@22.20.0)(esbuild@0.28.1)(tsx@4.22.5)(yaml@2.9.0))
+        version: 4.1.10(@types/node@22.20.0)(@vitest/coverage-v8@4.1.10)(jsdom@29.1.1)(vite@8.1.3(@types/node@22.20.0)(esbuild@0.28.1)(tsx@4.22.5)(yaml@2.9.0))
 
 packages:
 
   '@alcalzone/ansi-tokenize@0.1.3':
     resolution: {integrity: sha512-3yWxPTq3UQ/FY9p1ErPxIyfT64elWaMvM9lIHnaqpyft63tkxodF5aUElYHrdisWve5cETkh1+KBw1yJuW0aRw==}
     engines: {node: '>=14.13.1'}
+
+  '@antfu/install-pkg@1.1.0':
+    resolution: {integrity: sha512-MGQsmw10ZyI+EJo45CdSER4zEb+p31LpDAFp2Z3gkSd1yqVZGi0Ebx++YTEMonJy4oChEMLsxZ64j8FH6sSqtQ==}
 
   '@anthropic-ai/sdk@0.103.0':
     resolution: {integrity: sha512-1uG7RNgoHTUxzOXqSCODKt0UTVlxWiHk/2Tt2/uQJiPW7XzBeKVuJyd3Aw6T3LPyvZV/jDTnPLX7SaM70WLLjA==}
@@ -126,6 +138,21 @@ packages:
 
   '@anthropic-ai/vertex-sdk@0.19.0':
     resolution: {integrity: sha512-Ja5NkDAmdCcvCJCvkY/6uJ+9krOiXFN56dzb+8n5apElHrYpUMlOCHCVRuLLsJCVWTsN8w60sgN9RSXZ+LPqNA==}
+
+  '@asamuzakjp/css-color@5.1.11':
+    resolution: {integrity: sha512-KVw6qIiCTUQhByfTd78h2yD1/00waTmm9uy/R7Ck/ctUyAPj+AEDLkQIdJW0T8+qGgj3j5bpNKK7Q3G+LedJWg==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
+  '@asamuzakjp/dom-selector@7.1.1':
+    resolution: {integrity: sha512-67RZDnYRc8H/8MLDgQCDE//zoqVFwajkepHZgmXrbwybzXOEwOWGPYGmALYl9J2DOLfFPPs6kKCqmbzV895hTQ==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
+  '@asamuzakjp/generational-cache@1.0.1':
+    resolution: {integrity: sha512-wajfB8KqzMCN2KGNFdLkReeHncd0AslUSrvHVvvYWuU8ghncRJoA50kT3zP9MVL0+9g4/67H+cdvBskj9THPzg==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
+  '@asamuzakjp/nwsapi@2.3.9':
+    resolution: {integrity: sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==}
 
   '@aws-sdk/client-bedrock-agent-runtime@3.1080.0':
     resolution: {integrity: sha512-TAlQgf77IMEBrleZ8ToOiGSEbB8wg4TnssNTLYNlIeqfuO63dgcxXXG4KEuNtcUWQ3Ph0zXTtT/GgJTXXL8FqA==}
@@ -236,8 +263,54 @@ packages:
     resolution: {integrity: sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==}
     engines: {node: '>=18'}
 
+  '@braintree/sanitize-url@7.1.2':
+    resolution: {integrity: sha512-jigsZK+sMF/cuiB7sERuo9V7N9jx+dhmHHnQyDSVdpZwVutaBu7WvNYqMDLSgFgfB30n452TP3vjDAvFC973mA==}
+
+  '@bramus/specificity@2.4.2':
+    resolution: {integrity: sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==}
+    hasBin: true
+
   '@cfworker/json-schema@4.1.1':
     resolution: {integrity: sha512-gAmrUZSGtKc3AiBL71iNWxDsyUC5uMaKKGdvzYsBoTW/xi42JQHl7eKV2OYzCUqvc+D2RCcf7EXY2iCyFIk6og==}
+
+  '@chevrotain/types@11.1.2':
+    resolution: {integrity: sha512-U+HFai5+zmJCkK86QsaJtoITlboZHBqrVketcO2ROv865xfCMSFpELQoz1GkX5GzME8pTa+3kbKrZHQtI0gdbw==}
+
+  '@csstools/color-helpers@6.1.0':
+    resolution: {integrity: sha512-064IFJdjTfUqnjpCVpMOdbr8FLQBhinbZj6yRv2An2E41O/pLEXqfFRWqGq/SxlE5PEUYTlvWsG2r8MswAVvkg==}
+    engines: {node: '>=20.19.0'}
+
+  '@csstools/css-calc@3.2.1':
+    resolution: {integrity: sha512-DtdHlgXh5ZkA43cwBcAm+huzgJiwx3ZTWVjBs94kwz2xKqSimDA3lBgCjphYgwgVUMWatSM0pDd8TILB1yrVVg==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^4.0.0
+      '@csstools/css-tokenizer': ^4.0.0
+
+  '@csstools/css-color-parser@4.1.9':
+    resolution: {integrity: sha512-paQcIaOO53Rk5+YrBaBjm/SgrV4INImjo2BT1DtQRYr+XeTRbeAYlS+jxXp9drqvKmtFnWRJKIalDLhZZDu42A==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^4.0.0
+      '@csstools/css-tokenizer': ^4.0.0
+
+  '@csstools/css-parser-algorithms@4.0.0':
+    resolution: {integrity: sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@csstools/css-tokenizer': ^4.0.0
+
+  '@csstools/css-syntax-patches-for-csstree@1.1.6':
+    resolution: {integrity: sha512-TcJCWFbXLPpJYq6z7bfOyjWYJDiDg2/I4gyUC9pqPNqHFRIey0EB0q0L5cSnQDfWJg8Jd6VadakxdIez/3zkqQ==}
+    peerDependencies:
+      css-tree: ^3.2.1
+    peerDependenciesMeta:
+      css-tree:
+        optional: true
+
+  '@csstools/css-tokenizer@4.0.0':
+    resolution: {integrity: sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==}
+    engines: {node: '>=20.19.0'}
 
   '@emnapi/core@1.11.1':
     resolution: {integrity: sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==}
@@ -443,6 +516,15 @@ packages:
     resolution: {integrity: sha512-+CNAzxglkrpNf/kKywqQfk74QjtceuOE7Qm+AF8miRvPF/wmmK5+OJOgVh3AVTT3RP2mH3+FOaxlE5v72owk0A==}
     engines: {node: ^20.19.0 || ^22.13.0 || >=24}
 
+  '@exodus/bytes@1.15.1':
+    resolution: {integrity: sha512-S6mL0yNB/Abt9Ei4tq8gDhcczc4S3+vQ4ra7vxnAf+YHC02srtqxKKZghx2Dq6p0e66THKwR6r8N6P95wEty7Q==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+    peerDependencies:
+      '@noble/hashes': ^1.8.0 || ^2.0.0
+    peerDependenciesMeta:
+      '@noble/hashes':
+        optional: true
+
   '@humanfs/core@0.19.2':
     resolution: {integrity: sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==}
     engines: {node: '>=18.18.0'}
@@ -462,6 +544,12 @@ packages:
   '@humanwhocodes/retry@0.4.3':
     resolution: {integrity: sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==}
     engines: {node: '>=18.18'}
+
+  '@iconify/types@2.0.0':
+    resolution: {integrity: sha512-+wluvCrRhXrhyOmRDJ3q8mux9JkKy5SJ/v8ol2tu4FVjyYvtEzkc/3pK15ET6RKg4b4w4BmTk1+gsCUhf21Ykg==}
+
+  '@iconify/utils@3.1.4':
+    resolution: {integrity: sha512-b1S7B1k9ohZ+iNTi2ATxbRYG9fTrJmUT0rc46bvVnNxqNRGW7dyo/vRREwyniI5IRN2RSJHDcm+s3BjWrSAjHw==}
 
   '@jridgewell/resolve-uri@3.1.2':
     resolution: {integrity: sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==}
@@ -559,6 +647,9 @@ packages:
     engines: {node: '>=20'}
     peerDependencies:
       '@langchain/core': ^1.0.0
+
+  '@mermaid-js/parser@1.2.0':
+    resolution: {integrity: sha512-oYPyv8A4As1yH5Bx+04iQEQxXuIQDe0GKCNSRgao6z8AM9jixXIfP0vsppRLvGf+nKIOb9/LdpWA4YuJiVvESA==}
 
   '@napi-rs/wasm-runtime@1.1.6':
     resolution: {integrity: sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==}
@@ -721,6 +812,99 @@ packages:
   '@types/chai@5.2.3':
     resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
 
+  '@types/d3-array@3.2.2':
+    resolution: {integrity: sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==}
+
+  '@types/d3-axis@3.0.6':
+    resolution: {integrity: sha512-pYeijfZuBd87T0hGn0FO1vQ/cgLk6E1ALJjfkC0oJ8cbwkZl3TpgS8bVBLZN+2jjGgg38epgxb2zmoGtSfvgMw==}
+
+  '@types/d3-brush@3.0.6':
+    resolution: {integrity: sha512-nH60IZNNxEcrh6L1ZSMNA28rj27ut/2ZmI3r96Zd+1jrZD++zD3LsMIjWlvg4AYrHn/Pqz4CF3veCxGjtbqt7A==}
+
+  '@types/d3-chord@3.0.6':
+    resolution: {integrity: sha512-LFYWWd8nwfwEmTZG9PfQxd17HbNPksHBiJHaKuY1XeqscXacsS2tyoo6OdRsjf+NQYeB6XrNL3a25E3gH69lcg==}
+
+  '@types/d3-color@3.1.3':
+    resolution: {integrity: sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==}
+
+  '@types/d3-contour@3.0.6':
+    resolution: {integrity: sha512-BjzLgXGnCWjUSYGfH1cpdo41/hgdWETu4YxpezoztawmqsvCeep+8QGfiY6YbDvfgHz/DkjeIkkZVJavB4a3rg==}
+
+  '@types/d3-delaunay@6.0.4':
+    resolution: {integrity: sha512-ZMaSKu4THYCU6sV64Lhg6qjf1orxBthaC161plr5KuPHo3CNm8DTHiLw/5Eq2b6TsNP0W0iJrUOFscY6Q450Hw==}
+
+  '@types/d3-dispatch@3.0.7':
+    resolution: {integrity: sha512-5o9OIAdKkhN1QItV2oqaE5KMIiXAvDWBDPrD85e58Qlz1c1kI/J0NcqbEG88CoTwJrYe7ntUCVfeUl2UJKbWgA==}
+
+  '@types/d3-drag@3.0.7':
+    resolution: {integrity: sha512-HE3jVKlzU9AaMazNufooRJ5ZpWmLIoc90A37WU2JMmeq28w1FQqCZswHZ3xR+SuxYftzHq6WU6KJHvqxKzTxxQ==}
+
+  '@types/d3-dsv@3.0.7':
+    resolution: {integrity: sha512-n6QBF9/+XASqcKK6waudgL0pf/S5XHPPI8APyMLLUHd8NqouBGLsU8MgtO7NINGtPBtk9Kko/W4ea0oAspwh9g==}
+
+  '@types/d3-ease@3.0.2':
+    resolution: {integrity: sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==}
+
+  '@types/d3-fetch@3.0.7':
+    resolution: {integrity: sha512-fTAfNmxSb9SOWNB9IoG5c8Hg6R+AzUHDRlsXsDZsNp6sxAEOP0tkP3gKkNSO/qmHPoBFTxNrjDprVHDQDvo5aA==}
+
+  '@types/d3-force@3.0.10':
+    resolution: {integrity: sha512-ZYeSaCF3p73RdOKcjj+swRlZfnYpK1EbaDiYICEEp5Q6sUiqFaFQ9qgoshp5CzIyyb/yD09kD9o2zEltCexlgw==}
+
+  '@types/d3-format@3.0.4':
+    resolution: {integrity: sha512-fALi2aI6shfg7vM5KiR1wNJnZ7r6UuggVqtDA+xiEdPZQwy/trcQaHnwShLuLdta2rTymCNpxYTiMZX/e09F4g==}
+
+  '@types/d3-geo@3.1.0':
+    resolution: {integrity: sha512-856sckF0oP/diXtS4jNsiQw/UuK5fQG8l/a9VVLeSouf1/PPbBE1i1W852zVwKwYCBkFJJB7nCFTbk6UMEXBOQ==}
+
+  '@types/d3-hierarchy@3.1.7':
+    resolution: {integrity: sha512-tJFtNoYBtRtkNysX1Xq4sxtjK8YgoWUNpIiUee0/jHGRwqvzYxkq0hGVbbOGSz+JgFxxRu4K8nb3YpG3CMARtg==}
+
+  '@types/d3-interpolate@3.0.4':
+    resolution: {integrity: sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==}
+
+  '@types/d3-path@3.1.1':
+    resolution: {integrity: sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==}
+
+  '@types/d3-polygon@3.0.2':
+    resolution: {integrity: sha512-ZuWOtMaHCkN9xoeEMr1ubW2nGWsp4nIql+OPQRstu4ypeZ+zk3YKqQT0CXVe/PYqrKpZAi+J9mTs05TKwjXSRA==}
+
+  '@types/d3-quadtree@3.0.6':
+    resolution: {integrity: sha512-oUzyO1/Zm6rsxKRHA1vH0NEDG58HrT5icx/azi9MF1TWdtttWl0UIUsjEQBBh+SIkrpd21ZjEv7ptxWys1ncsg==}
+
+  '@types/d3-random@3.0.4':
+    resolution: {integrity: sha512-UHYId5WTCx4L4YNel7NU00XUXXgvgpgZOvp10PuvsQENjMDXhh2RyFc0KBjO7B45ne4Ha1yVH7ii0vnzKkuzWA==}
+
+  '@types/d3-scale-chromatic@3.1.0':
+    resolution: {integrity: sha512-iWMJgwkK7yTRmWqRB5plb1kadXyQ5Sj8V/zYlFGMUBbIPKQScw+Dku9cAAMgJG+z5GYDoMjWGLVOvjghDEFnKQ==}
+
+  '@types/d3-scale@4.0.9':
+    resolution: {integrity: sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==}
+
+  '@types/d3-selection@3.0.11':
+    resolution: {integrity: sha512-bhAXu23DJWsrI45xafYpkQ4NtcKMwWnAC/vKrd2l+nxMFuvOT3XMYTIj2opv8vq8AO5Yh7Qac/nSeP/3zjTK0w==}
+
+  '@types/d3-shape@3.1.8':
+    resolution: {integrity: sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==}
+
+  '@types/d3-time-format@4.0.3':
+    resolution: {integrity: sha512-5xg9rC+wWL8kdDj153qZcsJ0FWiFt0J5RB6LYUNZjwSnesfblqrI/bJ1wBdJ8OQfncgbJG5+2F+qfqnqyzYxyg==}
+
+  '@types/d3-time@3.0.4':
+    resolution: {integrity: sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==}
+
+  '@types/d3-timer@3.0.2':
+    resolution: {integrity: sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==}
+
+  '@types/d3-transition@3.0.9':
+    resolution: {integrity: sha512-uZS5shfxzO3rGlu0cC3bjmMFKsXv+SmZZcgp0KD22ts4uGXp5EVYGzu/0YdwZeKmddhcAccYtREJKkPfXkZuCg==}
+
+  '@types/d3-zoom@3.0.8':
+    resolution: {integrity: sha512-iqMC4/YlFCSlO8+2Ii1GGGliCAY4XdeG748w5vQUbevlbDu0zSjH/+jojorQVBK/se0j6DUFNPBGSqD3YWYnDw==}
+
+  '@types/d3@7.4.3':
+    resolution: {integrity: sha512-lZXZ9ckh5R8uiFVt8ogUNf+pIrK4EsWrx2Np75WvF/eTpJ0FMHNhjXk8CKEx/+gpHbNQyJWehbFaTvqmHWB3ww==}
+
   '@types/deep-eql@4.0.2':
     resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
 
@@ -729,6 +913,12 @@ packages:
 
   '@types/estree@1.0.9':
     resolution: {integrity: sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==}
+
+  '@types/geojson@7946.0.16':
+    resolution: {integrity: sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==}
+
+  '@types/jsdom@28.0.3':
+    resolution: {integrity: sha512-/HQ2uFoetFTXuye8vzIcHw2z6Fwi7Hi/qcgC+RoS9NCyewiqxhVGqlG+ViGB6lkax481R6dmhf1I7lIGlzJStQ==}
 
   '@types/json-schema@7.0.15':
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
@@ -741,6 +931,12 @@ packages:
 
   '@types/react@18.3.31':
     resolution: {integrity: sha512-vfEqpXTvwT91yhmwdfouStN2hSKwTvyRs8qpLfADyrq/kxDw0hZM7Wk9Ug1FELj8hIby+S/+kQCSRFF32nv2Qw==}
+
+  '@types/tough-cookie@4.0.5':
+    resolution: {integrity: sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==}
+
+  '@types/trusted-types@2.0.7':
+    resolution: {integrity: sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==}
 
   '@typescript-eslint/eslint-plugin@8.62.1':
     resolution: {integrity: sha512-4EQM77WgVNxj7OkL/5b/D/xZsw00G577+UriYTC7JF5opcF3T2AuoeY7ueLaZgSVjSgCS6yOAJB5bRGLPSJUzA==}
@@ -800,6 +996,9 @@ packages:
   '@typescript-eslint/visitor-keys@8.62.1':
     resolution: {integrity: sha512-4g3BLxfdTMy8iZG0MaBkadnlRrCJ74cQiFbyEVMrkwIoqdyaXXQM22cotDvrl4x28wgIZ9rEJRoM+mmhSJpJ1g==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@upsetjs/venn.js@2.0.0':
+    resolution: {integrity: sha512-WbBhLrooyePuQ1VZxrJjtLvTc4NVfpOyKx0sKqioq9bX1C1m7Jgykkn8gLrtwumBioXIqam8DLxp88Adbue6Hw==}
 
   '@vitest/coverage-v8@4.1.10':
     resolution: {integrity: sha512-IM49HmthevbgAO4anp1hwtoT9wYe59w0LR00gr+eagHE+ZJ5lK4sLPeO0ubgoJcwLk6dehU3R24N+FbEEKDc8g==}
@@ -890,6 +1089,9 @@ packages:
     resolution: {integrity: sha512-dq9AtApgg5PGFtBzPFSBl3HZQjHok5gaQCM6zh2Yk0aSmDCs1CbnVI8/HgASQkNKsWFpseIO9beg5xxpYhbIfA==}
     engines: {node: 20.x || 22.x || 23.x || 24.x || 25.x || 26.x}
 
+  bidi-js@1.0.3:
+    resolution: {integrity: sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==}
+
   bignumber.js@9.3.1:
     resolution: {integrity: sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==}
 
@@ -947,12 +1149,26 @@ packages:
     resolution: {integrity: sha512-xxodCmBen3iy2i0WtAK8FlFNrRzjUqjRsMfho58xT/wvZU1YTM3fCnRjcy1gJPMepaRlgm/0e6w8SpWHpn3/cA==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
+  commander@7.2.0:
+    resolution: {integrity: sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==}
+    engines: {node: '>= 10'}
+
+  commander@8.3.0:
+    resolution: {integrity: sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==}
+    engines: {node: '>= 12'}
+
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
 
   convert-to-spaces@2.0.1:
     resolution: {integrity: sha512-rcQ1bsQO9799wq24uE5AM2tAILy4gXGIK/njFWcVQkGNZ96edlpY+A7bjwvzjYvLDyzmG1MmMLZhpcsb+klNMQ==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
+  cose-base@1.0.3:
+    resolution: {integrity: sha512-s9whTXInMSgAp/NVXVNuVxVKzGH2qck3aQlVHxDCdAEPgtMKwc4Wq6/QKhgdEdgbLSi9rBTAcPoRa6JpiG4ksg==}
+
+  cose-base@2.2.0:
+    resolution: {integrity: sha512-AzlgcsCbUMymkADOJtQm3wO9S3ltPfYOFD5033keQn9NJzIbtnZj+UdBJe7DYml/8TdbtHJW3j58SOnKhWY/5g==}
 
   cron-parser@5.6.1:
     resolution: {integrity: sha512-QBm4o1PwZiuY7KFbVvW7FLC8bozy7YWzv+Fz6KRS7sQghzcbDZCGxr/Bc5b6TQreAoSwuWVP491dIcK0THCX6A==}
@@ -966,12 +1182,179 @@ packages:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
 
+  css-tree@3.2.1:
+    resolution: {integrity: sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==}
+    engines: {node: ^10 || ^12.20.0 || ^14.13.0 || >=15.0.0}
+
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
+
+  cytoscape-cose-bilkent@4.1.0:
+    resolution: {integrity: sha512-wgQlVIUJF13Quxiv5e1gstZ08rnZj2XaLHGoFMYXz7SkNfCDOOteKBE6SYRfA9WxxI/iBc3ajfDoc6hb/MRAHQ==}
+    peerDependencies:
+      cytoscape: ^3.2.0
+
+  cytoscape-fcose@2.2.0:
+    resolution: {integrity: sha512-ki1/VuRIHFCzxWNrsshHYPs6L7TvLu3DL+TyIGEsRcvVERmxokbf5Gdk7mFxZnTdiGtnA4cfSmjZJMviqSuZrQ==}
+    peerDependencies:
+      cytoscape: ^3.2.0
+
+  cytoscape@3.34.0:
+    resolution: {integrity: sha512-62rNSrioXw93uliKFBwjukeQyeWwH2PqDrTac31r2P6464u3AUvTk0xS4LVvT251g7IgkFunrI48ZEZGjywSOg==}
+    engines: {node: '>=0.10'}
+
+  d3-array@2.12.1:
+    resolution: {integrity: sha512-B0ErZK/66mHtEsR1TkPEEkwdy+WDesimkM5gpZr5Dsg54BiTA5RXtYW5qTLIAcekaS9xfZrzBLF/OAkB3Qn1YQ==}
+
+  d3-array@3.2.4:
+    resolution: {integrity: sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==}
+    engines: {node: '>=12'}
+
+  d3-axis@3.0.0:
+    resolution: {integrity: sha512-IH5tgjV4jE/GhHkRV0HiVYPDtvfjHQlQfJHs0usq7M30XcSBvOotpmH1IgkcXsO/5gEQZD43B//fc7SRT5S+xw==}
+    engines: {node: '>=12'}
+
+  d3-brush@3.0.0:
+    resolution: {integrity: sha512-ALnjWlVYkXsVIGlOsuWH1+3udkYFI48Ljihfnh8FZPF2QS9o+PzGLBslO0PjzVoHLZ2KCVgAM8NVkXPJB2aNnQ==}
+    engines: {node: '>=12'}
+
+  d3-chord@3.0.1:
+    resolution: {integrity: sha512-VE5S6TNa+j8msksl7HwjxMHDM2yNK3XCkusIlpX5kwauBfXuyLAtNg9jCp/iHH61tgI4sb6R/EIMWCqEIdjT/g==}
+    engines: {node: '>=12'}
+
+  d3-color@3.1.0:
+    resolution: {integrity: sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==}
+    engines: {node: '>=12'}
+
+  d3-contour@4.0.2:
+    resolution: {integrity: sha512-4EzFTRIikzs47RGmdxbeUvLWtGedDUNkTcmzoeyg4sP/dvCexO47AaQL7VKy/gul85TOxw+IBgA8US2xwbToNA==}
+    engines: {node: '>=12'}
+
+  d3-delaunay@6.0.4:
+    resolution: {integrity: sha512-mdjtIZ1XLAM8bm/hx3WwjfHt6Sggek7qH043O8KEjDXN40xi3vx/6pYSVTwLjEgiXQTbvaouWKynLBiUZ6SK6A==}
+    engines: {node: '>=12'}
+
+  d3-dispatch@3.0.1:
+    resolution: {integrity: sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg==}
+    engines: {node: '>=12'}
+
+  d3-drag@3.0.0:
+    resolution: {integrity: sha512-pWbUJLdETVA8lQNJecMxoXfH6x+mO2UQo8rSmZ+QqxcbyA3hfeprFgIT//HW2nlHChWeIIMwS2Fq+gEARkhTkg==}
+    engines: {node: '>=12'}
+
+  d3-dsv@3.0.1:
+    resolution: {integrity: sha512-UG6OvdI5afDIFP9w4G0mNq50dSOsXHJaRE8arAS5o9ApWnIElp8GZw1Dun8vP8OyHOZ/QJUKUJwxiiCCnUwm+Q==}
+    engines: {node: '>=12'}
+    hasBin: true
+
+  d3-ease@3.0.1:
+    resolution: {integrity: sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==}
+    engines: {node: '>=12'}
+
+  d3-fetch@3.0.1:
+    resolution: {integrity: sha512-kpkQIM20n3oLVBKGg6oHrUchHM3xODkTzjMoj7aWQFq5QEM+R6E4WkzT5+tojDY7yjez8KgCBRoj4aEr99Fdqw==}
+    engines: {node: '>=12'}
+
+  d3-force@3.0.0:
+    resolution: {integrity: sha512-zxV/SsA+U4yte8051P4ECydjD/S+qeYtnaIyAs9tgHCqfguma/aAQDjo85A9Z6EKhBirHRJHXIgJUlffT4wdLg==}
+    engines: {node: '>=12'}
+
+  d3-format@3.1.2:
+    resolution: {integrity: sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==}
+    engines: {node: '>=12'}
+
+  d3-geo@3.1.1:
+    resolution: {integrity: sha512-637ln3gXKXOwhalDzinUgY83KzNWZRKbYubaG+fGVuc/dxO64RRljtCTnf5ecMyE1RIdtqpkVcq0IbtU2S8j2Q==}
+    engines: {node: '>=12'}
+
+  d3-hierarchy@3.1.2:
+    resolution: {integrity: sha512-FX/9frcub54beBdugHjDCdikxThEqjnR93Qt7PvQTOHxyiNCAlvMrHhclk3cD5VeAaq9fxmfRp+CnWw9rEMBuA==}
+    engines: {node: '>=12'}
+
+  d3-interpolate@3.0.1:
+    resolution: {integrity: sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==}
+    engines: {node: '>=12'}
+
+  d3-path@1.0.9:
+    resolution: {integrity: sha512-VLaYcn81dtHVTjEHd8B+pbe9yHWpXKZUC87PzoFmsFrJqgFwDe/qxfp5MlfsfM1V5E/iVt0MmEbWQ7FVIXh/bg==}
+
+  d3-path@3.1.0:
+    resolution: {integrity: sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==}
+    engines: {node: '>=12'}
+
+  d3-polygon@3.0.1:
+    resolution: {integrity: sha512-3vbA7vXYwfe1SYhED++fPUQlWSYTTGmFmQiany/gdbiWgU/iEyQzyymwL9SkJjFFuCS4902BSzewVGsHHmHtXg==}
+    engines: {node: '>=12'}
+
+  d3-quadtree@3.0.1:
+    resolution: {integrity: sha512-04xDrxQTDTCFwP5H6hRhsRcb9xxv2RzkcsygFzmkSIOJy3PeRJP7sNk3VRIbKXcog561P9oU0/rVH6vDROAgUw==}
+    engines: {node: '>=12'}
+
+  d3-random@3.0.1:
+    resolution: {integrity: sha512-FXMe9GfxTxqd5D6jFsQ+DJ8BJS4E/fT5mqqdjovykEB2oFbTMDVdg1MGFxfQW+FBOGoB++k8swBrgwSHT1cUXQ==}
+    engines: {node: '>=12'}
+
+  d3-sankey@0.12.3:
+    resolution: {integrity: sha512-nQhsBRmM19Ax5xEIPLMY9ZmJ/cDvd1BG3UVvt5h3WRxKg5zGRbvnteTyWAbzeSvlh3tW7ZEmq4VwR5mB3tutmQ==}
+
+  d3-scale-chromatic@3.1.0:
+    resolution: {integrity: sha512-A3s5PWiZ9YCXFye1o246KoscMWqf8BsD9eRiJ3He7C9OBaxKhAd5TFCdEx/7VbKtxxTsu//1mMJFrEt572cEyQ==}
+    engines: {node: '>=12'}
+
+  d3-scale@4.0.2:
+    resolution: {integrity: sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==}
+    engines: {node: '>=12'}
+
+  d3-selection@3.0.0:
+    resolution: {integrity: sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==}
+    engines: {node: '>=12'}
+
+  d3-shape@1.3.7:
+    resolution: {integrity: sha512-EUkvKjqPFUAZyOlhY5gzCxCeI0Aep04LwIRpsZ/mLFelJiUfnK56jo5JMDSE7yyP2kLSb6LtF+S5chMk7uqPqw==}
+
+  d3-shape@3.2.0:
+    resolution: {integrity: sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==}
+    engines: {node: '>=12'}
+
+  d3-time-format@4.1.0:
+    resolution: {integrity: sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==}
+    engines: {node: '>=12'}
+
+  d3-time@3.1.0:
+    resolution: {integrity: sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==}
+    engines: {node: '>=12'}
+
+  d3-timer@3.0.1:
+    resolution: {integrity: sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==}
+    engines: {node: '>=12'}
+
+  d3-transition@3.0.1:
+    resolution: {integrity: sha512-ApKvfjsSR6tg06xrL434C0WydLr7JewBB3V+/39RMHsaXTOG0zmt/OAXeng5M5LBm0ojmxJrpomQVZ1aPvBL4w==}
+    engines: {node: '>=12'}
+    peerDependencies:
+      d3-selection: 2 - 3
+
+  d3-zoom@3.0.0:
+    resolution: {integrity: sha512-b8AmV3kfQaqWAuacbPuNbL6vahnOJflOhexLzMMNLga62+/nh0JzvJ0aO/5a5MVgUFGS7Hu1P9P03o3fJkDCyw==}
+    engines: {node: '>=12'}
+
+  d3@7.9.0:
+    resolution: {integrity: sha512-e1U46jVP+w7Iut8Jt8ri1YsPOvFpg46k+K8TpCb0P+zjCkjkPnV7WzfDJzMHy1LnA+wj5pLT1wjO901gLXeEhA==}
+    engines: {node: '>=12'}
+
+  dagre-d3-es@7.0.14:
+    resolution: {integrity: sha512-P4rFMVq9ESWqmOgK+dlXvOtLwYg0i7u0HBGJER0LZDJT2VHIPAMZ/riPxqJceWMStH5+E61QxFra9kIS3AqdMg==}
 
   data-uri-to-buffer@4.0.1:
     resolution: {integrity: sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==}
     engines: {node: '>= 12'}
+
+  data-urls@7.0.0:
+    resolution: {integrity: sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
+  dayjs@1.11.21:
+    resolution: {integrity: sha512-98IT+HOahAisibz/yjKbzuOBwYcjJ7BCLPzARyHiyEBmRz4fatF+KPJszEHXsGYjUG234aH/cOjW1wwTbKUZlA==}
 
   debug@4.4.3:
     resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
@@ -981,6 +1364,9 @@ packages:
     peerDependenciesMeta:
       supports-color:
         optional: true
+
+  decimal.js@10.6.0:
+    resolution: {integrity: sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==}
 
   decompress-response@6.0.0:
     resolution: {integrity: sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==}
@@ -1003,9 +1389,15 @@ packages:
       langchain: ^1.5.0
       langsmith: ^0.7.1
 
+  delaunator@5.1.0:
+    resolution: {integrity: sha512-AGrQ4QSgssa1NGmWmLPqN5NY2KajF5MqxetNEO+o0n3ZwZZeTmt7bBnvzHWrmkZFxGgr4HdyFgelzgi06otLuQ==}
+
   detect-libc@2.1.2:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
     engines: {node: '>=8'}
+
+  dompurify@3.4.12:
+    resolution: {integrity: sha512-zQvGet8Z2sWbQhCmfFz/T5QWH2oBmjnqK3qvOjaqaNLrLEF912WamU+ohnTp0TCep/MFVHpdJuCZEdFOdTnEFg==}
 
   ecdsa-sig-formatter@1.0.11:
     resolution: {integrity: sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==}
@@ -1015,6 +1407,10 @@ packages:
 
   end-of-stream@1.4.5:
     resolution: {integrity: sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==}
+
+  entities@8.0.0:
+    resolution: {integrity: sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==}
+    engines: {node: '>=20.19.0'}
 
   environment@1.1.0:
     resolution: {integrity: sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q==}
@@ -1202,9 +1598,16 @@ packages:
     resolution: {integrity: sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA==}
     engines: {node: '>=14'}
 
+  hachure-fill@0.5.2:
+    resolution: {integrity: sha512-3GKBOn+m2LX9iq+JC1064cSFprJY4jL1jCXTcpnfER5HYE2l/4EfWSGzkPa/ZDBmYI0ZOEj5VHV/eKnPGkHuOg==}
+
   has-flag@4.0.0:
     resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
     engines: {node: '>=8'}
+
+  html-encoding-sniffer@6.0.0:
+    resolution: {integrity: sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
 
   html-escaper@2.0.2:
     resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
@@ -1212,6 +1615,10 @@ packages:
   https-proxy-agent@7.0.6:
     resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
     engines: {node: '>= 14'}
+
+  iconv-lite@0.6.3:
+    resolution: {integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==}
+    engines: {node: '>=0.10.0'}
 
   ieee754@1.2.1:
     resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
@@ -1223,6 +1630,9 @@ packages:
   ignore@7.0.5:
     resolution: {integrity: sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==}
     engines: {node: '>= 4'}
+
+  import-meta-resolve@4.2.0:
+    resolution: {integrity: sha512-Iqv2fzaTQN28s/FwZAoFq0ZSs/7hMAHJVX+w8PZl3cY19Pxk6jFFalxQoIfW2826i/fDLXv8IiEZRIT0lDuWcg==}
 
   imurmurhash@0.1.4:
     resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
@@ -1250,6 +1660,13 @@ packages:
         optional: true
       react-devtools-core:
         optional: true
+
+  internmap@1.0.1:
+    resolution: {integrity: sha512-lDB5YccMydFBtasVtxnZ3MRBHuaoE8GKsppq+EchKL2U4nK/DmEpPHNH8MZe5HkMtpSiTSOZwfN0tzYjO/lJEw==}
+
+  internmap@2.0.3:
+    resolution: {integrity: sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==}
+    engines: {node: '>=12'}
 
   is-extglob@2.1.1:
     resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
@@ -1280,6 +1697,9 @@ packages:
     resolution: {integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==}
     engines: {node: '>=0.12.0'}
 
+  is-potential-custom-element-name@1.0.1:
+    resolution: {integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==}
+
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
 
@@ -1307,6 +1727,15 @@ packages:
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
+  jsdom@29.1.1:
+    resolution: {integrity: sha512-ECi4Fi2f7BdJtUKTflYRTiaMxIB0O6zfR1fX0GXpUrf6flp8QIYn1UT20YQqdSOfk2dfkCwS8LAFoJDEppNK5Q==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24.0.0}
+    peerDependencies:
+      canvas: ^3.0.0
+    peerDependenciesMeta:
+      canvas:
+        optional: true
+
   json-bigint@1.0.0:
     resolution: {integrity: sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==}
 
@@ -1329,8 +1758,15 @@ packages:
   jws@4.0.1:
     resolution: {integrity: sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==}
 
+  katex@0.16.47:
+    resolution: {integrity: sha512-Eeo8Ys1doU1z+x8AZsPpQu+p/QcZBI5PeOo7QGQdy2x2m0MU/hYagBbGOmXwr5KVbEfVuWv9LpnQWeehogurjg==}
+    hasBin: true
+
   keyv@4.5.4:
     resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
+
+  khroma@2.1.0:
+    resolution: {integrity: sha512-Ls993zuzfayK269Svk9hzpeGUKob/sIgZzyHYdjQoAdQetRKpOLj+k/QQQ/6Qi0Yz65mlROrfd+Ev+1+7dz9Kw==}
 
   langchain@1.5.3:
     resolution: {integrity: sha512-YRYPy1xPq4CgKe0NdPoscYHnKBW5cViEyWiZsUKQfN3xL1X5DpGlIpaBQg1A/t6o9ePKE7J5b7nqrfLz8t7/Rw==}
@@ -1357,6 +1793,12 @@ packages:
         optional: true
       ws:
         optional: true
+
+  layout-base@1.0.2:
+    resolution: {integrity: sha512-8h2oVEZNktL4BH2JCOI90iD1yXwL6iNW7KcCKT2QZgQJR2vbqDsldCTPRU9NifTCqHZci57XvQQ15YTu+sTYPg==}
+
+  layout-base@2.0.1:
+    resolution: {integrity: sha512-dp3s92+uNI1hWIpPGH3jK2kxE2lMjdXdr+DH8ynZHpd6PUlH6x6cbuXnoMmiNumznqaNO31xu9e79F0uuZ0JFg==}
 
   levn@0.4.1:
     resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==}
@@ -1440,9 +1882,16 @@ packages:
     resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
     engines: {node: '>=10'}
 
+  lodash-es@4.18.1:
+    resolution: {integrity: sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==}
+
   loose-envify@1.4.0:
     resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
     hasBin: true
+
+  lru-cache@11.5.2:
+    resolution: {integrity: sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==}
+    engines: {node: 20 || >=22}
 
   luxon@3.7.2:
     resolution: {integrity: sha512-vtEhXh/gNjI9Yg1u4jX/0YVPMvxzHuGgCm6tC5kZyb08yjGWGnqAjGJvcXbqQR2P3MyMEFnRbpcdFS6PBcLqew==}
@@ -1458,14 +1907,25 @@ packages:
     resolution: {integrity: sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==}
     engines: {node: '>=10'}
 
+  marked@16.4.2:
+    resolution: {integrity: sha512-TI3V8YYWvkVf3KJe1dRkpnjs68JUPyEa5vjKrp1XEEJUAOaQc+Qj+L1qWbPd0SJuAdQkFU0h73sXXqwDYxsiDA==}
+    engines: {node: '>= 20'}
+    hasBin: true
+
   marked@18.0.5:
     resolution: {integrity: sha512-S6GcvALHg6K4ohtu4E7x0a1AqhAjp6cV8KhLSyN9qVapnzJkusVBxZRcIU9AeYsbe6P1hKDusSbEOzGyyuce6w==}
     engines: {node: '>= 20'}
     hasBin: true
 
+  mdn-data@2.27.1:
+    resolution: {integrity: sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==}
+
   merge2@1.4.1:
     resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
     engines: {node: '>= 8'}
+
+  mermaid@11.16.0:
+    resolution: {integrity: sha512-Zvm3kbstgdpvIJPPItlL7fppIZ3kibvc1oZIGxdvk9t6UFz6flv+Jw7FtRGKwfcI8OckmH04LqG6LlS6X4B1pA==}
 
   micromatch@4.0.8:
     resolution: {integrity: sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==}
@@ -1587,9 +2047,18 @@ packages:
     resolution: {integrity: sha512-AxTM2wDGORHGEkPCt8yqxOTMgpfbEHqF51f/5fJCmwFC3C/zNcGT63SymH2ttOAaiIws2zVg4+izQCjrakcwHg==}
     engines: {node: '>=20'}
 
+  package-manager-detector@1.7.0:
+    resolution: {integrity: sha512-xg1eHpwYL/D/HEdWw2goFZP6vV0FH7W+PZ5rFkGjdIDLtxq7EkzBUeT3m+lndYCt8wKbmofUu1MUdMCXkCk9ZQ==}
+
+  parse5@8.0.1:
+    resolution: {integrity: sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==}
+
   patch-console@2.0.0:
     resolution: {integrity: sha512-0YNdUceMdaQwoKce1gatDScmMo5pu/tfABfnzEqeG0gtTmd7mh/WcwgUjtAeOU7N8nFFlbQBnFK2gXW5fGvmMA==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
+  path-data-parser@0.1.0:
+    resolution: {integrity: sha512-NOnmBpt5Y2RWbuv0LMzsayp3lVylAHLPUTut412ZA3l+C4uw4ZVkQbjShYCQ8TCpUMdPapr4YjUqLYD6v68j+w==}
 
   path-exists@4.0.0:
     resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
@@ -1612,6 +2081,12 @@ packages:
   picomatch@4.0.5:
     resolution: {integrity: sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==}
     engines: {node: '>=12'}
+
+  points-on-curve@0.2.0:
+    resolution: {integrity: sha512-0mYKnYYe9ZcqMCWhUjItv/oHjvgEsfKvnUTg8sAtnHr3GVy7rGkXCb6d5cSyqrWqL4k81b9CPg3urd+T7aop3A==}
+
+  points-on-path@0.2.1:
+    resolution: {integrity: sha512-25ClnWWuw7JbWZcgqY/gJ4FQWadKxGWk+3kR/7kD0tCaDtPPMj7oHu2ToLaVhfpnHrZzYby2w6tUA0eOIuUg8g==}
 
   postcss@8.5.16:
     resolution: {integrity: sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg==}
@@ -1669,6 +2144,10 @@ packages:
     resolution: {integrity: sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==}
     engines: {node: '>= 6'}
 
+  require-from-string@2.0.2:
+    resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
+    engines: {node: '>=0.10.0'}
+
   restore-cursor@4.0.0:
     resolution: {integrity: sha512-I9fPXU9geO9bHOt9pHHOhOkYerIMsmVaWB0rA2AI9ERh/+x/i7MV5HKBNrg+ljO5eoPVgCcnFuRjJ9uH6I/3eg==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
@@ -1677,16 +2156,32 @@ packages:
     resolution: {integrity: sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==}
     engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
 
+  robust-predicates@3.0.3:
+    resolution: {integrity: sha512-NS3levdsRIUOmiJ8FZWCP7LG3QpJyrs/TE0Zpf1yvZu8cAJJ6QMW92H1c7kWpdIHo8RvmLxN/o2JXTKHp74lUA==}
+
   rolldown@1.1.4:
     resolution: {integrity: sha512-IjZYiLxZwpnhwhdBH2ugdTGVSdhCQUmLxLoqyjiL0JxYjyRst+5a0P3xfrTxJ5F638j4Mvvw5FAX5XE6eHpXbA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
 
+  roughjs@4.6.6:
+    resolution: {integrity: sha512-ZUz/69+SYpFN/g/lUlo2FXcIjRkSu3nDarreVdGGndHEBJ6cXPdKguS8JGxwj5HA5xIbVKSmLgr5b3AWxtRfvQ==}
+
   run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
 
+  rw@1.3.3:
+    resolution: {integrity: sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ==}
+
   safe-buffer@5.2.1:
     resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
+
+  safer-buffer@2.1.2:
+    resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
+
+  saxes@6.0.0:
+    resolution: {integrity: sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==}
+    engines: {node: '>=v12.22.7'}
 
   scheduler@0.23.2:
     resolution: {integrity: sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==}
@@ -1756,9 +2251,15 @@ packages:
     resolution: {integrity: sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==}
     engines: {node: '>=0.10.0'}
 
+  stylis@4.4.0:
+    resolution: {integrity: sha512-5Z9ZpRzfuH6l/UAvCPAPUo3665Nk2wLaZU3x+TLHKVzIz33+sbJqbtrYoC3KD4/uVOr2Zp+L0LySezP9OHV9yA==}
+
   supports-color@7.2.0:
     resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
     engines: {node: '>=8'}
+
+  symbol-tree@3.2.4:
+    resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
 
   tar-fs@2.1.5:
     resolution: {integrity: sha512-OboTd8mmMhZDNPV+UjQcK9yKAatXu2aJ+r1w4im1Otd4M4fl2hwvdoXUxIYHFTHWK/3y3FarBP70v3vwmGlOxw==}
@@ -1782,9 +2283,24 @@ packages:
     resolution: {integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==}
     engines: {node: '>=14.0.0'}
 
+  tldts-core@7.4.8:
+    resolution: {integrity: sha512-c1P7u0EhACHj7lPy4MJm8iTFEU8+nB0LCtddH0fhP7noaVoXAqafMtOOeX+ulpuPBqnrRgRhw494RICT3mbhnw==}
+
+  tldts@7.4.8:
+    resolution: {integrity: sha512-htwgN/8KRB3z3vnC0BOETVh2m499g5GmyTK9Wq5JBLX3FNz6tSBveAd+fQhzy9hkjif8vy2jwDMR1sGhLtZl2A==}
+    hasBin: true
+
   to-regex-range@5.0.1:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
     engines: {node: '>=8.0'}
+
+  tough-cookie@6.0.2:
+    resolution: {integrity: sha512-exgYmnmL/sJpR3upZfXG5PoatXQii55xAiXGXzY+sROLZ/Y+SLcp9PgJNI9Vz37HpQ74WvDcLT8eqm+kV3FzrA==}
+    engines: {node: '>=16'}
+
+  tr46@6.0.0:
+    resolution: {integrity: sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==}
+    engines: {node: '>=20'}
 
   ts-algebra@2.0.0:
     resolution: {integrity: sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==}
@@ -1794,6 +2310,10 @@ packages:
     engines: {node: '>=18.12'}
     peerDependencies:
       typescript: '>=4.8.4'
+
+  ts-dedent@2.3.0:
+    resolution: {integrity: sha512-JfJeIHke7y2egdGGgRAvpCwYFUsHlM2gPcrVOxFkznt/4uzQ7HFmvE63iFHVLBJNDuyDOQgijDK/tXH/f6Msjg==}
+    engines: {node: '>=6.10'}
 
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
@@ -1829,11 +2349,22 @@ packages:
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
 
+  undici-types@7.28.0:
+    resolution: {integrity: sha512-LJAfY+2w6HGeT8d8J1wNQsUGUEGio6NWWpwdwurQe4f6oojzCFuGLizl1KSve4irsTxyLly1QhEeE6iapdaIvQ==}
+
+  undici@7.28.0:
+    resolution: {integrity: sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==}
+    engines: {node: '>=20.18.1'}
+
   uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
 
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
+
+  uuid@14.0.1:
+    resolution: {integrity: sha512-6ZxzVpzDXDa3bJWaHilVayA+BH/1zmxCJoVgvmqJnid/gPoKHxUrS/aC/T6LGQtNHT+XHG9fXPJB4d+IrU30Ew==}
+    hasBin: true
 
   vite@8.1.3:
     resolution: {integrity: sha512-Ds+gBRbj0lwRO2Y5hwnUBdxSwlAve9LeRyU4sNnAr0ewW0gWF0n5bgXgUzbgZ49MV9BVUAQUFYVcDUcilUExMA==}
@@ -1919,9 +2450,25 @@ packages:
       jsdom:
         optional: true
 
+  w3c-xmlserializer@5.0.0:
+    resolution: {integrity: sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==}
+    engines: {node: '>=18'}
+
   web-streams-polyfill@3.3.3:
     resolution: {integrity: sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==}
     engines: {node: '>= 8'}
+
+  webidl-conversions@8.0.1:
+    resolution: {integrity: sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==}
+    engines: {node: '>=20'}
+
+  whatwg-mimetype@5.0.0:
+    resolution: {integrity: sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==}
+    engines: {node: '>=20'}
+
+  whatwg-url@16.0.1:
+    resolution: {integrity: sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
 
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
@@ -1960,6 +2507,13 @@ packages:
       utf-8-validate:
         optional: true
 
+  xml-name-validator@5.0.0:
+    resolution: {integrity: sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==}
+    engines: {node: '>=18'}
+
+  xmlchars@2.2.0:
+    resolution: {integrity: sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==}
+
   yaml@2.9.0:
     resolution: {integrity: sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==}
     engines: {node: '>= 14.6'}
@@ -1982,6 +2536,11 @@ snapshots:
       ansi-styles: 6.2.3
       is-fullwidth-code-point: 4.0.0
 
+  '@antfu/install-pkg@1.1.0':
+    dependencies:
+      package-manager-detector: 1.7.0
+      tinyexec: 1.2.4
+
   '@anthropic-ai/sdk@0.103.0(zod@4.4.3)':
     dependencies:
       json-schema-to-ts: 3.1.1
@@ -1996,6 +2555,26 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
       - zod
+
+  '@asamuzakjp/css-color@5.1.11':
+    dependencies:
+      '@asamuzakjp/generational-cache': 1.0.1
+      '@csstools/css-calc': 3.2.1(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-color-parser': 4.1.9(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@asamuzakjp/dom-selector@7.1.1':
+    dependencies:
+      '@asamuzakjp/generational-cache': 1.0.1
+      '@asamuzakjp/nwsapi': 2.3.9
+      bidi-js: 1.0.3
+      css-tree: 3.2.1
+      is-potential-custom-element-name: 1.0.1
+
+  '@asamuzakjp/generational-cache@1.0.1': {}
+
+  '@asamuzakjp/nwsapi@2.3.9': {}
 
   '@aws-sdk/client-bedrock-agent-runtime@3.1080.0':
     dependencies:
@@ -2209,7 +2788,39 @@ snapshots:
 
   '@bcoe/v8-coverage@1.0.2': {}
 
+  '@braintree/sanitize-url@7.1.2': {}
+
+  '@bramus/specificity@2.4.2':
+    dependencies:
+      css-tree: 3.2.1
+
   '@cfworker/json-schema@4.1.1': {}
+
+  '@chevrotain/types@11.1.2': {}
+
+  '@csstools/color-helpers@6.1.0': {}
+
+  '@csstools/css-calc@3.2.1(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)':
+    dependencies:
+      '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@csstools/css-color-parser@4.1.9(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)':
+    dependencies:
+      '@csstools/color-helpers': 6.1.0
+      '@csstools/css-calc': 3.2.1(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0)':
+    dependencies:
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@csstools/css-syntax-patches-for-csstree@1.1.6(css-tree@3.2.1)':
+    optionalDependencies:
+      css-tree: 3.2.1
+
+  '@csstools/css-tokenizer@4.0.0': {}
 
   '@emnapi/core@1.11.1':
     dependencies:
@@ -2339,6 +2950,8 @@ snapshots:
       '@eslint/core': 1.2.1
       levn: 0.4.1
 
+  '@exodus/bytes@1.15.1': {}
+
   '@humanfs/core@0.19.2':
     dependencies:
       '@humanfs/types': 0.15.0
@@ -2354,6 +2967,14 @@ snapshots:
   '@humanwhocodes/module-importer@1.0.1': {}
 
   '@humanwhocodes/retry@0.4.3': {}
+
+  '@iconify/types@2.0.0': {}
+
+  '@iconify/utils@3.1.4':
+    dependencies:
+      '@antfu/install-pkg': 1.1.0
+      '@iconify/types': 2.0.0
+      import-meta-resolve: 4.2.0
 
   '@jridgewell/resolve-uri@3.1.2': {}
 
@@ -2481,6 +3102,10 @@ snapshots:
       '@langchain/core': 1.2.1(openai@6.45.0(@aws-sdk/credential-provider-node@3.972.63)(@smithy/signature-v4@5.6.2)(ws@8.21.0)(zod@4.4.3))(ws@8.21.0)
       zod: 4.4.3
 
+  '@mermaid-js/parser@1.2.0':
+    dependencies:
+      '@chevrotain/types': 11.1.2
+
   '@napi-rs/wasm-runtime@1.1.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)':
     dependencies:
       '@emnapi/core': 1.11.1
@@ -2606,11 +3231,137 @@ snapshots:
       '@types/deep-eql': 4.0.2
       assertion-error: 2.0.1
 
+  '@types/d3-array@3.2.2': {}
+
+  '@types/d3-axis@3.0.6':
+    dependencies:
+      '@types/d3-selection': 3.0.11
+
+  '@types/d3-brush@3.0.6':
+    dependencies:
+      '@types/d3-selection': 3.0.11
+
+  '@types/d3-chord@3.0.6': {}
+
+  '@types/d3-color@3.1.3': {}
+
+  '@types/d3-contour@3.0.6':
+    dependencies:
+      '@types/d3-array': 3.2.2
+      '@types/geojson': 7946.0.16
+
+  '@types/d3-delaunay@6.0.4': {}
+
+  '@types/d3-dispatch@3.0.7': {}
+
+  '@types/d3-drag@3.0.7':
+    dependencies:
+      '@types/d3-selection': 3.0.11
+
+  '@types/d3-dsv@3.0.7': {}
+
+  '@types/d3-ease@3.0.2': {}
+
+  '@types/d3-fetch@3.0.7':
+    dependencies:
+      '@types/d3-dsv': 3.0.7
+
+  '@types/d3-force@3.0.10': {}
+
+  '@types/d3-format@3.0.4': {}
+
+  '@types/d3-geo@3.1.0':
+    dependencies:
+      '@types/geojson': 7946.0.16
+
+  '@types/d3-hierarchy@3.1.7': {}
+
+  '@types/d3-interpolate@3.0.4':
+    dependencies:
+      '@types/d3-color': 3.1.3
+
+  '@types/d3-path@3.1.1': {}
+
+  '@types/d3-polygon@3.0.2': {}
+
+  '@types/d3-quadtree@3.0.6': {}
+
+  '@types/d3-random@3.0.4': {}
+
+  '@types/d3-scale-chromatic@3.1.0': {}
+
+  '@types/d3-scale@4.0.9':
+    dependencies:
+      '@types/d3-time': 3.0.4
+
+  '@types/d3-selection@3.0.11': {}
+
+  '@types/d3-shape@3.1.8':
+    dependencies:
+      '@types/d3-path': 3.1.1
+
+  '@types/d3-time-format@4.0.3': {}
+
+  '@types/d3-time@3.0.4': {}
+
+  '@types/d3-timer@3.0.2': {}
+
+  '@types/d3-transition@3.0.9':
+    dependencies:
+      '@types/d3-selection': 3.0.11
+
+  '@types/d3-zoom@3.0.8':
+    dependencies:
+      '@types/d3-interpolate': 3.0.4
+      '@types/d3-selection': 3.0.11
+
+  '@types/d3@7.4.3':
+    dependencies:
+      '@types/d3-array': 3.2.2
+      '@types/d3-axis': 3.0.6
+      '@types/d3-brush': 3.0.6
+      '@types/d3-chord': 3.0.6
+      '@types/d3-color': 3.1.3
+      '@types/d3-contour': 3.0.6
+      '@types/d3-delaunay': 6.0.4
+      '@types/d3-dispatch': 3.0.7
+      '@types/d3-drag': 3.0.7
+      '@types/d3-dsv': 3.0.7
+      '@types/d3-ease': 3.0.2
+      '@types/d3-fetch': 3.0.7
+      '@types/d3-force': 3.0.10
+      '@types/d3-format': 3.0.4
+      '@types/d3-geo': 3.1.0
+      '@types/d3-hierarchy': 3.1.7
+      '@types/d3-interpolate': 3.0.4
+      '@types/d3-path': 3.1.1
+      '@types/d3-polygon': 3.0.2
+      '@types/d3-quadtree': 3.0.6
+      '@types/d3-random': 3.0.4
+      '@types/d3-scale': 4.0.9
+      '@types/d3-scale-chromatic': 3.1.0
+      '@types/d3-selection': 3.0.11
+      '@types/d3-shape': 3.1.8
+      '@types/d3-time': 3.0.4
+      '@types/d3-time-format': 4.0.3
+      '@types/d3-timer': 3.0.2
+      '@types/d3-transition': 3.0.9
+      '@types/d3-zoom': 3.0.8
+
   '@types/deep-eql@4.0.2': {}
 
   '@types/esrecurse@4.3.1': {}
 
   '@types/estree@1.0.9': {}
+
+  '@types/geojson@7946.0.16': {}
+
+  '@types/jsdom@28.0.3':
+    dependencies:
+      '@types/node': 22.20.0
+      '@types/tough-cookie': 4.0.5
+      parse5: 8.0.1
+      undici-types: 7.28.0
 
   '@types/json-schema@7.0.15': {}
 
@@ -2624,6 +3375,11 @@ snapshots:
     dependencies:
       '@types/prop-types': 15.7.15
       csstype: 3.2.3
+
+  '@types/tough-cookie@4.0.5': {}
+
+  '@types/trusted-types@2.0.7':
+    optional: true
 
   '@typescript-eslint/eslint-plugin@8.62.1(@typescript-eslint/parser@8.62.1(eslint@10.6.0)(typescript@5.9.3))(eslint@10.6.0)(typescript@5.9.3)':
     dependencies:
@@ -2716,6 +3472,11 @@ snapshots:
       '@typescript-eslint/types': 8.62.1
       eslint-visitor-keys: 5.0.1
 
+  '@upsetjs/venn.js@2.0.0':
+    optionalDependencies:
+      d3-selection: 3.0.0
+      d3-transition: 3.0.1(d3-selection@3.0.0)
+
   '@vitest/coverage-v8@4.1.10(vitest@4.1.10)':
     dependencies:
       '@bcoe/v8-coverage': 1.0.2
@@ -2728,7 +3489,7 @@ snapshots:
       obug: 2.1.3
       std-env: 4.1.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.10(@types/node@22.20.0)(@vitest/coverage-v8@4.1.10)(vite@8.1.3(@types/node@22.20.0)(esbuild@0.28.1)(tsx@4.22.5)(yaml@2.9.0))
+      vitest: 4.1.10(@types/node@22.20.0)(@vitest/coverage-v8@4.1.10)(jsdom@29.1.1)(vite@8.1.3(@types/node@22.20.0)(esbuild@0.28.1)(tsx@4.22.5)(yaml@2.9.0))
 
   '@vitest/expect@4.1.10':
     dependencies:
@@ -2813,6 +3574,10 @@ snapshots:
       bindings: 1.5.0
       prebuild-install: 7.1.3
 
+  bidi-js@1.0.3:
+    dependencies:
+      require-from-string: 2.0.2
+
   bignumber.js@9.3.1: {}
 
   bindings@1.5.0:
@@ -2865,9 +3630,21 @@ snapshots:
     dependencies:
       convert-to-spaces: 2.0.1
 
+  commander@7.2.0: {}
+
+  commander@8.3.0: {}
+
   convert-source-map@2.0.0: {}
 
   convert-to-spaces@2.0.1: {}
+
+  cose-base@1.0.3:
+    dependencies:
+      layout-base: 1.0.2
+
+  cose-base@2.2.0:
+    dependencies:
+      layout-base: 2.0.1
 
   cron-parser@5.6.1:
     dependencies:
@@ -2881,13 +3658,213 @@ snapshots:
       shebang-command: 2.0.0
       which: 2.0.2
 
+  css-tree@3.2.1:
+    dependencies:
+      mdn-data: 2.27.1
+      source-map-js: 1.2.1
+
   csstype@3.2.3: {}
 
+  cytoscape-cose-bilkent@4.1.0(cytoscape@3.34.0):
+    dependencies:
+      cose-base: 1.0.3
+      cytoscape: 3.34.0
+
+  cytoscape-fcose@2.2.0(cytoscape@3.34.0):
+    dependencies:
+      cose-base: 2.2.0
+      cytoscape: 3.34.0
+
+  cytoscape@3.34.0: {}
+
+  d3-array@2.12.1:
+    dependencies:
+      internmap: 1.0.1
+
+  d3-array@3.2.4:
+    dependencies:
+      internmap: 2.0.3
+
+  d3-axis@3.0.0: {}
+
+  d3-brush@3.0.0:
+    dependencies:
+      d3-dispatch: 3.0.1
+      d3-drag: 3.0.0
+      d3-interpolate: 3.0.1
+      d3-selection: 3.0.0
+      d3-transition: 3.0.1(d3-selection@3.0.0)
+
+  d3-chord@3.0.1:
+    dependencies:
+      d3-path: 3.1.0
+
+  d3-color@3.1.0: {}
+
+  d3-contour@4.0.2:
+    dependencies:
+      d3-array: 3.2.4
+
+  d3-delaunay@6.0.4:
+    dependencies:
+      delaunator: 5.1.0
+
+  d3-dispatch@3.0.1: {}
+
+  d3-drag@3.0.0:
+    dependencies:
+      d3-dispatch: 3.0.1
+      d3-selection: 3.0.0
+
+  d3-dsv@3.0.1:
+    dependencies:
+      commander: 7.2.0
+      iconv-lite: 0.6.3
+      rw: 1.3.3
+
+  d3-ease@3.0.1: {}
+
+  d3-fetch@3.0.1:
+    dependencies:
+      d3-dsv: 3.0.1
+
+  d3-force@3.0.0:
+    dependencies:
+      d3-dispatch: 3.0.1
+      d3-quadtree: 3.0.1
+      d3-timer: 3.0.1
+
+  d3-format@3.1.2: {}
+
+  d3-geo@3.1.1:
+    dependencies:
+      d3-array: 3.2.4
+
+  d3-hierarchy@3.1.2: {}
+
+  d3-interpolate@3.0.1:
+    dependencies:
+      d3-color: 3.1.0
+
+  d3-path@1.0.9: {}
+
+  d3-path@3.1.0: {}
+
+  d3-polygon@3.0.1: {}
+
+  d3-quadtree@3.0.1: {}
+
+  d3-random@3.0.1: {}
+
+  d3-sankey@0.12.3:
+    dependencies:
+      d3-array: 2.12.1
+      d3-shape: 1.3.7
+
+  d3-scale-chromatic@3.1.0:
+    dependencies:
+      d3-color: 3.1.0
+      d3-interpolate: 3.0.1
+
+  d3-scale@4.0.2:
+    dependencies:
+      d3-array: 3.2.4
+      d3-format: 3.1.2
+      d3-interpolate: 3.0.1
+      d3-time: 3.1.0
+      d3-time-format: 4.1.0
+
+  d3-selection@3.0.0: {}
+
+  d3-shape@1.3.7:
+    dependencies:
+      d3-path: 1.0.9
+
+  d3-shape@3.2.0:
+    dependencies:
+      d3-path: 3.1.0
+
+  d3-time-format@4.1.0:
+    dependencies:
+      d3-time: 3.1.0
+
+  d3-time@3.1.0:
+    dependencies:
+      d3-array: 3.2.4
+
+  d3-timer@3.0.1: {}
+
+  d3-transition@3.0.1(d3-selection@3.0.0):
+    dependencies:
+      d3-color: 3.1.0
+      d3-dispatch: 3.0.1
+      d3-ease: 3.0.1
+      d3-interpolate: 3.0.1
+      d3-selection: 3.0.0
+      d3-timer: 3.0.1
+
+  d3-zoom@3.0.0:
+    dependencies:
+      d3-dispatch: 3.0.1
+      d3-drag: 3.0.0
+      d3-interpolate: 3.0.1
+      d3-selection: 3.0.0
+      d3-transition: 3.0.1(d3-selection@3.0.0)
+
+  d3@7.9.0:
+    dependencies:
+      d3-array: 3.2.4
+      d3-axis: 3.0.0
+      d3-brush: 3.0.0
+      d3-chord: 3.0.1
+      d3-color: 3.1.0
+      d3-contour: 4.0.2
+      d3-delaunay: 6.0.4
+      d3-dispatch: 3.0.1
+      d3-drag: 3.0.0
+      d3-dsv: 3.0.1
+      d3-ease: 3.0.1
+      d3-fetch: 3.0.1
+      d3-force: 3.0.0
+      d3-format: 3.1.2
+      d3-geo: 3.1.1
+      d3-hierarchy: 3.1.2
+      d3-interpolate: 3.0.1
+      d3-path: 3.1.0
+      d3-polygon: 3.0.1
+      d3-quadtree: 3.0.1
+      d3-random: 3.0.1
+      d3-scale: 4.0.2
+      d3-scale-chromatic: 3.1.0
+      d3-selection: 3.0.0
+      d3-shape: 3.2.0
+      d3-time: 3.1.0
+      d3-time-format: 4.1.0
+      d3-timer: 3.0.1
+      d3-transition: 3.0.1(d3-selection@3.0.0)
+      d3-zoom: 3.0.0
+
+  dagre-d3-es@7.0.14:
+    dependencies:
+      d3: 7.9.0
+      lodash-es: 4.18.1
+
   data-uri-to-buffer@4.0.1: {}
+
+  data-urls@7.0.0:
+    dependencies:
+      whatwg-mimetype: 5.0.0
+      whatwg-url: 16.0.1
+    transitivePeerDependencies:
+      - '@noble/hashes'
+
+  dayjs@1.11.21: {}
 
   debug@4.4.3:
     dependencies:
       ms: 2.1.3
+
+  decimal.js@10.6.0: {}
 
   decompress-response@6.0.0:
     dependencies:
@@ -2910,7 +3887,15 @@ snapshots:
       yaml: 2.9.0
       zod: 4.4.3
 
+  delaunator@5.1.0:
+    dependencies:
+      robust-predicates: 3.0.3
+
   detect-libc@2.1.2: {}
+
+  dompurify@3.4.12:
+    optionalDependencies:
+      '@types/trusted-types': 2.0.7
 
   ecdsa-sig-formatter@1.0.11:
     dependencies:
@@ -2921,6 +3906,8 @@ snapshots:
   end-of-stream@1.4.5:
     dependencies:
       once: 1.4.0
+
+  entities@8.0.0: {}
 
   environment@1.1.0: {}
 
@@ -3142,7 +4129,15 @@ snapshots:
 
   google-logging-utils@1.1.3: {}
 
+  hachure-fill@0.5.2: {}
+
   has-flag@4.0.0: {}
+
+  html-encoding-sniffer@6.0.0:
+    dependencies:
+      '@exodus/bytes': 1.15.1
+    transitivePeerDependencies:
+      - '@noble/hashes'
 
   html-escaper@2.0.2: {}
 
@@ -3153,11 +4148,17 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  iconv-lite@0.6.3:
+    dependencies:
+      safer-buffer: 2.1.2
+
   ieee754@1.2.1: {}
 
   ignore@5.3.2: {}
 
   ignore@7.0.5: {}
+
+  import-meta-resolve@4.2.0: {}
 
   imurmurhash@0.1.4: {}
 
@@ -3200,6 +4201,10 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
+  internmap@1.0.1: {}
+
+  internmap@2.0.3: {}
+
   is-extglob@2.1.1: {}
 
   is-fullwidth-code-point@4.0.0: {}
@@ -3217,6 +4222,8 @@ snapshots:
   is-network-error@1.3.2: {}
 
   is-number@7.0.0: {}
+
+  is-potential-custom-element-name@1.0.1: {}
 
   isexe@2.0.0: {}
 
@@ -3242,6 +4249,32 @@ snapshots:
   js-tokens@10.0.0: {}
 
   js-tokens@4.0.0: {}
+
+  jsdom@29.1.1:
+    dependencies:
+      '@asamuzakjp/css-color': 5.1.11
+      '@asamuzakjp/dom-selector': 7.1.1
+      '@bramus/specificity': 2.4.2
+      '@csstools/css-syntax-patches-for-csstree': 1.1.6(css-tree@3.2.1)
+      '@exodus/bytes': 1.15.1
+      css-tree: 3.2.1
+      data-urls: 7.0.0
+      decimal.js: 10.6.0
+      html-encoding-sniffer: 6.0.0
+      is-potential-custom-element-name: 1.0.1
+      lru-cache: 11.5.2
+      parse5: 8.0.1
+      saxes: 6.0.0
+      symbol-tree: 3.2.4
+      tough-cookie: 6.0.2
+      undici: 7.28.0
+      w3c-xmlserializer: 5.0.0
+      webidl-conversions: 8.0.1
+      whatwg-mimetype: 5.0.0
+      whatwg-url: 16.0.1
+      xml-name-validator: 5.0.0
+    transitivePeerDependencies:
+      - '@noble/hashes'
 
   json-bigint@1.0.0:
     dependencies:
@@ -3269,9 +4302,15 @@ snapshots:
       jwa: 2.0.1
       safe-buffer: 5.2.1
 
+  katex@0.16.47:
+    dependencies:
+      commander: 8.3.0
+
   keyv@4.5.4:
     dependencies:
       json-buffer: 3.0.1
+
+  khroma@2.1.0: {}
 
   langchain@1.5.3(@langchain/core@1.2.1(openai@6.45.0(@aws-sdk/credential-provider-node@3.972.63)(@smithy/signature-v4@5.6.2)(ws@8.21.0)(zod@4.4.3))(ws@8.21.0))(openai@6.45.0(@aws-sdk/credential-provider-node@3.972.63)(@smithy/signature-v4@5.6.2)(ws@8.21.0)(zod@4.4.3))(react@18.3.1)(ws@8.21.0):
     dependencies:
@@ -3297,6 +4336,10 @@ snapshots:
     optionalDependencies:
       openai: 6.45.0(@aws-sdk/credential-provider-node@3.972.63)(@smithy/signature-v4@5.6.2)(ws@8.21.0)(zod@4.4.3)
       ws: 8.21.0
+
+  layout-base@1.0.2: {}
+
+  layout-base@2.0.1: {}
 
   levn@0.4.1:
     dependencies:
@@ -3356,9 +4399,13 @@ snapshots:
     dependencies:
       p-locate: 5.0.0
 
+  lodash-es@4.18.1: {}
+
   loose-envify@1.4.0:
     dependencies:
       js-tokens: 4.0.0
+
+  lru-cache@11.5.2: {}
 
   luxon@3.7.2: {}
 
@@ -3376,9 +4423,37 @@ snapshots:
     dependencies:
       semver: 7.8.5
 
+  marked@16.4.2: {}
+
   marked@18.0.5: {}
 
+  mdn-data@2.27.1: {}
+
   merge2@1.4.1: {}
+
+  mermaid@11.16.0:
+    dependencies:
+      '@braintree/sanitize-url': 7.1.2
+      '@iconify/utils': 3.1.4
+      '@mermaid-js/parser': 1.2.0
+      '@types/d3': 7.4.3
+      '@upsetjs/venn.js': 2.0.0
+      cytoscape: 3.34.0
+      cytoscape-cose-bilkent: 4.1.0(cytoscape@3.34.0)
+      cytoscape-fcose: 2.2.0(cytoscape@3.34.0)
+      d3: 7.9.0
+      d3-sankey: 0.12.3
+      dagre-d3-es: 7.0.14
+      dayjs: 1.11.21
+      dompurify: 3.4.12
+      es-toolkit: 1.49.0
+      katex: 0.16.47
+      khroma: 2.1.0
+      marked: 16.4.2
+      roughjs: 4.6.6
+      stylis: 4.4.0
+      ts-dedent: 2.3.0
+      uuid: 14.0.1
 
   micromatch@4.0.8:
     dependencies:
@@ -3475,7 +4550,15 @@ snapshots:
 
   p-timeout@7.0.1: {}
 
+  package-manager-detector@1.7.0: {}
+
+  parse5@8.0.1:
+    dependencies:
+      entities: 8.0.0
+
   patch-console@2.0.0: {}
+
+  path-data-parser@0.1.0: {}
 
   path-exists@4.0.0: {}
 
@@ -3488,6 +4571,13 @@ snapshots:
   picomatch@2.3.2: {}
 
   picomatch@4.0.5: {}
+
+  points-on-curve@0.2.0: {}
+
+  points-on-path@0.2.1:
+    dependencies:
+      path-data-parser: 0.1.0
+      points-on-curve: 0.2.0
 
   postcss@8.5.16:
     dependencies:
@@ -3550,12 +4640,16 @@ snapshots:
       string_decoder: 1.3.0
       util-deprecate: 1.0.2
 
+  require-from-string@2.0.2: {}
+
   restore-cursor@4.0.0:
     dependencies:
       onetime: 5.1.2
       signal-exit: 3.0.7
 
   reusify@1.1.0: {}
+
+  robust-predicates@3.0.3: {}
 
   rolldown@1.1.4:
     dependencies:
@@ -3578,11 +4672,26 @@ snapshots:
       '@rolldown/binding-win32-arm64-msvc': 1.1.4
       '@rolldown/binding-win32-x64-msvc': 1.1.4
 
+  roughjs@4.6.6:
+    dependencies:
+      hachure-fill: 0.5.2
+      path-data-parser: 0.1.0
+      points-on-curve: 0.2.0
+      points-on-path: 0.2.1
+
   run-parallel@1.2.0:
     dependencies:
       queue-microtask: 1.2.3
 
+  rw@1.3.3: {}
+
   safe-buffer@5.2.1: {}
+
+  safer-buffer@2.1.2: {}
+
+  saxes@6.0.0:
+    dependencies:
+      xmlchars: 2.2.0
 
   scheduler@0.23.2:
     dependencies:
@@ -3649,9 +4758,13 @@ snapshots:
 
   strip-json-comments@2.0.1: {}
 
+  stylis@4.4.0: {}
+
   supports-color@7.2.0:
     dependencies:
       has-flag: 4.0.0
+
+  symbol-tree@3.2.4: {}
 
   tar-fs@2.1.5:
     dependencies:
@@ -3679,15 +4792,31 @@ snapshots:
 
   tinyrainbow@3.1.0: {}
 
+  tldts-core@7.4.8: {}
+
+  tldts@7.4.8:
+    dependencies:
+      tldts-core: 7.4.8
+
   to-regex-range@5.0.1:
     dependencies:
       is-number: 7.0.0
+
+  tough-cookie@6.0.2:
+    dependencies:
+      tldts: 7.4.8
+
+  tr46@6.0.0:
+    dependencies:
+      punycode: 2.3.1
 
   ts-algebra@2.0.0: {}
 
   ts-api-utils@2.5.0(typescript@5.9.3):
     dependencies:
       typescript: 5.9.3
+
+  ts-dedent@2.3.0: {}
 
   tslib@2.8.1: {}
 
@@ -3722,11 +4851,17 @@ snapshots:
 
   undici-types@6.21.0: {}
 
+  undici-types@7.28.0: {}
+
+  undici@7.28.0: {}
+
   uri-js@4.4.1:
     dependencies:
       punycode: 2.3.1
 
   util-deprecate@1.0.2: {}
+
+  uuid@14.0.1: {}
 
   vite@8.1.3(@types/node@22.20.0)(esbuild@0.28.1)(tsx@4.22.5)(yaml@2.9.0):
     dependencies:
@@ -3742,7 +4877,7 @@ snapshots:
       tsx: 4.22.5
       yaml: 2.9.0
 
-  vitest@4.1.10(@types/node@22.20.0)(@vitest/coverage-v8@4.1.10)(vite@8.1.3(@types/node@22.20.0)(esbuild@0.28.1)(tsx@4.22.5)(yaml@2.9.0)):
+  vitest@4.1.10(@types/node@22.20.0)(@vitest/coverage-v8@4.1.10)(jsdom@29.1.1)(vite@8.1.3(@types/node@22.20.0)(esbuild@0.28.1)(tsx@4.22.5)(yaml@2.9.0)):
     dependencies:
       '@vitest/expect': 4.1.10
       '@vitest/mocker': 4.1.10(vite@8.1.3(@types/node@22.20.0)(esbuild@0.28.1)(tsx@4.22.5)(yaml@2.9.0))
@@ -3767,10 +4902,27 @@ snapshots:
     optionalDependencies:
       '@types/node': 22.20.0
       '@vitest/coverage-v8': 4.1.10(vitest@4.1.10)
+      jsdom: 29.1.1
     transitivePeerDependencies:
       - msw
 
+  w3c-xmlserializer@5.0.0:
+    dependencies:
+      xml-name-validator: 5.0.0
+
   web-streams-polyfill@3.3.3: {}
+
+  webidl-conversions@8.0.1: {}
+
+  whatwg-mimetype@5.0.0: {}
+
+  whatwg-url@16.0.1:
+    dependencies:
+      '@exodus/bytes': 1.15.1
+      tr46: 6.0.0
+      webidl-conversions: 8.0.1
+    transitivePeerDependencies:
+      - '@noble/hashes'
 
   which@2.0.2:
     dependencies:
@@ -3796,6 +4948,10 @@ snapshots:
   wrappy@1.0.2: {}
 
   ws@8.21.0: {}
+
+  xml-name-validator@5.0.0: {}
+
+  xmlchars@2.2.0: {}
 
   yaml@2.9.0: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -59,18 +59,12 @@ importers:
       ink:
         specifier: ^5.1.0
         version: 5.2.1(@types/react@18.3.31)(react@18.3.1)
-      jsdom:
-        specifier: ^29.1.1
-        version: 29.1.1
       langchain:
         specifier: ^1.5.3
         version: 1.5.3(@langchain/core@1.2.1(openai@6.45.0(@aws-sdk/credential-provider-node@3.972.63)(@smithy/signature-v4@5.6.2)(ws@8.21.0)(zod@4.4.3))(ws@8.21.0))(openai@6.45.0(@aws-sdk/credential-provider-node@3.972.63)(@smithy/signature-v4@5.6.2)(ws@8.21.0)(zod@4.4.3))(react@18.3.1)(ws@8.21.0)
       marked:
         specifier: ^18.0.5
         version: 18.0.5
-      mermaid:
-        specifier: ^11.16.0
-        version: 11.16.0
       posthog-node:
         specifier: ^5.39.4
         version: 5.40.0
@@ -102,6 +96,12 @@ importers:
       eslint:
         specifier: ^10.5.0
         version: 10.6.0
+      jsdom:
+        specifier: ^29.1.1
+        version: 29.1.1
+      mermaid:
+        specifier: ^11.16.0
+        version: 11.16.0
       prettier:
         specifier: ^3.8.4
         version: 3.9.4

--- a/skills/mermaid-diagrams/SKILL.md
+++ b/skills/mermaid-diagrams/SKILL.md
@@ -33,6 +33,7 @@ These rules prevent the most common render breakages. When in doubt, rephrase th
 - In `flowchart`, wrap any label containing parentheses, brackets, or other punctuation in double quotes: `A["calls foo(bar)"]`.
 - In `flowchart`, never use the bare word `end` as a node id, and never start a node id with `o` or `x` followed by a dash (both are edge-marker syntax); rename the node.
 - In `sequenceDiagram`, participant names with spaces or punctuation need an alias: `participant AS as Auth Service`.
+- Never use a Mermaid reserved word as a participant name, alias, or node id: `note`, `end`, `loop`, `alt`, `opt`, `par`, `and`, `else`, `activate`, `deactivate`, `class`, `state`, `click`, `link`. For example a notification participant must be `Notifier`, not `Note` (which collides with the `note` keyword).
 - In `erDiagram`, entity and attribute names must be single identifier-like tokens; put human phrasing in the relationship label.
 - Keep labels short. Move explanation into the surrounding prose or the caption, not the diagram.
 

--- a/skills/mermaid-diagrams/SKILL.md
+++ b/skills/mermaid-diagrams/SKILL.md
@@ -1,0 +1,42 @@
+---
+name: mermaid-diagrams
+description: Embed Mermaid diagrams in generated wiki pages. Use whenever documenting a runtime or request flow, a call sequence, a state machine or lifecycle, a data model or entity relationships, or non-trivial control flow, since these are clearer as a diagram than as prose. Also use when an update run touches a page that already contains a mermaid fence, or a page that contains a text fence a previous run degraded.
+---
+
+# Mermaid Diagrams In Generated Wiki Pages
+
+Diagrams are part of high-quality wiki generation, not decoration. Where a flow,
+lifecycle, or data model is easier to grasp visually, embed a Mermaid diagram in
+a fenced ```mermaid block on the most relevant page.
+
+## Choosing a diagram type
+
+- `sequenceDiagram` for runtime and request flows across components (auth flows, request lifecycles, agent tool loops).
+- `stateDiagram-v2` for lifecycles and state machines (job states, connection states, run phases).
+- `erDiagram` for the data model: entities and their relationships.
+- `flowchart TD` for branching control flow and decision logic.
+
+## Discipline
+
+- Ground every diagram in inspected source. Do not invent participants, states, entities, or relationships the code does not support.
+- Prefer a few high-value diagrams over decorating every page. One accurate sequence diagram on the architecture page beats a flowchart on every page.
+- Give each diagram a one-line caption directly below it stating what it shows.
+- OpenWiki validates every mermaid fence after your run and converts fences that fail to parse into plain text fences. A degraded diagram is a quality failure; follow the syntax rules below so it does not happen.
+
+## Syntax safety
+
+These rules prevent the most common render breakages. When in doubt, rephrase the label.
+
+- Never place semicolons or pipes inside node, message, or edge labels.
+- Never place unescaped angle brackets in labels; write "returns Promise of User" instead of "returns Promise<User>".
+- In `flowchart`, wrap any label containing parentheses, brackets, or other punctuation in double quotes: `A["calls foo(bar)"]`.
+- In `flowchart`, never use the bare word `end` as a node id, and never start a node id with `o` or `x` followed by a dash (both are edge-marker syntax); rename the node.
+- In `sequenceDiagram`, participant names with spaces or punctuation need an alias: `participant AS as Auth Service`.
+- In `erDiagram`, entity and attribute names must be single identifier-like tokens; put human phrasing in the relationship label.
+- Keep labels short. Move explanation into the surrounding prose or the caption, not the diagram.
+
+## Update runs
+
+- A wrong diagram is a stale claim, not existing structure to preserve. If a source change makes a diagram inaccurate, update the diagram in the same edit as the surrounding prose.
+- Do not rewrite a diagram that is still accurate. Regenerating unchanged diagrams creates diff noise.
+- If a page contains a text fence preceded by an HTML comment starting with "openwiki: mermaid parse failed", that is a diagram a previous run degraded. Fix the syntax using the parser error in the comment, restore the ```mermaid fence, and delete the comment.

--- a/skills/mermaid-diagrams/SKILL.md
+++ b/skills/mermaid-diagrams/SKILL.md
@@ -19,7 +19,8 @@ a fenced ```mermaid block on the most relevant page.
 ## Discipline
 
 - Ground every diagram in inspected source. Do not invent participants, states, entities, or relationships the code does not support.
-- Prefer a few high-value diagrams over decorating every page. One accurate sequence diagram on the architecture page beats a flowchart on every page.
+- Cover the high-value cases: add a diagram wherever a page documents a request or runtime flow, a call sequence, a lifecycle or state machine, or a data model. A repository wiki usually has several such diagrams, not one overall. Skip pages that are navigation, reference tables, or pure configuration.
+- Still prefer a few strong diagrams over decorating every page: one accurate diagram on the page that needs it beats a diagram forced onto every page.
 - Give each diagram a one-line caption directly below it stating what it shows.
 - OpenWiki validates every mermaid fence after your run and converts fences that fail to parse into plain text fences. A degraded diagram is a quality failure; follow the syntax rules below so it does not happen.
 

--- a/src/agent/okf-middleware.ts
+++ b/src/agent/okf-middleware.ts
@@ -2,6 +2,7 @@ import { ToolMessage } from "@langchain/core/messages";
 import type { BackendProtocolV2 } from "deepagents";
 import { createMiddleware } from "langchain";
 import path from "node:path";
+import { validateWikiMermaid } from "../mermaid/wiki.js";
 import {
   validatePersistedFile,
   type FrontmatterIssue,
@@ -35,6 +36,7 @@ export function createOpenWikiIndexMiddleware(
         request.toolCall.name,
       ),
     afterAgent: async () => {
+      await validateWikiMermaid(backend, outputMode);
       await synchronizeWikiIndexes(backend, outputMode);
     },
   });

--- a/src/agent/prompt.ts
+++ b/src/agent/prompt.ts
@@ -255,6 +255,7 @@ export function createModeInstructions(
 - Only edit pages whose current content is inaccurate, incomplete, or misleading because of the recent changes. Do not refresh every page.
 - Keep each concept in one canonical page. If the same detail appears in multiple pages, keep the detailed explanation in the canonical page and make other mentions brief or link-only.
 - Do not make formatting-only edits. Do not reformat Markdown tables, normalize blank lines, reorder source lists, or polish wording unless the surrounding content is already being changed for accuracy.
+- When updating a page that documents a runtime flow, lifecycle, or data model but has no diagram, adding one is a valuable improvement, not a formatting-only change. Add it opportunistically when you are already editing that area or have spare diff budget, following the diagram discipline above.
 - Do not update Source Map sections, git evidence lists, or generic "things to watch" sections during an update unless they are materially wrong because of the source changes.
 - Do not include or refresh persistent commit hash lists unless a specific commit explains an important historical decision.
 - Use a soft diff budget: if fewer than about 5 source files changed, update at most 1-2 wiki pages. Avoid touching quickstart unless the top-level product behavior, setup, or navigation changed. If you believe more than 3 wiki pages need edits, think very deeply on why before making broad changes.

--- a/src/agent/prompt.ts
+++ b/src/agent/prompt.ts
@@ -194,10 +194,21 @@ Coverage self-check:
 - Verify that ${output.planPath} has been deleted. Do not finish while the temporary plan remains in the wiki as a concept.
 - Keep deferred areas in a concise \`## Backlog\` section at the end of ${output.quickstartPath}; do not create a separate backlog page.
 - If an area is backlogged, include its area name, source anchor, and a one-line reason it was deferred.
-
+${createDiagramInstructions()}
 Mode-specific behavior:
 ${createModeInstructions(command, outputMode)}
 `.trim();
+}
+
+export function createDiagramInstructions(): string {
+  return `
+Diagram discipline:
+- Where a flow, lifecycle, or data model is easier to grasp visually, embed a Mermaid diagram in a fenced \`\`\`mermaid block on the most relevant page: sequenceDiagram for runtime/request flows, stateDiagram for lifecycles, erDiagram for the data model, and flowchart for control flow.
+- Ground every diagram in inspected source. Do not invent participants, states, entities, or relationships the code does not support.
+- Keep diagrams accurate on update runs: if a source change makes an existing diagram stale, update the diagram in the same edit as the surrounding prose. A wrong diagram is a stale claim, not existing structure to preserve.
+- Mermaid label safety: never place semicolons, pipes, or unescaped angle brackets inside node, message, or edge labels; they break rendering. Rephrase the label instead.
+- Prefer a few high-value diagrams over decorating every page, and give each a short caption so its purpose is clear.
+`;
 }
 
 export function createModeInstructions(

--- a/src/agent/prompt.ts
+++ b/src/agent/prompt.ts
@@ -203,11 +203,11 @@ ${createModeInstructions(command, outputMode)}
 export function createDiagramInstructions(): string {
   return `
 Diagram discipline:
-- Where a flow, lifecycle, or data model is easier to grasp visually, embed a Mermaid diagram in a fenced \`\`\`mermaid block on the most relevant page: sequenceDiagram for runtime/request flows, stateDiagram for lifecycles, erDiagram for the data model, and flowchart for control flow.
+- Where a runtime flow, lifecycle, data model, or non-trivial control flow is clearer as a picture than as prose, embed a Mermaid diagram in a fenced \`\`\`mermaid block on the most relevant page. Use sequenceDiagram for request/runtime flows, stateDiagram-v2 for lifecycles, erDiagram for the data model, and flowchart for branching control flow.
 - Ground every diagram in inspected source. Do not invent participants, states, entities, or relationships the code does not support.
-- Keep diagrams accurate on update runs: if a source change makes an existing diagram stale, update the diagram in the same edit as the surrounding prose. A wrong diagram is a stale claim, not existing structure to preserve.
-- Mermaid label safety: never place semicolons, pipes, or unescaped angle brackets inside node, message, or edge labels; they break rendering. Rephrase the label instead.
-- Prefer a few high-value diagrams over decorating every page, and give each a short caption so its purpose is clear.
+- Keep diagrams accurate on update runs. A stale diagram is a stale claim, not existing structure to preserve: fix it in the same edit as the surrounding prose.
+- Prefer a few high-value diagrams over decorating every page, and give each a one-line caption. Consult the mermaid-diagrams skill for label-safety rules.
+- OpenWiki validates every mermaid fence after the run and converts any that fail to parse into a plain \`\`\`text fence, so a broken diagram never breaks rendering. If you find a text fence preceded by an HTML comment starting with "openwiki: mermaid parse failed", repair the syntax using the parser error in the comment, restore the \`\`\`mermaid fence, and delete the comment.
 `;
 }
 

--- a/src/agent/prompt.ts
+++ b/src/agent/prompt.ts
@@ -206,7 +206,7 @@ Diagram discipline:
 - Where a runtime flow, lifecycle, data model, or non-trivial control flow is clearer as a picture than as prose, embed a Mermaid diagram in a fenced \`\`\`mermaid block on the most relevant page. Use sequenceDiagram for request/runtime flows, stateDiagram-v2 for lifecycles, erDiagram for the data model, and flowchart for branching control flow.
 - Ground every diagram in inspected source. Do not invent participants, states, entities, or relationships the code does not support.
 - Keep diagrams accurate on update runs. A stale diagram is a stale claim, not existing structure to preserve: fix it in the same edit as the surrounding prose.
-- Prefer a few high-value diagrams over decorating every page, and give each a one-line caption. Consult the mermaid-diagrams skill for label-safety rules.
+- Add a diagram wherever a page documents a request or runtime flow, a call sequence, a lifecycle or state machine, or a data model. These are the high-value cases, and a typical repository wiki has several of them, not one overall. Skip pages that are navigation, reference tables, or configuration. Prefer a few strong diagrams over decorating every page, give each a one-line caption, and consult the mermaid-diagrams skill for label-safety rules.
 - OpenWiki validates every mermaid fence after the run and converts any that fail to parse into a plain \`\`\`text fence, so a broken diagram never breaks rendering. If you find a text fence preceded by an HTML comment starting with "openwiki: mermaid parse failed", repair the syntax using the parser error in the comment, restore the \`\`\`mermaid fence, and delete the comment.
 `;
 }

--- a/src/code-mode.ts
+++ b/src/code-mode.ts
@@ -1,5 +1,6 @@
 import { mkdir, readFile, writeFile } from "node:fs/promises";
 import path from "node:path";
+import { OPENWIKI_VERSION } from "./constants.js";
 import { isFileNotFoundError } from "./fs-errors.js";
 
 const OPENWIKI_AGENTS_SNIPPET_START = "<!-- OPENWIKI:START -->";
@@ -92,7 +93,7 @@ jobs:
 
       - name: Install OpenWiki
         # mermaid + jsdom are optional; they add high-fidelity validation of Mermaid diagrams. Remove if your wiki has none.
-        run: npm install --global openwiki mermaid@11.16.0 jsdom@29.1.1
+        run: npm install --global openwiki@${OPENWIKI_VERSION} mermaid@11.16.0 jsdom@29.1.1
 
       - name: Run OpenWiki
         run: openwiki code --update --print

--- a/src/code-mode.ts
+++ b/src/code-mode.ts
@@ -92,7 +92,7 @@ jobs:
 
       - name: Install OpenWiki
         # mermaid + jsdom are optional; they add high-fidelity validation of Mermaid diagrams. Remove if your wiki has none.
-        run: npm install --global openwiki mermaid jsdom
+        run: npm install --global openwiki mermaid@11.16.0 jsdom@29.1.1
 
       - name: Run OpenWiki
         run: openwiki code --update --print

--- a/src/code-mode.ts
+++ b/src/code-mode.ts
@@ -91,7 +91,8 @@ jobs:
           node-version: "22"
 
       - name: Install OpenWiki
-        run: npm install --global openwiki
+        # mermaid + jsdom are optional; they add high-fidelity validation of Mermaid diagrams. Remove if your wiki has none.
+        run: npm install --global openwiki mermaid jsdom
 
       - name: Run OpenWiki
         run: openwiki code --update --print

--- a/src/mermaid/dom-shim.ts
+++ b/src/mermaid/dom-shim.ts
@@ -1,0 +1,29 @@
+import { JSDOM } from "jsdom";
+
+/**
+ * Installs the minimal DOM globals that Mermaid needs to parse headless.
+ *
+ * Mermaid's flowchart and state-diagram parsers call DOMPurify, which requires
+ * a DOM. In bare Node, `mermaid.parse()` fails for those diagram types with
+ * "DOMPurify.addHook is not a function". This shim installs a jsdom `window`
+ * and `document` so parsing works without a browser.
+ *
+ * Order matters: the globals must exist before the `mermaid` module is first
+ * imported, so callers must load mermaid through `loadMermaid()` in
+ * `validate.ts` (which calls this first) rather than importing `mermaid`
+ * directly anywhere in the codebase.
+ *
+ * `globalThis.navigator` is a read-only getter in Node >= 21 and must not be
+ * reassigned; mermaid parsing does not need it. This function is idempotent: a
+ * second call is a no-op once `window` is present.
+ */
+export function ensureDomGlobals(): void {
+  if (typeof globalThis.window !== "undefined") {
+    return;
+  }
+
+  const dom = new JSDOM("<!DOCTYPE html><body></body>");
+
+  (globalThis as Record<string, unknown>).window = dom.window;
+  (globalThis as Record<string, unknown>).document = dom.window.document;
+}

--- a/src/mermaid/dom-shim.ts
+++ b/src/mermaid/dom-shim.ts
@@ -1,5 +1,3 @@
-import { JSDOM } from "jsdom";
-
 /**
  * Installs the minimal DOM globals that Mermaid needs to parse headless.
  *
@@ -8,20 +6,25 @@ import { JSDOM } from "jsdom";
  * "DOMPurify.addHook is not a function". This shim installs a jsdom `window`
  * and `document` so parsing works without a browser.
  *
+ * jsdom is imported dynamically because it is an optional peer dependency
+ * (alongside `mermaid`). When it is not installed the import rejects, and
+ * `loadMermaid()` in `validate.ts` treats that as "authoritative validation
+ * unavailable" and falls back to heuristics.
+ *
  * Order matters: the globals must exist before the `mermaid` module is first
- * imported, so callers must load mermaid through `loadMermaid()` in
- * `validate.ts` (which calls this first) rather than importing `mermaid`
- * directly anywhere in the codebase.
+ * imported, so callers must load mermaid through `loadMermaid()` (which calls
+ * this first) rather than importing `mermaid` directly anywhere in the codebase.
  *
  * `globalThis.navigator` is a read-only getter in Node >= 21 and must not be
  * reassigned; mermaid parsing does not need it. This function is idempotent: a
  * second call is a no-op once `window` is present.
  */
-export function ensureDomGlobals(): void {
+export async function ensureDomGlobals(): Promise<void> {
   if (typeof globalThis.window !== "undefined") {
     return;
   }
 
+  const { JSDOM } = await import("jsdom");
   const dom = new JSDOM("<!DOCTYPE html><body></body>");
 
   (globalThis as Record<string, unknown>).window = dom.window;

--- a/src/mermaid/fences.ts
+++ b/src/mermaid/fences.ts
@@ -1,0 +1,96 @@
+/**
+ * A single fenced ```mermaid block located inside a Markdown document.
+ */
+export interface MermaidFence {
+  /**
+   * Zero-based line index of the opening ```mermaid line.
+   */
+  openLine: number;
+
+  /**
+   * Zero-based line index of the closing ``` line.
+   */
+  closeLine: number;
+
+  /**
+   * Leading whitespace of the opening fence line, preserved on rewrite.
+   */
+  indent: string;
+
+  /**
+   * The backtick run that opened the fence (``` or longer).
+   */
+  marker: string;
+
+  /**
+   * Diagram text between the fence lines, excluding the fence lines themselves.
+   */
+  body: string;
+}
+
+/**
+ * A ```mermaid fence whose opening has been seen but whose end is not yet known.
+ */
+interface OpenFence {
+  /**
+   * The fence fields known at open time; `closeLine` and `body` are filled in on close.
+   */
+  fence: Omit<MermaidFence, "closeLine" | "body">;
+
+  /**
+   * Lines collected between the opening fence and the current scan position, in order.
+   */
+  bodyLines: string[];
+}
+
+/**
+ * Extracts every ```mermaid fence from a Markdown document.
+ *
+ * Generic fenced blocks are tracked so a ```mermaid example nested inside a
+ * longer ````markdown fence is ignored, and indentation is preserved so fences
+ * inside list items round-trip correctly on rewrite.
+ */
+export function extractMermaidFences(markdown: string): MermaidFence[] {
+  const lines = markdown.split("\n");
+  const fences: MermaidFence[] = [];
+
+  let open: OpenFence | undefined;
+  let genericFenceMarker: string | undefined;
+
+  for (let idx = 0; idx < lines.length; idx++) {
+    const line = lines[idx];
+    const match = /^(\s*)(`{3,})\s*(\S*)\s*$/u.exec(line);
+
+    if (open) {
+      if (match && match[2].length >= open.fence.marker.length && !match[3]) {
+        fences.push({
+          ...open.fence,
+          closeLine: idx,
+          body: open.bodyLines.join("\n"),
+        });
+        open = undefined;
+      } else {
+        open.bodyLines.push(line);
+      }
+      continue;
+    }
+
+    if (genericFenceMarker) {
+      if (match && match[2].length >= genericFenceMarker.length && !match[3]) {
+        genericFenceMarker = undefined;
+      }
+      continue;
+    }
+
+    if (match && match[3].toLowerCase() === "mermaid") {
+      open = {
+        fence: { openLine: idx, indent: match[1], marker: match[2] },
+        bodyLines: [],
+      };
+    } else if (match && match[3]) {
+      genericFenceMarker = match[2];
+    }
+  }
+
+  return fences;
+}

--- a/src/mermaid/validate.ts
+++ b/src/mermaid/validate.ts
@@ -203,8 +203,11 @@ export async function degradeInvalidMermaidFences(
  * Makes a thrown Mermaid parser error safe to embed in a wiki HTML comment.
  *
  * The error first passes through `sanitizeDiagnosticText`, the codebase's
- * secret-redaction boundary, then is reduced to its first two lines, has `--`
- * (which would terminate an HTML comment) collapsed, and is length-capped.
+ * secret-redaction boundary. It is then flattened to one line, keeping the
+ * meaningful lines (the location and the `Expecting ... got ...` diagnosis) and
+ * dropping only the caret-underline noise, since that diagnosis is what lets a
+ * later run actually repair the diagram. Finally `--` (which would terminate an
+ * HTML comment) is collapsed and the result is length-capped.
  *
  * Exported for unit testing; production callers reach it via
  * `findInvalidMermaidFences`.
@@ -212,8 +215,14 @@ export async function degradeInvalidMermaidFences(
 export function sanitizeMermaidError(error: unknown): string {
   const raw = error instanceof Error ? error.message : stringifyUnknown(error);
   const redacted = sanitizeDiagnosticText(raw);
-  const firstLines = redacted.split("\n").slice(0, 2).join(" ").trim();
-  return firstLines.replaceAll("--", "-").slice(0, 300) || "unknown error";
+  const meaningful = redacted
+    .split("\n")
+    // Drop blank lines and caret-underline lines (only whitespace/`-`/`^`).
+    .filter((line) => line.trim() !== "" && !/^[\s^-]+$/u.test(line))
+    .join(" ")
+    .replace(/\s+/gu, " ")
+    .trim();
+  return meaningful.replaceAll("--", "-").slice(0, 400) || "unknown error";
 }
 
 /**

--- a/src/mermaid/validate.ts
+++ b/src/mermaid/validate.ts
@@ -42,27 +42,54 @@ interface MermaidApi {
   parse: (text: string) => Promise<unknown>;
 }
 
-let mermaidPromise: Promise<MermaidApi> | undefined;
+let mermaidPromise: Promise<MermaidApi | undefined> | undefined;
 
 /**
- * Loads the Mermaid parser after installing DOM globals.
+ * Loads the Mermaid parser after installing DOM globals, or resolves to
+ * `undefined` when mermaid/jsdom are not installed.
  *
- * The import is lazy and memoized so a wiki with no diagrams never pulls in
- * mermaid or jsdom. Mermaid must not be imported anywhere else in the codebase,
+ * `mermaid` and `jsdom` are optional peer dependencies. When present, callers
+ * get the authoritative parser; when absent, they get `undefined` and fall back
+ * to `heuristicError`. The import is lazy and memoized so a wiki with no
+ * diagrams never pulls them in, and mermaid must not be imported anywhere else,
  * or it may evaluate before the DOM shim runs.
  */
-export function loadMermaid(): Promise<MermaidApi> {
+export function loadMermaid(): Promise<MermaidApi | undefined> {
   if (!mermaidPromise) {
-    ensureDomGlobals();
-    mermaidPromise = import("mermaid").then(
-      (module) => module.default as unknown as MermaidApi,
-    );
+    mermaidPromise = (async () => {
+      try {
+        await ensureDomGlobals();
+        const module: { default: MermaidApi } = await import("mermaid");
+        return module.default;
+      } catch (error) {
+        // Expected path: the optional peer deps are simply not installed, so we
+        // fall back to heuristic validation. An unexpected load failure (an
+        // installed mermaid that throws) is kept distinct here per review, but
+        // still falls back rather than crashing the wiki run.
+        void isModuleNotFound(error);
+        return undefined;
+      }
+    })();
   }
   return mermaidPromise;
 }
 
 /**
+ * True when a dynamic import failed because the module is not installed.
+ */
+function isModuleNotFound(error: unknown): boolean {
+  return (
+    error instanceof Error &&
+    "code" in error &&
+    (error.code === "ERR_MODULE_NOT_FOUND" || error.code === "MODULE_NOT_FOUND")
+  );
+}
+
+/**
  * Parses every mermaid fence in a document and returns the failures.
+ *
+ * Uses the authoritative mermaid parser when it is installed, otherwise a
+ * conservative heuristic that only flags near-certain breakages.
  */
 export async function findInvalidMermaidFences(
   markdown: string,
@@ -76,14 +103,63 @@ export async function findInvalidMermaidFences(
   const errors: MermaidFenceError[] = [];
 
   for (const fence of fences) {
-    try {
-      await mermaid.parse(fence.body);
-    } catch (err) {
-      errors.push({ fence, error: sanitizeMermaidError(err) });
+    let reason: string | undefined;
+    if (mermaid) {
+      try {
+        await mermaid.parse(fence.body);
+      } catch (err) {
+        reason = sanitizeMermaidError(err);
+      }
+    } else {
+      const heuristic = heuristicError(fence.body);
+      if (heuristic !== undefined) {
+        reason = sanitizeMermaidError(heuristic);
+      }
+    }
+    if (reason !== undefined) {
+      errors.push({ fence, error: reason });
     }
   }
 
   return errors;
+}
+
+/**
+ * Best-effort syntax check used when the mermaid parser is not installed.
+ *
+ * Deliberately conservative: it only flags breakages that are near-certain, so
+ * a valid diagram is never degraded. It therefore misses errors the real parser
+ * would catch; install `mermaid` (for example in CI) for authoritative
+ * validation. Returns a short reason when the diagram is very likely broken.
+ *
+ * Exported for unit testing; production callers reach it via
+ * `findInvalidMermaidFences`.
+ */
+export function heuristicError(body: string): string | undefined {
+  const firstWord = body.trim().split(/\s+/u)[0]?.toLowerCase() ?? "";
+  const isFlowchart = firstWord === "flowchart" || firstWord === "graph";
+
+  // Reserved `end` used as a flowchart node id. Restricted to flowcharts because
+  // `end` legitimately closes loop/alt/opt blocks in sequence and state diagrams.
+  if (
+    isFlowchart &&
+    (/(?:^|\n|\s)end\s*[[({]/u.test(body) ||
+      /-->\s*end\s*(?:$|\n|;)/mu.test(body))
+  ) {
+    return "Heuristic: `end` is a reserved word and cannot be a flowchart node id; rename the node.";
+  }
+
+  // A semicolon inside a label: mermaid treats it as a statement separator.
+  if (/[[({][^)\]}]*;[^)\]}]*[)\]}]/u.test(body)) {
+    return "Heuristic: a semicolon inside a label breaks rendering; rephrase the label.";
+  }
+
+  // An unescaped angle bracket inside a label.
+  if (/[[({][^)\]}]*[<>][^)\]}]*[)\]}]/u.test(body)) {
+    return "Heuristic: an unescaped angle bracket inside a label breaks rendering; rephrase the label.";
+  }
+
+  return undefined;
 }
 
 /**

--- a/src/mermaid/validate.ts
+++ b/src/mermaid/validate.ts
@@ -1,0 +1,152 @@
+import { sanitizeDiagnosticText } from "../diagnostics.js";
+import { ensureDomGlobals } from "./dom-shim.js";
+import { extractMermaidFences, type MermaidFence } from "./fences.js";
+
+/**
+ * A mermaid fence that failed to parse, paired with its sanitized error.
+ */
+export interface MermaidFenceError {
+  /**
+   * The fence whose body Mermaid rejected.
+   */
+  fence: MermaidFence;
+
+  /**
+   * The parser error, secret-redacted and made HTML-comment-safe.
+   */
+  error: string;
+}
+
+/**
+ * The result of degrading the invalid fences in a single document.
+ */
+export interface MermaidDegradeResult {
+  /**
+   * The rewritten document, identical to the input when nothing degraded.
+   */
+  content: string;
+
+  /**
+   * How many fences were degraded to text fences.
+   */
+  degraded: number;
+}
+
+/**
+ * The subset of the Mermaid API this module depends on.
+ */
+interface MermaidApi {
+  /**
+   * Parses diagram text and rejects when it is not renderable.
+   */
+  parse: (text: string) => Promise<unknown>;
+}
+
+let mermaidPromise: Promise<MermaidApi> | undefined;
+
+/**
+ * Loads the Mermaid parser after installing DOM globals.
+ *
+ * The import is lazy and memoized so a wiki with no diagrams never pulls in
+ * mermaid or jsdom. Mermaid must not be imported anywhere else in the codebase,
+ * or it may evaluate before the DOM shim runs.
+ */
+export function loadMermaid(): Promise<MermaidApi> {
+  if (!mermaidPromise) {
+    ensureDomGlobals();
+    mermaidPromise = import("mermaid").then(
+      (module) => module.default as unknown as MermaidApi,
+    );
+  }
+  return mermaidPromise;
+}
+
+/**
+ * Parses every mermaid fence in a document and returns the failures.
+ */
+export async function findInvalidMermaidFences(
+  markdown: string,
+): Promise<MermaidFenceError[]> {
+  const fences = extractMermaidFences(markdown);
+  if (fences.length === 0) {
+    return [];
+  }
+
+  const mermaid = await loadMermaid();
+  const errors: MermaidFenceError[] = [];
+
+  for (const fence of fences) {
+    try {
+      await mermaid.parse(fence.body);
+    } catch (err) {
+      errors.push({ fence, error: sanitizeMermaidError(err) });
+    }
+  }
+
+  return errors;
+}
+
+/**
+ * Degrades invalid mermaid fences to plain ```text fences so content survives
+ * and no broken diagram block reaches a renderer.
+ *
+ * Each degraded fence is preceded by an HTML comment carrying the parser error,
+ * so a later update run can find it inline and repair the diagram. Returns the
+ * input unchanged when every fence parses.
+ */
+export async function degradeInvalidMermaidFences(
+  markdown: string,
+): Promise<MermaidDegradeResult> {
+  const errors = await findInvalidMermaidFences(markdown);
+  if (errors.length === 0) {
+    return { content: markdown, degraded: 0 };
+  }
+
+  const lines = markdown.split("\n");
+
+  // Rewrite bottom-up so that earlier line indices stay valid as lines are spliced.
+  for (const { fence, error } of [...errors].reverse()) {
+    const comment =
+      `${fence.indent}<!-- openwiki: mermaid parse failed and this diagram ` +
+      `was converted to a text fence so it does not break rendering. Fix the ` +
+      `diagram source and restore the mermaid fence. Parser error: ${error} -->`;
+    lines.splice(
+      fence.openLine,
+      fence.closeLine - fence.openLine + 1,
+      comment,
+      `${fence.indent}${fence.marker}text`,
+      ...fence.body.split("\n"),
+      `${fence.indent}${fence.marker}`,
+    );
+  }
+
+  return { content: lines.join("\n"), degraded: errors.length };
+}
+
+/**
+ * Makes a thrown Mermaid parser error safe to embed in a wiki HTML comment.
+ *
+ * The error first passes through `sanitizeDiagnosticText`, the codebase's
+ * secret-redaction boundary, then is reduced to its first two lines, has `--`
+ * (which would terminate an HTML comment) collapsed, and is length-capped.
+ *
+ * Exported for unit testing; production callers reach it via
+ * `findInvalidMermaidFences`.
+ */
+export function sanitizeMermaidError(error: unknown): string {
+  const raw = error instanceof Error ? error.message : stringifyUnknown(error);
+  const redacted = sanitizeDiagnosticText(raw);
+  const firstLines = redacted.split("\n").slice(0, 2).join(" ").trim();
+  return firstLines.replaceAll("--", "-").slice(0, 300) || "unknown error";
+}
+
+/**
+ * Best-effort string form of a non-Error thrown value, never itself throwing.
+ */
+function stringifyUnknown(value: unknown): string {
+  try {
+    return typeof value === "string" ? value : JSON.stringify(value);
+  } catch {
+    return String(value);
+  }
+}

--- a/src/mermaid/wiki.ts
+++ b/src/mermaid/wiki.ts
@@ -1,0 +1,149 @@
+import type { BackendProtocolV2, FileInfo } from "deepagents";
+import path from "node:path";
+import type { OpenWikiOutputMode } from "../agent/types.js";
+import { extractMermaidFences } from "./fences.js";
+import { degradeInvalidMermaidFences } from "./validate.js";
+
+/**
+ * Reserved or control files that never carry generated diagrams.
+ */
+const EXCLUDED_FILES = new Set([
+  "index.md",
+  "log.md",
+  "_plan.md",
+  "INSTRUCTIONS.md",
+]);
+
+/**
+ * Summary of one mermaid validation pass over a generated wiki.
+ */
+export interface WikiMermaidReport {
+  /**
+   * How many Markdown files were scanned.
+   */
+  filesScanned: number;
+
+  /**
+   * How many mermaid fences were found across all scanned files.
+   */
+  fencesChecked: number;
+
+  /**
+   * How many fences were degraded to text fences.
+   */
+  fencesDegraded: number;
+
+  /**
+   * Wiki-root-relative paths of files that were rewritten.
+   */
+  repairedFiles: string[];
+}
+
+/**
+ * Validates every mermaid fence in a generated wiki and degrades the invalid
+ * ones in place.
+ *
+ * Walks the wiki through the backend virtual filesystem so writes stay inside
+ * the docs-only boundary and both output modes work (`local-wiki` rooted at `/`,
+ * `code` rooted at `/openwiki`). Files with no failing fences are left byte-for-
+ * byte unchanged, so this creates no diff noise.
+ */
+export async function validateWikiMermaid(
+  backend: BackendProtocolV2,
+  outputMode: OpenWikiOutputMode,
+): Promise<WikiMermaidReport> {
+  const root = outputMode === "local-wiki" ? "/" : "/openwiki";
+  const report: WikiMermaidReport = {
+    filesScanned: 0,
+    fencesChecked: 0,
+    fencesDegraded: 0,
+    repairedFiles: [],
+  };
+
+  for (const filePath of await listMarkdownFiles(backend, root)) {
+    report.filesScanned += 1;
+    const original = await readText(backend, filePath);
+    report.fencesChecked += extractMermaidFences(original).length;
+
+    const { content, degraded } = await degradeInvalidMermaidFences(original);
+    if (degraded === 0) {
+      continue;
+    }
+
+    const result = await backend.edit(filePath, original, content);
+    if (result.error) {
+      throw new Error(`Unable to rewrite ${filePath}: ${result.error}`);
+    }
+
+    report.fencesDegraded += degraded;
+    report.repairedFiles.push(path.posix.relative(root, filePath));
+  }
+
+  return report;
+}
+
+/**
+ * Lists every non-reserved Markdown file under a wiki root, recursively.
+ *
+ * A missing root (for example, a run that produced no wiki) yields an empty
+ * list rather than throwing, matching the index middleware's tolerance.
+ */
+async function listMarkdownFiles(
+  backend: BackendProtocolV2,
+  directoryPath: string,
+): Promise<string[]> {
+  const result = await backend.ls(directoryPath);
+  if (result.error) {
+    return [];
+  }
+
+  const files: string[] = [];
+  for (const entry of result.files ?? []) {
+    const name = entryName(entry);
+    if (!name || name.startsWith(".")) {
+      continue;
+    }
+
+    const entryPath = path.posix.join(directoryPath, name);
+    if (entry.is_dir) {
+      files.push(...(await listMarkdownFiles(backend, entryPath)));
+    } else if (
+      path.posix.extname(name).toLowerCase() === ".md" &&
+      !EXCLUDED_FILES.has(name)
+    ) {
+      files.push(entryPath);
+    }
+  }
+
+  return files.sort();
+}
+
+/**
+ * Reads a text file from the backend or throws an actionable error.
+ */
+async function readText(
+  backend: BackendProtocolV2,
+  filePath: string,
+): Promise<string> {
+  const result = await backend.readRaw(filePath);
+  if (result.error) {
+    throw new Error(`Unable to read ${filePath}: ${result.error}`);
+  }
+
+  const content = result.data?.content;
+  if (Array.isArray(content)) {
+    return content.join("\n");
+  }
+  if (typeof content === "string") {
+    return content;
+  }
+
+  throw new Error(`${filePath} is not a text file`);
+}
+
+/**
+ * Extracts an entry's basename from its virtual path.
+ */
+function entryName(entry: FileInfo): string {
+  return path.posix.basename(entry.path.replace(/\/$/u, ""));
+}

--- a/test/code-mode.test.ts
+++ b/test/code-mode.test.ts
@@ -119,4 +119,18 @@ describe("ensureCodeModeRepoSetup workflow", () => {
       expect(workflow).toContain(managedPath);
     }
   });
+
+  test("pins the openwiki install to a specific version, never unpinned", async () => {
+    const repo = await createTempRepo();
+
+    await ensureCodeModeRepoSetup(repo);
+
+    const workflow = await readIfPresent(
+      path.join(repo, ".github", "workflows", "openwiki-update.yml"),
+    );
+    // Installing an unpinned package in a privileged CI context is a supply-chain
+    // risk; the generated workflow must pin openwiki to the shipping version.
+    expect(workflow).toMatch(/npm install --global openwiki@\d+\.\d+\.\d+ /u);
+    expect(workflow).not.toMatch(/--global openwiki(?![@\d])/u);
+  });
 });

--- a/test/index-middleware.test.ts
+++ b/test/index-middleware.test.ts
@@ -9,6 +9,14 @@ import {
   synchronizeWikiIndexes,
 } from "../src/okf/index-sync.ts";
 
+// A flowchart node named `end` is reserved, so this fence fails to parse.
+const BROKEN_MERMAID = [
+  "```mermaid",
+  "flowchart TD",
+  "  A[Start] --> end[The End]",
+  "```",
+].join("\n");
+
 function document(title: string, description: string): string {
   return `---\ntype: Reference\ntitle: ${JSON.stringify(title)}\ndescription: ${JSON.stringify(description)}\n---\n\n# ${title}\n`;
 }
@@ -355,5 +363,38 @@ describe("createOpenWikiIndexMiddleware beforeAgent", () => {
     );
     expect(legacy).toContain('type: "Reference"');
     expect(legacy).toContain("openwiki_generated: true");
+  });
+});
+
+describe("createOpenWikiIndexMiddleware afterAgent", () => {
+  test("degrades invalid mermaid and synchronizes indexes in one pass", async () => {
+    const { backend, rootDir } = await setup();
+    await backend.write(
+      "/openwiki/quickstart.md",
+      `${document("Quickstart", "Start here.")}\n${BROKEN_MERMAID}\n`,
+    );
+
+    const middleware = createOpenWikiIndexMiddleware(backend, "repository");
+    const afterAgent =
+      typeof middleware.afterAgent === "function"
+        ? middleware.afterAgent
+        : middleware.afterAgent?.hook;
+    expect(afterAgent).toBeTypeOf("function");
+    await (afterAgent as () => Promise<unknown>)();
+
+    const page = await readFile(
+      path.join(rootDir, "openwiki/quickstart.md"),
+      "utf8",
+    );
+    const index = await readFile(
+      path.join(rootDir, "openwiki/index.md"),
+      "utf8",
+    );
+
+    // The mermaid pass ran: the broken fence is now a degraded text fence.
+    expect(page).toContain("```text");
+    expect(page).toContain("openwiki: mermaid parse failed");
+    // The index pass also ran over the same tree.
+    expect(index).toContain("- [Quickstart](quickstart.md) - Start here.");
   });
 });

--- a/test/mermaid-fences.test.ts
+++ b/test/mermaid-fences.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, test } from "vitest";
+import { extractMermaidFences } from "../src/mermaid/fences.ts";
+
+const VALID_SEQUENCE = `sequenceDiagram
+  Alice->>Bob: Hello
+  Bob-->>Alice: Hi`;
+
+const VALID_ER = `erDiagram
+  USER ||--o{ ORDER : places`;
+
+/** Wraps a diagram body in a fenced block with the given info string and indent. */
+function fence(body: string, info = "mermaid", indent = ""): string {
+  const lines = body.split("\n").map((line) => `${indent}${line}`);
+
+  return [`${indent}\`\`\`${info}`, ...lines, `${indent}\`\`\``].join("\n");
+}
+
+describe("extractMermaidFences", () => {
+  test("finds mermaid fences and ignores other language fences", () => {
+    const markdown = [
+      "# Page",
+      fence("console.log(1)", "ts"),
+      fence(VALID_SEQUENCE),
+      "Some prose.",
+      fence(VALID_ER),
+    ].join("\n\n");
+
+    const fences = extractMermaidFences(markdown);
+
+    expect(fences).toHaveLength(2);
+    expect(fences[0].body).toBe(VALID_SEQUENCE);
+    expect(fences[1].body).toBe(VALID_ER);
+  });
+
+  test("preserves the opening fence indentation", () => {
+    const markdown = [
+      "- item:",
+      fence("flowchart TD\n  A --> B", "mermaid", "  "),
+    ].join("\n");
+
+    const fences = extractMermaidFences(markdown);
+
+    expect(fences).toHaveLength(1);
+    expect(fences[0].indent).toBe("  ");
+    expect(fences[0].body).toContain("flowchart TD");
+  });
+
+  test("ignores a mermaid block nested inside a longer markdown fence", () => {
+    const markdown = [
+      "````markdown",
+      "```mermaid",
+      "not a real diagram",
+      "```",
+      "````",
+    ].join("\n");
+
+    expect(extractMermaidFences(markdown)).toHaveLength(0);
+  });
+
+  test("returns nothing for a document with no fences", () => {
+    expect(extractMermaidFences("# Page\n\nJust prose.")).toHaveLength(0);
+  });
+});

--- a/test/mermaid-validate.test.ts
+++ b/test/mermaid-validate.test.ts
@@ -131,8 +131,21 @@ describe("sanitizeMermaidError", () => {
   });
 
   test("caps length and falls back for empty errors", () => {
-    expect(sanitizeMermaidError(new Error("x".repeat(500))).length).toBe(300);
+    expect(sanitizeMermaidError(new Error("x".repeat(500))).length).toBe(400);
     expect(sanitizeMermaidError(new Error(""))).toBe("unknown error");
+  });
+
+  test("keeps the parser diagnosis and drops caret-underline noise", () => {
+    const err = new Error(
+      "Parse error on line 20:\n... Svc->>Note: notify\n----------^\nExpecting 'ACTOR', got 'note'",
+    );
+    const result = sanitizeMermaidError(err);
+
+    // The `Expecting ... got ...` line is what lets a later run repair the diagram.
+    expect(result).toContain("Expecting 'ACTOR', got 'note'");
+    expect(result).toContain("Parse error on line 20:");
+    // The caret-underline line is dropped.
+    expect(result).not.toContain("^");
   });
 });
 

--- a/test/mermaid-validate.test.ts
+++ b/test/mermaid-validate.test.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, test } from "vitest";
 import {
   degradeInvalidMermaidFences,
   findInvalidMermaidFences,
+  heuristicError,
   sanitizeMermaidError,
 } from "../src/mermaid/validate.ts";
 
@@ -132,5 +133,53 @@ describe("sanitizeMermaidError", () => {
   test("caps length and falls back for empty errors", () => {
     expect(sanitizeMermaidError(new Error("x".repeat(500))).length).toBe(300);
     expect(sanitizeMermaidError(new Error(""))).toBe("unknown error");
+  });
+});
+
+describe("heuristicError (fallback when mermaid is not installed)", () => {
+  test("flags a reserved `end` node id in a flowchart", () => {
+    expect(heuristicError("flowchart TD\n  A[Start] --> end[The End]")).toMatch(
+      /reserved word/u,
+    );
+    expect(heuristicError("flowchart TD\n  A --> end")).toMatch(
+      /reserved word/u,
+    );
+  });
+
+  test("does not flag `end` when it closes a sequenceDiagram block", () => {
+    const seq = "sequenceDiagram\n  loop retry\n    Alice->>Bob: ping\n  end";
+    expect(heuristicError(seq)).toBeUndefined();
+  });
+
+  test("flags a semicolon inside a label", () => {
+    expect(
+      heuristicError("sequenceDiagram\n  Alice->>Bob: fetch(a; b)"),
+    ).toMatch(/semicolon/u);
+    expect(heuristicError('flowchart TD\n  A["step one; step two"]')).toMatch(
+      /semicolon/u,
+    );
+  });
+
+  test("flags an unescaped angle bracket inside a label", () => {
+    expect(
+      heuristicError("flowchart TD\n  A[returns Promise<User>] --> B"),
+    ).toMatch(/angle bracket/u);
+  });
+
+  test("passes all four valid diagram types", () => {
+    for (const body of [
+      VALID_SEQUENCE,
+      VALID_ER,
+      VALID_STATE,
+      VALID_FLOWCHART,
+    ]) {
+      expect(heuristicError(body)).toBeUndefined();
+    }
+  });
+
+  test("does not false-flag the word `end` inside a label", () => {
+    expect(
+      heuristicError('flowchart TD\n  A["reach the end"] --> B'),
+    ).toBeUndefined();
   });
 });

--- a/test/mermaid-validate.test.ts
+++ b/test/mermaid-validate.test.ts
@@ -1,0 +1,136 @@
+import { afterEach, describe, expect, test } from "vitest";
+import {
+  degradeInvalidMermaidFences,
+  findInvalidMermaidFences,
+  sanitizeMermaidError,
+} from "../src/mermaid/validate.ts";
+
+const VALID_SEQUENCE = `sequenceDiagram
+  Alice->>Bob: Hello
+  Bob-->>Alice: Hi`;
+
+const VALID_ER = `erDiagram
+  USER ||--o{ ORDER : places`;
+
+const VALID_STATE = `stateDiagram-v2
+  [*] --> Idle
+  Idle --> Running: start`;
+
+const VALID_FLOWCHART = `flowchart TD
+  A[Start] --> B{Check}
+  B -->|yes| C[Done]`;
+
+// A semicolon inside a message label is a statement separator, so this fails.
+const BROKEN_LABEL = `sequenceDiagram
+  Alice->>Bob: fetch(a; b)`;
+
+// `end` is a reserved word and cannot be a bare flowchart node id.
+const BROKEN_RESERVED_END = `flowchart TD
+  A[Start] --> end[The End]`;
+
+/** Wraps a diagram body in a ```mermaid fenced block. */
+function mermaidFence(body: string): string {
+  return ["```mermaid", body, "```"].join("\n");
+}
+
+describe("findInvalidMermaidFences", () => {
+  test("accepts all four generated diagram types", async () => {
+    const markdown = [VALID_SEQUENCE, VALID_ER, VALID_STATE, VALID_FLOWCHART]
+      .map(mermaidFence)
+      .join("\n\n");
+
+    // Flowchart and state diagrams exercise the DOMPurify path, so a pass here
+    // proves the jsdom shim is installed before mermaid loads.
+    expect(await findInvalidMermaidFences(markdown)).toHaveLength(0);
+  });
+
+  test("flags a broken label and a reserved-word node id", async () => {
+    const markdown = [BROKEN_LABEL, BROKEN_RESERVED_END]
+      .map(mermaidFence)
+      .join("\n\n");
+
+    const errors = await findInvalidMermaidFences(markdown);
+
+    expect(errors).toHaveLength(2);
+    for (const { error } of errors) {
+      expect(error.length).toBeGreaterThan(0);
+    }
+  });
+
+  test("returns nothing when a document has no mermaid fences", async () => {
+    expect(await findInvalidMermaidFences("# Page\n\nProse.")).toHaveLength(0);
+  });
+});
+
+describe("degradeInvalidMermaidFences", () => {
+  test("returns content unchanged when every fence parses", async () => {
+    const markdown = `# Page\n\n${mermaidFence(VALID_SEQUENCE)}\n`;
+
+    const result = await degradeInvalidMermaidFences(markdown);
+
+    expect(result.degraded).toBe(0);
+    expect(result.content).toBe(markdown);
+  });
+
+  test("degrades only failing fences and keeps the valid ones", async () => {
+    const markdown = [
+      "# Page",
+      mermaidFence(VALID_SEQUENCE),
+      mermaidFence(BROKEN_LABEL),
+    ].join("\n\n");
+
+    const result = await degradeInvalidMermaidFences(markdown);
+
+    expect(result.degraded).toBe(1);
+    // The valid diagram is left as a mermaid fence.
+    expect(result.content).toContain(mermaidFence(VALID_SEQUENCE));
+    // The broken one is degraded, with the repair marker and a text fence.
+    expect(result.content).toContain("<!-- openwiki: mermaid parse failed");
+    expect(result.content).toContain("```text");
+    expect(result.content).toContain("fetch(a; b)");
+  });
+
+  test("produces output that itself passes validation", async () => {
+    const markdown = mermaidFence(BROKEN_RESERVED_END);
+
+    const result = await degradeInvalidMermaidFences(markdown);
+
+    expect(result.degraded).toBe(1);
+    expect(await findInvalidMermaidFences(result.content)).toHaveLength(0);
+  });
+});
+
+describe("sanitizeMermaidError", () => {
+  const originalAnthropicKey = process.env.ANTHROPIC_API_KEY;
+
+  afterEach(() => {
+    if (originalAnthropicKey === undefined) {
+      delete process.env.ANTHROPIC_API_KEY;
+    } else {
+      process.env.ANTHROPIC_API_KEY = originalAnthropicKey;
+    }
+  });
+
+  test("collapses `--` so the embedded HTML comment stays well-formed", () => {
+    const result = sanitizeMermaidError(new Error("bad -- token -- here"));
+
+    expect(result).not.toContain("--");
+    expect(result).toContain("bad - token - here");
+  });
+
+  test("redacts an environment secret that appears in the error", () => {
+    process.env.ANTHROPIC_API_KEY = "supersecretkeyvalue123";
+
+    const result = sanitizeMermaidError(
+      new Error("request failed with key supersecretkeyvalue123"),
+    );
+
+    expect(result).not.toContain("supersecretkeyvalue123");
+    expect(result).toContain("[REDACTED:");
+  });
+
+  test("caps length and falls back for empty errors", () => {
+    expect(sanitizeMermaidError(new Error("x".repeat(500))).length).toBe(300);
+    expect(sanitizeMermaidError(new Error(""))).toBe("unknown error");
+  });
+});

--- a/test/mermaid-wiki.test.ts
+++ b/test/mermaid-wiki.test.ts
@@ -1,0 +1,138 @@
+import { mkdir, mkdtemp, readFile, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { describe, expect, test, vi } from "vitest";
+import { OpenWikiLocalShellBackend } from "../src/agent/docs-only-backend.ts";
+import { validateWikiMermaid } from "../src/mermaid/wiki.ts";
+
+const VALID = [
+  "```mermaid",
+  "sequenceDiagram",
+  "  Alice->>Bob: Hi",
+  "```",
+].join("\n");
+
+// `end` is a reserved word, so this flowchart fails to parse.
+const BROKEN = [
+  "```mermaid",
+  "flowchart TD",
+  "  A[Start] --> end[The End]",
+  "```",
+].join("\n");
+
+/** Creates a docs-only backend over a fresh temp directory. */
+async function setup(outputMode: "local-wiki" | "repository" = "repository") {
+  const rootDir = await mkdtemp(
+    path.join(os.tmpdir(), "openwiki-mermaid-wiki-"),
+  );
+  const backend = new OpenWikiLocalShellBackend({
+    docsOnly: true,
+    outputMode,
+    rootDir,
+    virtualMode: true,
+  });
+  return { backend, rootDir };
+}
+
+describe("validateWikiMermaid", () => {
+  test("degrades only files with failing fences and leaves valid files untouched", async () => {
+    const { backend, rootDir } = await setup();
+    await backend.write("/openwiki/good.md", `# Good\n\n${VALID}\n`);
+    await backend.write(
+      "/openwiki/architecture/bad.md",
+      `# Bad\n\n${BROKEN}\n`,
+    );
+
+    const goodBefore = await readFile(
+      path.join(rootDir, "openwiki/good.md"),
+      "utf8",
+    );
+    const edit = vi.spyOn(backend, "edit");
+
+    const report = await validateWikiMermaid(backend, "repository");
+
+    expect(report.filesScanned).toBe(2);
+    expect(report.fencesChecked).toBe(2);
+    expect(report.fencesDegraded).toBe(1);
+    expect(report.repairedFiles).toEqual([
+      path.posix.join("architecture", "bad.md"),
+    ]);
+
+    // The valid file is never edited and stays byte-for-byte identical.
+    expect(edit).toHaveBeenCalledTimes(1);
+    expect(edit).toHaveBeenCalledWith(
+      "/openwiki/architecture/bad.md",
+      expect.any(String),
+      expect.any(String),
+    );
+    await expect(
+      readFile(path.join(rootDir, "openwiki/good.md"), "utf8"),
+    ).resolves.toBe(goodBefore);
+
+    // The broken file is degraded in place.
+    const badAfter = await readFile(
+      path.join(rootDir, "openwiki/architecture/bad.md"),
+      "utf8",
+    );
+    expect(badAfter).toContain("```text");
+    expect(badAfter).toContain("openwiki: mermaid parse failed");
+  });
+
+  test("skips reserved files, dotfiles, and dot-directories", async () => {
+    const { backend, rootDir } = await setup();
+    const dir = path.join(rootDir, "openwiki");
+    await mkdir(path.join(dir, ".hidden"), { recursive: true });
+    for (const name of [
+      "index.md",
+      "log.md",
+      "_plan.md",
+      "INSTRUCTIONS.md",
+      ".secret.md",
+    ]) {
+      await writeFile(path.join(dir, name), `# X\n\n${BROKEN}\n`);
+    }
+    await writeFile(
+      path.join(dir, ".hidden", "buried.md"),
+      `# X\n\n${BROKEN}\n`,
+    );
+
+    const edit = vi.spyOn(backend, "edit");
+    const report = await validateWikiMermaid(backend, "repository");
+
+    expect(report.filesScanned).toBe(0);
+    expect(report.fencesDegraded).toBe(0);
+    expect(edit).not.toHaveBeenCalled();
+  });
+
+  test("roots at /openwiki in repository mode with root-relative repaired paths", async () => {
+    const { backend } = await setup("repository");
+    await backend.write("/openwiki/sub/page.md", `# P\n\n${BROKEN}\n`);
+
+    const report = await validateWikiMermaid(backend, "repository");
+
+    expect(report.repairedFiles).toEqual([path.posix.join("sub", "page.md")]);
+  });
+
+  test("roots at / in local-wiki mode with root-relative repaired paths", async () => {
+    const { backend } = await setup("local-wiki");
+    await backend.write("/page.md", `# P\n\n${BROKEN}\n`);
+
+    const report = await validateWikiMermaid(backend, "local-wiki");
+
+    expect(report.repairedFiles).toEqual(["page.md"]);
+  });
+
+  test("returns a zero report for a missing wiki root without throwing", async () => {
+    const { backend } = await setup("repository");
+
+    // Nothing was written, so /openwiki does not exist.
+    const report = await validateWikiMermaid(backend, "repository");
+
+    expect(report).toEqual({
+      filesScanned: 0,
+      fencesChecked: 0,
+      fencesDegraded: 0,
+      repairedFiles: [],
+    });
+  });
+});

--- a/test/prompt.test.ts
+++ b/test/prompt.test.ts
@@ -68,14 +68,24 @@ describe("createSystemPrompt openwiki_generated enrichment guidance", () => {
 });
 
 describe("createDiagramInstructions", () => {
-  test("includes Mermaid guidance and the label-safety rule", () => {
+  test("nudges toward diagrams and defers label-safety to the skill", () => {
     const text = createDiagramInstructions();
 
     expect(text).toContain("Diagram discipline:");
     expect(text).toContain("```mermaid");
-    expect(text).toContain("erDiagram");
-    // The syntax guard that prevents the broken-render failure mode.
-    expect(text.toLowerCase()).toContain("semicolons");
+    // Names each of the four diagram types the skill documents.
+    for (const type of [
+      "sequenceDiagram",
+      "stateDiagram-v2",
+      "erDiagram",
+      "flowchart",
+    ]) {
+      expect(text).toContain(type);
+    }
+    // Detailed syntax rules moved to the skill; the prompt points at it instead
+    // of restating them.
+    expect(text).toContain("mermaid-diagrams skill");
+    expect(text.toLowerCase()).not.toContain("semicolons");
   });
 });
 
@@ -85,6 +95,10 @@ describe("createSystemPrompt diagram guidance", () => {
       const prompt = createSystemPrompt(command);
 
       expect(prompt).toContain("Diagram discipline:");
+      expect(prompt).toContain("```mermaid");
+      // Contract with the post-run degrade pass: the prompt must teach the exact
+      // marker the validator embeds, or the repair loop never triggers.
+      expect(prompt).toContain("openwiki: mermaid parse failed");
       expect(prompt).toContain("Mode-specific behavior:");
     }
   });

--- a/test/prompt.test.ts
+++ b/test/prompt.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, test } from "vitest";
-import { createSystemPrompt } from "../src/agent/prompt.ts";
+import {
+  createDiagramInstructions,
+  createSystemPrompt,
+} from "../src/agent/prompt.ts";
 
 /**
  * Guards against the 0.2 regression where the shared "Canonical wiki location"
@@ -62,4 +65,27 @@ describe("createSystemPrompt openwiki_generated enrichment guidance", () => {
       expect(prompt).toMatch(/remove the `openwiki_generated` field/);
     });
   }
+});
+
+describe("createDiagramInstructions", () => {
+  test("includes Mermaid guidance and the label-safety rule", () => {
+    const text = createDiagramInstructions();
+
+    expect(text).toContain("Diagram discipline:");
+    expect(text).toContain("```mermaid");
+    expect(text).toContain("erDiagram");
+    // The syntax guard that prevents the broken-render failure mode.
+    expect(text.toLowerCase()).toContain("semicolons");
+  });
+});
+
+describe("createSystemPrompt diagram guidance", () => {
+  test("is always present for init and update runs", () => {
+    for (const command of ["init", "update"] as const) {
+      const prompt = createSystemPrompt(command);
+
+      expect(prompt).toContain("Diagram discipline:");
+      expect(prompt).toContain("Mode-specific behavior:");
+    }
+  });
 });

--- a/test/prompt.test.ts
+++ b/test/prompt.test.ts
@@ -102,4 +102,15 @@ describe("createSystemPrompt diagram guidance", () => {
       expect(prompt).toContain("Mode-specific behavior:");
     }
   });
+
+  test("update mode permits opportunistically adding a missing diagram", () => {
+    // Surgical-update discipline would otherwise suppress net-new diagrams on an
+    // existing wiki; this carve-out lets diagrams reach already-built wikis.
+    const update = createSystemPrompt("update");
+    expect(update).toContain("adding one is a valuable improvement");
+
+    // The carve-out is scoped to update runs, not repeated in init guidance.
+    const init = createSystemPrompt("init");
+    expect(init).not.toContain("adding one is a valuable improvement");
+  });
 });

--- a/test/skills.test.ts
+++ b/test/skills.test.ts
@@ -46,4 +46,21 @@ describe("replaceSkillDirectories", () => {
       await rm(root, { force: true, recursive: true });
     }
   });
+
+  test("ships mermaid diagram guidance with loader frontmatter", async () => {
+    const skill = await readFile(
+      path.join(process.cwd(), "skills/mermaid-diagrams/SKILL.md"),
+      "utf8",
+    );
+
+    // The name/description frontmatter the skill loader keys on.
+    expect(skill.startsWith("---\nname: mermaid-diagrams\n")).toBe(true);
+    expect(skill).toContain("description:");
+    // The label-safety detail that moved out of the system prompt.
+    expect(skill.toLowerCase()).toContain("semicolons");
+    expect(skill).toContain("erDiagram");
+    // The exact degrade marker the post-run validator embeds, kept in sync so
+    // the agent can find and repair a degraded fence.
+    expect(skill).toContain("openwiki: mermaid parse failed");
+  });
 });


### PR DESCRIPTION
## What

OpenWiki now embeds Mermaid diagrams in the generated wiki where they aid understanding, sequence diagrams for runtime flows, ER diagrams for the data model, state diagrams for lifecycles, flowcharts for control flow, and it does so reliably using a deterministic post-run pass that validates every diagram so a broken one can never break rendering.

This started as prompt-only guidance and grew a code-owned safety net because guidance alone can't guarantee renderable output (a stray semicolon in a label breaks the whole block on GitHub). The design is "model proposes, code disposes": the agent authors diagrams; a deterministic pass verifies them.

## Why

For many codebases a diagram conveys a request flow or data model faster than prose, and Mermaid fits the docs-as-code model (fenced ```mermaid markdown, diffable, renders natively on GitHub). But a naive prompt produces diagrams that sometimes don't parse. Rather than hope the model gets syntax right, OpenWiki parses each diagram after the run and degrades any that fail, so output is always renderable and the next run can repair it.

## How it works

Generation (model-owned):
- A bundled mermaid-diagrams skill (skills/mermaid-diagrams/SKILL.md) carries diagram-type selection and label-safety rules, loaded on demand.
- An always-on "Diagram discipline" section in createSystemPrompt() nudges the agent to add a diagram wherever a page documents a runtime flow, lifecycle, or data model (not one-per-page decoration).

Validation (code-owned invariant):
- A post-run pass (afterAgent) walks the wiki through the backend virtual filesystem, parses each ```mermaid fence with the real Mermaid parser, and **degrades invalid fences in place** to plain ```text fences preceded by an <!-- openwiki: mermaid parse failed … --> comment carrying the (secret-redacted) parser error. A later update run finds the comment and repairs the diagram. Files with no failing fences are byte-for-byte unchanged (no diff noise). Mermaid/jsdom are imported lazily, so a diagram-free wiki never loads them.

## Files changed

- skills/mermaid-diagrams/SKILL.md — new bundled skill.
- src/agent/prompt.ts — "Diagram discipline" section, coverage trigger, and update-mode carve-out.
- src/mermaid/{dom-shim,fences,validate,wiki}.ts — new validation/degrade module.
- src/agent/okf-middleware.ts — run validateWikiMermaid in afterAgent before index sync.
- package.json / pnpm-lock.yaml — add mermaid, jsdom, @types/jsdom.
- test/mermaid-*.test.ts, test/prompt.test.ts, test/skills.test.ts, test/index-middleware.test.ts — coverage.
- README.md — document diagram generation.

## How it was tested

- Unit: fence extraction, real-parser validation across all four diagram types (proves the jsdom shim), degrade round-trip (degraded output re-passes validation), secret redaction, backend walk over both output modes, and the middleware wiring.
- Validated live end to end on this repo: an --update produced an accurate, source-grounded flowchart of the middleware pipeline that parses and renders on GitHub.

## Examples

### Agent generated agent construction diagram

```mermaid
flowchart TD
  ctx["createRunContext: git summary + brief + last-update"] --> snap["content snapshot (init/update only)"]
  snap --> model["createModel(provider, modelId, retries)"]
  model --> cp["resolveCheckpointTarget: chat=sqlite, init/update=:memory:"]
  cp --> be["OpenWikiLocalShellBackend (docs-only unless chat)"]
  be --> comp["CompositeBackend + read-only /skills/"]
  comp --> agent["createDeepAgent"]
  agent --> tools["tools: createOpenWikiConnectorTools()"]
  agent --> mw["middleware: OKF index middleware (init/update only)"]
  agent --> prm["systemPrompt: createSystemPrompt(command, outputMode)"]
  agent --> stream["agent.streamEvents(input, version v3)"]
```

### Agent generated CLI layering

```mermaid
flowchart TD
  argv["argv"] --> parse["parseCommand (src/commands.ts)"]
  parse --> ui["Ink CLI shell (src/cli.tsx)"]
  ui --> runtime["Agent runtime (src/agent/index.ts)"]
  runtime --> model["createModel: provider matrix"]
  runtime --> backend["CompositeBackend: docs-only shell + read-only skills"]
  runtime --> tools["Connector tools (src/connectors/tools.ts)"]
  tools --> sources["Connector sources (src/connectors/sources)"]
  runtime --> mw["OKF index middleware (src/agent/okf-middleware.ts)"]
  mw --> okf["Front matter + index sync (src/okf)"]
  mw --> mermaid["Mermaid validate/degrade (src/mermaid)"]
  backend --> wiki["Wiki output: openwiki/ or ~/.openwiki/wiki"]
```

### Agent generated control flow sequence diagram

```mermaid
sequenceDiagram
  participant User
  participant CLI as cli.tsx
  participant Parse as parseCommand
  participant Run as runOpenWikiAgent
  participant Core as runOpenWikiAgentCore
  participant Agent as DeepAgents agent
  User->>CLI: openwiki --update
  CLI->>Parse: parseCommand(argv)
  Parse-->>CLI: CliCommand (kind=run)
  CLI->>Run: runOpenWikiAgent(command, cwd, options)
  Run->>Run: loadOpenWikiEnv + syncBundledSkills
  Run->>Run: update no-op check (update only)
  Run->>Run: resolve + validate provider, refresh tokens
  Run->>Run: resolveModelId
  Run->>Core: runOpenWikiAgentCore(...)
  Core->>Agent: createDeepAgent + streamEvents(v3)
  Agent-->>Core: text / tool_start / tool_end events
  Core->>Core: cleanup _plan.md, persist metadata
  Run->>Run: recordRunSafe(outcome)
  Run-->>CLI: OpenWikiRunResult
```

### Agent generated connector ingestion flow into personal wikis

```mermaid
flowchart LR
  cfg["onboarding.json + ~/.openwiki/.env"] --> ing["ingest (src/ingestion.ts)"]
  ing --> src["ConnectorRuntime.ingest (src/connectors/sources)"]
  src --> raw["~/.openwiki/connectors/<id>/raw"]
  raw --> agent["personal-mode agent synthesis"]
  agent --> wiki["~/.openwiki/wiki"]
```

### Invalid mermaid self-correction

#### Bad mermaid results in the following
```
<!-- openwiki: mermaid parse failed and this diagram was converted to a text fence so it does not break rendering. Fix the diagram source and restore the mermaid fence. Parser error: Parse error on line 5: ...leted]  notify -> end[Response] -->
```

```text
flowchart TD
  req[Incoming request] --> validate[validateTitle]
  validate --> store[TaskStore.create]
  store --> notify[notifyCompleted]
  notify --> end[Response]
```

#### Agent recognizing the issue
```
* Complete openwiki update

  * I'll inspect the existing wiki and repository to identify what needs updating.
  * Ran 5 actions

  * The architecture overview has a degraded mermaid diagram (converted to a text fence). This is exactly the case I should repair. Let me read the source files and the mermaid skill.
  * Ran 5 actions

  * The wiki content is accurate. The only issue is the degraded mermaid diagram. The parser error was on end[Response] — end is a reserved keyword in Mermaid flowcharts. Let me check the skill for the exact fix.
  * Read 1 file

  * Confirmed: the bare word end as a node id is the exact breakage. I'll rename it and restore the mermaid fence. The diagram is also accurate to the source flow (validate → store.create → notify → response), so
    only the syntax fix is needed.
  * Applied changes to 1 file

  * Now let me verify the edit and confirm the rest of the wiki is accurate against the source.
  * Examined 1 file

  * The diagram is repaired: the bare end node id was renamed to response, the mermaid fence restored, and the degradation comment removed.
    The rest of the wiki is accurate against the current source (validation → store → notifier flow behind the route table in src/routes.ts), and no source files changed since the initial commit, so no other edits
    are warranted.
    Summary of changes:
    - `/openwiki/architecture/overview.md` — repaired the degraded diagram that a prior run had converted to a `text` fence. The parser error was caused by using the reserved word `end` as a flowchart node id;
    renamed it to `response`, restored the ```mermaid fence, removed the `openwiki: mermaid parse failed` comment, and added a one-line caption.
    No content in /openwiki/quickstart.md needed changes.
```

#### On next update the agent can fix the invalid mermaid
```mermaid
flowchart TD
  req[Incoming request] --> validate[validateTitle]
  validate --> store[TaskStore.create]
  store --> notify[notifyCompleted]
  notify --> response[Response]
```

## Authorship

Co-authored by @yogeshchavan2008 and @colifran.

---

Closes #198
