### PR TITLE
feat: add no agent instructions flag

### DIFF
--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -134,7 +134,9 @@ async function runOpenWikiAgentCore(
       timeout: 120,
       virtualMode: true,
     }),
-    systemPrompt: createSystemPrompt(command),
+    systemPrompt: createSystemPrompt(command, {
+      noAgentInstructions: options.noAgentInstructions === true,
+    }),
   });
   emitDebug(options, "agent=created");
 

--- a/src/agent/prompt.ts
+++ b/src/agent/prompt.ts
@@ -1,6 +1,10 @@
 import { OPEN_WIKI_DIR, UPDATE_METADATA_PATH } from "../constants.js";
 import { OpenWikiCommand, RunContext, UpdateMetadata } from "./types.js";
 
+type SystemPromptOptions = {
+  noAgentInstructions?: boolean;
+};
+
 function formatLastUpdate(lastUpdate: UpdateMetadata | null): string {
   if (lastUpdate === null) {
     return "No previous OpenWiki update metadata was found.";
@@ -9,7 +13,12 @@ function formatLastUpdate(lastUpdate: UpdateMetadata | null): string {
   return JSON.stringify(lastUpdate, null, 2);
 }
 
-export function createSystemPrompt(command: OpenWikiCommand): string {
+export function createSystemPrompt(
+  command: OpenWikiCommand,
+  options: SystemPromptOptions = {},
+): string {
+  const noAgentInstructions = options.noAgentInstructions === true;
+
   return `
 You are OpenWiki, an expert technical writer, software architect, and product analyst.
 
@@ -54,28 +63,7 @@ Existing documentation discipline:
 - Summarize and link to existing docs when they are still useful instead of duplicating them wholesale.
 - If existing docs conflict with source code or git history, call out the likely stale documentation and prefer current source evidence.
 
-Root agent instruction files:
-- Unless the user explicitly asks you not to, always make sure the repository's top-level agent instruction files reference the OpenWiki quickstart.
-- Only consider top-level /AGENTS.md and /CLAUDE.md for this step. Do not edit nested AGENTS.md or CLAUDE.md files.
-- If /AGENTS.md or /CLAUDE.md exists, add or update the OpenWiki reference section there. If both exist, ensure the same section is added to both (duplicated).
-- If neither exists, create top-level /AGENTS.md containing only the OpenWiki reference section.
-- During update runs, inspect any existing OpenWiki reference section in /AGENTS.md and/or /CLAUDE.md and refresh it only if the section is missing or semantically stale. This check is required even when the wiki itself is otherwise current.
-- Preserve surrounding instructions in existing files. Replace/update an existing OpenWiki reference section instead of adding duplicates.
-- Do not edit /AGENTS.md or /CLAUDE.md only to normalize formatting, blank lines, wrapping, or punctuation if the existing OpenWiki section is already semantically correct.
-- Use this exact section structure every time:
-
-\`\`\`markdown
-## OpenWiki
-
-This repository has documentation located in the /openwiki directory.
-
-Start here:
-- [OpenWiki quickstart](openwiki/quickstart.md)
-
-OpenWiki includes repository overview, architecture notes, workflows, domain concepts, operations, integrations, testing guidance, and source maps.
-
-When working in this repository, read the OpenWiki quickstart first, then follow its links to the relevant architecture, workflow, domain, operation, and testing notes.
-\`\`\`
+${createAgentInstructionFileInstructions(noAgentInstructions)}
 
 OpenWiki CLI reference:
 - \`openwiki\` opens the interactive chat interface and waits for user input.
@@ -93,7 +81,7 @@ Security and privacy rules:
 - Do not read .env files. .env.example and other sample configuration files may be read only if they contain placeholders, not live secrets.
 - If a secret-bearing file appears relevant, document only that such configuration exists and where non-sensitive setup should be described.
 - Keep all documentation under ${OPEN_WIKI_DIR}/.
-- Do not modify source code outside ${OPEN_WIKI_DIR}/. The only allowed exceptions are top-level /AGENTS.md and /CLAUDE.md, and only for the OpenWiki reference section described above.
+${createWriteBoundaryInstruction(noAgentInstructions)}
 
 Documentation goals:
 - Someone with zero knowledge of the repository should be able to start at ${OPEN_WIKI_DIR}/quickstart.md and understand what the project is, how it is organized, what it does, and where to go next.
@@ -129,6 +117,52 @@ Required documentation structure:
 Mode-specific behavior:
 ${createModeInstructions(command)}
 `.trim();
+}
+
+function createAgentInstructionFileInstructions(
+  noAgentInstructions: boolean,
+): string {
+  if (noAgentInstructions) {
+    return `
+Root agent instruction files:
+- Do not create, edit, append, or refresh top-level /AGENTS.md or /CLAUDE.md.
+- Do not add OpenWiki references, quickstart links, generated sections, or other documentation guidance to /AGENTS.md or /CLAUDE.md during this run.
+- Keep all generated documentation and update metadata under ${OPEN_WIKI_DIR}/.
+`.trim();
+  }
+
+  return `
+Root agent instruction files:
+- Unless the user explicitly asks you not to, always make sure the repository's top-level agent instruction files reference the OpenWiki quickstart.
+- Only consider top-level /AGENTS.md and /CLAUDE.md for this step. Do not edit nested AGENTS.md or CLAUDE.md files.
+- If /AGENTS.md or /CLAUDE.md exists, add or update the OpenWiki reference section there. If both exist, ensure the same section is added to both (duplicated).
+- If neither exists, create top-level /AGENTS.md containing only the OpenWiki reference section.
+- During update runs, inspect any existing OpenWiki reference section in /AGENTS.md and/or /CLAUDE.md and refresh it only if the section is missing or semantically stale. This check is required even when the wiki itself is otherwise current.
+- Preserve surrounding instructions in existing files. Replace/update an existing OpenWiki reference section instead of adding duplicates.
+- Do not edit /AGENTS.md or /CLAUDE.md only to normalize formatting, blank lines, wrapping, or punctuation if the existing OpenWiki section is already semantically correct.
+- Use this exact section structure every time:
+
+\`\`\`markdown
+## OpenWiki
+
+This repository has documentation located in the /openwiki directory.
+
+Start here:
+- [OpenWiki quickstart](openwiki/quickstart.md)
+
+OpenWiki includes repository overview, architecture notes, workflows, domain concepts, operations, integrations, testing guidance, and source maps.
+
+When working in this repository, read the OpenWiki quickstart first, then follow its links to the relevant architecture, workflow, domain, operation, and testing notes.
+\`\`\`
+`.trim();
+}
+
+function createWriteBoundaryInstruction(noAgentInstructions: boolean): string {
+  if (noAgentInstructions) {
+    return `- Do not modify files outside ${OPEN_WIKI_DIR}/. In particular, do not create, edit, append, or refresh top-level /AGENTS.md or /CLAUDE.md.`;
+  }
+
+  return `- Do not modify source code outside ${OPEN_WIKI_DIR}/. The only allowed exceptions are top-level /AGENTS.md and /CLAUDE.md, and only for the OpenWiki reference section described above.`;
 }
 
 export function createModeInstructions(command: OpenWikiCommand): string {

--- a/src/agent/types.ts
+++ b/src/agent/types.ts
@@ -34,6 +34,7 @@ export type OpenWikiRunOptions = {
   debug?: boolean;
   isFollowup?: boolean;
   modelId?: string | null;
+  noAgentInstructions?: boolean;
   onEvent?: (event: OpenWikiRunEvent) => void;
   threadId?: string;
   userMessage?: string | null;

--- a/src/cli.tsx
+++ b/src/cli.tsx
@@ -294,6 +294,7 @@ function App({ command }: AppProps) {
       debug: isDebugMode(),
       isFollowup: activeMessageIsFollowup,
       modelId: sessionModelId,
+      noAgentInstructions: command.noAgentInstructions,
       threadId: sessionThreadId.current,
       userMessage: activeUserMessage,
       onEvent: (event) => {
@@ -3018,6 +3019,7 @@ async function runPrintCommand(
       debug: isDebugMode(),
       isFollowup: command.command === "chat",
       modelId: command.modelId,
+      noAgentInstructions: command.noAgentInstructions,
       threadId: createOpenWikiThreadId(process.cwd()),
       userMessage: command.userMessage,
       onEvent: (event) => {

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -25,6 +25,7 @@ export type CliCommand =
       command: OpenWikiCommand;
       dryRun: boolean;
       modelId: string | null;
+      noAgentInstructions: boolean;
       print: boolean;
       shouldStart: boolean;
       userMessage: string | null;
@@ -42,6 +43,7 @@ export function parseCommand(argv: string[]): CliCommand {
 
   let dryRun = false;
   let modelId: string | null = null;
+  let noAgentInstructions = false;
   let print = false;
   let command: OpenWikiCommand = "chat";
   const userMessageParts: string[] = [];
@@ -68,6 +70,11 @@ export function parseCommand(argv: string[]): CliCommand {
 
     if (arg === "--print" || arg === "-p") {
       print = true;
+      continue;
+    }
+
+    if (arg === "--no-agent-instructions") {
+      noAgentInstructions = true;
       continue;
     }
 
@@ -157,6 +164,7 @@ export function parseCommand(argv: string[]): CliCommand {
     command,
     dryRun,
     modelId,
+    noAgentInstructions,
     print,
     shouldStart,
     userMessage,
@@ -215,6 +223,10 @@ export const helpContent: HelpContent = {
     {
       label: "-p, --print",
       description: "Run once and print the final assistant output.",
+    },
+    {
+      label: "--no-agent-instructions",
+      description: "Do not add OpenWiki references to AGENTS.md or CLAUDE.md.",
     },
     {
       label: "--modelId <id>",

--- a/test/commands.test.ts
+++ b/test/commands.test.ts
@@ -1,5 +1,9 @@
 import { afterEach, beforeEach, describe, expect, test } from "vitest";
-import { parseCommand, shouldRunNonInteractively } from "../src/commands.ts";
+import {
+  getHelpText,
+  parseCommand,
+  shouldRunNonInteractively,
+} from "../src/commands.ts";
 
 // parseCommand's --dry-run gate consults isDevelopmentMode(), which reads
 // NODE_ENV / OPENWIKI_DEV. Pin both to a non-development state per test and
@@ -39,6 +43,7 @@ describe("parseCommand — chat default", () => {
       command: "chat",
       shouldStart: false,
       userMessage: null,
+      noAgentInstructions: false,
       print: false,
       dryRun: false,
       modelId: null,
@@ -86,6 +91,14 @@ describe("parseCommand — init/update", () => {
 
   test("repeating the same command flag is allowed", () => {
     expect(parseCommand(["--init", "--init"]).kind).toBe("run");
+  });
+
+  test("--no-agent-instructions suppresses root instruction file updates", () => {
+    expect(parseCommand(["--init", "--no-agent-instructions"])).toMatchObject({
+      kind: "run",
+      command: "init",
+      noAgentInstructions: true,
+    });
   });
 });
 
@@ -166,6 +179,12 @@ describe("parseCommand — --modelId", () => {
 
   test("invalid model id via equals form is an error", () => {
     expect(parseCommand(["--modelId="]).kind).toBe("error");
+  });
+});
+
+describe("help text", () => {
+  test("documents --no-agent-instructions", () => {
+    expect(getHelpText()).toContain("--no-agent-instructions");
   });
 });
 

--- a/test/prompt.test.ts
+++ b/test/prompt.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, test } from "vitest";
+import { OPEN_WIKI_DIR } from "../src/constants.ts";
+import { createSystemPrompt } from "../src/agent/prompt.ts";
+
+describe("createSystemPrompt", () => {
+  test("includes root agent instruction guidance by default", () => {
+    const prompt = createSystemPrompt("init");
+
+    expect(prompt).toContain("Root agent instruction files:");
+    expect(prompt).toContain("If neither exists, create top-level /AGENTS.md");
+    expect(prompt).toContain("Use this exact section structure every time");
+    expect(prompt).toContain("OpenWiki reference section described above");
+  });
+
+  test("omits root instruction-file edits with --no-agent-instructions", () => {
+    const prompt = createSystemPrompt("init", {
+      noAgentInstructions: true,
+    });
+
+    expect(prompt).toContain(
+      "Do not create, edit, append, or refresh top-level /AGENTS.md or /CLAUDE.md.",
+    );
+    expect(prompt).toContain(`Keep all documentation under ${OPEN_WIKI_DIR}/.`);
+    expect(prompt).not.toContain(
+      "If neither exists, create top-level /AGENTS.md",
+    );
+    expect(prompt).not.toContain("Use this exact section structure every time");
+    expect(prompt).not.toContain("OpenWiki reference section described above");
+  });
+});


### PR DESCRIPTION
## Summary

- Add `--no-agent-instructions` to the CLI parser/help output.
- Carry the flag into `OpenWikiRunOptions`.
- When enabled, omit the root `AGENTS.md` / `CLAUDE.md` OpenWiki reference-section instructions from the system prompt and replace them with explicit no-edit guidance.

## Why

Scheduled repository-docs automation often wants generated docs confined to `openwiki/**` unless a human explicitly opts into broader repo changes. This flag gives workflows a narrow prompt-level control without claiming to solve full filesystem sandboxing.

This complements #47's stronger write-restriction discussion; it does not replace declarative filesystem permissions.

## Tests

- `pnpm exec vitest run test/commands.test.ts test/prompt.test.ts`
- `pnpm run typecheck`
- `pnpm run format:check`
- `pnpm run lint:check`
- `pnpm run build`
- `pnpm test`

Related: #47
