### PR TITLE
fix: gate scheduled OpenWiki Update workflow to the origin repository

### DIFF
--- a/.github/workflows/openwiki-update.yml
+++ b/.github/workflows/openwiki-update.yml
@@ -11,6 +11,13 @@ permissions:
 
 jobs:
   update:
+    # Scheduled (and manually-dispatched) runs only fire in the origin repo by
+    # default, so forking to contribute doesn't silently arm a daily job that
+    # is guaranteed to fail without a configured provider secret. Fork owners
+    # who want scheduled updates on their own fork can opt in without editing
+    # this file by setting the OPENWIKI_ENABLE_SCHEDULED_UPDATE repository
+    # variable (Settings -> Actions -> Variables) to "true".
+    if: github.repository == 'langchain-ai/openwiki' || vars.OPENWIKI_ENABLE_SCHEDULED_UPDATE == 'true'
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository


### PR DESCRIPTION
Closes #302

## Summary

I forked this repo to contribute a provider PR.

Enabling Actions to see my own CI also armed the scheduled `OpenWiki Update` workflow — which has failed every day since. The workflow assumes an `OPENROUTER_API_KEY` repo secret, but nothing tells a new fork owner to set one up.

**Default (no variable set)**
The job only runs in the origin repository. Forking to contribute no longer silently arms a daily job that's guaranteed to fail.

**Opt-in (`OPENWIKI_ENABLE_SCHEDULED_UPDATE=true`)**
Fork owners who want scheduled updates on their own fork can set this repository variable (Settings → Actions → Variables) instead of editing the workflow file. The choice survives future upstream syncs instead of drifting out of a hand-edited copy. Deleting the variable (or setting it to anything other than `true`) reverts to the default.

## Testing

A schedule trigger can't be exercised on demand, so I verified both branches of the guard live on my fork via `workflow_dispatch`:

**Default (no variable set)**
Run's overall conclusion is `skipped`.
https://github.com/jyje/openwiki/actions/runs/29223553562

**Opt-in**
With `OPENWIKI_ENABLE_SCHEDULED_UPDATE=true` set, checkout / setup-node / install steps all succeed — confirming the guard let the job through. It then fails at the "Run OpenWiki" step because my fork has no `OPENROUTER_API_KEY` configured. That's the same symptom this issue reports, now happening on purpose — proof the opt-in works and nothing else changed.
https://github.com/jyje/openwiki/actions/runs/29223609215

No source files changed, so `pnpm test` / `typecheck` / `build` are unaffected. Ran `pnpm run format:check` to confirm the YAML is still Prettier-clean.
