### PR TITLE
fix: replace binary file reads with a text placeholder

### DIFF
--- a/src/agent/docs-only-backend.ts
+++ b/src/agent/docs-only-backend.ts
@@ -2,6 +2,7 @@ import {
   LocalShellBackend,
   type EditResult,
   type LocalShellBackendOptions,
+  type ReadResult,
   type WriteResult,
 } from "deepagents";
 import { OPEN_WIKI_DIR } from "../constants.js";
@@ -48,6 +49,34 @@ export class OpenWikiLocalShellBackend extends LocalShellBackend {
     return super.edit(filePath, oldString, newString, replaceAll);
   }
 
+  override async read(
+    filePath: string,
+    offset?: number,
+    limit?: number,
+  ): Promise<ReadResult> {
+    const result = await super.read(filePath, offset, limit);
+
+    // Leave errors and empty reads untouched.
+    if (result.error !== undefined || result.content === undefined) {
+      return result;
+    }
+
+    if (isBinaryReadContent(result.content)) {
+      const size =
+        result.content instanceof Uint8Array
+          ? `${result.content.byteLength} bytes`
+          : `${result.content.length} chars`;
+      return {
+        content: `Binary file skipped: ${filePath} (${
+          result.mimeType ?? "unknown type"
+        }, ${size}). OpenWiki reads text sources only.`,
+        mimeType: "text/plain",
+      };
+    }
+
+    return result;
+  }
+
   private getDocsOnlyWriteError(filePath: string): string | null {
     if (
       !this.docsOnly ||
@@ -68,4 +97,64 @@ export function isOpenWikiDocsPath(filePath: string): boolean {
   return (
     virtualPath === OPEN_WIKI_DIR || virtualPath.startsWith(`${OPEN_WIKI_DIR}/`)
   );
+}
+
+/**
+ * True when a read result's content is binary rather than usable text.
+ *
+ * OpenWiki documents code and never needs raw bytes, so two cases get
+ * collapsed to a placeholder:
+ *  1. `Uint8Array` — deepagents returns raw bytes for MIME types it maps as
+ *     binary (images, etc.). Serialized downstream as a base64 `document`
+ *     block, which the Anthropic Messages API rejects for anything but
+ *     `application/pdf` — the original crash (langchain-ai/openwiki#114).
+ *  2. A `string` that is actually binary — deepagents now defaults unmapped
+ *     extensions to `text/plain` (deepagentsjs#656), so genuine binaries such
+ *     as `.sqlite` / `.zip` / `.so` arrive as strings full of raw bytes: no
+ *     longer a crash, but useless token noise in the agent's context.
+ */
+export function isBinaryReadContent(content: string | Uint8Array): boolean {
+  if (content instanceof Uint8Array) {
+    return true;
+  }
+
+  return isBinaryText(content);
+}
+
+/**
+ * Heuristic binary sniff for string content — a NUL byte, or a high density of
+ * control characters and UTF-8 replacement characters, mirroring the test used
+ * by grep/git. Only the head of the content is inspected so large text files
+ * stay cheap.
+ */
+function isBinaryText(text: string): boolean {
+  if (text.length === 0) {
+    return false;
+  }
+
+  const sampleLength = Math.min(text.length, 8192);
+  let suspiciousCount = 0;
+
+  for (let index = 0; index < sampleLength; index++) {
+    const code = text.charCodeAt(index);
+
+    // A NUL byte is definitive: valid UTF-8 text never contains one.
+    if (code === 0) {
+      return true;
+    }
+
+    // Strong binary evidence: C0 control chars other than tab (9), LF (10),
+    // FF (12), CR (13), plus the U+FFFD replacement character a lossy UTF-8
+    // decode leaves behind for invalid bytes. A binary that deepagents surfaces
+    // as text/plain (e.g. a 0xFF-filled firmware image) decodes to a run of
+    // U+FFFD before this sniff runs, so counting only C0 controls would miss it.
+    if (
+      (code < 32 && code !== 9 && code !== 10 && code !== 12 && code !== 13) ||
+      code === 0xfffd
+    ) {
+      suspiciousCount++;
+    }
+  }
+
+  return suspiciousCount / sampleLength > 0.3;
 }

--- a/test/docs-only-backend.test.ts
+++ b/test/docs-only-backend.test.ts
@@ -1,8 +1,9 @@
-import { mkdtemp, readFile } from "node:fs/promises";
+import { mkdtemp, readFile, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { describe, expect, test } from "vitest";
 import {
+  isBinaryReadContent,
   isOpenWikiDocsPath,
   OpenWikiLocalShellBackend,
 } from "../src/agent/docs-only-backend.ts";
@@ -76,5 +77,109 @@ describe("OpenWikiLocalShellBackend", () => {
     await expect(
       readFile(path.join(rootDir, "notes.md"), "utf8"),
     ).resolves.toBe("ok");
+  });
+
+  test("passes text file reads through unchanged", async () => {
+    const rootDir = await mkdtemp(path.join(os.tmpdir(), "openwiki-backend-"));
+    const backend = new OpenWikiLocalShellBackend({
+      docsOnly: true,
+      rootDir,
+      virtualMode: true,
+    });
+    await writeFile(path.join(rootDir, "readme.md"), "# Title\n\nHello.\n");
+
+    const result = await backend.read("/readme.md");
+    expect(result.error).toBeUndefined();
+    expect(result.content).toContain("Hello.");
+    expect(String(result.content)).not.toContain("Binary file skipped");
+  });
+
+  test("replaces binary file reads with a text placeholder", async () => {
+    const rootDir = await mkdtemp(path.join(os.tmpdir(), "openwiki-backend-"));
+    const backend = new OpenWikiLocalShellBackend({
+      docsOnly: true,
+      rootDir,
+      virtualMode: true,
+    });
+    // SQLite-style header with a NUL byte — the residual case after
+    // deepagentsjs#656: no longer a crash, just token noise without this guard.
+    const binary = Buffer.from([
+      0x53, 0x51, 0x4c, 0x69, 0x74, 0x65, 0x00, 0x01, 0x02, 0x03,
+    ]);
+    await writeFile(path.join(rootDir, "cache.sqlite"), binary);
+
+    const result = await backend.read("/cache.sqlite");
+    expect(result.error).toBeUndefined();
+    expect(result.mimeType).toBe("text/plain");
+    expect(String(result.content)).toContain(
+      "Binary file skipped: /cache.sqlite",
+    );
+  });
+
+  test("replaces invalid-UTF-8 binary reads (0xFF firmware) with a placeholder", async () => {
+    const rootDir = await mkdtemp(path.join(os.tmpdir(), "openwiki-backend-"));
+    const backend = new OpenWikiLocalShellBackend({
+      docsOnly: true,
+      rootDir,
+      virtualMode: true,
+    });
+    // A 0xFF-filled region decodes to U+FFFD (not NUL/C0) before the sniff runs
+    // — the gap Codex caught: it slipped through as text without this case.
+    await writeFile(
+      path.join(rootDir, "firmware.bin"),
+      Buffer.alloc(16384, 0xff),
+    );
+
+    const result = await backend.read("/firmware.bin");
+    expect(result.error).toBeUndefined();
+    expect(result.mimeType).toBe("text/plain");
+    expect(String(result.content)).toContain(
+      "Binary file skipped: /firmware.bin",
+    );
+  });
+
+  test("preserves read errors for missing files", async () => {
+    const rootDir = await mkdtemp(path.join(os.tmpdir(), "openwiki-backend-"));
+    const backend = new OpenWikiLocalShellBackend({
+      docsOnly: true,
+      rootDir,
+      virtualMode: true,
+    });
+
+    const result = await backend.read("/does-not-exist.md");
+    expect(result.error).toBeDefined();
+    expect(result.content).toBeUndefined();
+  });
+});
+
+describe("isBinaryReadContent", () => {
+  test("treats Uint8Array content as binary", () => {
+    expect(isBinaryReadContent(new Uint8Array([1, 2, 3]))).toBe(true);
+  });
+
+  test("flags strings containing a NUL byte", () => {
+    expect(isBinaryReadContent("PK\u0003\u0004\u0000payload")).toBe(true);
+  });
+
+  test("flags strings dense with control characters", () => {
+    expect(isBinaryReadContent("\u0001\u0002\u0003\u0004\u0005abc")).toBe(true);
+  });
+
+  test("flags strings dense with UTF-8 replacement characters", () => {
+    expect(isBinaryReadContent("\uFFFD".repeat(50) + "abc")).toBe(true);
+  });
+
+  test("passes normal source text", () => {
+    expect(isBinaryReadContent("export function f() {\n  return 1;\n}\n")).toBe(
+      false,
+    );
+  });
+
+  test("treats empty content as text", () => {
+    expect(isBinaryReadContent("")).toBe(false);
+  });
+
+  test("tolerates ordinary whitespace control chars", () => {
+    expect(isBinaryReadContent("a\tb\r\nc\f\n")).toBe(false);
   });
 });


### PR DESCRIPTION
## What & why

Follow-up to #114 / #115. deepagentsjs#656 fixed the crash by defaulting unmapped extensions to `text/plain`, so OpenWiki no longer dies on a `__pycache__/*.pyc`. The trade-off is that genuine binaries — `.sqlite`, `.zip`, `.so`, firmware images — now come back as strings full of raw bytes: no longer fatal, but a wall of useless token noise in the agent's context. This is the residual @colifran and I flagged on #115.

This adds a `read()` override to `OpenWikiLocalShellBackend` that substitutes a short placeholder for binary content, layered on top of the upstream `text/plain` default:

- `Uint8Array` content (MIME types deepagents maps as binary) → placeholder
- string content that trips a binary sniff — a NUL byte, or a high density of C0 control characters / U+FFFD replacement characters left behind by a lossy UTF-8 decode → placeholder

The placeholder reads `Binary file skipped: <path> (<mime>, <size>). OpenWiki reads text sources only.`, so the agent notes the file and moves on. OpenWiki documents code and never needs raw bytes. Errors and empty reads pass through untouched.

## How it was tested

- Unit coverage of the sniff: NUL byte, control-dense, U+FFFD-dense (the invalid-UTF-8 / firmware case), clean source, empty, whitespace-only, and `Uint8Array`.
- Backend integration: text passthrough unchanged; a `.sqlite`-with-NUL and a 16&nbsp;KB `0xFF`-filled `firmware.bin` both return the placeholder; read errors preserved.
- Full Vitest suite (189) green; `typecheck`, `lint`, and `prettier --check` clean.

Happy to adjust the sniff threshold or the placeholder wording.
