### PR TITLE
feat: add Requesty to the model provider list

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,7 +188,7 @@ notes.
 
 ## Customizing
 
-OpenWiki supports OpenAI (with an API key or a ChatGPT login), OpenRouter, Fireworks, Baseten, an OpenAI-compatible provider, and Anthropic out of the box. The onboarding default is OpenAI with `gpt-5.6-terra`, and each inference provider also includes pre-defined model options plus support for custom model IDs.
+OpenWiki supports OpenAI (with an API key or a ChatGPT login), OpenRouter, Requesty, Fireworks, Baseten, an OpenAI-compatible provider, and Anthropic out of the box. The onboarding default is OpenAI with `gpt-5.6-terra`, and each inference provider also includes pre-defined model options plus support for custom model IDs.
 
 ### Alternative base URLs
 

--- a/src/cli.tsx
+++ b/src/cli.tsx
@@ -1888,7 +1888,7 @@ function ChatInput({
 
     if (provider === null) {
       setError(
-        "Enter a valid provider: openai, openrouter, baseten, fireworks, or anthropic.",
+        "Enter a valid provider: openai, openrouter, requesty, baseten, fireworks, or anthropic.",
       );
       return;
     }

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -16,6 +16,7 @@ export const OPENAI_CHATGPT_PLAN_ENV_KEY = "OPENAI_CHATGPT_PLAN";
 export const ANTHROPIC_API_KEY_ENV_KEY = "ANTHROPIC_API_KEY";
 export const ANTHROPIC_BASE_URL_ENV_KEY = "ANTHROPIC_BASE_URL";
 export const OPENROUTER_API_KEY_ENV_KEY = "OPENROUTER_API_KEY";
+export const REQUESTY_API_KEY_ENV_KEY = "REQUESTY_API_KEY";
 export const OPENWIKI_PROVIDER_ENV_KEY = "OPENWIKI_PROVIDER";
 export const OPENWIKI_MODEL_ID_ENV_KEY = "OPENWIKI_MODEL_ID";
 export const OPENWIKI_PROVIDER_RETRY_ATTEMPTS_ENV_KEY =
@@ -51,6 +52,7 @@ export const OPENWIKI_X_REFRESH_TOKEN_ENV_KEY = "OPENWIKI_X_REFRESH_TOKEN";
 export const OPENWIKI_TAVILY_API_KEY_ENV_KEY = "TAVILY_API_KEY";
 export const DEFAULT_PROVIDER = "openai";
 export const OPENROUTER_BASE_URL = "https://openrouter.ai/api/v1";
+export const REQUESTY_BASE_URL = "https://router.requesty.ai/v1";
 
 export type OpenWikiProvider =
   | "anthropic"
@@ -59,7 +61,8 @@ export type OpenWikiProvider =
   | "openai"
   | "openai-chatgpt"
   | "openai-compatible"
-  | "openrouter";
+  | "openrouter"
+  | "requesty";
 
 /**
  * How a provider authenticates. Providers default to `"api-key"` (a pasted
@@ -119,6 +122,7 @@ export const SELECTABLE_OPENWIKI_PROVIDERS = [
   "openai-compatible",
   "fireworks",
   "baseten",
+  "requesty",
 ] as const satisfies readonly SelectableOpenWikiProvider[];
 
 export const PROVIDER_CONFIGS: Record<OpenWikiProvider, ProviderConfig> = {
@@ -183,6 +187,18 @@ export const PROVIDER_CONFIGS: Record<OpenWikiProvider, ProviderConfig> = {
       { id: "anthropic/claude-sonnet-5", label: "Claude Sonnet" },
       { id: "openai/gpt-5.4-mini", label: "GPT 5.4 mini" },
       { id: "openai/gpt-5.5", label: "GPT 5.5" },
+    ],
+  },
+  requesty: {
+    apiKeyEnvKey: REQUESTY_API_KEY_ENV_KEY,
+    baseURL: REQUESTY_BASE_URL,
+    label: "Requesty",
+    modelOptions: [
+      { id: "openai/gpt-4o-mini", label: "GPT-4o mini" },
+      { id: "openai/gpt-4o", label: "GPT-4o" },
+      { id: "anthropic/claude-sonnet-4-5", label: "Claude Sonnet" },
+      { id: "deepseek/deepseek-chat", label: "DeepSeek Chat" },
+      { id: "google/gemini-2.5-flash", label: "Gemini 2.5 Flash" },
     ],
   },
 };
@@ -300,13 +316,15 @@ export function resolveConfiguredProvider(
         ? "openai-compatible"
         : env[OPENROUTER_API_KEY_ENV_KEY]
           ? "openrouter"
-          : env[ANTHROPIC_API_KEY_ENV_KEY]
-            ? "anthropic"
-            : env[BASETEN_API_KEY_ENV_KEY]
-              ? "baseten"
-              : env[FIREWORKS_API_KEY_ENV_KEY]
-                ? "fireworks"
-                : DEFAULT_PROVIDER)
+          : env[REQUESTY_API_KEY_ENV_KEY]
+            ? "requesty"
+            : env[ANTHROPIC_API_KEY_ENV_KEY]
+              ? "anthropic"
+              : env[BASETEN_API_KEY_ENV_KEY]
+                ? "baseten"
+                : env[FIREWORKS_API_KEY_ENV_KEY]
+                  ? "fireworks"
+                  : DEFAULT_PROVIDER)
   );
 }
 

--- a/src/diagnostics.ts
+++ b/src/diagnostics.ts
@@ -5,6 +5,7 @@ import {
   OPENAI_API_KEY_ENV_KEY,
   OPENAI_COMPATIBLE_API_KEY_ENV_KEY,
   OPENROUTER_API_KEY_ENV_KEY,
+  REQUESTY_API_KEY_ENV_KEY,
 } from "./constants.js";
 
 /**
@@ -26,6 +27,7 @@ export function sanitizeDiagnosticText(value: string): string {
     OPENAI_COMPATIBLE_API_KEY_ENV_KEY,
     ANTHROPIC_API_KEY_ENV_KEY,
     OPENROUTER_API_KEY_ENV_KEY,
+    REQUESTY_API_KEY_ENV_KEY,
     "LANGSMITH_API_KEY",
   ]) {
     const secret = process.env[key];

--- a/test/constants.test.ts
+++ b/test/constants.test.ts
@@ -76,6 +76,12 @@ describe("resolveConfiguredProvider", () => {
     );
   });
 
+  test("falls back to requesty when only a Requesty key is present", () => {
+    expect(resolveConfiguredProvider({ REQUESTY_API_KEY: "x" })).toBe(
+      "requesty",
+    );
+  });
+
   test("falls back to the default provider when nothing is configured", () => {
     expect(resolveConfiguredProvider({})).toBe(DEFAULT_PROVIDER);
   });
@@ -91,6 +97,9 @@ describe("resolveProviderBaseUrl", () => {
   test("returns the built-in default when no override is set", () => {
     expect(resolveProviderBaseUrl("openrouter", {})).toBe(
       "https://openrouter.ai/api/v1",
+    );
+    expect(resolveProviderBaseUrl("requesty", {})).toBe(
+      "https://router.requesty.ai/v1",
     );
   });
 


### PR DESCRIPTION
Adds Requesty to the model provider list. Requesty is an OpenAI-compatible LLM gateway that uses the same `provider/model` naming convention as OpenRouter (e.g. `openai/gpt-4o-mini`, `anthropic/claude-sonnet-4-5`), so this mirrors the existing OpenRouter wiring on the generic OpenAI-compatible path (`ChatOpenAI` + a fixed base URL), not the OpenRouter-SDK-specific path.

Changes:
- `src/constants.ts` — `REQUESTY_API_KEY_ENV_KEY`, `REQUESTY_BASE_URL` (`https://router.requesty.ai/v1`), `requesty` added to the `OpenWikiProvider` type, `SELECTABLE_OPENWIKI_PROVIDERS`, a `PROVIDER_CONFIGS.requesty` entry, and the `resolveConfiguredProvider` fallback chain (right after openrouter).
- `src/diagnostics.ts` — `REQUESTY_API_KEY` added to the secret-redaction list (parity with OpenRouter).
- `src/cli.tsx` — `requesty` added to the invalid-provider error message.
- `README.md` — Requesty added to the committed provider list.
- `test/constants.test.ts` — tests mirroring the OpenRouter `resolveConfiguredProvider` / `resolveProviderBaseUrl` cases.

Testing: `tsc --noEmit` clean; `vitest` 177/177 pass (constants suite 23→25); eslint clean on the edited files. Live-tested against the real endpoint: a `POST /v1/chat/completions` to `https://router.requesty.ai/v1` with `openai/gpt-4o-mini` returned successfully.

Note: the `openwiki/` pages that list providers are generated by the scheduled OpenWiki workflow (per AGENTS.md "do not hand-edit generated OpenWiki pages"), so I left them for regeneration rather than editing by hand.

Docs: https://requesty.ai · https://docs.requesty.ai · https://app.requesty.ai/api-keys · https://app.requesty.ai/router/list

I work at Requesty. This mirrors the existing OpenRouter provider as closely as possible. Happy to adjust or close it if it's not a fit.
