### PR TITLE
fix: disable thinking for openai-compatible models

### DIFF
--- a/.changeset/disable-openai-compatible-thinking.md
+++ b/.changeset/disable-openai-compatible-thinking.md
@@ -1,0 +1,5 @@
+---
+"openwiki": patch
+---
+
+Disable thinking parameters for OpenAI-compatible models.

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -151,6 +151,10 @@ export {
   createAgentBackend,
 };
 
+const OPENAI_COMPATIBLE_MODEL_KWARGS = {
+  enable_thinking: false,
+} as const;
+
 export async function runOpenWikiAgent(
   command: OpenWikiCommand,
   cwd = openWikiLocalWikiDir,
@@ -1243,6 +1247,14 @@ export function createModel(
     // than assigning a boolean: `streaming: false` is not the same as omitting
     // the key, because LangChain turns it into `disableStreaming`.
     ...(providerUsesStreaming(provider) ? { streaming: true } : {}),
+    // Thinking-mode models behind OpenAI-compatible gateways hang with no
+    // output, because the reasoning stream never reaches the Chat Completions
+    // transport. Safe to spread last today: no `openai-compatible` model
+    // declares a reasoning capability, so `chatCompletionsReasoningOptions` is
+    // always empty here. Merge the two if that ever stops being true.
+    ...(provider === "openai-compatible"
+      ? { modelKwargs: OPENAI_COMPATIBLE_MODEL_KWARGS }
+      : {}),
     ...retryOptions,
   });
 }

--- a/test/openai-compatible-model.test.ts
+++ b/test/openai-compatible-model.test.ts
@@ -1,0 +1,40 @@
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+const chatOpenAiCalls: unknown[] = [];
+
+vi.mock("@langchain/openai", () => ({
+  ChatOpenAI: vi.fn(function ChatOpenAIMock(options: unknown) {
+    chatOpenAiCalls.push(options);
+    return {};
+  }),
+}));
+
+vi.mock("../src/connectors/tools.js", () => ({
+  createOpenWikiConnectorTools: vi.fn(() => []),
+}));
+
+vi.mock("../src/connectors/write-connector-skill.js", () => ({
+  ensureWriteConnectorSkill: vi.fn(() => undefined),
+}));
+
+describe("openai-compatible model creation", () => {
+  beforeEach(() => {
+    chatOpenAiCalls.length = 0;
+  });
+
+  test("disables provider-side thinking mode for OpenAI-compatible models", async () => {
+    const { createModel } = await import("../src/agent/index.ts");
+
+    createModel("openai-compatible", "qwen3.7-plus", 3);
+
+    expect(chatOpenAiCalls).toHaveLength(1);
+    expect(chatOpenAiCalls[0]).toEqual(
+      expect.objectContaining({
+        model: "qwen3.7-plus",
+        modelKwargs: {
+          enable_thinking: false,
+        },
+      }),
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- Disable provider-side thinking for OpenAI-compatible `ChatOpenAI` model creation, so thinking/reasoning models behind an OpenAI-compatible gateway no longer hang with zero output.
- Cover the Qwen thinking-model path with a constructor-options regression test.

Fixes #256

Rebased onto current `main`. The conflict in `src/agent/index.ts` was with `chatCompletionsReasoningOptions`, which also sets `modelKwargs`; both spreads are kept, since `REASONING_CAPABILITIES` has no `openai-compatible` entry and that option is therefore always empty for this provider.

## Test verification (RED -> GREEN)

RED, on unmodified `main` with only the new regression test applied (the production fix is not present):

```text
pnpm exec vitest run test/openai-compatible-model.test.ts --reporter verbose

FAIL test/openai-compatible-model.test.ts > openai-compatible model creation >
  disables provider-side thinking mode for OpenAI-compatible models
AssertionError: expected { apiKey: undefined, …(4) } to deeply equal ObjectContaining{…}

- ObjectContaining {
+ {
    "model": "qwen3.7-plus",
-   "modelKwargs": {
-     "enable_thinking": false,
-   },
+   "useResponsesApi": false,
  }

Test Files  1 failed (1)
     Tests  1 failed (1)
```

GREEN, with the fix applied:

```text
pnpm exec vitest run test/openai-compatible-model.test.ts --reporter verbose

✓ test/openai-compatible-model.test.ts > openai-compatible model creation >
  disables provider-side thinking mode for OpenAI-compatible models

Test Files  1 passed (1)
     Tests  1 passed (1)
```

## Full local validation

Node 22, against the rebased branch:

```text
pnpm run format:check   # All matched files use Prettier code style!
pnpm run lint:check     # passed
pnpm run typecheck      # passed
pnpm run build          # passed
OPENWIKI_DEV=1 node dist/cli/cli.js code --dry-run --init   # passed

pnpm exec vitest run --coverage
Test Files  182 passed | 2 skipped (184)
     Tests  2433 passed | 3 skipped (2436)

pnpm exec changeset status --since=origin/main
openwiki  patch
```

Baseline on `main` before the change was `2432 passed | 3 skipped`, so this adds the one new test and changes nothing else.

Not runnable locally: the Node 24 matrix leg, the Windows portability job, and the Trivy audit.
