### PR TITLE
fix: read text config files as text

### DIFF
--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -5,9 +5,10 @@ import { ChatAnthropic } from "@langchain/anthropic";
 import { SqliteSaver } from "@langchain/langgraph-checkpoint-sqlite";
 import { ChatOpenAI } from "@langchain/openai";
 import { ChatOpenRouter } from "@langchain/openrouter";
-import { createDeepAgent, LocalShellBackend } from "deepagents";
+import { createDeepAgent } from "deepagents";
 import { DEBUG_ENV_KEYS, loadOpenWikiEnv, openWikiEnvDir } from "../env.js";
 import { isFileNotFoundError } from "../fs-errors.js";
+import { OpenWikiLocalShellBackend } from "./openwiki-backend.js";
 import { createSystemPrompt, createUserPrompt } from "./prompt.js";
 import type {
   OpenWikiCommand,
@@ -127,7 +128,7 @@ async function runOpenWikiAgentCore(
     model,
     tools: [],
     checkpointer,
-    backend: new LocalShellBackend({
+    backend: new OpenWikiLocalShellBackend({
       maxOutputBytes: 100_000,
       rootDir: cwd,
       timeout: 120,

--- a/src/agent/openwiki-backend.ts
+++ b/src/agent/openwiki-backend.ts
@@ -1,0 +1,103 @@
+import {
+  LocalShellBackend,
+  type LocalShellBackendOptions,
+  type ReadRawResult,
+  type ReadResult,
+} from "deepagents";
+
+const UNKNOWN_BINARY_MIME_TYPE = "application/octet-stream";
+const OPENWIKI_TEXT_MIME_TYPE = "text/plain";
+
+export class OpenWikiLocalShellBackend extends LocalShellBackend {
+  constructor(options: LocalShellBackendOptions = {}) {
+    super(options);
+  }
+
+  async read(filePath: string, offset = 0, limit = 500): Promise<ReadResult> {
+    const result = await super.read(filePath, offset, limit);
+
+    if (!isUnknownBinaryResult(result)) {
+      return result;
+    }
+
+    const text = decodeTextContent(result.content);
+
+    if (text === null) {
+      return result;
+    }
+
+    return {
+      content: sliceLines(text, offset, limit),
+      mimeType: OPENWIKI_TEXT_MIME_TYPE,
+    };
+  }
+
+  async readRaw(filePath: string): Promise<ReadRawResult> {
+    const result = await super.readRaw(filePath);
+
+    if (!isUnknownBinaryRawResult(result)) {
+      return result;
+    }
+
+    const text = decodeTextContent(result.data.content);
+
+    if (text === null) {
+      return result;
+    }
+
+    return {
+      data: {
+        ...result.data,
+        content: text,
+        mimeType: OPENWIKI_TEXT_MIME_TYPE,
+      },
+    };
+  }
+}
+
+function isUnknownBinaryResult(
+  result: ReadResult,
+): result is ReadResult & { content: Uint8Array; mimeType: string } {
+  return (
+    result.error === undefined &&
+    result.mimeType === UNKNOWN_BINARY_MIME_TYPE &&
+    result.content instanceof Uint8Array
+  );
+}
+
+function isUnknownBinaryRawResult(
+  result: ReadRawResult,
+): result is ReadRawResult & {
+  data: NonNullable<ReadRawResult["data"]> & {
+    content: Uint8Array;
+    mimeType: string;
+  };
+} {
+  return (
+    result.error === undefined &&
+    result.data !== undefined &&
+    "mimeType" in result.data &&
+    result.data.mimeType === UNKNOWN_BINARY_MIME_TYPE &&
+    result.data.content instanceof Uint8Array
+  );
+}
+
+function decodeTextContent(content: Uint8Array): string | null {
+  if (content.includes(0)) {
+    return null;
+  }
+
+  try {
+    return new TextDecoder("utf-8", { fatal: true }).decode(content);
+  } catch {
+    return null;
+  }
+}
+
+function sliceLines(content: string, offset: number, limit: number): string {
+  const lines = content.split("\n");
+  const startIdx = offset;
+  const endIdx = Math.min(startIdx + limit, lines.length);
+
+  return lines.slice(startIdx, endIdx).join("\n");
+}

--- a/test/openwiki-backend.test.ts
+++ b/test/openwiki-backend.test.ts
@@ -1,0 +1,53 @@
+import { mkdtemp, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { describe, expect, test } from "vitest";
+import { OpenWikiLocalShellBackend } from "../src/agent/openwiki-backend.ts";
+
+async function createRepoFile(fileName: string, content: Buffer | string) {
+  const repo = await mkdtemp(path.join(tmpdir(), "openwiki-backend-"));
+  await writeFile(path.join(repo, fileName), content);
+
+  return {
+    backend: new OpenWikiLocalShellBackend({
+      rootDir: repo,
+      virtualMode: true,
+    }),
+    virtualPath: `/${fileName}`,
+  };
+}
+
+describe("OpenWikiLocalShellBackend", () => {
+  test.each([
+    [".env.example"],
+    [".prettierrc"],
+    [".trivyignore"],
+    [".gitignore"],
+    ["Dockerfile"],
+    ["query.snap"],
+  ])("reads textual repository config files as text: %s", async (fileName) => {
+    const { backend, virtualPath } = await createRepoFile(
+      fileName,
+      "EXAMPLE=value\n",
+    );
+
+    const result = await backend.read(virtualPath);
+
+    expect(result).toMatchObject({
+      content: "EXAMPLE=value\n",
+      mimeType: "text/plain",
+    });
+  });
+
+  test("keeps unknown binary files as binary", async () => {
+    const { backend, virtualPath } = await createRepoFile(
+      "archive.custom",
+      Buffer.from([0x00, 0x01, 0x02, 0xff]),
+    );
+
+    const result = await backend.read(virtualPath);
+
+    expect(result.content).toBeInstanceOf(Uint8Array);
+    expect(result.mimeType).toBe("application/octet-stream");
+  });
+});


### PR DESCRIPTION
Fixes OpenWiki agent failures when DeepAgents treats common textual repo files such as Dockerfile, .env.example, .prettierrc, .trivyignore, and .snap files as binary application/octet-stream content.

  This adds an OpenWiki backend wrapper that only reclassifies unknown octet-stream files as text when their bytes decode cleanly as UTF-8 and contain no NUL bytes, while keeping real binary files binary.

  Verified with:
  - pnpm test
  - pnpm run typecheck
  - pnpm run lint:check
  - pnpm run format:check
  - pnpm run build