### PR TITLE
fix: make auth list action parsing explicit instead of fragile

### DIFF
--- a/src/commands.ts
+++ b/src/commands.ts
@@ -84,11 +84,15 @@ export function parseCommand(argv: string[]): CliCommand {
         ? "configure"
         : argv[1] === "tools"
           ? "tools"
-          : "oauth";
+          : argv[1] === "list"
+            ? "list"
+            : "oauth";
     const provider =
       action === "configure" || action === "tools"
         ? argv[2]
-        : (argv[1] ?? "list");
+        : action === "list"
+          ? null
+          : (argv[1] ?? "list");
     const optionArgs =
       action === "configure" || action === "tools"
         ? argv.slice(3)
@@ -104,7 +108,7 @@ export function parseCommand(argv: string[]): CliCommand {
       };
     }
 
-    if (provider === "list" && action === "oauth") {
+    if (action === "list") {
       return {
         kind: "auth",
         action: "list",


### PR DESCRIPTION
The auth parser used a fragile pattern where 'list' was treated as both an action and provider. Made 'list' an explicit action in the detection chain for cleaner, more maintainable code.