### PR TITLE
fix: support GPT-5.6 with ChatGPT OAuth

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,7 +173,7 @@ notes.
 
 ## Customizing
 
-OpenWiki supports OpenAI (with an API key or a ChatGPT login), OpenRouter, Fireworks, Baseten, an OpenAI-compatible provider, and Anthropic out of the box. The onboarding default is OpenAI with `gpt-5.5`, and each inference provider also includes pre-defined model options plus support for custom model IDs.
+OpenWiki supports OpenAI (with an API key or a ChatGPT login), OpenRouter, Fireworks, Baseten, an OpenAI-compatible provider, and Anthropic out of the box. The onboarding default is OpenAI with `gpt-5.6-terra`, and each inference provider also includes pre-defined model options plus support for custom model IDs.
 
 ### Alternative base URLs
 
@@ -207,7 +207,8 @@ OPENWIKI_MODEL_ID=your-gateway-model-name
 The `openai-chatgpt` provider calls OpenAI's Codex backend using your ChatGPT
 subscription instead of a metered API key. Model usage draws on your ChatGPT
 Plus/Pro/Team plan's included Codex usage rather than per-token API billing. It
-serves the same models as the `openai` provider (`gpt-5.4-mini`, `gpt-5.5`).
+serves the same models as the `openai` provider (`gpt-5.6-terra`,
+`gpt-5.6-luna`, `gpt-5.6-sol`, `gpt-5.5`, `gpt-5.4-mini`).
 
 Instead of pasting an API key, run the setup wizard and complete a browser
 login:

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -19,9 +19,11 @@ import { isFileNotFoundError } from "../fs-errors.js";
 import { openWikiLocalWikiDir } from "../openwiki-home.js";
 import { OpenWikiLocalShellBackend } from "./docs-only-backend.js";
 import {
-  CODEX_ORIGINATOR,
   CODEX_RESPONSES_BASE_URL,
   codexTokensToEnv,
+  createCodexHeaders,
+  createCodexResponsesFetch,
+  CODEX_DEFAULT_INSTRUCTIONS,
   isChatGptTokenExpired,
   readCodexTokensFromEnv,
   refreshChatGptTokens,
@@ -413,6 +415,10 @@ function createModel(
       model: modelId,
       useResponsesApi: true,
       zdrEnabled: true,
+      modelKwargs: {
+        instructions: CODEX_DEFAULT_INSTRUCTIONS,
+        store: false,
+      },
       // The Codex backend rejects non-streaming requests
       // ("Stream must be set to true"), so force the streaming transport for
       // every generation — including the non-streaming `.invoke()` calls
@@ -421,12 +427,8 @@ function createModel(
       ...retryOptions,
       configuration: {
         baseURL: CODEX_RESPONSES_BASE_URL,
-        defaultHeaders: {
-          "chatgpt-account-id": tokens.accountId,
-          originator: CODEX_ORIGINATOR,
-          "OpenAI-Beta": "responses=experimental",
-        },
-        fetch: createCodexFetch(),
+        defaultHeaders: createCodexHeaders(tokens.accountId, modelId),
+        fetch: createCodexResponsesFetch(),
       },
     });
   }
