### PR TITLE
fix(agent): keep init/update checkpoints ephemeral

### DIFF
--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -163,10 +163,16 @@ async function runOpenWikiAgentCore(
   const model = createModel(provider, modelId, providerRetryAttempts);
   emitDebug(options, `model.provider=${provider}`);
   emitDebug(options, "model=initialized");
-  const checkpointer = await createCheckpointer();
-  emitDebug(options, `checkpointer=${formatUrlDebugValue(checkpointPath)}`);
   const threadId = options.threadId ?? createThreadId(cwd, createRunThreadId());
   emitDebug(options, `thread=${threadId}`);
+  const checkpointTarget = resolveCheckpointTarget(command);
+  const checkpointer = await createCheckpointer(checkpointTarget);
+  emitDebug(
+    options,
+    checkpointTarget.persistent
+      ? `checkpointer=${formatUrlDebugValue(checkpointTarget.connString)}`
+      : "checkpointer=memory",
+  );
   const agent = createDeepAgent({
     model,
     tools: createOpenWikiConnectorTools(),
@@ -221,7 +227,9 @@ async function runOpenWikiAgentCore(
     }
   }
   emitDebug(options, "stream=completed");
-  await chmodIfExists(checkpointPath, 0o600);
+  if (checkpointTarget.persistent) {
+    await chmodIfExists(checkpointTarget.connString, 0o600);
+  }
 
   if (
     command !== "chat" &&
@@ -246,6 +254,11 @@ async function runOpenWikiAgentCore(
 }
 
 const checkpointPath = path.join(openWikiEnvDir, "openwiki.sqlite");
+
+export type CheckpointTarget = {
+  connString: string;
+  persistent: boolean;
+};
 
 function createRunUserMessage(
   command: OpenWikiCommand,
@@ -288,14 +301,39 @@ function formatRuntimeRootInstruction(outputMode: OpenWikiOutputMode): string {
   return "Treat the repository root above as source evidence only. The canonical generated wiki is ~/.openwiki/wiki, not a repository-local openwiki/ directory. Filesystem tools use a virtual root: / means the repository root for source inspection paths such as /README.md, /agent/agents/main.py, and /package.json.";
 }
 
-async function createCheckpointer(): Promise<SqliteSaver> {
-  await mkdir(openWikiEnvDir, {
+async function createCheckpointer(
+  target: CheckpointTarget,
+): Promise<SqliteSaver> {
+  if (target.persistent) {
+    await prepareCheckpointDirectory(target.connString);
+  }
+
+  return SqliteSaver.fromConnString(target.connString);
+}
+
+async function prepareCheckpointDirectory(filePath: string): Promise<void> {
+  const checkpointDir = path.dirname(filePath);
+  await mkdir(checkpointDir, {
     recursive: true,
     mode: 0o700,
   });
-  await chmodIfExists(openWikiEnvDir, 0o700);
+  await chmodIfExists(checkpointDir, 0o700);
+}
 
-  return SqliteSaver.fromConnString(checkpointPath);
+export function resolveCheckpointTarget(
+  command: OpenWikiCommand,
+): CheckpointTarget {
+  if (command === "chat") {
+    return {
+      connString: checkpointPath,
+      persistent: true,
+    };
+  }
+
+  return {
+    connString: ":memory:",
+    persistent: false,
+  };
 }
 
 async function chmodIfExists(filePath: string, mode: number): Promise<void> {

--- a/test/checkpoint-policy.test.ts
+++ b/test/checkpoint-policy.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, test } from "vitest";
+import { resolveCheckpointTarget } from "../src/agent/index.ts";
+
+describe("checkpoint persistence policy", () => {
+  test("keeps chat checkpoints in the persistent OpenWiki database", () => {
+    const target = resolveCheckpointTarget("chat");
+
+    expect(target.persistent).toBe(true);
+    expect(target.connString).toMatch(/openwiki\.sqlite$/u);
+  });
+
+  test.each(["init", "update"] as const)(
+    "uses an in-memory checkpoint database for %s runs",
+    (command) => {
+      const target = resolveCheckpointTarget(command);
+
+      expect(target).toEqual({
+        connString: ":memory:",
+        persistent: false,
+      });
+    },
+  );
+});


### PR DESCRIPTION
Fixes #257.

## Summary
- keep `chat` runs on the persistent `~/.openwiki/openwiki.sqlite` checkpointer so interactive follow-up context can still persist
- switch one-shot `init` and `update` runs to an in-memory SQLite checkpointer (`:memory:`)
- add a focused checkpoint policy test covering persistent chat checkpoints and ephemeral init/update checkpoints

## Why
`~/.openwiki/openwiki.sqlite` is the LangGraph/DeepAgents checkpoint store. It is useful for interactive chat continuity, but `init` and `update` are one-shot agent runs. Persisting their checkpoints into the global SQLite database makes repeated or killed documentation runs accumulate internal graph state with no user-facing cleanup path, which can grow the database to GBs.

This changes the lifecycle rather than deleting user state: chat history remains persistent, while init/update checkpoints disappear when the process exits.

## Tests
- `pnpm test test/checkpoint-policy.test.ts`
- `pnpm typecheck`
- `pnpm run lint:check`
- `pnpm run build`

## Notes
Full `pnpm test` currently has one unrelated failure on the latest upstream snapshot:

```text
test/openai-chatgpt-credentials.test.ts:105
expected needsCredentialSetup(null) to be false, received true
```

This PR does not clean up an already-large `~/.openwiki/openwiki.sqlite`; it prevents future `init`/`update` runs from growing it. A separate cleanup/retention command could address existing databases and chat retention policy.