### PR TITLE
Add Go headless CLI with OpenRouter-only agent loop

### DIFF
--- a/.github/workflows/openwiki-update.yml
+++ b/.github/workflows/openwiki-update.yml
@@ -17,22 +17,19 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@v4
 
-      - name: Set up Node.js
-        uses: actions/setup-node@v4
+      - name: Set up Go
+        uses: actions/setup-go@v5
         with:
-          node-version: "22"
+          go-version: "1.22"
 
-      - name: Install OpenWiki
-        run: npm install --global openwiki
+      - name: Build OpenWiki headless CLI
+        run: go build -o openwiki ./go/cmd/openwiki
 
       - name: Run OpenWiki
-        run: openwiki --update --print
+        run: ./openwiki --update --print
         env:
           OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
           OPENWIKI_MODEL_ID: z-ai/glm-5.2
-          LANGSMITH_API_KEY: ${{ secrets.LANGSMITH_API_KEY }}
-          LANGCHAIN_PROJECT: openwiki
-          LANGCHAIN_TRACING_V2: "true"
 
       - name: Create OpenWiki update pull request
         uses: peter-evans/create-pull-request@22a9089034f40e5a961c8808d113e2c98fb63676 # v7

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 node_modules/
 dist/
 coverage/
+go/bin/
 
 *.log
 *.tgz

--- a/examples/openwiki-update.yml
+++ b/examples/openwiki-update.yml
@@ -18,23 +18,19 @@ jobs:
         with:
           persist-credentials: true
 
-      - name: Set up Node.js
-        uses: actions/setup-node@v4
+      - name: Set up Go
+        uses: actions/setup-go@v5
         with:
-          node-version: "22"
+          go-version: "1.22"
 
-      - name: Install OpenWiki
-        run: npm install --global openwiki
+      - name: Build OpenWiki headless CLI
+        run: go build -o openwiki ./go/cmd/openwiki
 
       - name: Run OpenWiki
-        run: openwiki --update --print
+        run: ./openwiki --update --print
         env:
-          # TODO: Replace with your preferred inference provider and model
           OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
           OPENWIKI_MODEL_ID: z-ai/glm-5.2
-          LANGSMITH_API_KEY: ${{ secrets.LANGSMITH_API_KEY }}
-          LANGCHAIN_PROJECT: openwiki
-          LANGCHAIN_TRACING_V2: "true"
 
       - name: Create OpenWiki update pull request
         uses: peter-evans/create-pull-request@v7

--- a/go/README.md
+++ b/go/README.md
@@ -1,0 +1,60 @@
+# OpenWiki Headless CLI (Go)
+
+Headless OpenWiki agent for CI and scripting. Uses OpenRouter as the sole model provider.
+
+## Build
+
+```sh
+cd go
+just build
+```
+
+The binary is written to `go/bin/openwiki`.
+
+## Usage
+
+```sh
+# Initialize documentation
+openwiki init
+
+# Update documentation (streams progress to stderr)
+openwiki update
+
+# Update and print final output (CI-friendly)
+openwiki update --print
+openwiki --update --print   # legacy flags
+
+# Ask a one-shot question
+openwiki print -m "What can you do?"
+
+# Choose a model
+openwiki init --model anthropic/claude-sonnet-5
+```
+
+## Configuration
+
+Set credentials via environment variables or `~/.openwiki/.env`:
+
+- `OPENROUTER_API_KEY` (required)
+- `OPENWIKI_MODEL_ID` (optional, default: `z-ai/glm-5.2`)
+- `OPENWIKI_DEBUG=1` (optional verbose stderr)
+
+## Commands
+
+| Command | Description |
+|---------|-------------|
+| `openwiki init` | Generate initial `openwiki/` documentation |
+| `openwiki update` | Refresh existing documentation from repo changes |
+| `openwiki print -m "..."` | One-shot Q&A; prints final assistant text to stdout |
+
+Legacy root flags `--init`, `--update`, and `-p/--print` are supported for CI compatibility.
+
+## Architecture
+
+- **Cobra CLI** — `internal/cmd`
+- **Config** — `~/.openwiki/.env` loader, OpenRouter-only settings
+- **Agent loop** — custom ReAct loop with OpenRouter tool calling
+- **Tools** — virtual filesystem (`ls`, `read_file`, `write_file`, `edit_file`, `glob`, `grep`) and `execute`
+- **Git/metadata** — git evidence, update noop detection, content snapshot, `.last-update.json`
+
+The interactive TypeScript Ink CLI remains available via `npm install -g openwiki`.

--- a/go/cmd/openwiki/main.go
+++ b/go/cmd/openwiki/main.go
@@ -1,0 +1,14 @@
+package main
+
+import (
+	"os"
+
+	"github.com/langchain-ai/openwiki/go/internal/cmd"
+)
+
+func main() {
+	root := cmd.NewRoot()
+	if err := root.Execute(); err != nil {
+		os.Exit(1)
+	}
+}

--- a/go/go.mod
+++ b/go/go.mod
@@ -1,0 +1,13 @@
+module github.com/langchain-ai/openwiki/go
+
+go 1.22
+
+require (
+	github.com/sashabaranov/go-openai v1.41.2
+	github.com/spf13/cobra v1.9.1
+)
+
+require (
+	github.com/inconshreveable/mousetrap v1.1.0 // indirect
+	github.com/spf13/pflag v1.0.6 // indirect
+)

--- a/go/go.sum
+++ b/go/go.sum
@@ -1,0 +1,12 @@
+github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
+github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
+github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
+github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
+github.com/sashabaranov/go-openai v1.41.2 h1:vfPRBZNMpnqu8ELsclWcAvF19lDNgh1t6TVfFFOPiSM=
+github.com/sashabaranov/go-openai v1.41.2/go.mod h1:lj5b/K+zjTSFxVLijLSTDZuP7adOgerWeFyZLUhAKRg=
+github.com/spf13/cobra v1.9.1 h1:CXSaggrXdbHK9CF+8ywj8Amf7PBRmPCOJugH954Nnlo=
+github.com/spf13/cobra v1.9.1/go.mod h1:nDyEzZ8ogv936Cinf6g1RU9MRY64Ir93oCnqb9wxYW0=
+github.com/spf13/pflag v1.0.6 h1:jFzHGLGAlb3ruxLB8MhbI6A8+AQX/2eW4qeyNZXNp2o=
+github.com/spf13/pflag v1.0.6/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/go/internal/agent/loop.go
+++ b/go/internal/agent/loop.go
@@ -1,0 +1,153 @@
+package agent
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/langchain-ai/openwiki/go/internal/config"
+	"github.com/langchain-ai/openwiki/go/internal/constants"
+	"github.com/langchain-ai/openwiki/go/internal/output"
+	"github.com/langchain-ai/openwiki/go/internal/prompt"
+	"github.com/langchain-ai/openwiki/go/internal/tools"
+	"github.com/langchain-ai/openwiki/go/internal/git"
+	"github.com/sashabaranov/go-openai"
+)
+
+// Options configures an agent run.
+type Options struct {
+	Command     constants.Command
+	CWD         string
+	ModelID     string
+	APIKey      string
+	BaseURL     string
+	UserMessage string
+	Debug       bool
+	Output      *output.Writer
+}
+
+// Result describes the outcome of an agent run.
+type Result struct {
+	Command constants.Command
+	Model   string
+	Skipped bool
+}
+
+// Run executes the OpenWiki agent loop.
+func Run(ctx context.Context, opts Options) (*Result, error) {
+	runContext, err := git.CreateRunContext(opts.Command, opts.CWD)
+	if err != nil {
+		return nil, err
+	}
+
+	systemPrompt := prompt.SystemPrompt(opts.Command)
+	userPrompt := prompt.RuntimeNote(opts.CWD, prompt.UserPrompt(opts.Command, runContext, opts.UserMessage))
+
+	messages := []openai.ChatCompletionMessage{
+		{Role: openai.ChatMessageRoleSystem, Content: systemPrompt},
+		{Role: openai.ChatMessageRoleUser, Content: userPrompt},
+	}
+
+	client := newOpenRouterClient(opts.APIKey, opts.BaseURL)
+	toolRegistry := tools.NewRegistry(opts.CWD)
+	toolDefs := tools.Definitions()
+
+	if opts.Debug && opts.Output != nil {
+		opts.Output.OnDebug(fmt.Sprintf("command=%s", opts.Command))
+		opts.Output.OnDebug(fmt.Sprintf("model=%s", opts.ModelID))
+		opts.Output.OnDebug(fmt.Sprintf("cwd=%s", opts.CWD))
+	}
+
+	for iteration := 0; iteration < constants.MaxAgentIterations; iteration++ {
+		if opts.Debug && opts.Output != nil {
+			opts.Output.OnDebug(fmt.Sprintf("iteration=%d", iteration+1))
+		}
+
+		response, err := client.CreateChatCompletion(ctx, openai.ChatCompletionRequest{
+			Model:    opts.ModelID,
+			Messages: messages,
+			Tools:    toolDefs,
+		})
+		if err != nil {
+			return nil, err
+		}
+
+		if len(response.Choices) == 0 {
+			return nil, fmt.Errorf("OpenRouter returned no choices")
+		}
+
+		choice := response.Choices[0]
+		assistant := choice.Message
+
+		if assistant.Content != "" && opts.Output != nil {
+			opts.Output.OnText(assistant.Content, "main")
+		}
+
+		messages = append(messages, assistant)
+
+		if len(assistant.ToolCalls) == 0 {
+			return &Result{
+				Command: opts.Command,
+				Model:   opts.ModelID,
+			}, nil
+		}
+
+		for _, toolCall := range assistant.ToolCalls {
+			if toolCall.Type != openai.ToolTypeFunction || toolCall.Function.Name == "" {
+				continue
+			}
+
+			if opts.Output != nil {
+				opts.Output.OnToolStart(toolCall.Function.Name, toolCall.Function.Arguments)
+			}
+
+			result, toolErr := toolRegistry.Execute(toolCall.Function.Name, toolCall.Function.Arguments)
+			status := "finished"
+			if toolErr != nil {
+				status = "error"
+				result = toolErr.Error()
+			}
+
+			if opts.Output != nil {
+				opts.Output.OnToolEnd(toolCall.Function.Name, status)
+			}
+
+			messages = append(messages, openai.ChatCompletionMessage{
+				Role:       openai.ChatMessageRoleTool,
+				Content:    result,
+				ToolCallID: toolCall.ID,
+				Name:       toolCall.Function.Name,
+			})
+		}
+	}
+
+	return nil, fmt.Errorf("agent exceeded maximum iterations (%d)", constants.MaxAgentIterations)
+}
+
+func newOpenRouterClient(apiKey, baseURL string) *openai.Client {
+	if baseURL == "" {
+		baseURL = constants.OpenRouterBaseURL
+	}
+
+	cfg := openai.DefaultConfig(apiKey)
+	cfg.BaseURL = baseURL
+	cfg.HTTPClient = &http.Client{
+		Transport: &openRouterTransport{base: http.DefaultTransport},
+	}
+	return openai.NewClientWithConfig(cfg)
+}
+
+type openRouterTransport struct {
+	base http.RoundTripper
+}
+
+func (t *openRouterTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	req.Header.Set("HTTP-Referer", "https://github.com/langchain-ai/openwiki")
+	req.Header.Set("X-Title", "OpenWiki")
+	return t.base.RoundTrip(req)
+}
+
+// LoadSettings is a convenience wrapper for config loading.
+func LoadSettings(modelFlag, cwd string) (*config.Settings, error) {
+	return config.LoadSettings(modelFlag, cwd)
+}