@@ -480,45 +482,6 @@ async function ensureFreshChatGptTokens(): Promise<void> {
   await saveOpenWikiEnv(
     codexTokensToEnv(await refreshChatGptTokens(tokens.refresh)),
   );
-}
-
-/**
- * The Codex backend rejects `system`-role input items ("System messages are not
- * allowed"); it expects system content under the `developer` role — the role
- * `@langchain/openai` already uses for genuine `SystemMessage`s on gpt-5 models.
- * DeepAgents injects its system prompt as a plain `system`-role message, so we
- * rewrite those to `developer` on the way out. Scoped to this client's
- * `configuration.fetch`, so it never touches the agent loop or streaming code.
- */
-function createCodexFetch(): typeof fetch {
-  return async (input, init) => {
-    if (init?.body != null && typeof init.body === "string") {
-      try {
-        const payload = JSON.parse(init.body) as {
-          input?: Array<{ role?: string } | null>;
-        };
-
-        if (Array.isArray(payload.input)) {
-          let changed = false;
-
-          for (const item of payload.input) {
-            if (item && item.role === "system") {
-              item.role = "developer";
-              changed = true;
-            }
-          }
-
-          if (changed) {
-            init = { ...init, body: JSON.stringify(payload) };
-          }
-        }
-      } catch {
-        // Non-JSON body: forward unchanged.
-      }
-    }
-
-    return globalThis.fetch(input, init);
-  };
 }
 
 function parseStreamEvent(chunk: unknown): OpenWikiRunEvent | null {

--- a/src/agent/openai-chatgpt-oauth.ts
+++ b/src/agent/openai-chatgpt-oauth.ts
@@ -29,9 +29,130 @@ const SCOPE = "openid profile email offline_access";
 
 /** Base URL for the Codex Responses backend; the OpenAI SDK appends `/responses`. */
 export const CODEX_RESPONSES_BASE_URL = "https://chatgpt.com/backend-api/codex";
+export const CODEX_DEFAULT_INSTRUCTIONS =
+  "You are ChatGPT, a large language model trained by OpenAI.";
 
-/** Free-text client label sent as the `originator` header/param. */
-export const CODEX_ORIGINATOR = "openwiki";
+/** Request identity expected by the Codex Responses backend. */
+export const CODEX_ORIGINATOR = "codex_cli_rs";
+export const CODEX_USER_AGENT = "codex_cli_rs/0.0.0";
+export const CODEX_RESPONSES_LITE_HEADER =
+  "x-openai-internal-codex-responses-lite";
+
+/** Headers required by Codex Responses requests authenticated with ChatGPT OAuth. */
+export function createCodexHeaders(
+  accountId: string,
+  modelId: string,
+): Record<string, string> {
+  return {
+    "chatgpt-account-id": accountId,
+    originator: CODEX_ORIGINATOR,
+    "user-agent": CODEX_USER_AGENT,
+    "OpenAI-Beta": "responses=experimental",
+    ...(modelId.startsWith("gpt-5.6-")
+      ? { [CODEX_RESPONSES_LITE_HEADER]: "true" }
+      : {}),
+  };
+}
+
+/**
+ * Codex rejects system and developer messages in `input`; the Responses API
+ * expects that content in the top-level `instructions` field instead.
+ */
+export function sanitizeCodexResponsesPayload(body: string): string {
+  let payload: unknown;
+
+  try {
+    payload = JSON.parse(body);
+  } catch {
+    return body;
+  }
+
+  if (!isRecord(payload) || !Array.isArray(payload.input)) {
+    return body;
+  }
+
+  const liftedInstructions: string[] = [];
+  const input = payload.input.filter((item) => {
+    if (!isRecord(item)) {
+      return true;
+    }
+
+    if (item.role !== "system" && item.role !== "developer") {
+      return true;
+    }
+
+    liftedInstructions.push(flattenResponsesInputContent(item.content));
+    return false;
+  });
+
+  if (liftedInstructions.length === 0) {
+    return body;
+  }
+
+  return JSON.stringify({
+    ...payload,
+    input,
+    instructions: [payload.instructions, ...liftedInstructions]
+      .filter(
+        (value): value is string =>
+          typeof value === "string" && value.length > 0,
+      )
+      .join("\n\n"),
+  });
+}
+
+export function createCodexResponsesFetch(
+  fetchImpl: typeof fetch = globalThis.fetch,
+): typeof fetch {
+  return async (input, init) => {
+    const url =
+      typeof input === "string"
+        ? input
+        : input instanceof URL
+          ? input.toString()
+          : input.url;
+
+    if (!url.includes(`${CODEX_RESPONSES_BASE_URL}/responses`)) {
+      return fetchImpl(input, init);
+    }
+
+    const body = typeof init?.body === "string" ? init.body : null;
+
+    if (body === null) {
+      return fetchImpl(input, init);
+    }
+
+    const headers = new Headers(init?.headers);
+    let requestBody = sanitizeCodexResponsesPayload(body);
+    headers.set("originator", CODEX_ORIGINATOR);
+    headers.set("user-agent", CODEX_USER_AGENT);
+
+    try {
+      const payload = JSON.parse(requestBody) as Record<string, unknown>;
+
+      if (
+        typeof payload.model === "string" &&
+        payload.model.startsWith("gpt-5.6-")
+      ) {
+        headers.set(CODEX_RESPONSES_LITE_HEADER, "true");
+        payload.reasoning = {
+          ...(isRecord(payload.reasoning) ? payload.reasoning : {}),
+          context: "all_turns",
+        };
+        payload.parallel_tool_calls = false;
+        requestBody = JSON.stringify(payload);
+      }
+    } catch {
+      // Leave malformed payloads untouched for the upstream API to reject.
+    }
+
+    return fetchImpl(input, {
+      ...init,
+      body: requestBody,
+      headers,
+    });
+  };
+}
 
 /**
  * Refresh the access token when it is within this many milliseconds of expiry,
@@ -188,6 +309,30 @@ function asRecord(value: unknown): Record<string, unknown> | null {
 
 function asString(value: unknown): string | null {
   return typeof value === "string" && value.length > 0 ? value : null;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function flattenResponsesInputContent(content: unknown): string {
+  if (typeof content === "string") {
+    return content;
+  }
+
+  if (!Array.isArray(content)) {
+    return "";
+  }
+
+  return content
+    .map((item) => {
+      if (typeof item === "string") {
+        return item;
+      }
+
+      return isRecord(item) && typeof item.text === "string" ? item.text : "";
+    })
+    .join("");
 }
 
 async function exchangeToken(body: URLSearchParams): Promise<CodexTokens> {

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -134,6 +134,9 @@ export const PROVIDER_CONFIGS: Record<OpenWikiProvider, ProviderConfig> = {
     apiKeyEnvKey: OPENAI_API_KEY_ENV_KEY,
     label: "OpenAI",
     modelOptions: [
+      { id: "gpt-5.6-terra", label: "5.6 Terra" },
+      { id: "gpt-5.6-luna", label: "5.6 Luna" },
+      { id: "gpt-5.6-sol", label: "5.6 Sol" },
       { id: "gpt-5.5", label: "5.5" },
       { id: "gpt-5.4-mini", label: "5.4 mini" },
     ],
@@ -143,6 +146,9 @@ export const PROVIDER_CONFIGS: Record<OpenWikiProvider, ProviderConfig> = {
     authMethod: "oauth",
     label: "OpenAI (ChatGPT login)",
     modelOptions: [
+      { id: "gpt-5.6-terra", label: "5.6 Terra" },
+      { id: "gpt-5.6-luna", label: "5.6 Luna" },
+      { id: "gpt-5.6-sol", label: "5.6 Sol" },
       { id: "gpt-5.5", label: "5.5" },
       { id: "gpt-5.4-mini", label: "5.4 mini" },
     ],

--- a/test/openai-chatgpt-credentials.test.ts
+++ b/test/openai-chatgpt-credentials.test.ts
@@ -102,7 +102,7 @@ describe("oauth credential step transitions", () => {
 
     expect(getInitialStep(null, "openai-chatgpt")).toBeNull();
     expect(getNextStepAfterProvider("openai-chatgpt", null)).toBeNull();
-    expect(needsCredentialSetup(null)).toBe(false);
+    expect(needsCredentialSetup(null, "code")).toBe(false);
   });
 });
 

--- a/test/openai-chatgpt-oauth.test.ts
+++ b/test/openai-chatgpt-oauth.test.ts
@@ -1,8 +1,14 @@
 import { afterEach, describe, expect, test, vi } from "vitest";
 import {
   CHATGPT_TOKEN_REFRESH_THRESHOLD_MS,
+  CODEX_ORIGINATOR,
+  CODEX_RESPONSES_LITE_HEADER,
+  CODEX_USER_AGENT,
   type CodexTokens,
   codexTokensToEnv,
+  createCodexHeaders,
+  createCodexResponsesFetch,
+  sanitizeCodexResponsesPayload,
   decodeChatGptIdentity,
   formatChatGptAccount,
   isChatGptTokenExpired,
@@ -59,6 +65,105 @@ function stubTokenResponse(
 
 afterEach(() => {
   vi.unstubAllGlobals();
+});
+
+describe("Codex Responses request headers", () => {
+  test("uses the Codex CLI request identity for the authenticated account", () => {
+    expect(CODEX_ORIGINATOR).toBe("codex_cli_rs");
+    expect(CODEX_USER_AGENT).toBe("codex_cli_rs/0.0.0");
+    expect(createCodexHeaders("acct_123", "gpt-5.5")).toEqual({
+      "chatgpt-account-id": "acct_123",
+      originator: "codex_cli_rs",
+      "user-agent": "codex_cli_rs/0.0.0",
+      "OpenAI-Beta": "responses=experimental",
+    });
+  });
+
+  test("enables Responses Lite for the GPT-5.6 model family", () => {
+    expect(createCodexHeaders("acct_123", "gpt-5.6-luna")).toMatchObject({
+      [CODEX_RESPONSES_LITE_HEADER]: "true",
+    });
+    expect(createCodexHeaders("acct_123", "gpt-5.5")).not.toHaveProperty(
+      CODEX_RESPONSES_LITE_HEADER,
+    );
+  });
+});
+
+describe("Codex Responses payloads", () => {
+  test("lifts system and developer input into instructions", () => {
+    const payload: unknown = JSON.parse(
+      sanitizeCodexResponsesPayload(
+        JSON.stringify({
+          input: [
+            { role: "system", content: "Follow the repository rules." },
+            {
+              role: "developer",
+              content: [{ type: "input_text", text: "Use concise prose." }],
+            },
+            { role: "user", content: "Document this project." },
+          ],
+        }),
+      ),
+    );
+
+    expect(payload).toEqual({
+      input: [{ role: "user", content: "Document this project." }],
+      instructions: "Follow the repository rules.\n\nUse concise prose.",
+    });
+  });
+
+  test("leaves malformed and unrelated payloads unchanged", () => {
+    expect(sanitizeCodexResponsesPayload("not-json")).toBe("not-json");
+    expect(sanitizeCodexResponsesPayload('{"input":"not-an-array"}')).toBe(
+      '{"input":"not-an-array"}',
+    );
+  });
+
+  test("sets Responses Lite at the final fetch boundary for GPT-5.6", async () => {
+    const fetchMock = vi.fn(() => Promise.resolve(new Response()));
+    const fetchCodexResponse = createCodexResponsesFetch(fetchMock);
+
+    await fetchCodexResponse(
+      "https://chatgpt.com/backend-api/codex/responses",
+      {
+        body: JSON.stringify({ model: "gpt-5.6-luna", input: [] }),
+        method: "POST",
+      },
+    );
+
+    const [, init] = fetchMock.mock.calls[0] as [
+      string,
+      { body: string; headers: Headers },
+    ];
+    expect(init.headers.get(CODEX_RESPONSES_LITE_HEADER)).toBe("true");
+    expect(init.headers.get("originator")).toBe(CODEX_ORIGINATOR);
+    expect(init.headers.get("user-agent")).toBe(CODEX_USER_AGENT);
+    expect(JSON.parse(init.body)).toMatchObject({
+      parallel_tool_calls: false,
+      reasoning: { context: "all_turns" },
+    });
+  });
+
+  test("does not enable Responses Lite for older models", async () => {
+    const fetchMock = vi.fn(() => Promise.resolve(new Response()));
+    const fetchCodexResponse = createCodexResponsesFetch(fetchMock);
+
+    await fetchCodexResponse(
+      "https://chatgpt.com/backend-api/codex/responses",
+      {
+        body: JSON.stringify({ model: "gpt-5.5", input: [] }),
+        method: "POST",
+      },
+    );
+
+    const [, init] = fetchMock.mock.calls[0] as [
+      string,
+      { body: string; headers: Headers },
+    ];
+    expect(init.headers.has(CODEX_RESPONSES_LITE_HEADER)).toBe(false);
+    expect(JSON.parse(init.body)).not.toHaveProperty("reasoning.context");
+    expect(JSON.parse(init.body)).not.toHaveProperty("parallel_tool_calls");
+  });
 });
 
 describe("refreshChatGptTokens", () => {

--- a/test/openai-chatgpt-provider.test.ts
+++ b/test/openai-chatgpt-provider.test.ts
@@ -39,6 +39,9 @@ describe("openai-chatgpt provider config", () => {
       getProviderModelOptions("openai"),
     );
     expect(getProviderModelOptions("openai-chatgpt").map((m) => m.id)).toEqual([
+      "gpt-5.6-terra",
+      "gpt-5.6-luna",
+      "gpt-5.6-sol",
       "gpt-5.5",
       "gpt-5.4-mini",
     ]);


### PR DESCRIPTION
## Summary

- add GPT-5.6 Terra, Luna, and Sol to both OpenAI API-key and ChatGPT-login model selection
- make the merged `openai-chatgpt` provider speak the GPT-5.6 Codex Responses Lite protocol while preserving GPT-5.5/5.4 behavior
- centralize Codex request headers and payload normalization with focused regression coverage
- isolate the ChatGPT credential test from personal onboarding state

This consolidates the completed OAuth work from #151 with the relevant request handling from #205, the model additions from #252, and the credential-test isolation from #255. It also advances the Codex-backed provider use case tracked in #59 without introducing a second overlapping OAuth provider.

## Root cause

The existing ChatGPT OAuth provider can call `gpt-5.5`, but `gpt-5.6-luna` returns `404 Model not found` even when the same account can use Luna through the official Codex CLI.

The failure has two layers:

1. `@langchain/openai` overwrites the configured user agent at the final request boundary. The Codex backend does not expose GPT-5.6 to the resulting `langchainjs-openai/...` request identity.
2. GPT-5.6 models use the Codex Responses Lite contract. Once the Codex request identity is preserved, the backend requires `x-openai-internal-codex-responses-lite: true`, `reasoning.context: all_turns`, and `parallel_tool_calls: false`.

The official Codex implementation applies those constraints from model metadata in [`codex-rs/core/src/client.rs`](https://github.com/openai/codex/blob/main/codex-rs/core/src/client.rs). This change mirrors them only for `gpt-5.6-*` requests and leaves older model payloads unchanged.

## Implementation

- keep the merged `openai-chatgpt` provider and its existing `~/.openwiki/.env` token lifecycle
- enforce the Codex originator/user-agent at the final fetch boundary
- lift system/developer messages into top-level Responses `instructions`
- apply Responses Lite headers and payload constraints only to the GPT-5.6 family
- retain normal Responses behavior for GPT-5.5 and GPT-5.4 mini

## Verification

- `pnpm test` (14 files, 150 tests)
- `pnpm run typecheck`
- `pnpm run lint:check`
- `pnpm run format:check`
- `pnpm build`
- live ChatGPT OAuth smoke: `gpt-5.6-luna` returned `LUNA_OK`
- live backward-compatibility smoke: `gpt-5.5` returned `GPT55_OK`
- live Luna tool-call smoke: OpenWiki invoked shell execute and returned the expected wiki root

Context7 does not currently index OpenWiki. Version-sensitive protocol behavior was verified against the current official OpenAI Codex source and Codex CLI `0.144.0` on 2026-07-10.
