### PR TITLE
chore: update "brain" to "personal"

### DIFF
--- a/src/agent/prompt.ts
+++ b/src/agent/prompt.ts
@@ -106,11 +106,11 @@ ${output.rootAgentInstructions}
 OpenWiki CLI reference:
 - \`openwiki\` opens the interactive chat interface and waits for user input.
 - \`openwiki "message"\` sends a chat message immediately, then keeps the chat open.
-- \`openwiki brain --init [message]\` initializes the local second-brain wiki under ~/.openwiki/wiki.
+- \`openwiki personal --init [message]\` initializes the local personal brain wiki under ~/.openwiki/wiki.
 - \`openwiki code --init [message]\` initializes repository documentation under openwiki/.
 - \`openwiki --update [message]\` updates the local OpenWiki knowledge base under ~/.openwiki/wiki.
 - \`openwiki --mode code --init [message]\` initializes repository documentation under openwiki/.
-- \`openwiki --mode brain --init [message]\` initializes the local second-brain wiki under ~/.openwiki/wiki. Bare \`openwiki --init\` is not supported because init requires an explicit mode.
+- \`openwiki --mode personal --init [message]\` initializes the local personal brain wiki under ~/.openwiki/wiki. Bare \`openwiki --init\` is not supported because init requires an explicit mode.
 - \`openwiki -p "message"\` or \`openwiki --print "message"\` runs once, prints the final assistant output, and exits.
 - \`openwiki --modelId <id>\` selects a model ID for that run.
 - \`openwiki --help\` prints current usage, options, and examples.
@@ -171,7 +171,7 @@ export function createModeInstructions(
 - This is an interactive chat turn.
 - Answer the user's message directly.
 - Do not create or update OpenWiki documentation unless the user explicitly asks you to modify documentation.
-- If the user asks to initialize or update the wiki, explain that they can run openwiki brain --init, openwiki code --init, or openwiki --update, or ask you to make a specific documentation change in chat.
+- If the user asks to initialize or update the wiki, explain that they can run openwiki personal --init, openwiki code --init, or openwiki --update, or ask you to make a specific documentation change in chat.
 `.trim();
   }
 