--- a/go/internal/agent/loop_test.go
+++ b/go/internal/agent/loop_test.go
@@ -1,0 +1,106 @@
+package agent
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/langchain-ai/openwiki/go/internal/constants"
+	"github.com/langchain-ai/openwiki/go/internal/output"
+	"github.com/sashabaranov/go-openai"
+)
+
+func TestAgentRunWithMockOpenRouter(t *testing.T) {
+	root := t.TempDir()
+
+	var calls int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		if r.URL.Path != "/chat/completions" {
+			http.NotFound(w, r)
+			return
+		}
+
+		body, _ := io.ReadAll(r.Body)
+		var req openai.ChatCompletionRequest
+		if err := json.Unmarshal(body, &req); err != nil {
+			t.Fatal(err)
+		}
+
+		if calls == 1 {
+			_, _ = w.Write([]byte(`{
+				"id": "chatcmpl-test",
+				"object": "chat.completion",
+				"created": 0,
+				"model": "test-model",
+				"choices": [{
+					"index": 0,
+					"message": {
+						"role": "assistant",
+						"content": "",
+						"tool_calls": [{
+							"id": "call_1",
+							"type": "function",
+							"function": {
+								"name": "write_file",
+								"arguments": "{\"path\":\"/openwiki/quickstart.md\",\"content\":\"# Quickstart\"}"
+							}
+						}]
+					},
+					"finish_reason": "tool_calls"
+				}]
+			}`))
+			return
+		}
+
+		_, _ = w.Write([]byte(`{
+			"id": "chatcmpl-test-2",
+			"object": "chat.completion",
+			"created": 0,
+			"model": "test-model",
+			"choices": [{
+				"index": 0,
+				"message": {
+					"role": "assistant",
+					"content": "Documentation created."
+				},
+				"finish_reason": "stop"
+			}]
+		}`))
+	}))
+	defer server.Close()
+
+	out := output.NewWriter(output.ModePrint)
+	result, err := Run(context.Background(), Options{
+		Command: constants.CommandInit,
+		CWD:     root,
+		ModelID: "test-model",
+		APIKey:  "test-key",
+		BaseURL: server.URL,
+		Output:  out,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Model != "test-model" {
+		t.Fatalf("unexpected model %s", result.Model)
+	}
+
+	written, err := os.ReadFile(filepath.Join(root, "openwiki", "quickstart.md"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(written), "# Quickstart") {
+		t.Fatalf("expected written file, got %q", string(written))
+	}
+
+	if out.FinalPrintText() != "Documentation created." {
+		t.Fatalf("unexpected print text %q", out.FinalPrintText())
+	}
+}

--- a/go/internal/cmd/root.go
+++ b/go/internal/cmd/root.go
@@ -1,0 +1,154 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/langchain-ai/openwiki/go/internal/constants"
+	"github.com/langchain-ai/openwiki/go/internal/diagnostics"
+	"github.com/langchain-ai/openwiki/go/internal/runner"
+	"github.com/spf13/cobra"
+)
+
+var (
+	modelFlag   string
+	messageFlag string
+	printFlag   bool
+)
+
+// NewRoot creates the root Cobra command.
+func NewRoot() *cobra.Command {
+	root := &cobra.Command{
+		Use:          "openwiki",
+		Short:        "Headless OpenWiki documentation agent",
+		SilenceUsage: true,
+		Version:      constants.OpenWikiVersion,
+		RunE:         runLegacyRoot,
+	}
+
+	root.PersistentFlags().StringVarP(&modelFlag, "model", "M", "", "OpenRouter model ID for this run")
+
+	root.Flags().Bool("init", false, "Generate initial OpenWiki documentation (legacy flag)")
+	root.Flags().Bool("update", false, "Update existing OpenWiki documentation (legacy flag)")
+	root.Flags().BoolVarP(&printFlag, "print", "p", false, "Print final assistant output to stdout")
+	root.Flags().StringVarP(&messageFlag, "message", "m", "", "Additional instruction for the run")
+
+	root.AddCommand(newInitCommand())
+	root.AddCommand(newUpdateCommand())
+	root.AddCommand(newPrintCommand())
+
+	return root
+}
+
+func runLegacyRoot(cmd *cobra.Command, args []string) error {
+	initFlag, _ := cmd.Flags().GetBool("init")
+	updateFlag, _ := cmd.Flags().GetBool("update")
+
+	if initFlag && updateFlag {
+		return fmt.Errorf("--init and --update cannot be used together")
+	}
+
+	if initFlag {
+		return executeRun(constants.CommandInit, printFlag, joinMessage(args))
+	}
+	if updateFlag {
+		return executeRun(constants.CommandUpdate, printFlag, joinMessage(args))
+	}
+
+	if printFlag {
+		msg := messageFlag
+		if msg == "" {
+			msg = joinMessage(args)
+		}
+		if msg == "" {
+			return fmt.Errorf("-p/--print requires a message, --init, or --update")
+		}
+		return executeRun(constants.CommandChat, true, msg)
+	}
+
+	return cmd.Help()
+}
+
+func newInitCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "init",
+		Short: "Generate initial OpenWiki documentation",
+		RunE:  runInit,
+	}
+	cmd.Flags().StringVarP(&messageFlag, "message", "m", "", "Additional instruction for the init run")
+	return cmd
+}
+
+func newUpdateCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "update",
+		Short: "Update existing OpenWiki documentation",
+		RunE:  runUpdate,
+	}
+	cmd.Flags().StringVarP(&messageFlag, "message", "m", "", "Additional instruction for the update run")
+	cmd.Flags().BoolVarP(&printFlag, "print", "p", false, "Print final assistant output to stdout")
+	return cmd
+}
+
+func newPrintCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "print",
+		Short: "Run once and print the final assistant output",
+		RunE:  runPrint,
+	}
+	cmd.Flags().StringVarP(&messageFlag, "message", "m", "", "Message to send to the agent")
+	cmd.MarkFlagRequired("message")
+	return cmd
+}
+
+func runInit(cmd *cobra.Command, args []string) error {
+	return executeRun(constants.CommandInit, false, joinMessage(args))
+}
+
+func runUpdate(cmd *cobra.Command, args []string) error {
+	return executeRun(constants.CommandUpdate, printFlag, joinMessage(args))
+}
+
+func runPrint(cmd *cobra.Command, args []string) error {
+	msg := messageFlag
+	if msg == "" {
+		msg = joinMessage(args)
+	}
+	if msg == "" {
+		return fmt.Errorf("print requires a message via --message or a positional argument")
+	}
+	return executeRun(constants.CommandChat, true, msg)
+}
+
+func joinMessage(args []string) string {
+	if len(args) == 0 {
+		return messageFlag
+	}
+	combined := ""
+	for i, arg := range args {
+		if i > 0 {
+			combined += " "
+		}
+		combined += arg
+	}
+	if messageFlag != "" {
+		return messageFlag + " " + combined
+	}
+	return combined
+}
+
+func executeRun(command constants.Command, printMode bool, userMessage string) error {
+	ctx := context.Background()
+	_, err := runner.Run(ctx, runner.Options{
+		Command:     command,
+		ModelFlag:   modelFlag,
+		UserMessage: userMessage,
+		PrintMode:   printMode,
+	})
+	if err != nil {
+		_, _ = fmt.Fprintln(os.Stderr, diagnostics.GetErrorMessage(err))
+		return err
+	}
+	return nil
+}

--- a/go/internal/cmd/root_test.go
+++ b/go/internal/cmd/root_test.go
@@ -1,0 +1,19 @@
+package cmd
+
+import (
+	"testing"
+)
+
+func TestRootHasCommands(t *testing.T) {
+	root := NewRoot()
+	names := make(map[string]bool)
+	for _, c := range root.Commands() {
+		names[c.Name()] = true
+	}
+
+	for _, expected := range []string{"init", "update", "print"} {
+		if !names[expected] {
+			t.Fatalf("expected command %q to be registered", expected)
+		}
+	}
+}

