### PR TITLE
chore: update chatgpt login model wording

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,7 +223,7 @@ OPENWIKI_MODEL_ID=your-gateway-model-name
 The `openai-chatgpt` provider calls OpenAI's Codex backend using your ChatGPT
 subscription instead of a metered API key. Model usage draws on your ChatGPT
 Plus/Pro/Team plan's included Codex usage rather than per-token API billing. It
-serves the same models as the `openai` provider (`gpt-5.4-mini`, `gpt-5.5`).
+serves the same model list as the `openai` provider.
 
 Instead of pasting an API key, run the setup wizard and complete a browser
 login:


### PR DESCRIPTION
## Summary
- update the ChatGPT-login provider README wording so it does not list stale model IDs
- point readers to the shared OpenAI provider model list instead

## Testing
- `corepack pnpm exec prettier --check README.md`
- `corepack pnpm exec vitest run test/openai-chatgpt-provider.test.ts test/constants.test.ts`
- `corepack pnpm run lint:check`
- `corepack pnpm run typecheck`
Note: `corepack pnpm test` currently fails locally on Windows in `test/env-behavior.test.ts > writes the env file with 0600 permissions` (`mode & 0o077` receives `54`). Targeted tests above pass.