### PR TITLE
fix: skip clean update prints before credentials

### DIFF
--- a/src/cli.tsx
+++ b/src/cli.tsx
@@ -10,6 +10,7 @@ import {
   type CliCommand,
   type HelpRow,
 } from "./commands.js";
+import { resolveStartupCommand } from "./startup.js";
 import {
   InitSetup,
   needsCredentialSetup,
@@ -2966,7 +2967,10 @@ if (parsedCommand.kind === "run" && !parsedCommand.dryRun) {
   await loadOpenWikiEnv();
 }
 
-const command = resolveStartupCommand(parsedCommand);
+const command = await resolveStartupCommand(parsedCommand, {
+  cwd: process.cwd(),
+  isStdinTTY: Boolean(process.stdin.isTTY),
+});
 
 if (shouldPrintStartupError(argv, parsedCommand, command)) {
   process.stderr.write(`${command.message}\n`);
@@ -3049,54 +3053,4 @@ function writePrintErrorDiagnostics(error: unknown): void {
   for (const diagnostic of diagnostics) {
     process.stderr.write(`${diagnostic.label}: ${diagnostic.value}\n`);
   }
-}
-
-function resolveStartupCommand(command: CliCommand): CliCommand {
-  if (
-    command.kind === "run" &&
-    !command.dryRun &&
-    !command.shouldStart &&
-    !process.stdin.isTTY
-  ) {
-    return {
-      kind: "error",
-      exitCode: 1,
-      message:
-        "Interactive chat requires a terminal. Pass a message or use --init or --update for non-interactive runs.",
-    };
-  }
-
-  if (
-    command.kind === "run" &&
-    !command.dryRun &&
-    command.shouldStart &&
-    (command.print || !process.stdin.isTTY)
-  ) {
-    const provider = resolveConfiguredProvider();
-    const apiKeyEnvKey = getProviderApiKeyEnvKey(provider);
-    const hasProviderKey = Boolean(process.env[apiKeyEnvKey]);
-
-    if (!hasProviderKey) {
-      return {
-        kind: "error",
-        exitCode: 1,
-        message: `${apiKeyEnvKey} is required for non-interactive runs. Run openwiki in an interactive terminal to save credentials.`,
-      };
-    }
-  }
-
-  if (
-    command.kind === "run" &&
-    !command.dryRun &&
-    command.userMessage !== null &&
-    command.userMessage.trim().length === 0
-  ) {
-    return {
-      kind: "error",
-      exitCode: 1,
-      message: "User message cannot be empty.",
-    };
-  }
-
-  return command;
 }

--- a/src/startup.ts
+++ b/src/startup.ts
@@ -1,0 +1,97 @@
+import { shouldCheckUpdateNoop, getUpdateNoopStatus } from "./agent/utils.js";
+import type { CliCommand } from "./commands.js";
+import {
+  getProviderApiKeyEnvKey,
+  resolveConfiguredProvider,
+} from "./constants.js";
+
+type ResolveStartupCommandOptions = {
+  cwd?: string;
+  isStdinTTY?: boolean;
+};
+
+export async function resolveStartupCommand(
+  command: CliCommand,
+  options: ResolveStartupCommandOptions = {},
+): Promise<CliCommand> {
+  const isStdinTTY = options.isStdinTTY ?? Boolean(process.stdin.isTTY);
+
+  if (
+    command.kind === "run" &&
+    !command.dryRun &&
+    !command.shouldStart &&
+    !isStdinTTY
+  ) {
+    return {
+      kind: "error",
+      exitCode: 1,
+      message:
+        "Interactive chat requires a terminal. Pass a message or use --init or --update for non-interactive runs.",
+    };
+  }
+
+  if (
+    command.kind === "run" &&
+    !command.dryRun &&
+    command.shouldStart &&
+    (command.print || !isStdinTTY)
+  ) {
+    const provider = resolveConfiguredProvider();
+    const apiKeyEnvKey = getProviderApiKeyEnvKey(provider);
+    const hasProviderKey = Boolean(process.env[apiKeyEnvKey]);
+
+    if (!hasProviderKey) {
+      if (
+        command.print &&
+        (await canSkipCleanUpdateBeforeCredentials(
+          command,
+          options.cwd ?? process.cwd(),
+        ))
+      ) {
+        return command;
+      }
+
+      return {
+        kind: "error",
+        exitCode: 1,
+        message: `${apiKeyEnvKey} is required for non-interactive runs. Run openwiki in an interactive terminal to save credentials.`,
+      };
+    }
+  }
+
+  if (
+    command.kind === "run" &&
+    !command.dryRun &&
+    command.userMessage !== null &&
+    command.userMessage.trim().length === 0
+  ) {
+    return {
+      kind: "error",
+      exitCode: 1,
+      message: "User message cannot be empty.",
+    };
+  }
+
+  return command;
+}
+
+async function canSkipCleanUpdateBeforeCredentials(
+  command: Extract<CliCommand, { kind: "run" }>,
+  cwd: string,
+): Promise<boolean> {
+  if (
+    command.command !== "update" ||
+    command.userMessage !== null ||
+    !shouldCheckUpdateNoop({ userMessage: command.userMessage })
+  ) {
+    return false;
+  }
+
+  try {
+    const noopStatus = await getUpdateNoopStatus(cwd);
+
+    return noopStatus.shouldSkip;
+  } catch {
+    return false;
+  }
+}

--- a/test/startup.test.ts
+++ b/test/startup.test.ts
@@ -1,0 +1,155 @@
+import { execFile } from "node:child_process";
+import { mkdtemp, mkdir, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { promisify } from "node:util";
+import { afterEach, beforeEach, describe, expect, test } from "vitest";
+import { resolveStartupCommand } from "../src/startup.ts";
+import type { CliCommand } from "../src/commands.ts";
+
+const execFileAsync = promisify(execFile);
+const originalProvider = process.env.OPENWIKI_PROVIDER;
+const originalOpenRouterKey = process.env.OPENROUTER_API_KEY;
+
+async function git(cwd: string, args: string[]): Promise<string> {
+  const { stdout } = await execFileAsync("git", args, { cwd });
+
+  return stdout.trim();
+}
+
+async function createRepoWithOpenWiki(): Promise<string> {
+  const repo = await mkdtemp(path.join(tmpdir(), "openwiki-startup-"));
+  await git(repo, ["init"]);
+  await git(repo, ["config", "user.email", "test@example.com"]);
+  await git(repo, ["config", "user.name", "OpenWiki Test"]);
+  await writeFile(path.join(repo, "README.md"), "# Test Repo\n", "utf8");
+  await mkdir(path.join(repo, "openwiki"));
+  await writeFile(
+    path.join(repo, "openwiki", "quickstart.md"),
+    "# Quickstart\n",
+    "utf8",
+  );
+  await git(repo, ["add", "."]);
+  await git(repo, ["commit", "-m", "initial"]);
+  return repo;
+}
+
+async function writeLastUpdate(repo: string, gitHead: string): Promise<void> {
+  await writeFile(
+    path.join(repo, "openwiki", ".last-update.json"),
+    `${JSON.stringify({
+      updatedAt: new Date().toISOString(),
+      command: "update",
+      gitHead,
+      model: "test-model",
+    })}\n`,
+    "utf8",
+  );
+}
+
+function updatePrintCommand(
+  overrides: Partial<Extract<CliCommand, { kind: "run" }>> = {},
+): Extract<CliCommand, { kind: "run" }> {
+  return {
+    kind: "run",
+    exitCode: 0,
+    command: "update",
+    dryRun: false,
+    modelId: null,
+    print: true,
+    shouldStart: true,
+    userMessage: null,
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  process.env.OPENWIKI_PROVIDER = "openrouter";
+  delete process.env.OPENROUTER_API_KEY;
+});
+
+afterEach(() => {
+  if (originalProvider === undefined) delete process.env.OPENWIKI_PROVIDER;
+  else process.env.OPENWIKI_PROVIDER = originalProvider;
+
+  if (originalOpenRouterKey === undefined)
+    delete process.env.OPENROUTER_API_KEY;
+  else process.env.OPENROUTER_API_KEY = originalOpenRouterKey;
+});
+
+describe("resolveStartupCommand", () => {
+  test("fails fast for non-TTY interactive chat without a message", async () => {
+    const result = await resolveStartupCommand(
+      {
+        kind: "run",
+        exitCode: 0,
+        command: "chat",
+        dryRun: false,
+        modelId: null,
+        print: false,
+        shouldStart: false,
+        userMessage: null,
+      },
+      { isStdinTTY: false },
+    );
+
+    expect(result.kind).toBe("error");
+    if (result.kind === "error") {
+      expect(result.message).toContain("Interactive chat requires a terminal");
+    }
+  });
+
+  test("allows clean update --print no-ops without provider credentials", async () => {
+    const repo = await createRepoWithOpenWiki();
+    const head = await git(repo, ["rev-parse", "HEAD"]);
+    await writeLastUpdate(repo, head);
+
+    const command = updatePrintCommand();
+    const result = await resolveStartupCommand(command, {
+      cwd: repo,
+      isStdinTTY: false,
+    });
+
+    expect(result).toBe(command);
+  });
+
+  test("still requires credentials when update --print has source changes", async () => {
+    const repo = await createRepoWithOpenWiki();
+    const head = await git(repo, ["rev-parse", "HEAD"]);
+    await writeLastUpdate(repo, head);
+    await writeFile(
+      path.join(repo, "README.md"),
+      "# Test Repo\nChanged\n",
+      "utf8",
+    );
+
+    const result = await resolveStartupCommand(updatePrintCommand(), {
+      cwd: repo,
+      isStdinTTY: false,
+    });
+
+    expect(result.kind).toBe("error");
+    if (result.kind === "error") {
+      expect(result.message).toContain("OPENROUTER_API_KEY is required");
+    }
+  });
+
+  test("still requires credentials when an update message is supplied", async () => {
+    const repo = await createRepoWithOpenWiki();
+    const head = await git(repo, ["rev-parse", "HEAD"]);
+    await writeLastUpdate(repo, head);
+
+    const result = await resolveStartupCommand(
+      updatePrintCommand({ userMessage: "refresh API docs" }),
+      {
+        cwd: repo,
+        isStdinTTY: false,
+      },
+    );
+
+    expect(result.kind).toBe("error");
+    if (result.kind === "error") {
+      expect(result.message).toContain("OPENROUTER_API_KEY is required");
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- Extract startup command resolution into a small testable helper.
- Allow `openwiki --update --print` to skip provider credential validation when the existing clean-update no-op detector says no model call is needed.
- Keep credential validation unchanged when source files changed or an update message is supplied.

## Why

Scheduled docs jobs should be able to run a no-change update without requiring model credentials. OpenWiki already detects clean update no-ops inside the agent path, but the `--print` startup credential check currently blocks before that detector can run.

This keeps the change narrow to the `--print` startup path so it complements, rather than overlaps with, #153's broader non-TTY routing work.

## Tests

- `pnpm exec vitest run test/startup.test.ts test/update-noop.test.ts`
- `pnpm run typecheck`
- `pnpm run format:check`
- `pnpm run lint:check`
- `pnpm run build`
- `pnpm test`

Related: #153
