### PR TITLE
fix: preserve customized code workflows

### DIFF
--- a/src/cli.tsx
+++ b/src/cli.tsx
@@ -579,7 +579,9 @@ function App({ command }: AppProps) {
 
     const setupPromise =
       runMode === "code"
-        ? ensureCodeModeRepoSetup(runtimeCwd)
+        ? ensureCodeModeRepoSetup(runtimeCwd, {
+            createWorkflow: resolvedCommand === "init",
+          })
         : Promise.resolve();
 
     setupPromise
@@ -4087,7 +4089,9 @@ async function runPrintCommand(
     const runtimeOutputMode = getRunModeOutputMode(command.mode);
 
     if (command.mode === "code") {
-      await ensureCodeModeRepoSetup(runtimeCwd);
+      await ensureCodeModeRepoSetup(runtimeCwd, {
+        createWorkflow: command.command === "init",
+      });
     }
 
     await runOpenWikiAgent(command.command, runtimeCwd, {

--- a/src/code-mode.ts
+++ b/src/code-mode.ts
@@ -11,15 +11,43 @@ const DEFAULT_CODE_MODE_CRON = "0 8 * * *";
 // Each is created when missing and refreshed in place when already present.
 const CODE_MODE_AGENT_FILES = ["AGENTS.md", "CLAUDE.md"];
 
+/** Controls which parts of the repo OpenWiki sets up for code mode. */
+export interface CodeModeRepoSetupOptions {
+  /**
+   * Write the scheduled-update workflow file. Only `openwiki code --init`
+   * should create it; `--update` and chat runs leave an existing file alone so
+   * operator customizations (fork guards, pinned actions, custom steps) are
+   * never silently overwritten.
+   */
+  createWorkflow?: boolean;
+  /** Cron expression for a freshly created workflow. Defaults to {@link DEFAULT_CODE_MODE_CRON}. */
+  cronExpression?: string;
+}
+
+/**
+ * Ensure the repo is set up for code mode: refresh the managed agent-instruction
+ * snippets, and, when `options.createWorkflow` is set, create the scheduled-update
+ * workflow if it does not already exist.
+ */
 export async function ensureCodeModeRepoSetup(
   cwd: string,
-  cronExpression = DEFAULT_CODE_MODE_CRON,
+  options: CodeModeRepoSetupOptions = {},
 ): Promise<void> {
-  await writeCodeModeWorkflow(cwd, cronExpression);
+  if (options.createWorkflow) {
+    await ensureCodeModeWorkflow(
+      cwd,
+      options.cronExpression ?? DEFAULT_CODE_MODE_CRON,
+    );
+  }
   await writeCodeModeAgentSnippets(cwd);
 }
 
-async function writeCodeModeWorkflow(
+/**
+ * Create the scheduled-update workflow file only when it is missing. An existing
+ * file is preserved verbatim so repo-specific customizations survive repeated
+ * runs; a plain overwrite would silently strip them.
+ */
+async function ensureCodeModeWorkflow(
   cwd: string,
   cronExpression: string,
 ): Promise<void> {
@@ -29,6 +57,16 @@ async function writeCodeModeWorkflow(
     "workflows",
     "openwiki-update.yml",
   );
+
+  try {
+    await readFile(workflowPath, "utf8");
+    return;
+  } catch (error) {
+    if (!isFileNotFoundError(error)) {
+      throw error;
+    }
+  }
+
   await mkdir(path.dirname(workflowPath), { recursive: true });
   await writeFile(workflowPath, createCodeModeWorkflow(cronExpression), "utf8");
 }

--- a/test/code-mode.test.ts
+++ b/test/code-mode.test.ts
@@ -103,7 +103,7 @@ describe("ensureCodeModeRepoSetup workflow", () => {
   test("generated PR includes agent files and the workflow in add-paths", async () => {
     const repo = await createTempRepo();
 
-    await ensureCodeModeRepoSetup(repo);
+    await ensureCodeModeRepoSetup(repo, { createWorkflow: true });
 
     const workflow = await readIfPresent(
       path.join(repo, ".github", "workflows", "openwiki-update.yml"),
@@ -123,7 +123,7 @@ describe("ensureCodeModeRepoSetup workflow", () => {
   test("pins the openwiki install to a specific version, never unpinned", async () => {
     const repo = await createTempRepo();
 
-    await ensureCodeModeRepoSetup(repo);
+    await ensureCodeModeRepoSetup(repo, { createWorkflow: true });
 
     const workflow = await readIfPresent(
       path.join(repo, ".github", "workflows", "openwiki-update.yml"),
@@ -132,5 +132,44 @@ describe("ensureCodeModeRepoSetup workflow", () => {
     // risk; the generated workflow must pin openwiki to the shipping version.
     expect(workflow).toMatch(/npm install --global openwiki@\d+\.\d+\.\d+ /u);
     expect(workflow).not.toMatch(/--global openwiki(?![@\d])/u);
+  });
+
+  test("does not create a workflow unless explicitly requested", async () => {
+    const repo = await createTempRepo();
+
+    await ensureCodeModeRepoSetup(repo);
+
+    expect(
+      await readIfPresent(
+        path.join(repo, ".github", "workflows", "openwiki-update.yml"),
+      ),
+    ).toBeNull();
+  });
+
+  test("preserves a customized workflow when setup runs again", async () => {
+    const repo = await createTempRepo();
+    const workflowPath = path.join(
+      repo,
+      ".github",
+      "workflows",
+      "openwiki-update.yml",
+    );
+    const customizedWorkflow = `name: Custom OpenWiki Update
+
+on:
+  workflow_dispatch:
+
+jobs:
+  update:
+    uses: ./.github/workflows/reusable-openwiki.yml
+    with:
+      model: gpt-5.6-terra
+`;
+
+    await ensureCodeModeRepoSetup(repo, { createWorkflow: true });
+    await writeFile(workflowPath, customizedWorkflow, "utf8");
+    await ensureCodeModeRepoSetup(repo, { createWorkflow: true });
+
+    expect(await readIfPresent(workflowPath)).toBe(customizedWorkflow);
   });
 });


### PR DESCRIPTION
## Summary

Fixes #282.

`openwiki code --update` and code-mode chat runs no longer rewrite `.github/workflows/openwiki-update.yml`. Existing workflow files are preserved exactly, including provider, model, checkout, branch, permissions, and custom steps.

The workflow is created only when `openwiki code --init` explicitly requests repository setup, and only when the file is missing. Managed `AGENTS.md` and `CLAUDE.md` snippets continue to refresh independently.

## Tests

- `pnpm test` — 197 passed
- `pnpm run build`
- `pnpm run lint:check`
- `pnpm run format:check`
- `git diff --check`
