### PR TITLE
Add self-managed Codex OAuth provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ npm install -g openwiki
 
 ## Quick Start
 
-Initialize OpenWiki, configure your model and API key, then generate documentation
+Initialize OpenWiki, configure your model provider, then generate documentation
 
 ```sh
 openwiki --init
@@ -65,13 +65,13 @@ openwiki --help
 
 `openwiki` will automatically append prompting to your `AGENTS.md` and/or `CLAUDE.md` files to instruct your coding agent to reference it when searching for context. If the file does not already exist in your repository, OpenWiki will create it for you.
 
-On the first interactive run, OpenWiki will have you configure your inference provider, API key, and LLM. You will also be able to set a LangSmith API key to trace your OpenWiki runs to a LangSmith tracing project named "openwiki" (optional).
+On the first interactive run, OpenWiki will have you configure your inference provider, credentials when the provider needs an API key, and LLM. You will also be able to set a LangSmith API key to trace your OpenWiki runs to a LangSmith tracing project named "openwiki" (optional).
 
-These configuration options and secrets will be saved to `~/.openwiki/.env` on your local machine.
+These configuration options and OpenWiki-managed secrets will be saved to `~/.openwiki/.env` on your local machine. The `codex-oauth` provider stores its OAuth tokens separately in `~/.openwiki/codex-oauth.json` with restrictive permissions.
 
 ## Customizing
 
-OpenWiki supports OpenRouter, Fireworks, Baseten, OpenAI, an OpenAI-compatible provider, and Anthropic out of the box. By default, there are a few models pre-defined (GLM 5.2, Kimi K2.6, Sonnet 5, etc) but for each inference provider, OpenWiki will allow you to specify your own custom model ID.
+OpenWiki supports OpenRouter, Codex OAuth, Fireworks, Baseten, OpenAI, an OpenAI-compatible provider, and Anthropic out of the box. By default, there are a few models pre-defined (GLM 5.2, Kimi K2.7 Code, GPT 5.5, Sonnet 5, etc) but for each inference provider, OpenWiki will allow you to specify your own custom model ID.
 
 ### Alternative base URLs
 
@@ -84,6 +84,22 @@ OPENWIKI_PROVIDER=anthropic
 ANTHROPIC_API_KEY=your-key
 ANTHROPIC_BASE_URL=https://your-gateway.example.com/anthropic
 ```
+
+### Codex OAuth
+
+The `codex-oauth` provider manages its own Codex OAuth login. Run the login
+command once, open the printed URL, then paste the final callback URL back into
+the terminal:
+
+```bash
+openwiki login codex-oauth
+OPENWIKI_PROVIDER=codex-oauth
+OPENWIKI_MODEL_ID=gpt-5.5
+```
+
+OpenWiki stores OAuth tokens in `~/.openwiki/codex-oauth.json`, refreshes
+near-expiry access tokens automatically, and sends Responses API requests to
+`https://chatgpt.com/backend-api/codex`.
 
 ### OpenAI-compatible endpoints
 