--- a/src/cli.tsx
+++ b/src/cli.tsx
@@ -157,7 +157,7 @@ const OPENWIKI_LOGO_WIDTH = Math.max(
 function App({ command }: AppProps) {
   const app = useApp();
   const startupModelId = command.kind === "run" ? command.modelId : null;
-  const startupRunMode = command.kind === "run" ? command.mode : "brain";
+  const startupRunMode = command.kind === "run" ? command.mode : "personal";
   const [runMode, setRunMode] = useState<OpenWikiRunMode>(startupRunMode);
   const runtimeCwd = getRunModeCwd(runMode);
   const runtimeOutputMode = getRunModeOutputMode(runMode);

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -9,7 +9,7 @@ export type HelpRow = {
   description: string;
 };
 
-export type OpenWikiRunMode = "brain" | "code";
+export type OpenWikiRunMode = "personal" | "code";
 type CronTarget = Extract<IngestionTarget, string>;
 
 export type HelpContent = {
@@ -325,7 +325,7 @@ export function parseCommand(argv: string[]): CliCommand {
     return parseRunCommand(argv.slice(1), argv[0], "positional");
   }
 
-  return parseRunCommand(argv, "brain", "default");
+  return parseRunCommand(argv, "personal", "default");
 }
 
 function parseRunCommand(
@@ -388,7 +388,7 @@ function parseRunCommand(
         return {
           kind: "error",
           exitCode: 1,
-          message: "--mode requires brain or code.",
+          message: "--mode requires personal or code.",
         };
       }
 
@@ -396,7 +396,7 @@ function parseRunCommand(
         return {
           kind: "error",
           exitCode: 1,
-          message: `Invalid mode: ${nextArg}. Expected brain or code.`,
+          message: `Invalid mode: ${nextArg}. Expected personal or code.`,
         };
       }
 
@@ -418,7 +418,7 @@ function parseRunCommand(
         return {
           kind: "error",
           exitCode: 1,
-          message: `Invalid mode: ${rawMode}. Expected brain or code.`,
+          message: `Invalid mode: ${rawMode}. Expected personal or code.`,
         };
       }
 
@@ -494,7 +494,7 @@ function parseRunCommand(
       kind: "error",
       exitCode: 1,
       message:
-        "openwiki --init requires a mode.\n\nRun one of:\n  openwiki brain --init  Build a local second-brain wiki in ~/.openwiki/wiki.\n  openwiki code --init   Build repository documentation in ./openwiki.",
+        "openwiki --init requires a mode.\n\nRun one of:\n  openwiki personal --init  Build your local personal brain wiki in ~/.openwiki/wiki.\n  openwiki code --init   Build repository documentation in ./openwiki.",
     };
   }
 
@@ -541,7 +541,7 @@ function resolveExplicitMode(
 function isOpenWikiRunMode(
   value: string | undefined,
 ): value is OpenWikiRunMode {
-  return value === "brain" || value === "code";
+  return value === "personal" || value === "code";
 }
 
 export function isDevelopmentMode(): boolean {
@@ -556,8 +556,8 @@ export const helpContent: HelpContent = {
     "Run an agent that generates and maintains a project or local knowledge wiki.",
   usage: [
     "openwiki code [--init|--update] [message]",
-    "openwiki brain [--init|--update] [message]",
-    "openwiki --mode <brain|code> [--init|--update] [message]",
+    "openwiki personal [--init|--update] [message]",
+    "openwiki --mode <personal|code> [--init|--update] [message]",
     "openwiki [--modelId <model>]",
     "openwiki [--modelId <model>] [message]",
     "openwiki --update [message]",
@@ -578,13 +578,13 @@ export const helpContent: HelpContent = {
         "Run OpenWiki for the current repository, writing docs under repo openwiki/ and using GitHub Actions for recurrence.",
     },
     {
-      label: "openwiki brain",
+      label: "openwiki personal",
       description:
-        "Run OpenWiki as a local second brain over configured sources, writing to ~/.openwiki/wiki.",
+        "Run OpenWiki as your local personal brain over configured sources, writing to ~/.openwiki/wiki.",
     },
     {
       label: "openwiki",
-      description: "Open the interactive OpenWiki brain chat.",
+      description: "Open the interactive OpenWiki personal brain chat.",
     },
     {
       label: "openwiki auth <provider>",
@@ -634,7 +634,7 @@ export const helpContent: HelpContent = {
     {
       label: "--init",
       description:
-        "Generate initial OpenWiki documentation for a selected mode. Use openwiki brain --init or openwiki code --init.",
+        "Generate initial OpenWiki documentation for a selected mode. Use openwiki personal --init or openwiki code --init.",
     },
     {
       label: "--update",
@@ -642,9 +642,9 @@ export const helpContent: HelpContent = {
         "Update existing OpenWiki documentation and ingest configured connectors when relevant.",
     },
     {
-      label: "--mode <brain|code>",
+      label: "--mode <personal|code>",
       description:
-        "Choose local second-brain mode or repository code-documentation mode.",
+        "Choose the personal brain (local, over configured sources) or the code brain (repository docs).",
     },
     {
       label: "-p, --print",
@@ -663,10 +663,10 @@ export const helpContent: HelpContent = {
   ],
   examples: [
     "openwiki",
-    "openwiki brain --init",
+    "openwiki personal --init",
     "openwiki code --init",
     "openwiki --update",
-    "openwiki --update --mode brain",
+    "openwiki --update --mode personal",
     'openwiki "What can you do?"',
     'openwiki -p "Summarize what OpenWiki can do"',
     "openwiki --modelId gpt-5.5",

--- a/src/credentials.tsx
+++ b/src/credentials.tsx
@@ -154,8 +154,8 @@ const ONBOARDING_TEMPLATES = [
   {
     description:
       "A personal assistant wiki that builds memory from email, notes, social/research sources, and web search so you can ask about projects, priorities, people, and recurring context.",
-    id: "brain",
-    name: "Brain",
+    id: "personal",
+    name: "Personal",
     sourceIds: [
       "git-repo",
       "google",
@@ -172,16 +172,16 @@ const ONBOARDING_TEMPLATES = [
       "X/Twitter",
     ],
     suggestedGoal:
-      "A second brain for personal assistance. Track active projects, people, organizations, decisions, commitments, follow-ups, useful links, recurring themes, and fresh external signals. Organize the wiki so a personal assistant can answer what changed, what matters, what needs attention, and where supporting evidence came from. Be selective: summarize durable context and explicit action items, not every raw item.",
+      "Your personal brain. Track active projects, people, organizations, decisions, commitments, follow-ups, useful links, recurring themes, and fresh external signals. Organize the wiki so a personal assistant can answer what changed, what matters, what needs attention, and where supporting evidence came from. Be selective: summarize durable context and explicit action items, not every raw item.",
   },
 ] as const satisfies readonly OnboardingMode[];
 
 const RUN_MODE_OPTIONS = [
   {
     description:
-      "Build a local second-brain wiki in ~/.openwiki/wiki from configured sources.",
-    id: "brain",
-    name: "Brain",
+      "Build a local personal brain wiki in ~/.openwiki/wiki from configured sources.",
+    id: "personal",
+    name: "Personal",
   },
   {
     description:
@@ -328,7 +328,7 @@ const FINAL_OPTIONS = [
 
 export function needsCredentialSetup(
   modelIdOverride: string | null = null,
-  mode: OpenWikiRunMode = "brain",
+  mode: OpenWikiRunMode = "personal",
 ): boolean {
   const provider = resolveConfiguredProvider();
   const apiKeyEnvKey = getProviderApiKeyEnvKey(provider);
@@ -342,7 +342,7 @@ export function needsCredentialSetup(
 
   return (
     needsCredentials ||
-    (mode === "brain" && !isOpenWikiOnboardingCompleteSync())
+    (mode === "personal" && !isOpenWikiOnboardingCompleteSync())
   );
 }
 
@@ -1501,9 +1501,9 @@ export function InitSetup({
           }
           detail={getRunModeName(selectedMode)}
         />
-        {selectedMode === "brain" ? (
+        {selectedMode === "personal" ? (
           <SetupStep
-            label="Brain profile"
+            label="Personal profile"
             state={
               onboardingConfig.templateId
                 ? "done"
@@ -1533,7 +1533,7 @@ export function InitSetup({
                 : `save onboarding profile to ${openWikiOnboardingPath}`
           }
         />
-        {selectedMode === "brain" ? (
+        {selectedMode === "personal" ? (
           <SetupStep
             label="Schedule"
             state={
@@ -1550,7 +1550,7 @@ export function InitSetup({
             }
           />
         ) : null}
-        {selectedMode === "brain" ? (
+        {selectedMode === "personal" ? (
           <SetupStep
             label="Sources"
             state={
@@ -2561,23 +2561,23 @@ function ensureRunModeConfig(
   config: OpenWikiOnboardingConfig,
   mode: OpenWikiRunMode,
 ): OpenWikiOnboardingConfig {
-  if (mode !== "brain" || getConfigModeId(config) === "brain") {
+  if (mode !== "personal" || getConfigModeId(config) === "personal") {
     return config;
   }
 
-  const brainMode = ONBOARDING_TEMPLATES.find(
-    (option) => option.id === "brain",
+  const personalMode = ONBOARDING_TEMPLATES.find(
+    (option) => option.id === "personal",
   );
-  if (!brainMode) {
+  if (!personalMode) {
     return config;
   }
 
   return {
     ...config,
-    modeId: brainMode.id,
-    modeName: brainMode.name,
-    templateId: brainMode.id,
-    templateName: brainMode.name,
+    modeId: personalMode.id,
+    modeName: personalMode.name,
+    templateId: personalMode.id,
+    templateName: personalMode.name,
   };
 }
 


### PR DESCRIPTION
### Summary

This PR updates "brain" to "personal" to align with the openwiki concept of everything being a brain, i.e. a code brain and a personal brain.