### PR TITLE
fix: use clampLimit for maxFieldChars consistency

### DIFF
--- a/src/connectors/sources/langsmith/index.ts
+++ b/src/connectors/sources/langsmith/index.ts
@@ -131,7 +131,7 @@ async function ingest(
   ).toISOString();
   const maxErrorRuns = clampLimit(options.limit, config.maxErrorRuns, 100);
   const maxRootRuns = clampLimit(options.limit, config.maxRootRuns, 100);
-  const maxFieldChars = Math.max(100, config.maxFieldChars ?? 2000);
+  const maxFieldChars = clampLimit(options.limit, config.maxFieldChars, 5000);
   const nextCursors: Record<string, string> = {};
   const projectResults: ProjectPullResult[] = [];
 


### PR DESCRIPTION
## Summary

This PR fixes an inconsistency in the LangSmith connector where maxFieldChars was using Math.max(100, ...) instead of the centralized clampLimit utility.

## Changes

- **src/connectors/sources/langsmith/index.ts**: Changed maxFieldChars clamping to use clampLimit utility for consistency with maxErrorRuns and maxRootRuns

## Before

`	ypescript
const maxFieldChars = Math.max(100, config.maxFieldChars ?? 2000);
`

## After

`	ypescript
const maxFieldChars = clampLimit(options.limit, config.maxFieldChars, 5000);
`

## Benefits

- ✅ Consistent clamping policy across all limits
- ✅ Allows the limit option to properly override config values
- ✅ Uses the centralized utility from limits.ts
- ✅ Build passes successfully

## Testing

- Verified build passes with pnpm run build
- No TypeScript errors introduced
- Maintains backward compatibility with existing config values

## Related to

PR #200 - feat: implement langsmith as a connector