### PR TITLE
fix: correct chatgpt credential test that fails in ci

### DIFF
--- a/test/openai-chatgpt-credentials.test.ts
+++ b/test/openai-chatgpt-credentials.test.ts
@@ -102,7 +102,11 @@ describe("oauth credential step transitions", () => {
 
     expect(getInitialStep(null, "openai-chatgpt")).toBeNull();
     expect(getNextStepAfterProvider("openai-chatgpt", null)).toBeNull();
-    expect(needsCredentialSetup(null)).toBe(false);
+    // Use code mode for assertion since the default (personal) mode also checks
+    // whether onboarding is complete by reading ~/.openwiki/onboarding.json,
+    // which would make this test depend on the machine's home directory instead
+    // of just the credential logic.
+    expect(needsCredentialSetup(null, "code")).toBe(false);
   });
 });
 


### PR DESCRIPTION
### What

`test/openai-chatgpt-credentials.test.ts` is failing on `main`.

### Why

The "needs no setup once token, model, and langsmith are all set" test calls `needsCredentialSetup(null)`, which defaults to `personal` mode. Personal mode also checks whether onboarding is done by looking for `~/.openwiki/onboarding.json`. When that file is missing (like in CI), the check returns `true` and the assertion (`false`) fails. It only passed on machines that were already onboarded.

### Solution

Assert in `code` mode which has no onboarding check so the test only verifies the credential logic and no longer depends on local machine state.