--- a/openwiki/agent/workflow.md
+++ b/openwiki/agent/workflow.md
@@ -7,12 +7,12 @@ The documentation agent is implemented in `src/agent/`. It takes a command (`cha
 `src/agent/index.ts` follows this sequence for non-chat runs:
 
 1. Load `~/.openwiki/.env` into `process.env`.
-2. Resolve the provider via `resolveConfiguredProvider()` and ensure the provider's API key exists.
+2. Resolve the provider via `resolveConfiguredProvider()` and ensure credentials exist: API-key providers require their env key, while `codex-oauth` reads and refreshes OpenWiki-managed OAuth tokens from `~/.openwiki/codex-oauth.json`.
 3. Resolve the model ID from CLI input, `OPENWIKI_MODEL_ID`, or the provider's default model.
 4. Create a run context from Git state and prior update metadata.
 5. Snapshot the current `openwiki/` content hash (before the run).
 6. Build the system prompt and user prompt.
-7. Create the provider-specific model client (`ChatAnthropic`, `ChatOpenRouter`, or `ChatOpenAI`).
+7. Create the provider-specific model client (`ChatAnthropic`, `ChatOpenRouter`, `ChatOpenAI`, or the Codex OAuth `ChatOpenAI` wrapper).
 8. Create a DeepAgents `LocalShellBackend` rooted at the repository with a SQLite checkpointer.
 9. Stream messages and tool events back to the CLI.
 10. For `init` and `update`, compare the post-run content snapshot to the pre-run snapshot. Write `openwiki/.last-update.json` **only if the content changed**.
@@ -24,6 +24,7 @@ Chat runs skip metadata writes entirely.
 `createModel()` in `src/agent/index.ts` branches by provider:
 
 - **anthropic**: `new ChatAnthropic(modelId, { apiKey, anthropicApiUrl? })` — uses `@langchain/anthropic` directly. When `ANTHROPIC_BASE_URL` is set, the resolved alternative base URL is passed as `anthropicApiUrl` so requests can be routed to a self-hosted or proxied Anthropic-compatible endpoint instead of the default API.
+- **codex-oauth**: `new CodexChatOpenAI({ codexCredentials, model })` — reads OpenWiki-managed OAuth tokens from `~/.openwiki/codex-oauth.json`, refreshes near-expiry tokens, targets `https://chatgpt.com/backend-api/codex` through the Responses API, forces streaming and `store: false`, and lifts system/developer messages into top-level `instructions`.
 - **openrouter**: `new ChatOpenRouter({ apiKey, baseURL, model, siteName: "OpenWiki" })` — uses the selected OpenRouter model directly.
 - **openai**: `new ChatOpenAI({ apiKey, model, useResponsesApi: true })` — uses OpenAI's Responses API for official OpenAI calls.
 - **baseten / fireworks / openai-compatible**: `new ChatOpenAI({ apiKey, configuration: { baseURL? }, model })` — OpenAI-compatible clients using the provider's base URL when configured. The `openai-compatible` provider has no default endpoint; its base URL is user-supplied via `OPENAI_COMPATIBLE_BASE_URL` and required (`requiresBaseUrl: true`), which lets OpenWiki target any OpenAI-compatible gateway (for example a LiteLLM gateway fronting upstream providers).
@@ -96,7 +97,7 @@ The agent is not just a generic chat wrapper. It is intentionally constrained so
 - Be careful with `.last-update.json` semantics, because update runs use it to decide what changed since the previous successful run.
 - The content-snapshot check means a no-op update will not update metadata. If you change the snapshot logic, ensure `.last-update.json` is still excluded.
 - Credential loading happens before model resolution; changes there affect both onboarding and agent startup.
-- When adding a provider, add a branch in `createModel()` and ensure the API key env key is checked in `ensureProviderKey()`.
+- When adding a provider, add a branch in `createModel()` and ensure `ensureProviderCredentials()` validates the correct credential source instead of assuming every provider has an API-key env var.
 - The DeepAgents backend is configured with `virtualMode: true`, which is important for documentation-only behavior.
 
 ## Source map

--- a/openwiki/architecture/overview.md
+++ b/openwiki/architecture/overview.md
@@ -4,8 +4,8 @@ OpenWiki has a small but layered architecture:
 
 1. `src/cli.tsx` provides the interactive terminal application and orchestrates runs, including auto-exit for init/update.
 2. `src/commands.ts` parses argv and defines help text and supported options.
-3. `src/credentials.tsx` manages interactive onboarding for provider selection, API keys, model selection, and optional LangSmith tracing.
-4. `src/env.ts` reads and writes `~/.openwiki/.env` and surfaces credential diagnostics for all supported providers.
+3. `src/credentials.tsx` manages interactive onboarding for provider selection, API keys when applicable, model selection, and optional LangSmith tracing.
+4. `src/env.ts` reads and writes `~/.openwiki/.env` and surfaces credential diagnostics for OpenWiki-managed providers.
 5. `src/agent/index.ts` runs the documentation agent, resolves the provider, creates the appropriate model client, collects Git context, and writes update metadata.
 6. `src/agent/prompt.ts` builds the system and user prompts that tell the model how to behave.
 7. `src/agent/utils.ts` gathers Git evidence, computes an OpenWiki content snapshot, and records `.last-update.json` after successful init/update runs.
@@ -41,6 +41,7 @@ The agent runtime resolves the provider via `resolveConfiguredProvider()` in `sr
 Model creation branches by provider in `src/agent/index.ts` (`createModel`):
 
 - **anthropic** → `ChatAnthropic` with the Anthropic API key.
+- **codex-oauth** → `CodexChatOpenAI`, which uses OpenWiki-managed OAuth tokens from `~/.openwiki/codex-oauth.json`, refreshes them when needed, and targets `https://chatgpt.com/backend-api/codex`.
 - **openrouter** → `ChatOpenRouter` with the selected model ID.
 - **openai** → `ChatOpenAI` with `useResponsesApi: true`.
 - **baseten / fireworks / openai-compatible** → `ChatOpenAI` with the provider's API key and optional custom `baseURL` from `PROVIDER_CONFIGS`.
@@ -72,7 +73,7 @@ The current design reflects a documentation product rather than a general-purpos
 
 - Add or refine CLI commands in `src/commands.ts` and the corresponding UI behavior in `src/cli.tsx`.
 - Change onboarding or local credential storage in `src/credentials.tsx` and `src/env.ts`.
-- Add a new model provider by extending `PROVIDER_CONFIGS` and `OpenWikiProvider` in `src/constants.ts`, then adding a branch in `createModel` in `src/agent/index.ts`.
+- Add a new model provider by extending `PROVIDER_CONFIGS` and `OpenWikiProvider` in `src/constants.ts`, then adding the credential source and `createModel` branch in `src/agent/index.ts`.
 - Adjust model defaults, validation, or fallback lists in `src/constants.ts`.
 - Extend the documentation prompt or Git evidence in `src/agent/prompt.ts` and `src/agent/utils.ts`.
 - Modify run persistence or snapshot behavior in `src/agent/utils.ts`.
@@ -83,7 +84,7 @@ The current design reflects a documentation product rather than a general-purpos
 - Credential setup writes to a real home-directory file, so permission handling matters.
 - The agent is expected to work from repository-local virtual paths like `/README.md` and `/openwiki/quickstart.md`; the prompt explicitly warns about this.
 - `openwiki/` in the target repository is both the docs output location and the metadata location for `.last-update.json`.
-- When adding a provider, update `managedEnvKeys` in `src/env.ts` so diagnostics and env formatting cover the new key.
+- When adding an API-key provider, update `managedEnvKeys` in `src/env.ts` so diagnostics and env formatting cover the new key. External credential-store providers, such as `codex-oauth`, should keep their credential source explicit instead.
 - The content-snapshot logic excludes `.last-update.json`; if new metadata files are added under `openwiki/`, decide whether they should be excluded too.
 
 ## Source map

--- a/openwiki/cli/usage.md
+++ b/openwiki/cli/usage.md
@@ -23,7 +23,7 @@ When `--init` or `--update` is run in a TTY (without `--print`), the CLI starts 
 
 ### Non-interactive mode
 
-If stdin is not a TTY (e.g. CI), or `--print` is used, the CLI requires a provider API key to be already saved in `~/.openwiki/.env` or present in the environment. It will error with a clear message if the key is missing, rather than prompting interactively.
+If stdin is not a TTY (e.g. CI), or `--print` is used, the CLI requires the selected provider's non-interactive credentials to already be available. API-key providers read keys from `~/.openwiki/.env` or the environment; `codex-oauth` requires a prior `openwiki login codex-oauth`.
 
 ## Interactive behavior
 
@@ -43,8 +43,8 @@ The UI persists provider and model selection back to `~/.openwiki/.env` through 
 
 The first interactive run can prompt for:
 
-- a **provider** (`OPENWIKI_PROVIDER`) — openrouter, baseten, fireworks, openai, openai-compatible, or anthropic,
-- the **provider API key** (e.g. `OPENROUTER_API_KEY`, `OPENAI_API_KEY`, `OPENAI_COMPATIBLE_API_KEY`, `ANTHROPIC_API_KEY`, `BASETEN_API_KEY`, `FIREWORKS_API_KEY`),
+- a **provider** (`OPENWIKI_PROVIDER`) — openrouter, codex-oauth, baseten, fireworks, openai, openai-compatible, or anthropic,
+- the **provider API key** for API-key providers (e.g. `OPENROUTER_API_KEY`, `OPENAI_API_KEY`, `OPENAI_COMPATIBLE_API_KEY`, `ANTHROPIC_API_KEY`, `BASETEN_API_KEY`, `FIREWORKS_API_KEY`); `codex-oauth` skips this step and uses `~/.openwiki/codex-oauth.json`,
 - a **base URL** for providers that require one (the openai-compatible provider prompts for `OPENAI_COMPATIBLE_BASE_URL`),
 - a **model ID** stored as `OPENWIKI_MODEL_ID` — chosen from the provider's model list or a custom ID,
 - optional `LANGSMITH_API_KEY` for tracing.
@@ -57,14 +57,15 @@ If a LangSmith key is provided, onboarding also enables `LANGCHAIN_PROJECT=openw
 
 Providers and their model options are defined in `PROVIDER_CONFIGS` in `src/constants.ts`:
 
-| Provider          | Env key                     | Base URL                                | Models                                                                |
-| ----------------- | --------------------------- | --------------------------------------- | --------------------------------------------------------------------- |
-| openrouter        | `OPENROUTER_API_KEY`        | `https://openrouter.ai/api/v1`          | GLM 5.2, Fusion, Kimi K2.7 Code, Claude Opus/Sonnet, GPT 5.4 mini/5.5 |
-| baseten           | `BASETEN_API_KEY`           | `https://inference.baseten.co/v1`       | GLM 5.2, Kimi K2.7 Code                                               |
-| fireworks         | `FIREWORKS_API_KEY`         | `https://api.fireworks.ai/inference/v1` | GLM 5.2, Kimi K2.7 Code                                               |
-| openai            | `OPENAI_API_KEY`            | (default)                               | GPT 5.4 mini, GPT 5.5                                                 |
-| openai-compatible | `OPENAI_COMPATIBLE_API_KEY` | `OPENAI_COMPATIBLE_BASE_URL` (required) | custom model ID only                                                  |
-| anthropic         | `ANTHROPIC_API_KEY`         | (default, or `ANTHROPIC_BASE_URL`)      | Haiku, Sonnet, Opus                                                   |
+| Provider          | Env key / auth source        | Base URL                                | Models                                                                |
+| ----------------- | ---------------------------- | --------------------------------------- | --------------------------------------------------------------------- |
+| openrouter        | `OPENROUTER_API_KEY`         | `https://openrouter.ai/api/v1`          | GLM 5.2, Fusion, Kimi K2.7 Code, Claude Opus/Sonnet, GPT 5.4 mini/5.5 |
+| codex-oauth       | `~/.openwiki/codex-oauth.json` | `https://chatgpt.com/backend-api/codex` | GPT 5.5, GPT 5.4 mini                                                 |
+| baseten           | `BASETEN_API_KEY`            | `https://inference.baseten.co/v1`       | GLM 5.2, Kimi K2.7 Code                                               |
+| fireworks         | `FIREWORKS_API_KEY`          | `https://api.fireworks.ai/inference/v1` | GLM 5.2, Kimi K2.7 Code                                               |
+| openai            | `OPENAI_API_KEY`             | (default)                               | GPT 5.4 mini, GPT 5.5                                                 |
+| openai-compatible | `OPENAI_COMPATIBLE_API_KEY`  | `OPENAI_COMPATIBLE_BASE_URL` (required) | custom model ID only                                                  |
+| anthropic         | `ANTHROPIC_API_KEY`          | (default, or `ANTHROPIC_BASE_URL`)      | Haiku, Sonnet, Opus                                                   |
 
 The default provider is `openrouter`. `resolveConfiguredProvider()` picks the provider from `OPENWIKI_PROVIDER`, falling back to openrouter if `OPENROUTER_API_KEY` is set, then to `DEFAULT_PROVIDER`.
 
@@ -75,6 +76,23 @@ Anthropic-compatible endpoint (for example a self-hosted or proxied gateway)
 instead of the default API. When set, it is passed to `ChatAnthropic` as
 `anthropicApiUrl`; the `ANTHROPIC_API_KEY` is still sent as the request
 credential.
+
+### Codex OAuth provider
+
+The `codex-oauth` provider targets the Codex ChatGPT backend at
+`https://chatgpt.com/backend-api/codex` through the OpenAI Responses API. It
+does not use an OpenWiki API key. Run the login flow once:
+
+```bash
+openwiki login codex-oauth
+OPENWIKI_PROVIDER=codex-oauth
+OPENWIKI_MODEL_ID=gpt-5.5
+```
+
+The login command prints an OAuth URL. Open it, finish login, then paste the
+final callback URL back into the terminal. OpenWiki stores tokens in
+`~/.openwiki/codex-oauth.json` with `0600` permissions and refreshes near-expiry
+access tokens automatically.
 
 ### OpenAI-compatible provider
 
@@ -111,7 +129,7 @@ The help content is centralized in `src/commands.ts` and is used by the CLI UI. 
 - Update parser behavior in `src/commands.ts` first.
 - Then update any user-visible text in `src/cli.tsx` and `README.md`.
 - If new options affect run behavior, make sure `src/agent/index.ts` and `src/credentials.tsx` still receive the right inputs.
-- If adding a provider, update `PROVIDER_CONFIGS` and `SELECTABLE_OPENWIKI_PROVIDERS` in `src/constants.ts`, `managedEnvKeys` in `src/env.ts`, and the `createModel` branch in `src/agent/index.ts`.
+- If adding a provider, update `PROVIDER_CONFIGS` and `SELECTABLE_OPENWIKI_PROVIDERS` in `src/constants.ts`; for API-key providers also update `managedEnvKeys` in `src/env.ts`; then add the `createModel` branch in `src/agent/index.ts`.
 - To let a provider accept an alternative base URL, set `baseUrlEnvKey` on its `PROVIDER_CONFIGS` entry, add that key to `managedEnvKeys` in `src/env.ts`, and read it through `resolveProviderBaseUrl()` in the provider's `createModel` branch.
 - To require a user-supplied base URL (a provider with no default endpoint, like `openai-compatible`), also set `requiresBaseUrl: true`. `ensureProviderBaseUrl()` in `src/agent/index.ts` enforces it at runtime, and the interactive setup adds a base-URL step for such providers.
 - Re-check the `package.json` bin entry and scripts if the entrypoint changes.

--- a/openwiki/operations/credentials-and-updates.md
+++ b/openwiki/operations/credentials-and-updates.md
@@ -14,7 +14,7 @@ It also ships with GitHub Actions and GitLab CI workflow examples for scheduled 
 - directory: `~/.openwiki` (mode `0o700`)
 - file: `~/.openwiki/.env` (mode `0o600`)
 
-The file stores provider configuration and API keys:
+The file stores provider configuration and OpenWiki-managed credentials:
 
 - `OPENWIKI_PROVIDER` — the selected model provider
 - `OPENWIKI_MODEL_ID` — the default model ID
@@ -22,18 +22,20 @@ The file stores provider configuration and API keys:
 - Base URLs: `ANTHROPIC_BASE_URL` (optional — routes the anthropic provider at an Anthropic-compatible endpoint other than the default API) and `OPENAI_COMPATIBLE_BASE_URL` (required by the openai-compatible provider, which has no default endpoint)
 - Optional LangSmith settings: `LANGSMITH_API_KEY`, `LANGCHAIN_PROJECT`, `LANGCHAIN_TRACING_V2`
 
+The `codex-oauth` provider is the exception: OpenWiki stores only `OPENWIKI_PROVIDER=codex-oauth` and the model selection in `~/.openwiki/.env`; OAuth tokens are stored separately in `~/.openwiki/codex-oauth.json` with restrictive permissions.
+
 The loader merges those values into `process.env`, while preferring existing process-level values over file values. Deprecated keys (`OPENAI_BASE_URL`, `OPENAI_ORG_ID`, `OPENAI_PROJECT`) are skipped on load and removed on save.
 
 `src/credentials.tsx` provides the interactive bootstrap flow when required:
 
 - prompts for a provider (arrow-key selection menu),
-- prompts for the provider's API key,
+- prompts for the provider's API key only when the selected provider uses one,
 - prompts for a model choice (arrow-key selection from the provider's model list, or a custom model ID),
 - optionally prompts for a LangSmith key,
 - writes the results with restrictive file permissions,
 - removes deprecated OpenAI-related environment variables when saving.
 
-The setup flow runs for **all** interactive commands (chat, init, and update) when credentials are missing — not just chat. In non-interactive mode (no TTY or `--print`), missing provider keys produce an error instead of a prompt.
+The setup flow runs for **all** interactive commands (chat, init, and update) when credentials are missing — not just chat. In non-interactive mode (no TTY or `--print`), missing API-provider keys or missing Codex OAuth credentials produce an error instead of a prompt.
 
 ## Provider resolution
 
@@ -43,7 +45,7 @@ The setup flow runs for **all** interactive commands (chat, init, and update) wh
 2. Otherwise, if `OPENROUTER_API_KEY` is present, default to `openrouter`.
 3. Otherwise, fall back to `DEFAULT_PROVIDER` (`openrouter`).
 
-`needsCredentialSetup()` in `src/credentials.tsx` checks whether the provider env var is valid and whether the provider's API key, a model ID (unless overridden), and a LangSmith key are all present. Any missing or invalid provider value triggers the interactive flow.
+`needsCredentialSetup()` in `src/credentials.tsx` checks whether the provider env var is valid and whether the provider's API key when applicable, a model ID (unless overridden), and a LangSmith key are all present. Any missing or invalid provider value triggers the interactive flow; `codex-oauth` deliberately skips the API-key step.
 
 ## Model and credential diagnostics
 
@@ -57,7 +59,7 @@ The env layer also produces diagnostics for the CLI UI. Those diagnostics report
 - invalid model IDs,
 - invalid provider values.
 
-Diagnostics cover all six provider keys plus `OPENWIKI_PROVIDER`, `OPENWIKI_MODEL_ID`, the base URLs (`ANTHROPIC_BASE_URL`, `OPENAI_COMPATIBLE_BASE_URL`), and `LANGSMITH_API_KEY`. This makes startup problems easier to diagnose without exposing secret values (non-secret values such as the provider, model ID, and base URLs are shown in full).
+Diagnostics cover all six provider keys plus `OPENWIKI_PROVIDER`, `OPENWIKI_MODEL_ID`, the base URLs (`ANTHROPIC_BASE_URL`, `OPENAI_COMPATIBLE_BASE_URL`), and `LANGSMITH_API_KEY`. Codex OAuth token contents are not surfaced because they live in `~/.openwiki/codex-oauth.json`, not `~/.openwiki/.env`. This makes startup problems easier to diagnose without exposing secret values (non-secret values such as the provider, model ID, and base URLs are shown in full).
 
 ## Update metadata
 
@@ -104,7 +106,7 @@ GitLab users should configure protected CI/CD variables for the model provider k
 - Never document real secret values; only document the presence and purpose of the configuration.
 - If update metadata semantics change, update both the agent runtime and the docs that explain how update runs are scoped.
 - Scheduled automation depends on the same CLI entrypoint as local users, so workflow changes should be validated against `package.json` and the CLI help text.
-- When adding a provider, update `managedEnvKeys` in `src/env.ts` so the env file is formatted correctly and diagnostics cover the new key.
+- When adding an API-key provider, update `managedEnvKeys` in `src/env.ts` so the env file is formatted correctly and diagnostics cover the new key. Providers backed by external credential stores, such as `codex-oauth`, should document that source instead of adding a fake API-key env var.
 - The content-snapshot check means CI runs that produce no changes will not update `.last-update.json` or open a PR with metadata-only changes.
 
 ## Source map

--- a/openwiki/quickstart.md
+++ b/openwiki/quickstart.md
@@ -6,7 +6,7 @@ OpenWiki is a TypeScript CLI that writes and maintains documentation for a repos
 
 - Launches an interactive Ink-based terminal app for chatting with the OpenWiki agent.
 - Supports one-shot documentation runs with `--init`, `--update`, and `--print`.
-- Supports multiple model providers — OpenRouter (default), Anthropic, OpenAI, Baseten, and Fireworks — each with their own API key and model list.
+- Supports multiple model providers — OpenRouter (default), Codex OAuth, Anthropic, OpenAI, Baseten, and Fireworks — with API-key providers managed in `~/.openwiki/.env` and Codex OAuth tokens stored separately in `~/.openwiki/codex-oauth.json`.
 - Uses a DeepAgents local shell backend with virtual filesystem paths rooted at the target repository.
 - Creates or refreshes documentation under the target repository's `openwiki/` directory.
 - Auto-exits after successful `--init` or `--update` runs in an interactive terminal, so the CLI works as both a one-shot and interactive tool.
@@ -30,7 +30,7 @@ OpenWiki is a TypeScript CLI that writes and maintains documentation for a repos
 - `src/agent/utils.ts` — git evidence collection, content snapshot, and `.last-update.json` handling.
 - `src/agent/types.ts` — shared agent types (`OpenWikiCommand`, `RunContext`, `UpdateMetadata`, run options/events).
 - `src/env.ts` — `~/.openwiki/.env` persistence and credential diagnostics.
-- `src/credentials.tsx` — interactive onboarding flow for provider selection, API keys, and model selection.
+- `src/credentials.tsx` — interactive onboarding flow for provider selection, API keys when applicable, and model selection.
 - `src/constants.ts` — provider configs, model options, env keys, and validation helpers.
 - `examples/openwiki-update.yml` — GitHub Actions scheduled automation example.
 - `examples/openwiki-update.gitlab-ci.yml` — GitLab CI scheduled automation example.
@@ -47,7 +47,7 @@ OpenWiki is a TypeScript CLI that writes and maintains documentation for a repos
 - The repository is intentionally focused: the main product surface is the CLI plus the documentation-generation agent.
 - Treat `openwiki/` in this repo as generated documentation output from a future OpenWiki run, not as application source.
 - When changing behavior, verify both the CLI parser and the agent prompt/runtime, because user-visible semantics are split across `src/commands.ts`, `src/cli.tsx`, and `src/agent/*`.
-- Provider support is centralized in `src/constants.ts`. Adding or changing a provider means updating `PROVIDER_CONFIGS`, the `OpenWikiProvider` type, and the model-creation branch in `src/agent/index.ts`.
+- Provider support is centralized in `src/constants.ts`. Adding or changing a provider means updating `PROVIDER_CONFIGS`, the `OpenWikiProvider` type, the credential-source handling, and the model-creation branch in `src/agent/index.ts`.
 
 ## Source map
 

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -8,6 +8,11 @@ import { ChatOpenRouter } from "@langchain/openrouter";
 import { createDeepAgent, LocalShellBackend } from "deepagents";
 import { DEBUG_ENV_KEYS, loadOpenWikiEnv, openWikiEnvDir } from "../env.js";
 import { isFileNotFoundError } from "../fs-errors.js";
+import {
+  CodexChatOpenAI,
+  resolveCodexOAuthCredentials,
+  type CodexOAuthCredentials,
+} from "../codex-oauth.js";
 import { createSystemPrompt, createUserPrompt } from "./prompt.js";
 import type {
   OpenWikiCommand,
@@ -29,6 +34,8 @@ import {
   OPENWIKI_MODEL_ID_ENV_KEY,
   OPENWIKI_PROVIDER_ENV_KEY,
   providerRequiresBaseUrl,
+  providerUsesApiKey,
+  providerUsesCodexOAuth,
   resolveConfiguredProvider,
   resolveProviderBaseUrl,
   type OpenWikiProvider,
@@ -86,8 +93,8 @@ export async function runOpenWikiAgent(
   if (providerBaseUrl) {
     emitDebug(options, `provider.baseUrl=${JSON.stringify(providerBaseUrl)}`);
   }
-  ensureProviderKey(provider);
-  emitDebug(options, `credentials=${provider} key present`);
+  const codexOAuthCredentials = await ensureProviderCredentials(provider);
+  emitDebug(options, `credentials=${provider} present`);
   ensureProviderBaseUrl(provider);
   const modelId = resolveModelId(options, provider);
   emitDebug(options, `model=${modelId}`);
@@ -95,7 +102,14 @@ export async function runOpenWikiAgent(
   const debugFetchCapture = installOpenRouterDebugFetch(options);
 
   try {
-    return await runOpenWikiAgentCore(command, cwd, options, provider, modelId);
+    return await runOpenWikiAgentCore(
+      command,
+      cwd,
+      options,
+      provider,
+      modelId,
+      codexOAuthCredentials,
+    );
   } catch (error) {
     attachOpenRouterDebugInfo(error, debugFetchCapture.getLastFailure());
     throw error;
@@ -104,19 +118,21 @@ export async function runOpenWikiAgent(
   }
 }
 
+
 async function runOpenWikiAgentCore(
   command: OpenWikiCommand,
   cwd: string,
   options: OpenWikiRunOptions,
   provider: OpenWikiProvider,
   modelId: string,
+  codexOAuthCredentials: CodexOAuthCredentials | null,
 ): Promise<OpenWikiRunResult> {
   const context = await createRunContext(command, cwd);
   emitDebug(options, "context=created");
   const openWikiSnapshotBefore =
     command === "chat" ? null : await createOpenWikiContentSnapshot(cwd);
   emitDebug(options, "openwiki.snapshot=created");
-  const model = createModel(provider, modelId);
+  const model = createModel(provider, modelId, codexOAuthCredentials);
   emitDebug(options, `model.provider=${provider}`);
   emitDebug(options, "model=initialized");
   const checkpointer = await createCheckpointer();
@@ -270,14 +286,26 @@ function emitDebug(options: OpenWikiRunOptions, message: string): void {
   });
 }
 
-function ensureProviderKey(provider: OpenWikiProvider): void {
+async function ensureProviderCredentials(
+  provider: OpenWikiProvider,
+): Promise<CodexOAuthCredentials | null> {
+  if (providerUsesCodexOAuth(provider)) {
+    return resolveCodexOAuthCredentials();
+  }
+
+  if (!providerUsesApiKey(provider)) {
+    return null;
+  }
+
   const apiKeyEnvKey = getProviderApiKeyEnvKey(provider);
 
-  if (!process.env[apiKeyEnvKey]) {
+  if (!apiKeyEnvKey || !process.env[apiKeyEnvKey]) {
     throw new Error(
-      `${apiKeyEnvKey} is required to run OpenWiki with ${getProviderLabel(provider)}.`,
+      `${apiKeyEnvKey ?? "Provider API key"} is required to run OpenWiki with ${getProviderLabel(provider)}.`,
     );
   }
+
+  return null;
 }
 
 function ensureProviderBaseUrl(provider: OpenWikiProvider): void {
@@ -313,13 +341,29 @@ function resolveModelId(
   return modelId;
 }
 
-function createModel(provider: OpenWikiProvider, modelId: string) {
+function createModel(
+  provider: OpenWikiProvider,
+  modelId: string,
+  codexOAuthCredentials: CodexOAuthCredentials | null = null,
+) {
   if (provider === "anthropic") {
+    const apiKeyEnvKey = getProviderApiKeyEnvKey(provider);
     const baseURL = resolveProviderBaseUrl(provider);
 
     return new ChatAnthropic(modelId, {
-      apiKey: process.env[getProviderApiKeyEnvKey(provider)],
+      apiKey: apiKeyEnvKey ? process.env[apiKeyEnvKey] : undefined,
       ...(baseURL ? { anthropicApiUrl: baseURL } : {}),
+    });
+  }
+
+  if (provider === "codex-oauth") {
+    if (!codexOAuthCredentials) {
+      throw new Error("Codex OAuth credentials are required.");
+    }
+
+    return new CodexChatOpenAI({
+      codexCredentials: codexOAuthCredentials,
+      model: modelId,
     });
   }
 
@@ -332,10 +376,11 @@ function createModel(provider: OpenWikiProvider, modelId: string) {
     });
   }
 
+  const apiKeyEnvKey = getProviderApiKeyEnvKey(provider);
   const baseURL = resolveProviderBaseUrl(provider);
 
   return new ChatOpenAI({
-    apiKey: process.env[getProviderApiKeyEnvKey(provider)],
+    apiKey: apiKeyEnvKey ? process.env[apiKeyEnvKey] : undefined,
     configuration: baseURL
       ? {
           baseURL,

--- a/src/cli.tsx
+++ b/src/cli.tsx
@@ -1,4 +1,6 @@
 #!/usr/bin/env node
+import { createInterface } from "node:readline/promises";
+import { stdin as input, stdout as output } from "node:process";
 import React, { useEffect, useRef, useState } from "react";
 import { Box, render, Text, useApp, useInput } from "ink";
 import { marked, type Token, type Tokens } from "marked";
@@ -21,6 +23,10 @@ import {
   type CredentialDiagnostic,
 } from "./env.js";
 import { createOpenWikiThreadId, runOpenWikiAgent } from "./agent/index.js";
+import {
+  completeCodexOAuthLogin,
+  startCodexOAuthLogin,
+} from "./codex-oauth.js";
 import { getErrorMessage, sanitizeDiagnosticText } from "./diagnostics.js";
 import { stripHtmlTags } from "./utils.js";
 import {
@@ -38,6 +44,8 @@ import {
   OPENWIKI_PROVIDER_ENV_KEY,
   OPENWIKI_MODEL_ID_ENV_KEY,
   OPEN_WIKI_DIR,
+  providerUsesApiKey,
+  providerUsesCodexOAuth,
   resolveConfiguredProvider,
   SELECTABLE_OPENWIKI_PROVIDERS,
   OPENWIKI_VERSION,
@@ -216,7 +224,7 @@ function App({ command }: AppProps) {
   }, []);
 
   useEffect(() => {
-    if (command.kind === "help" || command.kind === "error") {
+    if (command.kind === "help" || command.kind === "error" || command.kind === "login") {
       process.exitCode = command.exitCode;
       app.exit();
       return;
@@ -238,7 +246,12 @@ function App({ command }: AppProps) {
 
     const apiKeyEnvKey = getProviderApiKeyEnvKey(sessionProvider);
 
-    if (!process.env[apiKeyEnvKey] && !process.stdin.isTTY) {
+    if (
+      providerUsesApiKey(sessionProvider) &&
+      apiKeyEnvKey &&
+      !process.env[apiKeyEnvKey] &&
+      !process.stdin.isTTY
+    ) {
       setRunState({
         status: "error",
         message: `${apiKeyEnvKey} is required. Run openwiki in an interactive terminal to save credentials.`,
@@ -1503,9 +1516,7 @@ function ChatInput({
     const provider = normalizeProvider(rawProvider);
 
     if (provider === null) {
-      setError(
-        "Enter a valid provider: openrouter, baseten, fireworks, openai, or anthropic.",
-      );
+      setError(`Enter a valid provider: ${SELECTABLE_OPENWIKI_PROVIDERS.join(", ")}.`);
       return;
     }
 
@@ -1516,11 +1527,7 @@ function ChatInput({
     try {
       await onProviderSelect(provider);
       resetInput();
-      setNotice(
-        `Provider switched to ${getProviderLabel(provider)} with model ${getDefaultModelId(
-          provider,
-        )}. Ensure ${getProviderApiKeyEnvKey(provider)} is set.`,
-      );
+      setNotice(createProviderSelectionNotice(provider));
     } catch (saveError) {
       setError(
         saveError instanceof Error
@@ -1980,6 +1987,18 @@ function getCurrentProviderOptionIndex(
   );
 
   return matchingIndex === -1 ? 0 : matchingIndex;
+}
+
+function createProviderSelectionNotice(provider: OpenWikiProvider): string {
+  const modelId = getDefaultModelId(provider);
+
+  if (providerUsesCodexOAuth(provider)) {
+    return `Provider switched to ${getProviderLabel(provider)} with model ${modelId}. Run \`openwiki login codex-oauth\` if OAuth is not configured.`;
+  }
+
+  const apiKeyEnvKey = getProviderApiKeyEnvKey(provider);
+
+  return `Provider switched to ${getProviderLabel(provider)} with model ${modelId}. Ensure ${apiKeyEnvKey ?? "the provider API key"} is set.`;
 }
 
 function getModelMenuOptions(
@@ -2967,7 +2986,9 @@ if (parsedCommand.kind === "run" && !parsedCommand.dryRun) {
 
 const command = resolveStartupCommand(parsedCommand);
 
-if (shouldPrintStartupError(argv, parsedCommand, command)) {
+if (parsedCommand.kind === "login") {
+  await runCodexOAuthLogin();
+} else if (shouldPrintStartupError(argv, parsedCommand, command)) {
   process.stderr.write(`${command.message}\n`);
   process.exitCode = command.exitCode;
 } else if (command.kind === "run" && command.print && !command.dryRun) {
@@ -3001,6 +3022,28 @@ function shouldAutoExitStartupRun(command: CliCommand): boolean {
     command.shouldStart &&
     (command.command === "init" || command.command === "update")
   );
+}
+
+async function runCodexOAuthLogin(): Promise<void> {
+  try {
+    const login = await startCodexOAuthLogin();
+    process.stdout.write("Open this URL in your browser:\n\n");
+    process.stdout.write(`${login.authorizeUrl}\n\n`);
+    const readline = createInterface({ input, output });
+    const callbackUrl = await readline.question(
+      "Paste the full callback URL after login: ",
+    );
+    readline.close();
+    const credentials = await completeCodexOAuthLogin(callbackUrl);
+    process.stdout.write(
+      `Codex OAuth saved for account ${credentials.accountId}.\n`,
+    );
+    process.exitCode = 0;
+  } catch (error) {
+    process.stderr.write(`${getErrorMessage(error)}\n`);
+    writePrintErrorDiagnostics(error);
+    process.exitCode = 1;
+  }
 }
 
 async function runPrintCommand(
@@ -3059,13 +3102,15 @@ function resolveStartupCommand(command: CliCommand): CliCommand {
   ) {
     const provider = resolveConfiguredProvider();
     const apiKeyEnvKey = getProviderApiKeyEnvKey(provider);
-    const hasProviderKey = Boolean(process.env[apiKeyEnvKey]);
+    const hasProviderKey =
+      !providerUsesApiKey(provider) ||
+      (apiKeyEnvKey !== null && Boolean(process.env[apiKeyEnvKey]));
 
     if (!hasProviderKey) {
       return {
         kind: "error",
         exitCode: 1,
-        message: `${apiKeyEnvKey} is required for non-interactive runs. Run openwiki in an interactive terminal to save credentials.`,
+        message: `${apiKeyEnvKey ?? "Provider API key"} is required for non-interactive runs. Run openwiki in an interactive terminal to save credentials.`,
       };
     }
   }

--- a/src/codex-oauth.ts
+++ b/src/codex-oauth.ts
@@ -1,0 +1,615 @@
+import { createHash, randomBytes as nodeRandomBytes } from "node:crypto";
+import { chmod, mkdir, readFile, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { ChatOpenAI } from "@langchain/openai";
+import type { BaseMessage } from "@langchain/core/messages";
+import type { CallbackManagerForLLMRun } from "@langchain/core/callbacks/manager";
+import type { ChatGenerationChunk } from "@langchain/core/outputs";
+import type { ChatModelStreamEvent } from "@langchain/core/language_models/event";
+
+export const CODEX_OAUTH_PROVIDER = "codex-oauth";
+export const CODEX_OAUTH_PATH = path.join(os.homedir(), ".openwiki", "codex-oauth.json");
+export const CODEX_BACKEND_BASE_URL = "https://chatgpt.com/backend-api/codex";
+export const CODEX_OAUTH_AUTHORIZE_URL = "https://auth.openai.com/oauth/authorize";
+export const CODEX_OAUTH_TOKEN_URL = "https://auth.openai.com/oauth/token";
+export const CODEX_OAUTH_CLIENT_ID = "app_EMoamEEZ73f0CkXaXp7hrann";
+export const CODEX_OAUTH_REDIRECT_URI = "http://localhost:1455/auth/callback";
+export const CODEX_DEFAULT_INSTRUCTIONS =
+  "You are ChatGPT, a large language model trained by OpenAI.";
+
+const CODEX_ACCESS_TOKEN_REFRESH_WINDOW_MS = 5 * 60 * 1000;
+const CODEX_OAUTH_SCOPE = "openid profile email offline_access";
+
+type CodexOAuthTokenSet = {
+  accessToken: string;
+  refreshToken: string;
+  idToken: string | null;
+  accountId: string;
+  planType: string | null;
+  expiresAt: string;
+};
+
+type CodexOAuthPendingLogin = {
+  state: string;
+  codeVerifier: string;
+  redirectUri: string;
+  createdAt: string;
+};
+
+type CodexOAuthFile = {
+  tokens?: CodexOAuthTokenSet;
+  pending?: CodexOAuthPendingLogin;
+  updatedAt?: string;
+};
+
+export type CodexOAuthCredentials = {
+  accessToken: string;
+  accountId: string;
+};
+
+export type CodexOAuthLoginStart = {
+  authorizeUrl: string;
+  state: string;
+};
+
+type CodexOAuthOptions = {
+  authPath?: string;
+  env?: NodeJS.ProcessEnv;
+  fetch?: typeof fetch;
+  now?: Date;
+  randomBytes?: (size: number) => Buffer;
+};
+
+type TokenResponse = {
+  access_token?: unknown;
+  refresh_token?: unknown;
+  id_token?: unknown;
+  expires_in?: unknown;
+};
+
+type JwtAuthClaims = {
+  chatgpt_account_id?: unknown;
+  chatgpt_plan_type?: unknown;
+};
+
+type JwtClaims = {
+  exp?: unknown;
+  ["https://api.openai.com/auth"]?: JwtAuthClaims;
+};
+
+export async function startCodexOAuthLogin(
+  options: CodexOAuthOptions = {},
+): Promise<CodexOAuthLoginStart> {
+  const now = options.now ?? new Date();
+  const randomBytes = options.randomBytes ?? nodeRandomBytes;
+  const codeVerifier = base64Url(randomBytes(32));
+  const state = base64Url(randomBytes(24));
+  const codeChallenge = base64Url(
+    createHash("sha256").update(codeVerifier).digest(),
+  );
+  const authorizeUrl = new URL(CODEX_OAUTH_AUTHORIZE_URL);
+  authorizeUrl.searchParams.set("response_type", "code");
+  authorizeUrl.searchParams.set("client_id", CODEX_OAUTH_CLIENT_ID);
+  authorizeUrl.searchParams.set("redirect_uri", CODEX_OAUTH_REDIRECT_URI);
+  authorizeUrl.searchParams.set("scope", CODEX_OAUTH_SCOPE);
+  authorizeUrl.searchParams.set("code_challenge", codeChallenge);
+  authorizeUrl.searchParams.set("code_challenge_method", "S256");
+  authorizeUrl.searchParams.set("state", state);
+  authorizeUrl.searchParams.set("originator", "openwiki");
+
+  const authPath = options.authPath ?? CODEX_OAUTH_PATH;
+  const authFile = await readCodexOAuthFile(authPath);
+  await writeCodexOAuthFile(authPath, {
+    ...authFile,
+    pending: {
+      codeVerifier,
+      createdAt: now.toISOString(),
+      redirectUri: CODEX_OAUTH_REDIRECT_URI,
+      state,
+    },
+    updatedAt: now.toISOString(),
+  });
+
+  return { authorizeUrl: authorizeUrl.toString(), state };
+}
+
+export async function completeCodexOAuthLogin(
+  callbackUrl: string,
+  options: CodexOAuthOptions = {},
+): Promise<CodexOAuthCredentials> {
+  const authPath = options.authPath ?? CODEX_OAUTH_PATH;
+  const authFile = await readCodexOAuthFile(authPath);
+  const pending = authFile.pending;
+
+  if (!pending) {
+    throw new Error("No pending Codex OAuth login. Run `openwiki login codex-oauth` first.");
+  }
+
+  const callback = parseCodexOAuthCallbackUrl(callbackUrl);
+
+  if (callback.state !== pending.state) {
+    throw new Error("Codex OAuth callback state did not match the pending login.");
+  }
+
+  const tokenResponse = await exchangeCodexAuthorizationCode(
+    callback.code,
+    pending.codeVerifier,
+    pending.redirectUri,
+    options.fetch ?? fetch,
+  );
+  const tokens = normalizeTokenResponse(tokenResponse, options.now ?? new Date());
+
+  await writeCodexOAuthFile(authPath, {
+    tokens,
+    updatedAt: (options.now ?? new Date()).toISOString(),
+  });
+
+  return { accessToken: tokens.accessToken, accountId: tokens.accountId };
+}
+
+export async function resolveCodexOAuthCredentials(
+  options: CodexOAuthOptions = {},
+): Promise<CodexOAuthCredentials> {
+  const authPath = options.authPath ?? CODEX_OAUTH_PATH;
+  const authFile = await readCodexOAuthFile(authPath);
+  const tokens = authFile.tokens;
+
+  if (!tokens) {
+    throw new Error("Codex OAuth is not configured. Run `openwiki login codex-oauth` first.");
+  }
+
+  const now = options.now ?? new Date();
+
+  if (!shouldRefreshAccessToken(tokens, now)) {
+    return { accessToken: tokens.accessToken, accountId: tokens.accountId };
+  }
+
+  const refreshed = await refreshCodexOAuthTokens(
+    tokens.refreshToken,
+    options.fetch ?? fetch,
+  );
+  const nextTokens = normalizeTokenResponse(refreshed, now, tokens);
+
+  await writeCodexOAuthFile(authPath, {
+    ...authFile,
+    tokens: nextTokens,
+    updatedAt: now.toISOString(),
+  });
+
+  return { accessToken: nextTokens.accessToken, accountId: nextTokens.accountId };
+}
+
+export function parseCodexOAuthCallbackUrl(callbackUrl: string): {
+  code: string;
+  state: string;
+} {
+  let parsed: URL;
+
+  try {
+    parsed = new URL(callbackUrl.trim());
+  } catch {
+    throw new Error("Paste the full Codex OAuth callback URL, including code and state.");
+  }
+
+  const error = parsed.searchParams.get("error");
+
+  if (error) {
+    throw new Error(`Codex OAuth returned an error: ${error}`);
+  }
+
+  const code = parsed.searchParams.get("code");
+  const state = parsed.searchParams.get("state");
+
+  if (!code || !state) {
+    throw new Error("Codex OAuth callback URL must include code and state parameters.");
+  }
+
+  return { code, state };
+}
+
+async function exchangeCodexAuthorizationCode(
+  code: string,
+  codeVerifier: string,
+  redirectUri: string,
+  fetchImpl: typeof fetch,
+): Promise<TokenResponse> {
+  const body = new URLSearchParams({
+    client_id: CODEX_OAUTH_CLIENT_ID,
+    code,
+    code_verifier: codeVerifier,
+    grant_type: "authorization_code",
+    redirect_uri: redirectUri,
+  });
+
+  const response = await fetchImpl(CODEX_OAUTH_TOKEN_URL, {
+    body,
+    headers: { "content-type": "application/x-www-form-urlencoded" },
+    method: "POST",
+  });
+
+  return parseTokenResponse(response, "Codex OAuth token exchange");
+}
+
+async function refreshCodexOAuthTokens(
+  refreshToken: string,
+  fetchImpl: typeof fetch,
+): Promise<TokenResponse> {
+  const response = await fetchImpl(CODEX_OAUTH_TOKEN_URL, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({
+      client_id: CODEX_OAUTH_CLIENT_ID,
+      grant_type: "refresh_token",
+      refresh_token: refreshToken,
+    }),
+  });
+
+  return parseTokenResponse(response, "Codex OAuth token refresh");
+}
+
+async function parseTokenResponse(
+  response: Response,
+  operation: string,
+): Promise<TokenResponse> {
+  const parsed: unknown = await response.json().catch(() => null);
+
+  if (!response.ok) {
+    const message =
+      isRecord(parsed) && typeof parsed.error === "string"
+        ? parsed.error
+        : `HTTP ${response.status}`;
+    throw new Error(`${operation} failed: ${message}`);
+  }
+
+  if (!isRecord(parsed)) {
+    throw new Error(`${operation} response was not a JSON object.`);
+  }
+
+  return parsed;
+}
+
+function normalizeTokenResponse(
+  response: TokenResponse,
+  now: Date,
+  previous?: CodexOAuthTokenSet,
+): CodexOAuthTokenSet {
+  const accessToken = getStringField(response, "access_token") ?? previous?.accessToken;
+  const refreshToken = getStringField(response, "refresh_token") ?? previous?.refreshToken;
+  const idToken = getStringField(response, "id_token") ?? previous?.idToken ?? null;
+
+  if (!accessToken) {
+    throw new Error("Codex OAuth response did not include an access token.");
+  }
+
+  if (!refreshToken) {
+    throw new Error("Codex OAuth response did not include a refresh token.");
+  }
+
+  if (!idToken) {
+    throw new Error("Codex OAuth response did not include an ID token.");
+  }
+
+  const idTokenClaims = parseJwtClaims(idToken);
+  const authClaims = idTokenClaims["https://api.openai.com/auth"];
+  const accountId =
+    getStringField(authClaims, "chatgpt_account_id") ?? previous?.accountId;
+
+  if (!accountId) {
+    throw new Error("Codex OAuth ID token did not include a ChatGPT account ID.");
+  }
+
+  const expiresAt = getTokenExpiration(response, accessToken, now);
+
+  return {
+    accessToken,
+    accountId,
+    expiresAt: expiresAt.toISOString(),
+    idToken,
+    planType: getStringField(authClaims, "chatgpt_plan_type") ?? previous?.planType ?? null,
+    refreshToken,
+  };
+}
+
+function getTokenExpiration(
+  response: TokenResponse,
+  accessToken: string,
+  now: Date,
+): Date {
+  if (typeof response.expires_in === "number" && Number.isFinite(response.expires_in)) {
+    return new Date(now.getTime() + response.expires_in * 1000);
+  }
+
+  const exp = parseJwtClaims(accessToken).exp;
+
+  if (typeof exp === "number" && Number.isFinite(exp)) {
+    return new Date(exp * 1000);
+  }
+
+  return new Date(now.getTime() + 60 * 60 * 1000);
+}
+
+function shouldRefreshAccessToken(tokens: CodexOAuthTokenSet, now: Date): boolean {
+  const expiresAtMs = Date.parse(tokens.expiresAt);
+
+  return (
+    Number.isFinite(expiresAtMs) &&
+    expiresAtMs - now.getTime() <= CODEX_ACCESS_TOKEN_REFRESH_WINDOW_MS
+  );
+}
+
+async function readCodexOAuthFile(authPath: string): Promise<CodexOAuthFile> {
+  let raw: string;
+
+  try {
+    raw = await readFile(authPath, "utf8");
+  } catch (error) {
+    if (isFileNotFoundError(error)) {
+      return {};
+    }
+
+    throw error;
+  }
+
+  try {
+    const parsed: unknown = JSON.parse(raw);
+
+    if (isRecord(parsed)) {
+      return parsed;
+    }
+  } catch {
+    // Fall through to the consistent parse error below.
+  }
+
+  throw new Error(`Codex OAuth credentials at ${authPath} are not valid JSON.`);
+}
+
+async function writeCodexOAuthFile(
+  authPath: string,
+  authFile: CodexOAuthFile,
+): Promise<void> {
+  await mkdir(path.dirname(authPath), { recursive: true });
+  await writeFile(authPath, `${JSON.stringify(authFile, null, 2)}\n`, {
+    encoding: "utf8",
+    mode: 0o600,
+  });
+  await chmod(authPath, 0o600);
+}
+
+function parseJwtClaims(token: string): JwtClaims {
+  const [, payload] = token.split(".");
+
+  if (!payload) {
+    return {};
+  }
+
+  try {
+    const normalized = payload.replace(/-/gu, "+").replace(/_/gu, "/");
+    const padded = normalized.padEnd(
+      normalized.length + ((4 - (normalized.length % 4)) % 4),
+      "=",
+    );
+    const parsed: unknown = JSON.parse(Buffer.from(padded, "base64").toString("utf8"));
+
+    return isRecord(parsed) ? parsed : {};
+  } catch {
+    return {};
+  }
+}
+
+function getStringField(
+  record: Record<string, unknown> | undefined,
+  key: string,
+): string | null {
+  const value = record?.[key];
+
+  return typeof value === "string" && value.trim().length > 0 ? value : null;
+}
+
+function isFileNotFoundError(error: unknown): boolean {
+  return (
+    isRecord(error) &&
+    (error.code === "ENOENT" || error.code === "ENOTDIR")
+  );
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function base64Url(value: Buffer): string {
+  return value.toString("base64url");
+}
+
+type CodexChatOpenAIFields = ConstructorParameters<typeof ChatOpenAI>[0] & {
+  codexCredentials: CodexOAuthCredentials;
+};
+
+export class CodexChatOpenAI extends ChatOpenAI {
+  constructor(fields: CodexChatOpenAIFields) {
+    const { codexCredentials, ...chatFields } = fields;
+
+    super({
+      ...chatFields,
+      apiKey: codexCredentials.accessToken,
+      configuration: {
+        ...chatFields.configuration,
+        baseURL: CODEX_BACKEND_BASE_URL,
+        defaultHeaders: {
+          ...chatFields.configuration?.defaultHeaders,
+          "ChatGPT-Account-Id": codexCredentials.accountId,
+          originator: "openwiki",
+        },
+      },
+      modelKwargs: {
+        ...chatFields.modelKwargs,
+        instructions: CODEX_DEFAULT_INSTRUCTIONS,
+        store: false,
+      },
+      streaming: true,
+      useResponsesApi: true,
+      zdrEnabled: true,
+    });
+
+    this.installCodexResponseGuards();
+  }
+
+  private installCodexResponseGuards(): void {
+    const originalGenerate = this.responses._generate.bind(this.responses);
+    const originalStreamChunks = this.responses._streamResponseChunks.bind(
+      this.responses,
+    );
+    const originalStreamEvents = this.responses._streamChatModelEvents.bind(
+      this.responses,
+    );
+
+    this.responses._generate = (messages, options, runManager) =>
+      this.withCodexInstructions(messages, (nextMessages) =>
+        originalGenerate(nextMessages, options, runManager),
+      );
+
+    this.responses._streamResponseChunks = (messages, options, runManager) =>
+      this.streamResponseChunksWithCodexInstructions(
+        originalStreamChunks,
+        messages,
+        options,
+        runManager,
+      );
+
+    this.responses._streamChatModelEvents = (messages, options, runManager) =>
+      this.streamChatModelEventsWithCodexInstructions(
+        originalStreamEvents,
+        messages,
+        options,
+        runManager,
+      );
+  }
+
+  private async *streamResponseChunksWithCodexInstructions(
+    streamChunks: (
+      messages: BaseMessage[],
+      options: this["ParsedCallOptions"],
+      runManager?: CallbackManagerForLLMRun,
+    ) => AsyncGenerator<ChatGenerationChunk>,
+    messages: BaseMessage[],
+    options: this["ParsedCallOptions"],
+    runManager?: CallbackManagerForLLMRun,
+  ): AsyncGenerator<ChatGenerationChunk> {
+    const lifted = liftCodexInstructions(messages);
+    const restore = this.applyCodexInstructions(lifted.instructions);
+
+    try {
+      yield* streamChunks(lifted.messages, options, runManager);
+    } finally {
+      restore();
+    }
+  }
+
+  private async *streamChatModelEventsWithCodexInstructions(
+    streamEvents: (
+      messages: BaseMessage[],
+      options: this["ParsedCallOptions"],
+      runManager?: CallbackManagerForLLMRun,
+    ) => AsyncGenerator<ChatModelStreamEvent>,
+    messages: BaseMessage[],
+    options: this["ParsedCallOptions"],
+    runManager?: CallbackManagerForLLMRun,
+  ): AsyncGenerator<ChatModelStreamEvent> {
+    const lifted = liftCodexInstructions(messages);
+    const restore = this.applyCodexInstructions(lifted.instructions);
+
+    try {
+      yield* streamEvents(lifted.messages, options, runManager);
+    } finally {
+      restore();
+    }
+  }
+
+  private async withCodexInstructions<T>(
+    messages: BaseMessage[],
+    run: (messages: BaseMessage[]) => Promise<T>,
+  ): Promise<T> {
+    const lifted = liftCodexInstructions(messages);
+    const restore = this.applyCodexInstructions(lifted.instructions);
+
+    try {
+      return await run(lifted.messages);
+    } finally {
+      restore();
+    }
+  }
+
+  private applyCodexInstructions(instructions: string): () => void {
+    const previous = this.responses.modelKwargs;
+
+    this.responses.modelKwargs = {
+      ...previous,
+      instructions,
+      store: false,
+    };
+
+    return () => {
+      this.responses.modelKwargs = previous;
+    };
+  }
+}
+
+function liftCodexInstructions(messages: BaseMessage[]): {
+  instructions: string;
+  messages: BaseMessage[];
+} {
+  const instructions: string[] = [];
+  const nextMessages: BaseMessage[] = [];
+
+  for (const message of messages) {
+    if (isInstructionMessage(message)) {
+      instructions.push(flattenMessageContent(message.content));
+    } else {
+      nextMessages.push(message);
+    }
+  }
+
+  return {
+    instructions:
+      instructions.filter(Boolean).join("\n\n") || CODEX_DEFAULT_INSTRUCTIONS,
+    messages: nextMessages,
+  };
+}
+
+function isInstructionMessage(message: BaseMessage): boolean {
+  const messageType = message._getType();
+
+  return (
+    messageType === "system" ||
+    (messageType === "generic" &&
+      "role" in message &&
+      (message.role === "system" || message.role === "developer"))
+  );
+}
+
+function flattenMessageContent(content: BaseMessage["content"]): string {
+  if (typeof content === "string") {
+    return content;
+  }
+
+  return content
+    .map((part) => {
+      if (typeof part === "string") {
+        return part;
+      }
+
+      if (isRecord(part) && typeof part.text === "string") {
+        return part.text;
+      }
+
+      return "";
+    })
+    .join("");
+}
+
+export function createSyntheticJwt(claims: Record<string, unknown>): string {
+  const payload = Buffer.from(JSON.stringify(claims)).toString("base64url");
+  const signature = createHash("sha256").update(payload).digest("base64url");
+
+  return `header.${payload}.${signature}`;
+}

--- a/src/codex-oauth.ts
+++ b/src/codex-oauth.ts
@@ -421,6 +421,102 @@ function base64Url(value: Buffer): string {
   return value.toString("base64url");
 }
 
+function createCodexResponsesFetch(fetchImpl: typeof fetch | undefined): typeof fetch {
+  const nextFetch = fetchImpl ?? fetch;
+
+  return async (input, init) => {
+    const url =
+      typeof input === "string"
+        ? input
+        : input instanceof URL
+          ? input.toString()
+          : input.url;
+
+    if (!url.includes(`${CODEX_BACKEND_BASE_URL}/responses`)) {
+      return nextFetch(input, init);
+    }
+
+    const body = typeof init?.body === "string" ? init.body : null;
+
+    if (body === null) {
+      return nextFetch(input, init);
+    }
+
+    const payload = sanitizeCodexResponsesPayload(body);
+
+    return nextFetch(input, {
+      ...init,
+      body: payload,
+    });
+  };
+}
+
+function sanitizeCodexResponsesPayload(body: string): string {
+  let payload: unknown;
+
+  try {
+    payload = JSON.parse(body);
+  } catch {
+    return body;
+  }
+
+  if (!isRecord(payload) || !Array.isArray(payload.input)) {
+    return body;
+  }
+
+  const liftedInstructions: string[] = [];
+  const input = payload.input.filter((item) => {
+    if (!isRecord(item)) {
+      return true;
+    }
+
+    const role = item.role;
+
+    if (role !== "system" && role !== "developer") {
+      return true;
+    }
+
+    liftedInstructions.push(flattenResponsesInputContent(item.content));
+    return false;
+  });
+
+  if (liftedInstructions.length === 0) {
+    return body;
+  }
+
+  return JSON.stringify({
+    ...payload,
+    input,
+    instructions: [payload.instructions, ...liftedInstructions]
+      .filter((value): value is string => typeof value === "string" && value.length > 0)
+      .join("\n\n"),
+  });
+}
+
+function flattenResponsesInputContent(content: unknown): string {
+  if (typeof content === "string") {
+    return content;
+  }
+
+  if (!Array.isArray(content)) {
+    return "";
+  }
+
+  return content
+    .map((item) => {
+      if (typeof item === "string") {
+        return item;
+      }
+
+      if (isRecord(item) && typeof item.text === "string") {
+        return item.text;
+      }
+
+      return "";
+    })
+    .join("");
+}
+
 type CodexChatOpenAIFields = ConstructorParameters<typeof ChatOpenAI>[0] & {
   codexCredentials: CodexOAuthCredentials;
 };
@@ -438,8 +534,10 @@ export class CodexChatOpenAI extends ChatOpenAI {
         defaultHeaders: {
           ...chatFields.configuration?.defaultHeaders,
           "ChatGPT-Account-Id": codexCredentials.accountId,
-          originator: "openwiki",
+          originator: "codex_cli_rs",
+          "user-agent": "codex_cli_rs/0.0.0",
         },
+        fetch: createCodexResponsesFetch(chatFields.configuration?.fetch),
       },
       modelKwargs: {
         ...chatFields.modelKwargs,

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -30,6 +30,11 @@ export type CliCommand =
       userMessage: string | null;
     }
   | {
+      kind: "login";
+      exitCode: 0;
+      provider: "codex-oauth";
+    }
+  | {
       kind: "error";
       exitCode: 1;
       message: string;
@@ -38,6 +43,18 @@ export type CliCommand =
 export function parseCommand(argv: string[]): CliCommand {
   if (argv[0] === "--help" || argv[0] === "-h") {
     return { kind: "help", exitCode: 0 };
+  }
+
+  if (argv[0] === "login") {
+    if (argv[1] === "codex-oauth" && argv.length === 2) {
+      return { kind: "login", exitCode: 0, provider: "codex-oauth" };
+    }
+
+    return {
+      kind: "error",
+      exitCode: 1,
+      message: "Usage: openwiki login codex-oauth",
+    };
   }
 
   let dryRun = false;
@@ -178,11 +195,16 @@ export const helpContent: HelpContent = {
     "openwiki [--modelId <model>] [message]",
     "openwiki --init [message]",
     "openwiki --update [message]",
+    "openwiki login codex-oauth",
   ],
   commands: [
     {
       label: "openwiki",
       description: "Open the interactive OpenWiki chat.",
+    },
+    {
+      label: "openwiki login codex-oauth",
+      description: "Start Codex OAuth login and save tokens locally.",
     },
   ],
   options: [
@@ -216,6 +238,7 @@ export const helpContent: HelpContent = {
     'openwiki "What can you do?"',
     'openwiki -p "Summarize what OpenWiki can do"',
     "openwiki --modelId gpt-5.5",
+    "openwiki login codex-oauth",
     'openwiki --update --modelId gpt-5.5 "Please document the API routes first"',
   ],
   developmentExamples: ["openwiki --dry-run"],

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -12,10 +12,12 @@ export const OPENWIKI_PROVIDER_ENV_KEY = "OPENWIKI_PROVIDER";
 export const OPENWIKI_MODEL_ID_ENV_KEY = "OPENWIKI_MODEL_ID";
 export const DEFAULT_PROVIDER = "openrouter";
 export const OPENROUTER_BASE_URL = "https://openrouter.ai/api/v1";
+export const CODEX_OAUTH_BASE_URL = "https://chatgpt.com/backend-api/codex";
 
 export type OpenWikiProvider =
   | "anthropic"
   | "baseten"
+  | "codex-oauth"
   | "fireworks"
   | "openai"
   | "openai-compatible"
@@ -29,7 +31,7 @@ export type ProviderModelOption = {
 };
 
 type ProviderConfig = {
-  apiKeyEnvKey: string;
+  apiKeyEnvKey?: string;
   baseURL?: string;
   /**
    * Environment variable that, when set, overrides {@link ProviderConfig.baseURL}
@@ -43,10 +45,12 @@ type ProviderConfig = {
   requiresBaseUrl?: boolean;
   label: string;
   modelOptions: ProviderModelOption[];
+  usesCodexOAuth?: boolean;
 };
 
 export const SELECTABLE_OPENWIKI_PROVIDERS = [
   "openrouter",
+  "codex-oauth",
   "baseten",
   "fireworks",
   "openai",
@@ -63,6 +67,15 @@ export const PROVIDER_CONFIGS: Record<OpenWikiProvider, ProviderConfig> = {
       { id: "zai-org/GLM-5.2", label: "GLM 5.2" },
       { id: "moonshotai/Kimi-K2.7-Code", label: "Kimi K2.7 Code" },
     ],
+  },
+  "codex-oauth": {
+    baseURL: CODEX_OAUTH_BASE_URL,
+    label: "Codex OAuth",
+    modelOptions: [
+      { id: "gpt-5.5", label: "GPT 5.5" },
+      { id: "gpt-5.4-mini", label: "GPT 5.4 mini" },
+    ],
+    usesCodexOAuth: true,
   },
   fireworks: {
     apiKeyEnvKey: FIREWORKS_API_KEY_ENV_KEY,
@@ -132,8 +145,18 @@ export function getProviderLabel(provider: OpenWikiProvider): string {
   return getProviderConfig(provider).label;
 }
 
-export function getProviderApiKeyEnvKey(provider: OpenWikiProvider): string {
-  return getProviderConfig(provider).apiKeyEnvKey;
+export function getProviderApiKeyEnvKey(
+  provider: OpenWikiProvider,
+): string | null {
+  return getProviderConfig(provider).apiKeyEnvKey ?? null;
+}
+
+export function providerUsesApiKey(provider: OpenWikiProvider): boolean {
+  return getProviderApiKeyEnvKey(provider) !== null;
+}
+
+export function providerUsesCodexOAuth(provider: OpenWikiProvider): boolean {
+  return getProviderConfig(provider).usesCodexOAuth === true;
 }
 
 /**

--- a/src/credentials.tsx
+++ b/src/credentials.tsx
@@ -13,6 +13,7 @@ import {
   normalizeModelId,
   OPENWIKI_MODEL_ID_ENV_KEY,
   OPENWIKI_PROVIDER_ENV_KEY,
+  providerUsesApiKey,
   type OpenWikiProvider,
   providerRequiresBaseUrl,
   resolveConfiguredProvider,
@@ -42,16 +43,21 @@ export function needsCredentialSetup(
   modelIdOverride: string | null = null,
 ): boolean {
   const provider = resolveConfiguredProvider();
-  const apiKeyEnvKey = getProviderApiKeyEnvKey(provider);
 
   return (
     !hasValidConfiguredProvider() ||
-    !process.env[apiKeyEnvKey] ||
+    needsApiKeyStep(provider) ||
     needsBaseUrlStep(provider) ||
     (modelIdOverride === null &&
       process.env[OPENWIKI_MODEL_ID_ENV_KEY] === undefined) ||
     process.env.LANGSMITH_API_KEY === undefined
   );
+}
+
+function needsApiKeyStep(provider: OpenWikiProvider): boolean {
+  const apiKeyEnvKey = getProviderApiKeyEnvKey(provider);
+
+  return providerUsesApiKey(provider) && !process.env[apiKeyEnvKey ?? ""];
 }
 
 function needsBaseUrlStep(provider: OpenWikiProvider): boolean {
@@ -280,7 +286,7 @@ export function InitSetup({
 
       setBaseUrl(trimmedInput);
       setInput("");
-      const nextStep = getNextStepAfterBaseUrl(provider, modelIdOverride);
+      const nextStep = getNextStepAfterBaseUrl(modelIdOverride);
 
       if (nextStep) {
         setIsCustomModelInput(
@@ -381,7 +387,11 @@ export function InitSetup({
       }
 
       if (nextApiKey !== null) {
-        updates[getProviderApiKeyEnvKey(nextProvider)] = nextApiKey;
+        const apiKeyEnvKey = getProviderApiKeyEnvKey(nextProvider);
+
+        if (apiKeyEnvKey) {
+          updates[apiKeyEnvKey] = nextApiKey;
+        }
       }
 
       if (nextBaseUrl !== null) {
@@ -455,21 +465,29 @@ export function InitSetup({
           }
           detail={getProviderSetupDetail(provider)}
         />
-        <SetupStep
-          label="Provider key"
-          state={
-            process.env[getProviderApiKeyEnvKey(provider)]
-              ? "done"
-              : step === "api-key"
-                ? "current"
-                : "pending"
-          }
-          detail={
-            process.env[getProviderApiKeyEnvKey(provider)]
-              ? "available from environment"
-              : `save ${getProviderApiKeyEnvKey(provider)} to ${openWikiEnvPath}`
-          }
-        />
+        {providerUsesApiKey(provider) ? (
+          <SetupStep
+            label="Provider key"
+            state={
+              process.env[getProviderApiKeyEnvKey(provider) ?? ""]
+                ? "done"
+                : step === "api-key"
+                  ? "current"
+                  : "pending"
+            }
+            detail={
+              process.env[getProviderApiKeyEnvKey(provider) ?? ""]
+                ? "available from environment"
+                : `save ${getProviderApiKeyEnvKey(provider) ?? "provider key"} to ${openWikiEnvPath}`
+            }
+          />
+        ) : (
+          <SetupStep
+            label="Codex OAuth"
+            state="done"
+            detail="run openwiki login codex-oauth if needed"
+          />
+        )}
         {providerRequiresBaseUrl(provider) ? (
           <SetupStep
             label="Base URL"
@@ -751,7 +769,7 @@ function getInitialStep(
     return "provider";
   }
 
-  if (!process.env[getProviderApiKeyEnvKey(provider)]) {
+  if (needsApiKeyStep(provider)) {
     return "api-key";
   }
 
@@ -777,7 +795,7 @@ function getNextStepAfterProvider(
   provider: OpenWikiProvider,
   modelIdOverride: string | null,
 ): PromptStep | null {
-  if (!process.env[getProviderApiKeyEnvKey(provider)]) {
+  if (needsApiKeyStep(provider)) {
     return "api-key";
   }
 
@@ -792,11 +810,10 @@ function getNextStepAfterApiKey(
     return "base-url";
   }
 
-  return getNextStepAfterBaseUrl(provider, modelIdOverride);
+  return getNextStepAfterBaseUrl(modelIdOverride);
 }
 
 function getNextStepAfterBaseUrl(
-  provider: OpenWikiProvider,
   modelIdOverride: string | null,
 ): PromptStep | null {
   if (

--- a/test/codex-oauth-auth-file.test.ts
+++ b/test/codex-oauth-auth-file.test.ts
@@ -1,0 +1,178 @@
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, test, vi } from "vitest";
+import {
+  CODEX_OAUTH_CLIENT_ID,
+  CODEX_OAUTH_TOKEN_URL,
+  createSyntheticJwt,
+  resolveCodexOAuthCredentials,
+} from "../src/codex-oauth.ts";
+
+const tempDirs: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(
+    tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })),
+  );
+});
+
+async function createAuthPath(name: string): Promise<string> {
+  const dir = await mkdtemp(path.join(os.tmpdir(), `openwiki-${name}-`));
+  tempDirs.push(dir);
+  return path.join(dir, "auth.json");
+}
+
+describe("resolveCodexOAuthCredentials — auth.json", () => {
+  test("returns stored credentials without refreshing when the access token is still fresh", async () => {
+    const now = new Date("2026-07-08T11:45:00.000Z");
+    const authPath = await createAuthPath("codex-auth-fresh");
+    const accessToken = createSyntheticJwt({
+      exp: Math.floor((now.getTime() + 10 * 60 * 1000) / 1000),
+    });
+    const authJson = `${JSON.stringify(
+      {
+        tokens: {
+          accessToken,
+          refreshToken: "refresh-token",
+          idToken: createSyntheticJwt({
+            "https://api.openai.com/auth": {
+              chatgpt_account_id: "acct_fresh",
+              chatgpt_plan_type: "plus",
+            },
+          }),
+          accountId: "acct_fresh",
+          planType: "plus",
+          expiresAt: new Date(now.getTime() + 10 * 60 * 1000).toISOString(),
+        },
+        updatedAt: "2026-07-08T10:00:00.000Z",
+      },
+      null,
+      2,
+    )}
+`;
+    const fetchMock = vi.fn<typeof fetch>();
+
+    await writeFile(authPath, authJson, "utf8");
+
+    await expect(
+      resolveCodexOAuthCredentials({
+        authPath,
+        fetch: fetchMock,
+        now,
+      }),
+    ).resolves.toEqual({
+      accessToken,
+      accountId: "acct_fresh",
+    });
+    expect(fetchMock).not.toHaveBeenCalled();
+    await expect(readFile(authPath, "utf8")).resolves.toBe(authJson);
+  });
+
+  test("refreshes an expired token and persists the rotated access token", async () => {
+    const now = new Date("2026-07-08T11:45:00.000Z");
+    const authPath = await createAuthPath("codex-auth-refresh");
+    const expiredAccessToken = createSyntheticJwt({
+      exp: Math.floor((now.getTime() - 60 * 1000) / 1000),
+    });
+    const refreshedAccessToken = createSyntheticJwt({
+      exp: Math.floor((now.getTime() + 60 * 60 * 1000) / 1000),
+    });
+    const previousIdToken = createSyntheticJwt({
+      "https://api.openai.com/auth": {
+        chatgpt_account_id: "acct_refresh",
+        chatgpt_plan_type: "pro",
+      },
+    });
+    const fetchMock = vi.fn<typeof fetch>(() =>
+      Promise.resolve(
+        new Response(JSON.stringify({ access_token: refreshedAccessToken }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        }),
+      ),
+    );
+
+    await writeFile(
+      authPath,
+      `${JSON.stringify(
+        {
+          tokens: {
+            accessToken: expiredAccessToken,
+            refreshToken: "refresh-token-before-rotation",
+            idToken: previousIdToken,
+            accountId: "acct_refresh",
+            planType: "pro",
+            expiresAt: new Date(now.getTime() - 60 * 1000).toISOString(),
+          },
+          updatedAt: "2026-07-08T10:00:00.000Z",
+        },
+        null,
+        2,
+      )}
+`,
+      "utf8",
+    );
+
+    await expect(
+      resolveCodexOAuthCredentials({
+        authPath,
+        fetch: fetchMock,
+        now,
+      }),
+    ).resolves.toEqual({
+      accessToken: refreshedAccessToken,
+      accountId: "acct_refresh",
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0] ?? [];
+    expect(url).toBe(CODEX_OAUTH_TOKEN_URL);
+    expect(init?.method).toBe("POST");
+    expect(init?.headers).toEqual({ "content-type": "application/json" });
+    expect(typeof init?.body).toBe("string");
+    if (typeof init?.body !== "string") {
+      throw new Error("Expected refresh request body to be a JSON string.");
+    }
+    expect(JSON.parse(init.body)).toEqual({
+      client_id: CODEX_OAUTH_CLIENT_ID,
+      grant_type: "refresh_token",
+      refresh_token: "refresh-token-before-rotation",
+    });
+
+    const persisted = JSON.parse(await readFile(authPath, "utf8")) as {
+      updatedAt: string;
+      tokens: {
+        accessToken: string;
+        refreshToken: string;
+        idToken: string;
+        accountId: string;
+        planType: string;
+        expiresAt: string;
+      };
+    };
+    expect(persisted.updatedAt).toBe(now.toISOString());
+    expect(persisted.tokens.accountId).toBe("acct_refresh");
+    expect(persisted.tokens.accessToken).toBe(refreshedAccessToken);
+    expect(persisted.tokens.refreshToken).toBe(
+      "refresh-token-before-rotation",
+    );
+    expect(persisted.tokens.idToken).toBe(previousIdToken);
+    expect(persisted.tokens.planType).toBe("pro");
+    expect(persisted.tokens.expiresAt).toBe(
+      new Date(now.getTime() + 60 * 60 * 1000).toISOString(),
+    );
+  });
+
+  test("rejects an auth file that is not valid JSON", async () => {
+    const authPath = await createAuthPath("codex-auth-invalid-json");
+
+    await writeFile(authPath, "{not-json}\n", "utf8");
+
+    await expect(
+      resolveCodexOAuthCredentials({ authPath }),
+    ).rejects.toThrow(
+      `Codex OAuth credentials at ${authPath} are not valid JSON.`,
+    );
+  });
+});

--- a/test/codex-oauth-provider.test.ts
+++ b/test/codex-oauth-provider.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, test, vi } from "vitest";
+import {
+  getProviderApiKeyEnvKey,
+  getProviderLabel,
+  isValidProvider,
+  normalizeProvider,
+  providerUsesApiKey,
+  providerUsesCodexOAuth,
+  resolveConfiguredProvider,
+  SELECTABLE_OPENWIKI_PROVIDERS,
+} from "../src/constants.ts";
+import { needsCredentialSetup } from "../src/credentials.tsx";
+
+describe("codex-oauth provider integration", () => {
+  test("normalizes and resolves codex-oauth as a first-class provider", () => {
+    expect(normalizeProvider(" CODEX-OAUTH ")).toBe("codex-oauth");
+    expect(isValidProvider("codex-oauth")).toBe(true);
+    expect(resolveConfiguredProvider({ OPENWIKI_PROVIDER: "codex-oauth" })).toBe(
+      "codex-oauth",
+    );
+  });
+
+  test("exposes Codex OAuth as a selectable provider with managed credentials", () => {
+    expect(SELECTABLE_OPENWIKI_PROVIDERS).toContain("codex-oauth");
+    expect(getProviderLabel("codex-oauth")).toBe("Codex OAuth");
+    expect(getProviderApiKeyEnvKey("codex-oauth")).toBeNull();
+    expect(providerUsesApiKey("codex-oauth")).toBe(false);
+    expect(providerUsesCodexOAuth("codex-oauth")).toBe(true);
+  });
+
+  test("skips API-key credential setup for codex-oauth", () => {
+    vi.stubEnv("OPENWIKI_PROVIDER", "codex-oauth");
+    vi.stubEnv("OPENWIKI_MODEL_ID", "gpt-5.5");
+    vi.stubEnv("LANGSMITH_API_KEY", "");
+
+    try {
+      expect(needsCredentialSetup()).toBe(false);
+    } finally {
+      vi.unstubAllEnvs();
+    }
+  });
+});

--- a/test/codex-oauth.test.ts
+++ b/test/codex-oauth.test.ts
@@ -366,6 +366,7 @@ describe("CodexChatOpenAI", () => {
   test("routes requests to the Codex backend responses API and lifts system messages into instructions", async () => {
     let capturedBody = "";
     let capturedUrl = "";
+    let capturedOriginator = "";
     const fetchMock = vi.fn<typeof fetch>((input, init) => {
       capturedUrl =
         typeof input === "string"
@@ -374,6 +375,7 @@ describe("CodexChatOpenAI", () => {
             ? input.toString()
             : input.url;
       capturedBody = typeof init?.body === "string" ? init.body : "";
+      capturedOriginator = getHeaderValue(init?.headers, "originator");
 
       return Promise.resolve(
         new Response("{\"error\":\"stop\"}", {
@@ -405,6 +407,7 @@ describe("CodexChatOpenAI", () => {
     }).rejects.toThrow();
 
     expect(capturedUrl).toBe(`${CODEX_BACKEND_BASE_URL}/responses`);
+    expect(capturedOriginator).toBe("codex_cli_rs");
     const payload = JSON.parse(capturedBody) as {
       input: Array<{ role?: string }>;
       instructions?: string;
@@ -413,6 +416,37 @@ describe("CodexChatOpenAI", () => {
     expect(payload.input.map((item) => item.role)).toEqual(["user"]);
   });
 });
+
+function getHeaderValue(headers: unknown, key: string): string {
+  if (headers instanceof Headers) {
+    return headers.get(key) ?? "";
+  }
+
+  if (Array.isArray(headers)) {
+    for (const pair of headers) {
+      if (
+        Array.isArray(pair) &&
+        typeof pair[0] === "string" &&
+        typeof pair[1] === "string" &&
+        pair[0].toLowerCase() === key
+      ) {
+        return pair[1];
+      }
+    }
+
+    return "";
+  }
+
+  if (headers && typeof headers === "object") {
+    for (const [name, value] of Object.entries(headers)) {
+      if (name.toLowerCase() === key && typeof value === "string") {
+        return value;
+      }
+    }
+  }
+
+  return "";
+}
 
 type SavedCodexAuth = {
   pending?: {

--- a/test/codex-oauth.test.ts
+++ b/test/codex-oauth.test.ts
@@ -1,0 +1,449 @@
+import { createHash } from "node:crypto";
+import { mkdir, mkdtemp, readFile, rm, stat, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { HumanMessage, SystemMessage } from "@langchain/core/messages";
+import { afterEach, describe, expect, test, vi } from "vitest";
+import {
+  CODEX_BACKEND_BASE_URL,
+  CODEX_OAUTH_AUTHORIZE_URL,
+  CODEX_OAUTH_CLIENT_ID,
+  CODEX_OAUTH_REDIRECT_URI,
+  CODEX_OAUTH_TOKEN_URL,
+  CodexChatOpenAI,
+  completeCodexOAuthLogin,
+  createSyntheticJwt,
+  parseCodexOAuthCallbackUrl,
+  resolveCodexOAuthCredentials,
+  startCodexOAuthLogin,
+} from "../src/codex-oauth.ts";
+
+const tempDirs: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(
+    tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })),
+  );
+});
+
+describe("startCodexOAuthLogin", () => {
+  test("generates a PKCE authorize URL and persists the pending verifier with 0600 permissions", async () => {
+    const now = new Date("2026-07-08T12:00:00.000Z");
+    const authPath = await createAuthPath();
+    const verifierBytes = Buffer.from(Array.from({ length: 32 }, (_, index) => index + 1));
+    const stateBytes = Buffer.from(Array.from({ length: 24 }, (_, index) => 255 - index));
+    const randomBytes = vi.fn((size: number) => {
+      if (size === 32) {
+        return verifierBytes;
+      }
+
+      if (size === 24) {
+        return stateBytes;
+      }
+
+      throw new Error(`unexpected random byte request: ${size}`);
+    });
+
+    const { authorizeUrl, state } = await startCodexOAuthLogin({
+      authPath,
+      now,
+      randomBytes,
+    });
+
+    const expectedCodeVerifier = verifierBytes.toString("base64url");
+    const expectedState = stateBytes.toString("base64url");
+    const expectedCodeChallenge = createHash("sha256")
+      .update(expectedCodeVerifier)
+      .digest("base64url");
+    const saved = await readAuthFile(authPath);
+    const parsed = new URL(authorizeUrl);
+
+    expect(state).toBe(expectedState);
+    expect(randomBytes).toHaveBeenCalledTimes(2);
+    expect(`${parsed.origin}${parsed.pathname}`).toBe(CODEX_OAUTH_AUTHORIZE_URL);
+    expect(parsed.searchParams.get("response_type")).toBe("code");
+    expect(parsed.searchParams.get("client_id")).toBe(CODEX_OAUTH_CLIENT_ID);
+    expect(parsed.searchParams.get("redirect_uri")).toBe(CODEX_OAUTH_REDIRECT_URI);
+    expect(parsed.searchParams.get("scope")).toBe("openid profile email offline_access");
+    expect(parsed.searchParams.get("code_challenge")).toBe(expectedCodeChallenge);
+    expect(parsed.searchParams.get("code_challenge_method")).toBe("S256");
+    expect(parsed.searchParams.get("state")).toBe(expectedState);
+    expect(parsed.searchParams.get("originator")).toBe("openwiki");
+    expect(saved).toEqual({
+      pending: {
+        codeVerifier: expectedCodeVerifier,
+        createdAt: now.toISOString(),
+        redirectUri: CODEX_OAUTH_REDIRECT_URI,
+        state: expectedState,
+      },
+      updatedAt: now.toISOString(),
+    });
+    expect((await stat(authPath)).mode & 0o777).toBe(0o600);
+  });
+});
+
+describe("parseCodexOAuthCallbackUrl", () => {
+  test("parses a pasted callback URL after trimming surrounding whitespace", () => {
+    expect(
+      parseCodexOAuthCallbackUrl(
+        "  https://callback.example.invalid/oauth?code=synthetic-code&state=state-123  ",
+      ),
+    ).toEqual({
+      code: "synthetic-code",
+      state: "state-123",
+    });
+  });
+
+  test("requires both code and state parameters in the callback URL", () => {
+    expect(() =>
+      parseCodexOAuthCallbackUrl("https://callback.example.invalid/oauth?code=only-code"),
+    ).toThrow("Codex OAuth callback URL must include code and state parameters.");
+  });
+});
+
+describe("completeCodexOAuthLogin", () => {
+  test("rejects a callback whose state does not match the pending login", async () => {
+    const authPath = await createAuthPath();
+    const fetchMock = vi.fn<typeof fetch>();
+
+    await writeAuthFile(authPath, {
+      pending: {
+        codeVerifier: "verifier-123",
+        createdAt: "2026-07-08T12:00:00.000Z",
+        redirectUri: CODEX_OAUTH_REDIRECT_URI,
+        state: "expected-state",
+      },
+      updatedAt: "2026-07-08T12:00:00.000Z",
+    });
+
+    await expect(
+      completeCodexOAuthLogin(
+        "https://callback.example.invalid/oauth?code=synthetic-code&state=wrong-state",
+        {
+          authPath,
+          fetch: fetchMock,
+        },
+      ),
+    ).rejects.toThrow("Codex OAuth callback state did not match the pending login.");
+
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(await readAuthFile(authPath)).toEqual({
+      pending: {
+        codeVerifier: "verifier-123",
+        createdAt: "2026-07-08T12:00:00.000Z",
+        redirectUri: CODEX_OAUTH_REDIRECT_URI,
+        state: "expected-state",
+      },
+      updatedAt: "2026-07-08T12:00:00.000Z",
+    });
+  });
+
+  test("exchanges the callback code, extracts the account id from the id_token, and persists the token set with 0600 permissions", async () => {
+    const now = new Date("2026-07-08T13:00:00.000Z");
+    const authPath = await createAuthPath();
+    const idToken = createSyntheticJwt({
+      "https://api.openai.com/auth": {
+        chatgpt_account_id: "acct_test_123",
+        chatgpt_plan_type: "pro",
+      },
+    });
+    const captured = {
+      body: new URLSearchParams(),
+      headers: {} as Record<string, string>,
+      method: "",
+      url: "",
+    };
+    const fetchMock = vi.fn<typeof fetch>((input, init) => {
+      captured.url =
+        typeof input === "string"
+          ? input
+          : input instanceof URL
+            ? input.toString()
+            : input.url;
+      captured.method = init?.method ?? "";
+      captured.headers = (init?.headers ?? {}) as Record<string, string>;
+      if (init?.body instanceof URLSearchParams) {
+        captured.body = init.body;
+      } else if (typeof init?.body === "string") {
+        captured.body = new URLSearchParams(init.body);
+      } else {
+        captured.body = new URLSearchParams();
+      }
+
+      return Promise.resolve(
+        new Response(
+          JSON.stringify({
+            access_token: "access-token-1",
+            expires_in: 3600,
+            id_token: idToken,
+            refresh_token: "refresh-token-1",
+          }),
+          {
+            headers: { "content-type": "application/json" },
+            status: 200,
+          },
+        ),
+      );
+    });
+
+    await writeAuthFile(authPath, {
+      pending: {
+        codeVerifier: "verifier-xyz",
+        createdAt: "2026-07-08T12:55:00.000Z",
+        redirectUri: CODEX_OAUTH_REDIRECT_URI,
+        state: "state-xyz",
+      },
+      updatedAt: "2026-07-08T12:55:00.000Z",
+    });
+
+    await expect(
+      completeCodexOAuthLogin(
+        "https://callback.example.invalid/oauth?code=synthetic-code&state=state-xyz",
+        {
+          authPath,
+          fetch: fetchMock,
+          now,
+        },
+      ),
+    ).resolves.toEqual({
+      accessToken: "access-token-1",
+      accountId: "acct_test_123",
+    });
+
+    expect(captured.url).toBe(CODEX_OAUTH_TOKEN_URL);
+    expect(captured.method).toBe("POST");
+    expect(captured.headers["content-type"]).toBe("application/x-www-form-urlencoded");
+    expect(captured.body.get("client_id")).toBe(CODEX_OAUTH_CLIENT_ID);
+    expect(captured.body.get("code")).toBe("synthetic-code");
+    expect(captured.body.get("code_verifier")).toBe("verifier-xyz");
+    expect(captured.body.get("grant_type")).toBe("authorization_code");
+    expect(captured.body.get("redirect_uri")).toBe(CODEX_OAUTH_REDIRECT_URI);
+    expect(await readAuthFile(authPath)).toEqual({
+      tokens: {
+        accessToken: "access-token-1",
+        accountId: "acct_test_123",
+        expiresAt: "2026-07-08T14:00:00.000Z",
+        idToken,
+        planType: "pro",
+        refreshToken: "refresh-token-1",
+      },
+      updatedAt: now.toISOString(),
+    });
+    expect((await stat(authPath)).mode & 0o777).toBe(0o600);
+  });
+});
+
+describe("resolveCodexOAuthCredentials", () => {
+  test("keeps the persisted token when expiry is still just outside the refresh window", async () => {
+    const now = new Date("2026-07-08T12:00:00.000Z");
+    const authPath = await createAuthPath();
+    const idToken = createSyntheticJwt({
+      "https://api.openai.com/auth": {
+        chatgpt_account_id: "acct_test_123",
+      },
+    });
+    const fetchMock = vi.fn<typeof fetch>();
+
+    await writeAuthFile(authPath, {
+      tokens: {
+        accessToken: "cached-access-token",
+        accountId: "acct_test_123",
+        expiresAt: "2026-07-08T12:05:01.000Z",
+        idToken,
+        planType: null,
+        refreshToken: "cached-refresh-token",
+      },
+      updatedAt: "2026-07-08T11:59:00.000Z",
+    });
+
+    await expect(
+      resolveCodexOAuthCredentials({
+        authPath,
+        fetch: fetchMock,
+        now,
+      }),
+    ).resolves.toEqual({
+      accessToken: "cached-access-token",
+      accountId: "acct_test_123",
+    });
+
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(await readAuthFile(authPath)).toEqual({
+      tokens: {
+        accessToken: "cached-access-token",
+        accountId: "acct_test_123",
+        expiresAt: "2026-07-08T12:05:01.000Z",
+        idToken,
+        planType: null,
+        refreshToken: "cached-refresh-token",
+      },
+      updatedAt: "2026-07-08T11:59:00.000Z",
+    });
+  });
+
+  test("refreshes tokens exactly at the near-expiry boundary and persists a rotated refresh token", async () => {
+    const now = new Date("2026-07-08T12:00:00.000Z");
+    const authPath = await createAuthPath();
+    const idToken = createSyntheticJwt({
+      "https://api.openai.com/auth": {
+        chatgpt_account_id: "acct_test_123",
+        chatgpt_plan_type: "plus",
+      },
+    });
+    let capturedBody = "";
+    let capturedMethod = "";
+    let capturedUrl = "";
+    const fetchMock = vi.fn<typeof fetch>((input, init) => {
+      capturedUrl =
+        typeof input === "string"
+          ? input
+          : input instanceof URL
+            ? input.toString()
+            : input.url;
+      capturedMethod = init?.method ?? "";
+      capturedBody = typeof init?.body === "string" ? init.body : "";
+
+      return Promise.resolve(
+        new Response(
+          JSON.stringify({
+            access_token: "refreshed-access-token",
+            expires_in: 7200,
+            refresh_token: "rotated-refresh-token",
+          }),
+          {
+            headers: { "content-type": "application/json" },
+            status: 200,
+          },
+        ),
+      );
+    });
+
+    await writeAuthFile(authPath, {
+      tokens: {
+        accessToken: "stale-access-token",
+        accountId: "acct_test_123",
+        expiresAt: "2026-07-08T12:05:00.000Z",
+        idToken,
+        planType: "plus",
+        refreshToken: "stale-refresh-token",
+      },
+      updatedAt: "2026-07-08T11:00:00.000Z",
+    });
+
+    await expect(
+      resolveCodexOAuthCredentials({
+        authPath,
+        fetch: fetchMock,
+        now,
+      }),
+    ).resolves.toEqual({
+      accessToken: "refreshed-access-token",
+      accountId: "acct_test_123",
+    });
+
+    expect(capturedUrl).toBe(CODEX_OAUTH_TOKEN_URL);
+    expect(capturedMethod).toBe("POST");
+    expect(JSON.parse(capturedBody)).toEqual({
+      client_id: CODEX_OAUTH_CLIENT_ID,
+      grant_type: "refresh_token",
+      refresh_token: "stale-refresh-token",
+    });
+    expect(await readAuthFile(authPath)).toEqual({
+      tokens: {
+        accessToken: "refreshed-access-token",
+        accountId: "acct_test_123",
+        expiresAt: "2026-07-08T14:00:00.000Z",
+        idToken,
+        planType: "plus",
+        refreshToken: "rotated-refresh-token",
+      },
+      updatedAt: now.toISOString(),
+    });
+  });
+});
+
+describe("CodexChatOpenAI", () => {
+  test("routes requests to the Codex backend responses API and lifts system messages into instructions", async () => {
+    let capturedBody = "";
+    let capturedUrl = "";
+    const fetchMock = vi.fn<typeof fetch>((input, init) => {
+      capturedUrl =
+        typeof input === "string"
+          ? input
+          : input instanceof URL
+            ? input.toString()
+            : input.url;
+      capturedBody = typeof init?.body === "string" ? init.body : "";
+
+      return Promise.resolve(
+        new Response("{\"error\":\"stop\"}", {
+          headers: { "content-type": "application/json" },
+          status: 400,
+        }),
+      );
+    });
+    const model = new CodexChatOpenAI({
+      codexCredentials: {
+        accessToken: "access-token-1",
+        accountId: "acct_test_123",
+      },
+      configuration: { fetch: fetchMock },
+      model: "gpt-5.5",
+    });
+
+    await expect(async () => {
+      for await (const event of model.streamEvents(
+        [
+          new SystemMessage("system instructions"),
+          new SystemMessage("developer guardrails"),
+          new HumanMessage("hello"),
+        ],
+        { version: "v2" },
+      )) {
+        expect(event).toBeDefined();
+      }
+    }).rejects.toThrow();
+
+    expect(capturedUrl).toBe(`${CODEX_BACKEND_BASE_URL}/responses`);
+    const payload = JSON.parse(capturedBody) as {
+      input: Array<{ role?: string }>;
+      instructions?: string;
+    };
+    expect(payload.instructions).toBe("system instructions\n\ndeveloper guardrails");
+    expect(payload.input.map((item) => item.role)).toEqual(["user"]);
+  });
+});
+
+type SavedCodexAuth = {
+  pending?: {
+    codeVerifier?: string;
+    createdAt?: string;
+    redirectUri?: string;
+    state?: string;
+  };
+  tokens?: Record<string, unknown>;
+  updatedAt?: string;
+};
+
+async function createAuthPath(): Promise<string> {
+  const dir = await mkdtemp(path.join(os.tmpdir(), "openwiki-codex-oauth-"));
+  tempDirs.push(dir);
+  const authPath = path.join(dir, ".openwiki", "codex-oauth.json");
+
+  return authPath;
+}
+
+async function readAuthFile(authPath: string): Promise<SavedCodexAuth> {
+  const raw = await readFile(authPath, "utf8");
+  const parsed: unknown = JSON.parse(raw);
+
+  return parsed as SavedCodexAuth;
+}
+
+async function writeAuthFile(
+  authPath: string,
+  authFile: SavedCodexAuth,
+): Promise<void> {
+  await mkdir(path.dirname(authPath), { recursive: true });
+  await writeFile(authPath, `${JSON.stringify(authFile, null, 2)}\n`, "utf8");
+}


### PR DESCRIPTION
## Summary
- add a `codex-oauth` provider with a self-managed PKCE login flow (`openwiki login codex-oauth`)
- store Codex OAuth tokens in `~/.openwiki/codex-oauth.json` with restrictive permissions and refresh near-expiry tokens
- call the Codex Responses backend directly, sanitizing system/developer messages into top-level `instructions`
- document the provider and add focused OAuth/provider tests

## Verification
- `pnpm test` (11 files, 101 tests)
- `pnpm run typecheck`
- `pnpm run lint:check`
- `pnpm run build`
- `openwiki-codex -p "Reply exactly: OK"` from `~/ica/server` returned `OK`