### PR TITLE
docs: align openwiki update ci examples

### DIFF
--- a/examples/openwiki-update.bitbucket-pipelines.yml
+++ b/examples/openwiki-update.bitbucket-pipelines.yml
@@ -14,13 +14,13 @@ pipelines:
             - git config user.email "${BITBUCKET_USER_EMAIL:-openwiki@example.com}"
             - openwiki code --update --print
             - |
-              if git diff --quiet -- openwiki; then
+              if git diff --quiet -- openwiki AGENTS.md CLAUDE.md .github/workflows/openwiki-update.yml; then
                 echo "OpenWiki is already up to date."
                 exit 0
               fi
             - export OPENWIKI_BRANCH="openwiki/update-${BITBUCKET_BUILD_NUMBER}"
             - git checkout -b "$OPENWIKI_BRANCH"
-            - git add openwiki
+            - git add openwiki AGENTS.md CLAUDE.md .github/workflows/openwiki-update.yml
             - git commit -m "docs: update OpenWiki"
             - git push "https://x-token-auth:${OPENWIKI_BITBUCKET_TOKEN}@bitbucket.org/${BITBUCKET_WORKSPACE}/${BITBUCKET_REPO_SLUG}.git" "$OPENWIKI_BRANCH"
             - |

--- a/examples/openwiki-update.gitlab-ci.yml
+++ b/examples/openwiki-update.gitlab-ci.yml
@@ -12,13 +12,13 @@ openwiki_update:
   script:
     - openwiki code --update --print
     - |
-      if git diff --quiet -- openwiki; then
+      if git diff --quiet -- openwiki AGENTS.md CLAUDE.md .github/workflows/openwiki-update.yml; then
         echo "OpenWiki is already up to date."
         exit 0
       fi
     - export OPENWIKI_BRANCH="openwiki/update-${CI_PIPELINE_ID}"
     - git checkout -b "$OPENWIKI_BRANCH"
-    - git add openwiki
+    - git add openwiki AGENTS.md CLAUDE.md .github/workflows/openwiki-update.yml
     - git commit -m "docs: update OpenWiki"
     - git push "https://oauth2:${OPENWIKI_GITLAB_TOKEN}@${CI_SERVER_HOST}/${CI_PROJECT_PATH}.git" "$OPENWIKI_BRANCH"
     - |

--- a/examples/openwiki-update.yml
+++ b/examples/openwiki-update.yml
@@ -8,6 +8,7 @@ on:
 
 permissions:
   contents: write
+  pull-requests: write
 
 jobs:
   update:


### PR DESCRIPTION
## Summary
- add `pull-requests: write` to the GitHub Actions example that opens update PRs
- make GitLab and Bitbucket examples detect and commit all code-mode managed files

## Testing
- `corepack pnpm exec prettier --check examples/openwiki-update.yml examples/openwiki-update.gitlab-ci.yml examples/openwiki-update.bitbucket-pipelines.yml`
- `git diff --check`
- `corepack pnpm run lint:check`
- `corepack pnpm run typecheck`
Note: `corepack pnpm test` currently fails locally on Windows in `test/env-behavior.test.ts > writes the env file with 0600 permissions` (`mode & 0o077` receives `54`). Targeted tests above pass.