### PR TITLE
fix: return a readable error for non-image binary file reads

### DIFF
--- a/src/agent/docs-only-backend.ts
+++ b/src/agent/docs-only-backend.ts
@@ -2,6 +2,7 @@ import {
   LocalShellBackend,
   type EditResult,
   type LocalShellBackendOptions,
+  type ReadResult,
   type WriteResult,
 } from "deepagents";
 import { OPEN_WIKI_DIR } from "../constants.js";
@@ -20,6 +21,34 @@ export class OpenWikiLocalShellBackend extends LocalShellBackend {
     super(options);
     this.docsOnly = options.docsOnly === true;
     this.outputMode = options.outputMode ?? "repository";
+  }
+
+  override async read(
+    filePath: string,
+    offset?: number,
+    limit?: number,
+  ): Promise<ReadResult> {
+    const result = await super.read(filePath, offset, limit);
+
+    if (result.error !== undefined || typeof result.content === "string") {
+      return result;
+    }
+
+    // Binary reads that are not images become `file`/`audio`/`video` content
+    // blocks in the tool result, which Anthropic and OpenRouter reject with a
+    // 400 — and the checkpointed thread then replays the poisoned message on
+    // every retry. Return a readable error so the agent can move on instead.
+    const mimeType = result.mimeType ?? "application/octet-stream";
+    if (mimeType.startsWith("image/")) {
+      return result;
+    }
+
+    return {
+      error:
+        `Cannot read '${filePath}': binary content (${mimeType}) is not ` +
+        "supported. Skip this file and describe it from its path and " +
+        "surrounding context instead.",
+    };
   }
 
   override async write(

--- a/test/docs-only-backend.test.ts
+++ b/test/docs-only-backend.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, readFile } from "node:fs/promises";
+import { mkdtemp, readFile, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { describe, expect, test } from "vitest";
@@ -60,6 +60,60 @@ describe("OpenWikiLocalShellBackend", () => {
     await expect(
       readFile(path.join(rootDir, "quickstart.md"), "utf8"),
     ).resolves.toBe("ok");
+  });
+
+  test("reads text files normally regardless of extension", async () => {
+    const rootDir = await mkdtemp(path.join(os.tmpdir(), "openwiki-backend-"));
+    await writeFile(path.join(rootDir, "script.jl"), 'println("hi")\n');
+    await writeFile(path.join(rootDir, "Makefile"), "all:\n\techo hi\n");
+    const backend = new OpenWikiLocalShellBackend({
+      docsOnly: true,
+      rootDir,
+      virtualMode: true,
+    });
+
+    const julia = await backend.read("/script.jl");
+    expect(julia.error).toBeUndefined();
+    expect(julia.content).toContain('println("hi")');
+
+    const makefile = await backend.read("/Makefile");
+    expect(makefile.error).toBeUndefined();
+    expect(makefile.content).toContain("echo hi");
+  });
+
+  test("returns a readable error instead of binary content for non-image binary files", async () => {
+    const rootDir = await mkdtemp(path.join(os.tmpdir(), "openwiki-backend-"));
+    await writeFile(path.join(rootDir, "doc.pdf"), "%PDF-1.4 fake\n");
+    const backend = new OpenWikiLocalShellBackend({
+      docsOnly: true,
+      rootDir,
+      virtualMode: true,
+    });
+
+    const result = await backend.read("/doc.pdf");
+    expect(result.content).toBeUndefined();
+    expect(result.error).toContain("application/pdf");
+    expect(result.error).toContain("Skip this file");
+  });
+
+  test("passes image reads through unchanged", async () => {
+    const rootDir = await mkdtemp(path.join(os.tmpdir(), "openwiki-backend-"));
+    // 1x1 transparent PNG
+    const png = Buffer.from(
+      "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII=",
+      "base64",
+    );
+    await writeFile(path.join(rootDir, "logo.png"), png);
+    const backend = new OpenWikiLocalShellBackend({
+      docsOnly: true,
+      rootDir,
+      virtualMode: true,
+    });
+
+    const result = await backend.read("/logo.png");
+    expect(result.error).toBeUndefined();
+    expect(result.mimeType).toBe("image/png");
+    expect(ArrayBuffer.isView(result.content)).toBe(true);
   });
 
   test("keeps chat-mode style backends unrestricted when docsOnly is false", async () => {


### PR DESCRIPTION
Fixes #284

## What

Reading a file whose MIME type is neither text nor image makes the `read_file` tool emit a `{type: "file"}` content block in the tool result, which Anthropic/OpenRouter reject with `400 ... unknown variant 'file'`. Because the run is checkpointed, the poisoned message replays on every retry and the thread never recovers — the failure mode reported in #284.

This overrides `read()` in `OpenWikiLocalShellBackend` (same pattern as the existing `write`/`edit` overrides): when the underlying read returns binary content that isn't an image, return a `ReadResult` error instead of bytes. The deepagents tool layer turns backend errors into plain text blocks, so the agent gets actionable feedback ("skip this file, describe it from context") and the request stays valid. Image reads pass through untouched since image blocks are accepted in tool results, and text reads are completely unaffected.

## Notes from reproducing

- With the currently pinned deepagents (1.10.7), `.jl` and `Makefile` from the issue actually resolve to `text/plain` (unknown extensions fall back to text), so they read fine at HEAD — I verified this against a scratch repo. The still-crashing class today is extensions mapped to non-text types (`.pdf`, `.ppt`, `.pptx`), and any older bundled deepagents where the fallback differed. Guarding at the backend covers both.
- This prevents new threads from getting poisoned; a thread already bricked by a checkpointed `file` block still needs its thread/checkpoint deleted. Happy to look at that separately if wanted, but it seemed out of scope for one PR.

## Testing

Three new tests in `test/docs-only-backend.test.ts`: text-with-unknown-extension reads (`.jl`, `Makefile`), PDF read returns the error, PNG read passes through. `pnpm run format`, `pnpm run lint`, and `pnpm test` pass locally (the one `env-behavior` failure is the 0600-permissions test, which also fails on a clean checkout on Windows).