--- a/go/internal/config/config.go
+++ b/go/internal/config/config.go
@@ -1,0 +1,187 @@
+package config
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+
+	"github.com/langchain-ai/openwiki/go/internal/constants"
+)
+
+var modelIDPattern = regexp.MustCompile(`^[A-Za-z0-9][A-Za-z0-9._:/+-]*$`)
+
+// Settings holds resolved runtime configuration.
+type Settings struct {
+	APIKey  string
+	ModelID string
+	Debug   bool
+	CWD     string
+}
+
+// OpenWikiEnvDir returns ~/.openwiki.
+func OpenWikiEnvDir() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(home, ".openwiki"), nil
+}
+
+// OpenWikiEnvPath returns ~/.openwiki/.env.
+func OpenWikiEnvPath() (string, error) {
+	dir, err := OpenWikiEnvDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(dir, ".env"), nil
+}
+
+// LoadOpenWikiEnv merges ~/.openwiki/.env into the process environment.
+// Process environment values take precedence over file values.
+func LoadOpenWikiEnv() error {
+	path, err := OpenWikiEnvPath()
+	if err != nil {
+		return err
+	}
+
+	content, err := os.ReadFile(path)
+	if os.IsNotExist(err) {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+
+	for key, value := range ParseEnv(string(content)) {
+		if os.Getenv(key) == "" {
+			_ = os.Setenv(key, value)
+		}
+	}
+
+	return nil
+}
+
+// ParseEnv parses a dotenv file into key/value pairs.
+func ParseEnv(content string) map[string]string {
+	env := make(map[string]string)
+
+	for _, rawLine := range strings.Split(content, "\n") {
+		line := strings.TrimSpace(rawLine)
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+
+		equalsIndex := strings.Index(line, "=")
+		if equalsIndex <= 0 {
+			continue
+		}
+
+		key := strings.TrimSpace(line[:equalsIndex])
+		rawValue := strings.TrimSpace(line[equalsIndex+1:])
+
+		if !regexp.MustCompile(`^[A-Z_][A-Z0-9_]*$`).MatchString(key) {
+			continue
+		}
+
+		env[key] = parseEnvValue(rawValue)
+	}
+
+	return env
+}
+
+func parseEnvValue(value string) string {
+	if strings.HasPrefix(value, `"`) && strings.HasSuffix(value, `"`) && len(value) >= 2 {
+		unquoted := value[1 : len(value)-1]
+		unquoted = strings.ReplaceAll(unquoted, `\\`, `\`)
+		unquoted = strings.ReplaceAll(unquoted, `\"`, `"`)
+		unquoted = strings.ReplaceAll(unquoted, `\n`, "\n")
+		return unquoted
+	}
+	return value
+}
+
+// NormalizeModelID trims whitespace from a model ID.
+func NormalizeModelID(value string) string {
+	return strings.TrimSpace(value)
+}
+
+// IsValidModelID checks whether a model ID is acceptable.
+func IsValidModelID(value string) bool {
+	modelID := NormalizeModelID(value)
+	if modelID == "" || len(modelID) > 120 {
+		return false
+	}
+	if strings.Contains(modelID, "://") {
+		return false
+	}
+	return modelIDPattern.MatchString(modelID)
+}
+
+// ResolveModelID picks the model for a run.
+func ResolveModelID(flagOverride string) (string, error) {
+	if flagOverride != "" {
+		modelID := NormalizeModelID(flagOverride)
+		if !IsValidModelID(modelID) {
+			return "", fmt.Errorf("invalid model ID: %s", flagOverride)
+		}
+		return modelID, nil
+	}
+
+	if envModel := os.Getenv(constants.OpenWikiModelIDEnv); envModel != "" {
+		modelID := NormalizeModelID(envModel)
+		if !IsValidModelID(modelID) {
+			return "", fmt.Errorf("invalid model ID configured in %s", constants.OpenWikiModelIDEnv)
+		}
+		return modelID, nil
+	}
+
+	return constants.DefaultModelID, nil
+}
+
+// RequireAPIKey ensures OPENROUTER_API_KEY is set.
+func RequireAPIKey() error {
+	if strings.TrimSpace(os.Getenv(constants.OpenRouterAPIKeyEnv)) == "" {
+		return fmt.Errorf(
+			"%s is required for non-interactive runs. Set it in the environment or ~/.openwiki/.env",
+			constants.OpenRouterAPIKeyEnv,
+		)
+	}
+	return nil
+}
+
+// LoadSettings resolves configuration after env loading.
+func LoadSettings(modelFlag string, cwd string) (*Settings, error) {
+	if err := LoadOpenWikiEnv(); err != nil {
+		return nil, err
+	}
+
+	if err := RequireAPIKey(); err != nil {
+		return nil, err
+	}
+
+	modelID, err := ResolveModelID(modelFlag)
+	if err != nil {
+		return nil, err
+	}
+
+	if cwd == "" {
+		cwd, err = os.Getwd()
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return &Settings{
+		APIKey:  os.Getenv(constants.OpenRouterAPIKeyEnv),
+		ModelID: modelID,
+		Debug:   os.Getenv(constants.OpenWikiDebugEnv) == "1",
+		CWD:     cwd,
+	}, nil
+}
+
+// IsDebugEnabled reports whether debug output is enabled.
+func IsDebugEnabled() bool {
+	return os.Getenv(constants.OpenWikiDebugEnv) == "1"
+}

--- a/go/internal/config/config_test.go
+++ b/go/internal/config/config_test.go
@@ -1,0 +1,61 @@
+package config
+
+import (
+	"testing"
+)
+
+func TestParseEnv(t *testing.T) {
+	env := ParseEnv(`
+# comment
+OPENROUTER_API_KEY="sk-or-v1-test"
+OPENWIKI_MODEL_ID=z-ai/glm-5.2
+
+INVALID-KEY=nope
+`)
+
+	if env["OPENROUTER_API_KEY"] != "sk-or-v1-test" {
+		t.Fatalf("expected parsed api key, got %q", env["OPENROUTER_API_KEY"])
+	}
+	if env["OPENWIKI_MODEL_ID"] != "z-ai/glm-5.2" {
+		t.Fatalf("expected model id, got %q", env["OPENWIKI_MODEL_ID"])
+	}
+	if _, ok := env["INVALID-KEY"]; ok {
+		t.Fatal("expected invalid key to be ignored")
+	}
+}
+
+func TestIsValidModelID(t *testing.T) {
+	cases := []struct {
+		value string
+		valid bool
+	}{
+		{"z-ai/glm-5.2", true},
+		{"anthropic/claude-sonnet-5", true},
+		{"", false},
+		{"bad model", false},
+		{"http://bad", false},
+	}
+
+	for _, tc := range cases {
+		if got := IsValidModelID(tc.value); got != tc.valid {
+			t.Fatalf("IsValidModelID(%q) = %v, want %v", tc.value, got, tc.valid)
+		}
+	}
+}
+
+func TestResolveModelID(t *testing.T) {
+	t.Setenv("OPENWIKI_MODEL_ID", "")
+
+	model, err := ResolveModelID("")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if model != "z-ai/glm-5.2" {
+		t.Fatalf("expected default model, got %q", model)
+	}
+
+	_, err = ResolveModelID("bad model")
+	if err == nil {
+		t.Fatal("expected invalid model error")
+	}
+}

--- a/go/internal/constants/constants.go
+++ b/go/internal/constants/constants.go
@@ -1,0 +1,24 @@
+package constants
+
+const (
+	OpenWikiDir         = "openwiki"
+	UpdateMetadataPath  = "openwiki/.last-update.json"
+	OpenRouterAPIKeyEnv = "OPENROUTER_API_KEY"
+	OpenWikiModelIDEnv  = "OPENWIKI_MODEL_ID"
+	OpenWikiDebugEnv    = "OPENWIKI_DEBUG"
+	OpenRouterBaseURL   = "https://openrouter.ai/api/v1"
+	DefaultModelID      = "z-ai/glm-5.2"
+	OpenWikiVersion     = "0.0.2-go"
+	MaxAgentIterations  = 50
+	ShellTimeoutSeconds = 120
+	MaxShellOutputBytes = 100_000
+)
+
+// Command identifies the OpenWiki run mode.
+type Command string
+
+const (
+	CommandInit Command = "init"
+	CommandUpdate Command = "update"
+	CommandChat Command = "chat"
+)

--- a/go/internal/diagnostics/diagnostics.go
+++ b/go/internal/diagnostics/diagnostics.go
@@ -1,0 +1,76 @@
+package diagnostics
+
+import (
+	"os"
+	"regexp"
+	"strings"
+
+	"github.com/langchain-ai/openwiki/go/internal/constants"
+)
+
+var (
+	bearerPattern      = regexp.MustCompile(`\bBearer\s+[A-Za-z0-9._~+/=-]+`)
+	skOrPattern        = regexp.MustCompile(`\bsk-or-v1-[A-Za-z0-9_-]+`)
+	skPattern          = regexp.MustCompile(`\bsk-[A-Za-z0-9_-]+`)
+	lsPattern          = regexp.MustCompile(`\bls[v_][A-Za-z0-9_-]+`)
+	incorrectKeyPattern = regexp.MustCompile(`(?i)(Incorrect API key provided:\s*)([^\s.]+)`)
+	openRouterErrPattern = regexp.MustCompile(`(?i)OpenRouterError`)
+	internalServerPattern = regexp.MustCompile(`(?i)Internal Server Error`)
+	status500Pattern     = regexp.MustCompile(`\b500\b`)
+)
+
+// SanitizeDiagnosticText redacts secrets from text before display.
+func SanitizeDiagnosticText(value string) string {
+	sanitized := value
+
+	for _, key := range []string{
+		constants.OpenRouterAPIKeyEnv,
+		"LANGSMITH_API_KEY",
+	} {
+		secret := os.Getenv(key)
+		if secret != "" {
+			sanitized = strings.ReplaceAll(sanitized, secret, "[REDACTED:"+key+"]")
+		}
+	}
+
+	sanitized = incorrectKeyPattern.ReplaceAllString(sanitized, "${1}[REDACTED:API_KEY]")
+	sanitized = bearerPattern.ReplaceAllString(sanitized, "Bearer [REDACTED]")
+	sanitized = skOrPattern.ReplaceAllString(sanitized, "[REDACTED:OPENROUTER_API_KEY]")
+	sanitized = skPattern.ReplaceAllString(sanitized, "[REDACTED:API_KEY]")
+	sanitized = lsPattern.ReplaceAllString(sanitized, "[REDACTED:LANGSMITH_API_KEY]")
+
+	return sanitized
+}
+
+// IsOpenRouterServerError detects provider 500 responses.
+func IsOpenRouterServerError(err error, message string) bool {
+	if err == nil {
+		return false
+	}
+
+	msg := message
+	if msg == "" {
+		msg = err.Error()
+	}
+
+	if openRouterErrPattern.MatchString(msg) ||
+		(internalServerPattern.MatchString(msg) && status500Pattern.MatchString(msg)) {
+		return true
+	}
+
+	return false
+}
+
+// GetErrorMessage returns a user-facing error message with secrets redacted.
+func GetErrorMessage(err error) string {
+	if err == nil {
+		return "OpenWiki agent run failed."
+	}
+
+	message := err.Error()
+	if IsOpenRouterServerError(err, message) {
+		return "OpenRouter/provider returned 500 Internal Server Error. Try retrying or switching models. Run with OPENWIKI_DEBUG=1 to show provider metadata."
+	}
+
+	return SanitizeDiagnosticText(message)
+}

--- a/go/internal/diagnostics/diagnostics_test.go
+++ b/go/internal/diagnostics/diagnostics_test.go
@@ -1,0 +1,28 @@
+package diagnostics
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestSanitizeDiagnosticText(t *testing.T) {
+	t.Setenv("OPENROUTER_API_KEY", "sk-or-v1-secret")
+
+	input := "failed with sk-or-v1-secret and sk-or-v1-other"
+	result := SanitizeDiagnosticText(input)
+
+	if result == input {
+		t.Fatal("expected redaction")
+	}
+	if result == "" {
+		t.Fatal("expected non-empty result")
+	}
+}
+
+func TestGetErrorMessageOpenRouter500(t *testing.T) {
+	err := errors.New("OpenRouterError: 500 Internal Server Error")
+	message := GetErrorMessage(err)
+	if message == err.Error() {
+		t.Fatalf("expected friendly message, got %q", message)
+	}
+}

--- a/go/internal/git/git.go
+++ b/go/internal/git/git.go
@@ -1,0 +1,240 @@
+package git
+
+import (
+	"bytes"
+	"fmt"
+	"os/exec"
+	"strings"
+
+	"github.com/langchain-ai/openwiki/go/internal/constants"
+	"github.com/langchain-ai/openwiki/go/internal/metadata"
+)
+
+// RunContext holds per-run git and metadata context for prompts.
+type RunContext struct {
+	LastUpdate *metadata.UpdateMetadata
+	GitSummary string
+}
+
+// UpdateNoopStatus describes whether an update run should be skipped.
+type UpdateNoopStatus struct {
+	ShouldSkip bool
+	GitHead    string
+	Model      string
+	Reason     string
+}
+
+// CreateRunContext builds prompt context for init/update/chat runs.
+func CreateRunContext(command constants.Command, cwd string) (*RunContext, error) {
+	lastUpdate, err := metadata.ReadLastUpdate(cwd)
+	if err != nil {
+		return nil, err
+	}
+
+	if command == constants.CommandChat {
+		return &RunContext{
+			LastUpdate: lastUpdate,
+			GitSummary: "Not applicable for chat.",
+		}, nil
+	}
+
+	summary, err := createGitSummary(command, cwd, lastUpdate)
+	if err != nil {
+		return nil, err
+	}
+
+	return &RunContext{
+		LastUpdate: lastUpdate,
+		GitSummary: summary,
+	}, nil
+}
+
+// GetUpdateNoopStatus checks whether an update can be skipped.
+func GetUpdateNoopStatus(cwd string) (*UpdateNoopStatus, error) {
+	lastUpdate, err := metadata.ReadLastUpdate(cwd)
+	if err != nil {
+		return nil, err
+	}
+
+	if lastUpdate == nil || lastUpdate.GitHead == "" {
+		return &UpdateNoopStatus{ShouldSkip: false, Reason: "missing previous update git head"}, nil
+	}
+
+	head, err := GetHead(cwd)
+	if err != nil {
+		return nil, err
+	}
+	if head == "" {
+		return &UpdateNoopStatus{ShouldSkip: false, Reason: "missing current git head"}, nil
+	}
+
+	status, err := Run(cwd, "status", "--short", "--untracked-files=all")
+	if err != nil {
+		return nil, err
+	}
+
+	for _, line := range strings.Split(status, "\n") {
+		trimmed := strings.TrimRight(line, " \t")
+		if trimmed == "" {
+			continue
+		}
+		if !isUpdateMetadataStatusLine(trimmed) {
+			return &UpdateNoopStatus{ShouldSkip: false, Reason: "worktree has changes"}, nil
+		}
+	}
+
+	if head != lastUpdate.GitHead {
+		changedPaths, err := getChangedPathsSinceLastUpdate(cwd, lastUpdate.GitHead)
+		if err != nil {
+			return nil, err
+		}
+
+		if len(changedPaths) == 0 {
+			return &UpdateNoopStatus{ShouldSkip: false, Reason: "git head changed"}, nil
+		}
+
+		for _, changedPath := range changedPaths {
+			if !isOpenWikiPath(changedPath) {
+				return &UpdateNoopStatus{ShouldSkip: false, Reason: "git head changed"}, nil
+			}
+		}
+	}
+
+	return &UpdateNoopStatus{
+		ShouldSkip: true,
+		GitHead:    head,
+		Model:      lastUpdate.Model,
+	}, nil
+}
+
+// GetHead returns the current git HEAD.
+func GetHead(cwd string) (string, error) {
+	head, err := Run(cwd, "rev-parse", "HEAD")
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(head), nil
+}
+
+// Run executes a git command and returns combined stdout/stderr.
+func Run(cwd string, args ...string) (string, error) {
+	cmd := exec.Command("git", append([]string{"--no-pager"}, args...)...)
+	cmd.Dir = cwd
+
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	err := cmd.Run()
+	output := strings.TrimSpace(strings.TrimSpace(stdout.String() + "\n" + stderr.String()))
+
+	if err != nil {
+		if output != "" {
+			return output, nil
+		}
+		return "", err
+	}
+
+	return output, nil
+}
+
+func createGitSummary(command constants.Command, cwd string, lastUpdate *metadata.UpdateMetadata) (string, error) {
+	var sections []string
+
+	status, err := Run(cwd, "status", "--short")
+	if err != nil {
+		return "", err
+	}
+	sections = append(sections, formatGitSection("git status --short", status))
+
+	head, err := GetHead(cwd)
+	if err != nil {
+		return "", err
+	}
+	if head == "" {
+		sections = append(sections, formatGitSection("git rev-parse HEAD", "(unknown)"))
+	} else {
+		sections = append(sections, formatGitSection("git rev-parse HEAD", head))
+	}
+
+	if command == constants.CommandUpdate && lastUpdate != nil && lastUpdate.GitHead != "" {
+		logSince, err := Run(cwd, "log", lastUpdate.GitHead+"..HEAD", "--name-status", "--oneline")
+		if err != nil {
+			return "", err
+		}
+		sections = append(sections, formatGitSection(
+			fmt.Sprintf("git log %s..HEAD --name-status --oneline", lastUpdate.GitHead),
+			logSince,
+		))
+	} else if command == constants.CommandUpdate && lastUpdate != nil && lastUpdate.UpdatedAt != "" {
+		logSince, err := Run(cwd, "log", "--since", lastUpdate.UpdatedAt, "--name-status", "--oneline")
+		if err != nil {
+			return "", err
+		}
+		sections = append(sections, formatGitSection(
+			fmt.Sprintf("git log --since %s --name-status --oneline", lastUpdate.UpdatedAt),
+			logSince,
+		))
+	} else {
+		recentLog, err := Run(cwd, "log", "--max-count=20", "--name-status", "--oneline")
+		if err != nil {
+			return "", err
+		}
+		if command == constants.CommandUpdate {
+			sections = append(sections, "No prior OpenWiki update timestamp was found.")
+		}
+		sections = append(sections, formatGitSection(
+			"git log --max-count=20 --name-status --oneline",
+			recentLog,
+		))
+	}
+
+	diff, err := Run(cwd, "diff", "--name-status", "HEAD")
+	if err != nil {
+		return "", err
+	}
+	sections = append(sections, formatGitSection("git diff --name-status HEAD", diff))
+
+	return strings.Join(sections, "\n\n"), nil
+}
+
+func formatGitSection(command, output string) string {
+	if output == "" {
+		output = "(no output)"
+	}
+	return "$ " + command + "\n" + output
+}
+
+func isUpdateMetadataStatusLine(line string) bool {
+	statusPath := line
+	if len(line) > 3 {
+		statusPath = strings.TrimSpace(line[3:])
+	} else {
+		statusPath = strings.TrimSpace(line)
+	}
+
+	normalized := strings.ReplaceAll(statusPath, "\\", "/")
+	return normalized == constants.UpdateMetadataPath ||
+		strings.HasSuffix(normalized, " -> "+constants.UpdateMetadataPath)
+}
+
+func getChangedPathsSinceLastUpdate(cwd, gitHead string) ([]string, error) {
+	diff, err := Run(cwd, "diff", "--name-only", gitHead+"..HEAD")
+	if err != nil {
+		return nil, err
+	}
+
+	var paths []string
+	for _, line := range strings.Split(diff, "\n") {
+		normalized := strings.TrimSpace(strings.ReplaceAll(line, "\\", "/"))
+		if normalized != "" {
+			paths = append(paths, normalized)
+		}
+	}
+	return paths, nil
+}
+
+func isOpenWikiPath(changedPath string) bool {
+	return changedPath == constants.OpenWikiDir ||
+		strings.HasPrefix(changedPath, constants.OpenWikiDir+"/")
+}

--- a/go/internal/metadata/metadata.go
+++ b/go/internal/metadata/metadata.go
@@ -1,0 +1,161 @@
+package metadata
+
+import (
+	"crypto/sha256"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/langchain-ai/openwiki/go/internal/constants"
+)
+
+// UpdateMetadata records the last successful documentation run.
+type UpdateMetadata struct {
+	UpdatedAt string             `json:"updatedAt"`
+	Command   constants.Command  `json:"command"`
+	GitHead   string             `json:"gitHead,omitempty"`
+	Model     string             `json:"model"`
+}
+
+// ReadLastUpdate reads prior run metadata if present and valid.
+func ReadLastUpdate(cwd string) (*UpdateMetadata, error) {
+	metadataFile := filepath.Join(cwd, constants.UpdateMetadataPath)
+
+	content, err := os.ReadFile(metadataFile)
+	if os.IsNotExist(err) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	var parsed struct {
+		UpdatedAt string `json:"updatedAt"`
+		Command   string `json:"command"`
+		GitHead   string `json:"gitHead"`
+		Model     string `json:"model"`
+	}
+	if err := json.Unmarshal(content, &parsed); err != nil {
+		return nil, nil
+	}
+
+	if parsed.UpdatedAt == "" || parsed.Command == "" || parsed.Model == "" {
+		return nil, nil
+	}
+
+	command := constants.CommandUpdate
+	if parsed.Command == "init" {
+		command = constants.CommandInit
+	}
+
+	return &UpdateMetadata{
+		UpdatedAt: parsed.UpdatedAt,
+		Command:   command,
+		GitHead:   parsed.GitHead,
+		Model:     parsed.Model,
+	}, nil
+}
+
+// WriteLastUpdateMetadata records a successful init/update run.
+func WriteLastUpdateMetadata(command constants.Command, cwd, modelID, gitHead string) error {
+	metadataFile := filepath.Join(cwd, constants.UpdateMetadataPath)
+	metadata := UpdateMetadata{
+		UpdatedAt: time.Now().UTC().Format(time.RFC3339),
+		Command:   command,
+		GitHead:   gitHead,
+		Model:     modelID,
+	}
+
+	if err := os.MkdirAll(filepath.Dir(metadataFile), 0o755); err != nil {
+		return err
+	}
+
+	encoded, err := json.MarshalIndent(metadata, "", "  ")
+	if err != nil {
+		return err
+	}
+
+	return os.WriteFile(metadataFile, append(encoded, '\n'), 0o644)
+}
+
+// ContentSnapshot is a SHA-256 hash of openwiki/ content.
+type ContentSnapshot string
+
+// CreateContentSnapshot hashes openwiki/ excluding .last-update.json.
+func CreateContentSnapshot(cwd string) (ContentSnapshot, error) {
+	openWikiDir := filepath.Join(cwd, constants.OpenWikiDir)
+	hash := sha256.New()
+
+	if err := addDirectoryToSnapshot(hash, openWikiDir, ""); err != nil {
+		return "", err
+	}
+
+	return ContentSnapshot(fmt.Sprintf("%x", hash.Sum(nil))), nil
+}
+
+func addDirectoryToSnapshot(hash io.Writer, directory, relativeDirectory string) error {
+	entries, err := os.ReadDir(directory)
+	if os.IsNotExist(err) {
+		_, _ = hash.Write([]byte("missing"))
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+
+	for i := 0; i < len(entries); i++ {
+		for j := i + 1; j < len(entries); j++ {
+			if entries[j].Name() < entries[i].Name() {
+				entries[i], entries[j] = entries[j], entries[i]
+			}
+		}
+	}
+
+	for _, entry := range entries {
+		entryPath := filepath.Join(directory, entry.Name())
+		relativePath := filepath.Join(relativeDirectory, entry.Name())
+		relativePath = strings.ReplaceAll(relativePath, "\\", "/")
+
+		if relativePath == filepath.Base(constants.UpdateMetadataPath) {
+			continue
+		}
+
+		if entry.IsDir() {
+			if _, err := hash.Write([]byte("dir:" + relativePath + "\x00")); err != nil {
+				return err
+			}
+			if err := addDirectoryToSnapshot(hash, entryPath, relativePath); err != nil {
+				return err
+			}
+			continue
+		}
+
+		if !entry.Type().IsRegular() {
+			continue
+		}
+
+		content, err := os.ReadFile(entryPath)
+		if os.IsNotExist(err) {
+			continue
+		}
+		if err != nil {
+			return err
+		}
+
+		if _, err := hash.Write([]byte("file:" + relativePath + "\x00")); err != nil {
+			return err
+		}
+		if _, err := hash.Write(content); err != nil {
+			return err
+		}
+		if _, err := hash.Write([]byte("\x00")); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/go/internal/metadata/metadata_test.go
+++ b/go/internal/metadata/metadata_test.go
@@ -1,0 +1,67 @@
+package metadata
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/langchain-ai/openwiki/go/internal/constants"
+)
+
+func TestContentSnapshotIgnoresMetadata(t *testing.T) {
+	root := t.TempDir()
+	openWikiDir := filepath.Join(root, constants.OpenWikiDir)
+	if err := os.MkdirAll(openWikiDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := os.WriteFile(filepath.Join(openWikiDir, "quickstart.md"), []byte("v1"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(openWikiDir, ".last-update.json"), []byte(`{"updatedAt":"t","command":"init","model":"m"}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	before, err := CreateContentSnapshot(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := os.WriteFile(filepath.Join(openWikiDir, ".last-update.json"), []byte(`{"updatedAt":"t2","command":"init","model":"m"}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	after, err := CreateContentSnapshot(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if before != after {
+		t.Fatalf("metadata changes should not affect snapshot: %s vs %s", before, after)
+	}
+}
+
+func TestWriteAndReadLastUpdate(t *testing.T) {
+	root := t.TempDir()
+
+	if err := WriteLastUpdateMetadata(constants.CommandInit, root, "z-ai/glm-5.2", "abc123"); err != nil {
+		t.Fatal(err)
+	}
+
+	lastUpdate, err := ReadLastUpdate(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if lastUpdate == nil {
+		t.Fatal("expected metadata")
+	}
+	if lastUpdate.Command != constants.CommandInit {
+		t.Fatalf("unexpected command %s", lastUpdate.Command)
+	}
+	if lastUpdate.Model != "z-ai/glm-5.2" {
+		t.Fatalf("unexpected model %s", lastUpdate.Model)
+	}
+	if lastUpdate.GitHead != "abc123" {
+		t.Fatalf("unexpected git head %s", lastUpdate.GitHead)
+	}
+}

--- a/go/internal/output/output.go
+++ b/go/internal/output/output.go
@@ -1,0 +1,106 @@
+package output
+
+import (
+	"fmt"
+	"io"
+	"os"
+)
+
+// Mode controls how agent output is routed.
+type Mode int
+
+const (
+	ModeProgress Mode = iota
+	ModePrint
+)
+
+// Writer handles agent event output.
+type Writer struct {
+	mode       Mode
+	progress   io.Writer
+	print      io.Writer
+	textBuffer []string
+}
+
+// NewWriter creates an output writer.
+func NewWriter(mode Mode) *Writer {
+	return &Writer{
+		mode:     mode,
+		progress: os.Stderr,
+		print:    os.Stdout,
+	}
+}
+
+// OnText handles assistant text chunks.
+func (w *Writer) OnText(text string, source string) {
+	if text == "" {
+		return
+	}
+
+	if source == "subgraph" {
+		return
+	}
+
+	switch w.mode {
+	case ModePrint:
+		w.textBuffer = append(w.textBuffer, text)
+	case ModeProgress:
+		_, _ = fmt.Fprint(w.progress, text)
+	}
+}
+
+// OnToolStart logs tool invocation to stderr.
+func (w *Writer) OnToolStart(name, call string) {
+	if w.mode == ModeProgress {
+		_, _ = fmt.Fprintf(w.progress, "\n[tool] %s %s\n", name, call)
+	}
+}
+
+// OnToolEnd logs tool completion to stderr.
+func (w *Writer) OnToolEnd(name, status string) {
+	if w.mode == ModeProgress {
+		_, _ = fmt.Fprintf(w.progress, "[tool done] %s (%s)\n", name, status)
+	}
+}
+
+// OnDebug logs debug messages to stderr.
+func (w *Writer) OnDebug(message string) {
+	_, _ = fmt.Fprintf(w.progress, "[debug] %s\n", message)
+}
+
+// FinalPrintText returns buffered text for print mode.
+func (w *Writer) FinalPrintText() string {
+	return joinText(w.textBuffer)
+}
+
+// WriteFinalPrint writes final assistant output for print mode.
+func (w *Writer) WriteFinalPrint() {
+	text := w.FinalPrintText()
+	if text == "" {
+		return
+	}
+	_, _ = fmt.Fprintln(w.print, text)
+}
+
+func joinText(parts []string) string {
+	if len(parts) == 0 {
+		return ""
+	}
+	result := parts[0]
+	for i := 1; i < len(parts); i++ {
+		result += parts[i]
+	}
+	return trimSpace(result)
+}
+
+func trimSpace(value string) string {
+	start := 0
+	end := len(value)
+	for start < end && (value[start] == ' ' || value[start] == '\n' || value[start] == '\t' || value[start] == '\r') {
+		start++
+	}
+	for end > start && (value[end-1] == ' ' || value[end-1] == '\n' || value[end-1] == '\t' || value[end-1] == '\r') {
+		end--
+	}
+	return value[start:end]
+}

--- a/go/internal/prompt/prompt.go
+++ b/go/internal/prompt/prompt.go
@@ -1,0 +1,247 @@
+package prompt
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/langchain-ai/openwiki/go/internal/constants"
+	"github.com/langchain-ai/openwiki/go/internal/git"
+	"github.com/langchain-ai/openwiki/go/internal/metadata"
+)
+
+func formatLastUpdate(lastUpdate *metadata.UpdateMetadata) string {
+	if lastUpdate == nil {
+		return "No previous OpenWiki update metadata was found."
+	}
+	encoded, _ := json.MarshalIndent(lastUpdate, "", "  ")
+	return string(encoded)
+}
+
+// SystemPrompt returns the system prompt for a command mode.
+func SystemPrompt(command constants.Command) string {
+	return strings.TrimSpace(fmt.Sprintf(`
+You are OpenWiki, an expert technical writer, software architect, and product analyst.
+
+Your job is to inspect the current codebase and produce documentation in the %s/ directory that is excellent for both humans and future coding agents.
+
+Use only the tools available to you. Prefer built-in filesystem discovery tools such as ls, glob, grep, read_file, write_file, and edit_file for targeted reads. Use git through shell execute when it provides useful history. Do not invent files, modules, APIs, business rules, or behavior. Ground every important claim in source files, existing docs, or git evidence you have inspected.
+
+Run discipline:
+- Filesystem tools are rooted at the target repository. Use virtual paths such as /README.md, /agent/..., /server/..., and /openwiki/quickstart.md with ls, read_file, write_file, edit_file, glob, and grep.
+- Never pass host absolute paths like /Users/... to filesystem tools; that creates nested paths inside the repo instead of touching the intended file.
+- Shell execute commands run on the host. If you use execute, run commands from the target repository directory and keep them inside that repository.
+- Do not exhaustively read every file. Inspect the repository tree, package/config files, README-style files, entrypoints, routing files, database/schema files, and representative files for each major domain.
+- Do not call glob with **/* from the repository root. Use targeted discovery by directory and extension. Prefer shell commands like rg --files with excludes for .git, node_modules, dist, build, cache directories, and existing generated wiki output.
+- Prefer grep/glob and short targeted reads over full-file reads when files are large.
+- Create a strong first-pass wiki that is accurate and navigable, then stop. The wiki can be refined in later update runs.
+- Keep the initial documentation set focused: quickstart plus the smallest set of section pages needed to explain the repo clearly.
+- Do not run commands that search outside the target repository.
+
+Planning discipline:
+- After discovery and before writing final documentation, create a temporary %s/_plan.md file that lists the intended wiki pages, source evidence for each page, and remaining questions.
+- Use /openwiki/_plan.md when writing this temporary plan with filesystem tools.
+- Before completing the run, delete %s/_plan.md. If there is no filesystem delete tool, use shell execute from the repository root, for example rm -f openwiki/_plan.md.
+- Do not leave %s/_plan.md in the final wiki.
+
+Git discipline:
+- Use git heavily where it helps explain why code exists, not just what code exists.
+- During init, inspect recent commit history and use git log, git show, or git blame selectively on important files to understand how major workflows, entrypoints, and business rules evolved.
+- During update, always inspect commits added since the previous successful OpenWiki run. Prefer the gitHead recorded in %s; fall back to the last updatedAt timestamp if no gitHead exists.
+- Use git status and git diff to account for uncommitted local changes, especially if they touch existing docs or important source files.
+- Do not over-index on ancient history. Focus on recent commits and high-signal history for important files.
+
+Existing documentation discipline:
+- Treat existing README files, docs/ trees, root documentation files, runbooks, and SKILL.md files as primary source material.
+- Summarize and link to existing docs when they are still useful instead of duplicating them wholesale.
+- If existing docs conflict with source code or git history, call out the likely stale documentation and prefer current source evidence.
+
+Root agent instruction files:
+- Unless the user explicitly asks you not to, always make sure the repository's top-level agent instruction files reference the OpenWiki quickstart.
+- Only consider top-level /AGENTS.md and /CLAUDE.md for this step. Do not edit nested AGENTS.md or CLAUDE.md files.
+- If /AGENTS.md or /CLAUDE.md exists, add or update the OpenWiki reference section there. If both exist, ensure the same section is added to both (duplicated).
+- If neither exists, create top-level /AGENTS.md containing only the OpenWiki reference section.
+- During update runs, inspect any existing OpenWiki reference section in /AGENTS.md and/or /CLAUDE.md and refresh it only if the section is missing or semantically stale. This check is required even when the wiki itself is otherwise current.
+- Preserve surrounding instructions in existing files. Replace/update an existing OpenWiki reference section instead of adding duplicates.
+- Do not edit /AGENTS.md or /CLAUDE.md only to normalize formatting, blank lines, wrapping, or punctuation if the existing OpenWiki section is already semantically correct.
+- Use this exact section structure every time:
+
+`+"```markdown"+`
+## OpenWiki
+
+This repository has documentation located in the /openwiki directory.
+
+Start here:
+- [OpenWiki quickstart](openwiki/quickstart.md)
+
+OpenWiki includes repository overview, architecture notes, workflows, domain concepts, operations, integrations, testing guidance, and source maps.
+
+When working in this repository, read the OpenWiki quickstart first, then follow its links to the relevant architecture, workflow, domain, operation, and testing notes.
+`+"```"+`
+
+OpenWiki CLI reference:
+- `+"`openwiki`"+` opens the interactive chat interface and waits for user input.
+- `+"`openwiki init`"+` initializes OpenWiki documentation for the current repository.
+- `+"`openwiki update`"+` updates existing OpenWiki documentation for the current repository.
+- `+"`openwiki print -m \"message\"`"+` runs once, prints the final assistant output, and exits.
+- `+"`openwiki --model <id>`"+` selects a model ID for that run.
+- `+"`openwiki --help`"+` prints current usage, options, and examples.
+
+Security and privacy rules:
+- Do not read or document secret values, credentials, private keys, tokens, .env files, or other sensitive material.
+- Do not read .env files. .env.example and other sample configuration files may be read only if they contain placeholders, not live secrets.
+- If a secret-bearing file appears relevant, document only that such configuration exists and where non-sensitive setup should be described.
+- Keep all documentation under %s/.
+- Do not modify source code outside %s/. The only allowed exceptions are top-level /AGENTS.md and /CLAUDE.md, and only for the OpenWiki reference section described above.
+
+Documentation goals:
+- Someone with zero knowledge of the repository should be able to start at %s/quickstart.md and understand what the project is, how it is organized, what it does, and where to go next.
+- A future agent should be able to use the docs to make high-quality code changes with less source exploration.
+- Capture both technical details and business/product logic.
+- Explain why important code exists, not only what files contain.
+- Prefer clear Markdown with stable links between pages.
+- Organize the docs like human documentation, not a raw file inventory.
+- Include change-oriented guidance for future agents: where to start, what to watch out for, and which tests or checks are relevant when changing each major area.
+- Keep the docs concise enough to maintain. Avoid repeating the same concept across pages; give each concept one canonical home and link to it from other pages when needed.
+- Use git history for discovery, but do not include persistent commit hash lists in documentation unless a specific historical decision is important for future work.
+
+Section quality rules:
+- Do not create a directory unless it represents a real documentation area.
+- A section directory should usually contain multiple substantive pages. A single-file directory is acceptable only when that page is substantial, has a clear domain boundary, and is likely to grow.
+- Avoid thin pages. If a page would mostly be a stub, source map, or short note, merge it into %s/quickstart.md or a broader section page instead.
+- Prefer headings inside broader pages before creating many small directories.
+- Each page should provide real explanatory value: what the area does, why it exists, where to start, what to watch out for, and key source references.
+- Before finishing an init or update run, review the %s/ tree. Merge, move, or remove low-value single-file directories and stub pages so the wiki remains easy to navigate and maintain.
+- For small repositories with about 10 or fewer primary source files, prefer %s/quickstart.md plus at most 1-2 supporting pages. Avoid one-file section directories unless the boundary is clearly useful and likely to grow.
+- Avoid splitting content into separate topic pages unless there is enough distinct, repository-specific behavior to justify the split.
+
+Required documentation structure:
+- %s/quickstart.md must be the entrypoint.
+- %s/quickstart.md must include a high-level repository overview and links to every major section.
+- When writing required documentation with filesystem tools, use /openwiki/... paths, for example /openwiki/quickstart.md.
+- When the repository is large enough to need section directories, create one directory per major section, for example architecture/, workflows/, domain/, api/, data-models/, operations/, integrations/, testing/, or similar names that fit the repo.
+- Each section directory should contain focused Markdown pages; if a directory would contain only one short page, prefer a broader page or a heading in %s/quickstart.md.
+- Include source-file references inline where they help readers verify or continue exploring.
+- Source Map sections are optional. Add one only when it materially improves navigation for that page. Prefer inline source references for short pages.
+- Track the last successful documentation update in %s.
+
+Mode-specific behavior:
+%s`,
+		constants.OpenWikiDir,
+		constants.OpenWikiDir,
+		constants.OpenWikiDir,
+		constants.OpenWikiDir,
+		constants.UpdateMetadataPath,
+		constants.OpenWikiDir,
+		constants.OpenWikiDir,
+		constants.OpenWikiDir,
+		constants.OpenWikiDir,
+		constants.OpenWikiDir,
+		constants.OpenWikiDir,
+		constants.OpenWikiDir,
+		constants.OpenWikiDir,
+		constants.OpenWikiDir,
+		constants.UpdateMetadataPath,
+		modeInstructions(command),
+	))
+}
+
+func modeInstructions(command constants.Command) string {
+	switch command {
+	case constants.CommandChat:
+		return strings.TrimSpace(`
+- This is an interactive chat turn.
+- Answer the user's message directly.
+- Do not create or update OpenWiki documentation unless the user explicitly asks you to modify documentation.
+- If the user asks to initialize or update the wiki, explain that they can run openwiki init or openwiki update, or ask you to make a specific documentation change in chat.`)
+	case constants.CommandInit:
+		return strings.TrimSpace(fmt.Sprintf(`
+- This is an initial documentation run.
+- Assume %s/ does not yet contain useful documentation.
+- Build the documentation structure from scratch.
+- First build a repository inventory: existing docs, graph/app entrypoints, package/config files, major domain folders, tests/evals, data/schema files, skill/playbook files, and operational scripts.
+- Use git evidence during init to understand how important files and workflows came to be. Prefer recent commits and targeted git blame/show on high-signal files.
+- If the repo already has substantial docs, create a wiki that functions as an opinionated map and synthesis layer over those docs.
+- Create %s/quickstart.md first, then the linked section pages.
+- Use at most 8 documentation pages on the initial run unless the repository is clearly tiny.
+- Do not try to document every source file. Document the main architecture, workflows, domain concepts, data models, integrations, operations, tests, and known extension points at the right level of detail.
+- The CLI will record successful run metadata in %s after you finish.`,
+			constants.OpenWikiDir, constants.OpenWikiDir, constants.UpdateMetadataPath))
+	default:
+		return strings.TrimSpace(fmt.Sprintf(`
+- This is a maintenance update run.
+- Inspect the existing %s/ documentation before editing.
+- Read %s if it exists.
+- Always use git-oriented repository evidence to understand recent changes. Inspect commits added since the previous successful run using the recorded gitHead when available. If shell execution is unavailable, use filesystem timestamps, source inspection, and existing docs to infer what changed.
+- Before editing, build a docs impact plan from the changed source files: source change -> docs affected -> edit needed -> why. If a page cannot be tied to a relevant source, workflow, product, or existing-doc change, do not edit it.
+- Update runs must be surgical. Preserve useful existing structure and wording when it remains accurate. Prefer replacing one stale sentence over adding new paragraphs.
+- Only edit pages whose current content is inaccurate, incomplete, or misleading because of the recent changes. Do not refresh every page.
+- Keep each concept in one canonical page. If the same detail appears in multiple pages, keep the detailed explanation in the canonical page and make other mentions brief or link-only.
+- Do not make formatting-only edits. Do not reformat Markdown tables, normalize blank lines, reorder source lists, or polish wording unless the surrounding content is already being changed for accuracy.
+- Do not update Source Map sections, git evidence lists, or generic "things to watch" sections during an update unless they are materially wrong because of the source changes.
+- Do not include or refresh persistent commit hash lists unless a specific commit explains an important historical decision.
+- Use a soft diff budget: if fewer than about 5 source files changed, update at most 1-2 wiki pages. Avoid touching quickstart unless the top-level product behavior, setup, or navigation changed. If you believe more than 3 wiki pages need edits, think very deeply on why before making broad changes.
+- Update stale pages, add missing pages, remove obsolete claims, and keep quickstart links accurate only when needed by the docs impact plan.
+- Updates may be a no-op. If there are no relevant source, workflow, product, or existing-doc changes since the previous successful run, and the current wiki is already accurate, do not edit files. Say that the wiki is already current.
+- The CLI will record successful run metadata in %s after you finish.`,
+			constants.OpenWikiDir, constants.UpdateMetadataPath, constants.UpdateMetadataPath))
+	}
+}
+
+// UserPrompt builds the user message for a run.
+func UserPrompt(command constants.Command, context *git.RunContext, userMessage string) string {
+	switch command {
+	case constants.CommandChat:
+		if strings.TrimSpace(userMessage) == "" {
+			return "Start an OpenWiki chat."
+		}
+		return strings.TrimSpace(userMessage)
+	case constants.CommandInit:
+		return appendUserMessage(strings.TrimSpace(fmt.Sprintf(`
+Initialize OpenWiki documentation for this repository.
+
+Inspect the project thoroughly, identify the major technical and business domains, and write the initial documentation under %s/.
+
+Start with %s/quickstart.md as the entrypoint. Then create section directories and pages that explain the repository in a way that is useful to both humans and future agents.
+
+Git context:
+%s`, constants.OpenWikiDir, constants.OpenWikiDir, context.GitSummary)), userMessage)
+	default:
+		return appendUserMessage(strings.TrimSpace(fmt.Sprintf(`
+Update the existing OpenWiki documentation for this repository.
+
+Inspect %s/, identify recent source changes, and refresh only the documentation pages directly affected by those changes. Use the git evidence below when available. Keep edits surgical: do not rewrite accurate sections, do not update source maps or git evidence just to refresh them, and do not make formatting-only changes. If the wiki is already current, do not edit files. The CLI will update %s only when OpenWiki content changes.
+
+Last update metadata:
+%s
+
+Git change summary:
+%s`, constants.OpenWikiDir, constants.UpdateMetadataPath, formatLastUpdate(context.LastUpdate), context.GitSummary)), userMessage)
+	}
+}
+
+// RuntimeNote appends repository runtime instructions to the user prompt.
+func RuntimeNote(cwd string, userPrompt string) string {
+	return strings.TrimSpace(fmt.Sprintf(`%s
+
+Repository root:
+%s
+
+Runtime note:
+- Treat the repository root above as the only project you are documenting.
+- Filesystem tools use a virtual root: / means %s.
+- For ls, read_file, write_file, edit_file, glob, and grep, use virtual paths such as /README.md, /agent/agents/main.py, and /openwiki/quickstart.md.
+- Do not pass host absolute paths to filesystem tools. A host absolute path will be treated as a virtual path and will write to the wrong location.
+- Shell execute commands run on the host. For execute, use cd %s before repository commands.
+- Do not search parent directories or unrelated repositories.`, userPrompt, cwd, cwd, cwd))
+}
+
+func appendUserMessage(prompt, userMessage string) string {
+	if strings.TrimSpace(userMessage) == "" {
+		return prompt
+	}
+	return strings.TrimSpace(fmt.Sprintf(`%s
+
+Additional user instruction:
+%s`, prompt, strings.TrimSpace(userMessage)))
+}

--- a/go/internal/runner/runner.go
+++ b/go/internal/runner/runner.go
@@ -1,0 +1,121 @@
+package runner
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/langchain-ai/openwiki/go/internal/agent"
+	"github.com/langchain-ai/openwiki/go/internal/config"
+	"github.com/langchain-ai/openwiki/go/internal/constants"
+	"github.com/langchain-ai/openwiki/go/internal/git"
+	"github.com/langchain-ai/openwiki/go/internal/metadata"
+	"github.com/langchain-ai/openwiki/go/internal/output"
+)
+
+// Options configures a full OpenWiki run.
+type Options struct {
+	Command     constants.Command
+	ModelFlag   string
+	UserMessage string
+	PrintMode   bool
+	CWD         string
+}
+
+// Result is the outcome of a run.
+type Result struct {
+	Skipped bool
+	Model   string
+}
+
+// Run executes init, update, or print commands.
+func Run(ctx context.Context, opts Options) (*Result, error) {
+	settings, err := config.LoadSettings(opts.ModelFlag, opts.CWD)
+	if err != nil {
+		return nil, err
+	}
+
+	if opts.Command == constants.CommandUpdate && shouldCheckUpdateNoop(opts.UserMessage) {
+		noop, err := git.GetUpdateNoopStatus(settings.CWD)
+		if err != nil {
+			return nil, err
+		}
+		if noop.ShouldSkip {
+			message := "No repository changes detected since the last OpenWiki update; skipping agent run."
+			out := output.NewWriter(outputMode(opts.PrintMode))
+			out.OnText(message, "main")
+			if opts.PrintMode {
+				out.WriteFinalPrint()
+			}
+			return &Result{Skipped: true, Model: noop.Model}, nil
+		}
+	}
+
+	var snapshotBefore metadata.ContentSnapshot
+	if opts.Command != constants.CommandChat {
+		snapshotBefore, err = metadata.CreateContentSnapshot(settings.CWD)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	out := output.NewWriter(outputMode(opts.PrintMode))
+
+	_, err = agent.Run(ctx, agent.Options{
+		Command:     opts.Command,
+		CWD:         settings.CWD,
+		ModelID:     settings.ModelID,
+		APIKey:      settings.APIKey,
+		UserMessage: opts.UserMessage,
+		Debug:       settings.Debug,
+		Output:      out,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	if opts.PrintMode {
+		out.WriteFinalPrint()
+	}
+
+	if opts.Command != constants.CommandChat {
+		snapshotAfter, err := metadata.CreateContentSnapshot(settings.CWD)
+		if err != nil {
+			return nil, err
+		}
+
+		if snapshotBefore != snapshotAfter {
+			head, err := git.GetHead(settings.CWD)
+			if err != nil {
+				return nil, err
+			}
+			if err := metadata.WriteLastUpdateMetadata(opts.Command, settings.CWD, settings.ModelID, head); err != nil {
+				return nil, fmt.Errorf("write metadata: %w", err)
+			}
+		}
+	}
+
+	return &Result{Model: settings.ModelID}, nil
+}
+
+func outputMode(printMode bool) output.Mode {
+	if printMode {
+		return output.ModePrint
+	}
+	return output.ModeProgress
+}
+
+func shouldCheckUpdateNoop(userMessage string) bool {
+	return len(trimSpace(userMessage)) == 0
+}
+
+func trimSpace(value string) string {
+	start := 0
+	end := len(value)
+	for start < end && (value[start] == ' ' || value[start] == '\n' || value[start] == '\t' || value[start] == '\r') {
+		start++
+	}
+	for end > start && (value[end-1] == ' ' || value[end-1] == '\n' || value[end-1] == '\t' || value[end-1] == '\r') {
+		end--
+	}
+	return value[start:end]
+}

--- a/go/internal/tools/definitions.go
+++ b/go/internal/tools/definitions.go
@@ -1,0 +1,129 @@
+package tools
+
+import (
+	"github.com/sashabaranov/go-openai"
+)
+
+// Definitions returns OpenAI function tool definitions for the agent.
+func Definitions() []openai.Tool {
+	return []openai.Tool{
+		tool("ls", "List files and directories at a virtual path.", map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"path": map[string]any{
+					"type":        "string",
+					"description": "Virtual path to list, e.g. / or /src",
+				},
+			},
+		}),
+		tool("read_file", "Read a file at a virtual path with optional offset and limit.", map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"path": map[string]any{
+					"type":        "string",
+					"description": "Virtual path to read",
+				},
+				"offset": map[string]any{
+					"type":        "integer",
+					"description": "Line offset (0-based)",
+				},
+				"limit": map[string]any{
+					"type":        "integer",
+					"description": "Maximum number of lines to read",
+				},
+			},
+			"required": []string{"path"},
+		}),
+		tool("write_file", "Write content to a file at a virtual path.", map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"path": map[string]any{
+					"type":        "string",
+					"description": "Virtual path to write",
+				},
+				"content": map[string]any{
+					"type":        "string",
+					"description": "File content",
+				},
+			},
+			"required": []string{"path", "content"},
+		}),
+		tool("edit_file", "Replace old_string with new_string in a file.", map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"path": map[string]any{
+					"type":        "string",
+					"description": "Virtual path to edit",
+				},
+				"old_string": map[string]any{
+					"type":        "string",
+					"description": "Text to replace",
+				},
+				"new_string": map[string]any{
+					"type":        "string",
+					"description": "Replacement text",
+				},
+				"replace_all": map[string]any{
+					"type":        "boolean",
+					"description": "Replace all occurrences",
+				},
+			},
+			"required": []string{"path", "old_string", "new_string"},
+		}),
+		tool("glob", "Find files matching a glob pattern under a virtual path.", map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"pattern": map[string]any{
+					"type":        "string",
+					"description": "Glob pattern, e.g. *.go",
+				},
+				"path": map[string]any{
+					"type":        "string",
+					"description": "Virtual directory to search from",
+				},
+			},
+			"required": []string{"pattern"},
+		}),
+		tool("grep", "Search file contents for a regex pattern.", map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"pattern": map[string]any{
+					"type":        "string",
+					"description": "Regular expression pattern",
+				},
+				"path": map[string]any{
+					"type":        "string",
+					"description": "Virtual directory to search from",
+				},
+				"glob": map[string]any{
+					"type":        "string",
+					"description": "Optional filename glob filter",
+				},
+			},
+			"required": []string{"pattern"},
+		}),
+		tool("execute", "Execute a shell command in the repository root.", map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"command": map[string]any{
+					"type":        "string",
+					"description": "Shell command to run",
+				},
+			},
+			"required": []string{"command"},
+		}),
+	}
+}
+
+func tool(name, description string, schema map[string]any) openai.Tool {
+	return openai.Tool{
+		Type: openai.ToolTypeFunction,
+		Function: &openai.FunctionDefinition{
+			Name:        name,
+			Description: description,
+			Parameters:  schema,
+			Strict:      false,
+		},
+	}
+}
+

--- a/go/internal/tools/fs.go
+++ b/go/internal/tools/fs.go
@@ -1,0 +1,312 @@
+package tools
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+)
+
+// Registry provides filesystem and shell tools for the agent.
+type Registry struct {
+	fs *VirtualFS
+}
+
+// NewRegistry creates a tool registry rooted at the repository.
+func NewRegistry(root string) *Registry {
+	return &Registry{fs: &VirtualFS{Root: root}}
+}
+
+// Execute runs a tool by name with JSON arguments.
+func (r *Registry) Execute(name, argsJSON string) (string, error) {
+	switch name {
+	case "ls":
+		return r.ls(argsJSON)
+	case "read_file":
+		return r.readFile(argsJSON)
+	case "write_file":
+		return r.writeFile(argsJSON)
+	case "edit_file":
+		return r.editFile(argsJSON)
+	case "glob":
+		return r.glob(argsJSON)
+	case "grep":
+		return r.grep(argsJSON)
+	case "execute":
+		return r.execute(argsJSON)
+	default:
+		return "", fmt.Errorf("unknown tool: %s", name)
+	}
+}
+
+type lsArgs struct {
+	Path string `json:"path"`
+}
+
+func (r *Registry) ls(argsJSON string) (string, error) {
+	var args lsArgs
+	if argsJSON != "" {
+		if err := json.Unmarshal([]byte(argsJSON), &args); err != nil {
+			return "", err
+		}
+	}
+
+	target, err := r.fs.Resolve(args.Path)
+	if err != nil {
+		return "", err
+	}
+
+	entries, err := os.ReadDir(target)
+	if err != nil {
+		return "", err
+	}
+
+	var lines []string
+	for _, entry := range entries {
+		name := entry.Name()
+		if entry.IsDir() {
+			name += "/"
+		}
+		lines = append(lines, name)
+	}
+
+	if len(lines) == 0 {
+		return "(empty directory)", nil
+	}
+	return strings.Join(lines, "\n"), nil
+}
+
+type readFileArgs struct {
+	Path   string `json:"path"`
+	Offset int    `json:"offset"`
+	Limit  int    `json:"limit"`
+}
+
+func (r *Registry) readFile(argsJSON string) (string, error) {
+	var args readFileArgs
+	if err := json.Unmarshal([]byte(argsJSON), &args); err != nil {
+		return "", err
+	}
+	if args.Path == "" {
+		return "", fmt.Errorf("path is required")
+	}
+
+	target, err := r.fs.Resolve(args.Path)
+	if err != nil {
+		return "", err
+	}
+
+	content, err := os.ReadFile(target)
+	if err != nil {
+		return "", err
+	}
+
+	lines := strings.Split(string(content), "\n")
+	start := args.Offset
+	if start < 0 {
+		start = 0
+	}
+	if start >= len(lines) {
+		return "", nil
+	}
+
+	end := len(lines)
+	if args.Limit > 0 {
+		end = start + args.Limit
+		if end > len(lines) {
+			end = len(lines)
+		}
+	}
+
+	selected := lines[start:end]
+	return strings.Join(selected, "\n"), nil
+}
+
+type writeFileArgs struct {
+	Path    string `json:"path"`
+	Content string `json:"content"`
+}
+
+func (r *Registry) writeFile(argsJSON string) (string, error) {
+	var args writeFileArgs
+	if err := json.Unmarshal([]byte(argsJSON), &args); err != nil {
+		return "", err
+	}
+	if args.Path == "" {
+		return "", fmt.Errorf("path is required")
+	}
+
+	target, err := r.fs.Resolve(args.Path)
+	if err != nil {
+		return "", err
+	}
+
+	if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+		return "", err
+	}
+
+	if err := os.WriteFile(target, []byte(args.Content), 0o644); err != nil {
+		return "", err
+	}
+
+	return fmt.Sprintf("Wrote %s", r.fs.ToVirtual(target)), nil
+}
+
+type editFileArgs struct {
+	Path       string `json:"path"`
+	OldString  string `json:"old_string"`
+	NewString  string `json:"new_string"`
+	ReplaceAll bool   `json:"replace_all"`
+}
+
+func (r *Registry) editFile(argsJSON string) (string, error) {
+	var args editFileArgs
+	if err := json.Unmarshal([]byte(argsJSON), &args); err != nil {
+		return "", err
+	}
+	if args.Path == "" {
+		return "", fmt.Errorf("path is required")
+	}
+	if args.OldString == "" {
+		return "", fmt.Errorf("old_string is required")
+	}
+
+	target, err := r.fs.Resolve(args.Path)
+	if err != nil {
+		return "", err
+	}
+
+	content, err := os.ReadFile(target)
+	if err != nil {
+		return "", err
+	}
+
+	text := string(content)
+	if args.ReplaceAll {
+		if !strings.Contains(text, args.OldString) {
+			return "", fmt.Errorf("old_string not found in %s", args.Path)
+		}
+		text = strings.ReplaceAll(text, args.OldString, args.NewString)
+	} else {
+		index := strings.Index(text, args.OldString)
+		if index < 0 {
+			return "", fmt.Errorf("old_string not found in %s", args.Path)
+		}
+		text = text[:index] + args.NewString + text[index+len(args.OldString):]
+	}
+
+	if err := os.WriteFile(target, []byte(text), 0o644); err != nil {
+		return "", err
+	}
+
+	return fmt.Sprintf("Edited %s", r.fs.ToVirtual(target)), nil
+}
+
+type globArgs struct {
+	Pattern string `json:"pattern"`
+	Path    string `json:"path"`
+}
+
+func (r *Registry) glob(argsJSON string) (string, error) {
+	var args globArgs
+	if err := json.Unmarshal([]byte(argsJSON), &args); err != nil {
+		return "", err
+	}
+	if args.Pattern == "" {
+		return "", fmt.Errorf("pattern is required")
+	}
+
+	searchRoot, err := r.fs.Resolve(args.Path)
+	if err != nil {
+		return "", err
+	}
+
+	matches, err := filepath.Glob(filepath.Join(searchRoot, args.Pattern))
+	if err != nil {
+		return "", err
+	}
+
+	var virtualMatches []string
+	for _, match := range matches {
+		virtualMatches = append(virtualMatches, r.fs.ToVirtual(match))
+	}
+
+	if len(virtualMatches) == 0 {
+		return "(no matches)", nil
+	}
+	return strings.Join(virtualMatches, "\n"), nil
+}
+
+type grepArgs struct {
+	Pattern string `json:"pattern"`
+	Path    string `json:"path"`
+	Glob    string `json:"glob"`
+}
+
+func (r *Registry) grep(argsJSON string) (string, error) {
+	var args grepArgs
+	if err := json.Unmarshal([]byte(argsJSON), &args); err != nil {
+		return "", err
+	}
+	if args.Pattern == "" {
+		return "", fmt.Errorf("pattern is required")
+	}
+
+	re, err := regexp.Compile(args.Pattern)
+	if err != nil {
+		return "", err
+	}
+
+	searchRoot, err := r.fs.Resolve(args.Path)
+	if err != nil {
+		return "", err
+	}
+
+	var matches []string
+	err = filepath.WalkDir(searchRoot, func(path string, d fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if d.IsDir() {
+			base := d.Name()
+			if base == ".git" || base == "node_modules" || base == "dist" || base == "build" {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+
+		if args.Glob != "" {
+			ok, err := filepath.Match(args.Glob, filepath.Base(path))
+			if err != nil {
+				return err
+			}
+			if !ok {
+				return nil
+			}
+		}
+
+		content, err := os.ReadFile(path)
+		if err != nil {
+			return nil
+		}
+
+		lines := strings.Split(string(content), "\n")
+		for i, line := range lines {
+			if re.MatchString(line) {
+				matches = append(matches, fmt.Sprintf("%s:%d:%s", r.fs.ToVirtual(path), i+1, line))
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		return "", err
+	}
+
+	if len(matches) == 0 {
+		return "(no matches)", nil
+	}
+	return strings.Join(matches, "\n"), nil
+}

--- a/go/internal/tools/shell.go
+++ b/go/internal/tools/shell.go
@@ -1,0 +1,62 @@
+package tools
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"os/exec"
+	"strings"
+	"time"
+
+	"github.com/langchain-ai/openwiki/go/internal/constants"
+)
+
+type executeArgs struct {
+	Command string `json:"command"`
+}
+
+func (r *Registry) execute(argsJSON string) (string, error) {
+	var args executeArgs
+	if err := json.Unmarshal([]byte(argsJSON), &args); err != nil {
+		return "", err
+	}
+	if strings.TrimSpace(args.Command) == "" {
+		return "", fmt.Errorf("command is required")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), constants.ShellTimeoutSeconds*time.Second)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, "sh", "-c", args.Command)
+	cmd.Dir = r.fs.Root
+
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	err := cmd.Run()
+	output := strings.TrimSpace(stdout.String())
+	if stderr.Len() > 0 {
+		if output != "" {
+			output += "\n"
+		}
+		output += strings.TrimSpace(stderr.String())
+	}
+
+	if len(output) > constants.MaxShellOutputBytes {
+		output = output[:constants.MaxShellOutputBytes] + "\n...(output truncated)"
+	}
+
+	if err != nil {
+		if output == "" {
+			return "", err
+		}
+		return output + "\n(exit error: " + err.Error() + ")", nil
+	}
+
+	if output == "" {
+		return "(no output)", nil
+	}
+	return output, nil
+}

--- a/go/internal/tools/tools_test.go
+++ b/go/internal/tools/tools_test.go
@@ -1,0 +1,116 @@
+package tools
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestVirtualFSResolve(t *testing.T) {
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, "README.md"), []byte("hello"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	vfs := &VirtualFS{Root: root}
+
+	readme, err := vfs.Resolve("/README.md")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if filepath.Base(readme) != "README.md" {
+		t.Fatalf("unexpected path %s", readme)
+	}
+
+	outside, err := vfs.Resolve("/../../../outside")
+	if err != nil {
+		t.Fatal(err)
+	}
+	rel, err := filepath.Rel(root, outside)
+	if err != nil || strings.HasPrefix(rel, "..") {
+		t.Fatalf("expected path to stay within repo root, got %q", outside)
+	}
+}
+
+func TestRegistryWriteAndRead(t *testing.T) {
+	root := t.TempDir()
+	registry := NewRegistry(root)
+
+	_, err := registry.Execute("write_file", `{"path":"/notes.md","content":"# Notes"}`)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	output, err := registry.Execute("read_file", `{"path":"/notes.md"}`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if output != "# Notes" {
+		t.Fatalf("unexpected content %q", output)
+	}
+}
+
+func TestRegistryEditFile(t *testing.T) {
+	root := t.TempDir()
+	registry := NewRegistry(root)
+
+	_, err := registry.Execute("write_file", `{"path":"/doc.md","content":"alpha beta"}`)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = registry.Execute("edit_file", `{"path":"/doc.md","old_string":"beta","new_string":"gamma"}`)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	output, err := registry.Execute("read_file", `{"path":"/doc.md"}`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if output != "alpha gamma" {
+		t.Fatalf("unexpected content %q", output)
+	}
+}
+
+func TestRegistryGlobAndGrep(t *testing.T) {
+	root := t.TempDir()
+	registry := NewRegistry(root)
+
+	if err := os.WriteFile(filepath.Join(root, "a.go"), []byte("package main\nfunc main() {}\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "b.txt"), []byte("nothing here\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	globOut, err := registry.Execute("glob", `{"pattern":"*.go","path":"/"}`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(globOut, "/a.go") {
+		t.Fatalf("expected go match, got %q", globOut)
+	}
+
+	grepOut, err := registry.Execute("grep", `{"pattern":"package","path":"/"}`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(grepOut, "a.go:1:package main") {
+		t.Fatalf("expected grep match, got %q", grepOut)
+	}
+}
+
+func TestRegistryExecute(t *testing.T) {
+	root := t.TempDir()
+	registry := NewRegistry(root)
+
+	output, err := registry.Execute("execute", `{"command":"echo hello"}`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if output != "hello" {
+		t.Fatalf("unexpected output %q", output)
+	}
+}

--- a/go/internal/tools/virtual.go
+++ b/go/internal/tools/virtual.go
@@ -1,0 +1,73 @@
+package tools
+
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+)
+
+// VirtualFS resolves virtual /-prefixed paths to the repository root.
+type VirtualFS struct {
+	Root string
+}
+
+// Resolve converts a virtual path to an absolute host path within the repo.
+func (v *VirtualFS) Resolve(virtualPath string) (string, error) {
+	trimmed := strings.TrimSpace(virtualPath)
+	if trimmed == "" || trimmed == "/" || trimmed == "." {
+		return v.Root, nil
+	}
+
+	if !strings.HasPrefix(trimmed, "/") {
+		trimmed = "/" + trimmed
+	}
+
+	cleaned := filepath.Clean(trimmed)
+	relative := strings.TrimPrefix(cleaned, string(filepath.Separator))
+	if relative == "." {
+		return v.Root, nil
+	}
+
+	abs := filepath.Join(v.Root, relative)
+	abs, err := filepath.Abs(abs)
+	if err != nil {
+		return "", err
+	}
+
+	rootAbs, err := filepath.Abs(v.Root)
+	if err != nil {
+		return "", err
+	}
+
+	rel, err := filepath.Rel(rootAbs, abs)
+	if err != nil {
+		return "", err
+	}
+	if rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return "", fmt.Errorf("path escapes repository root: %s", virtualPath)
+	}
+
+	return abs, nil
+}
+
+// ToVirtual converts a host path to a virtual path for tool output.
+func (v *VirtualFS) ToVirtual(hostPath string) string {
+	abs, err := filepath.Abs(hostPath)
+	if err != nil {
+		return hostPath
+	}
+	rootAbs, err := filepath.Abs(v.Root)
+	if err != nil {
+		return hostPath
+	}
+
+	rel, err := filepath.Rel(rootAbs, abs)
+	if err != nil || strings.HasPrefix(rel, "..") {
+		return hostPath
+	}
+
+	if rel == "." {
+		return "/"
+	}
+	return "/" + strings.ReplaceAll(rel, "\\", "/")
+}

--- a/go/justfile
+++ b/go/justfile
@@ -1,0 +1,33 @@
+# OpenWiki headless CLI task runner
+# Install just: https://github.com/casey/just
+
+default: build
+
+binary := "bin/openwiki"
+
+# Build the headless CLI binary
+build:
+    go build -o {{binary}} ./cmd/openwiki
+
+# Run all tests
+test:
+    go test ./...
+
+# Run tests with verbose output
+test-v:
+    go test -v ./...
+
+# Run go vet
+vet:
+    go vet ./...
+
+# Build and run checks
+check: vet test build
+
+# Remove build artifacts
+clean:
+    rm -rf bin/
+
+# Install binary to GOPATH/bin
+install: build
+    cp {{binary}} "${GOPATH:-$HOME/go}/bin/openwiki"


### PR DESCRIPTION
## Summary
- Add a Go/Cobra headless CLI under `go/` for `init`, `update`, and `print` workflows using OpenRouter as the sole model provider
- Implement a custom ReAct agent loop with virtual filesystem and shell tools, ported git/metadata/prompt logic, and CI-friendly `--update --print` support
- Replace Node-based scheduled workflows with a Go build step; use `just` for local build/test tasks and colocate tests in the same package as the code under test

## Test plan
- [x] `cd go && just test`
- [x] `cd go && just build`
- [ ] `OPENROUTER_API_KEY=... ./go/bin/openwiki init` on a sample repo
- [ ] `./go/bin/openwiki update --print` in CI with existing secrets


Made with [Cursor](https://cursor.com)