### PR TITLE
fix: align cron schedule target help

### DIFF
--- a/src/commands.ts
+++ b/src/commands.ts
@@ -295,11 +295,11 @@ export function parseCommand(argv: string[]): CliCommand {
 
     if (argv[1] === "pause" || argv[1] === "resume" || argv[1] === "delete") {
       const target = parseIngestionTarget(argv[2] ?? "");
-      if (!target || typeof target !== "string" || argv.length > 3) {
+      if (target !== "all" || argv.length > 3) {
         return {
           kind: "error",
           exitCode: 1,
-          message: `Usage: openwiki cron ${argv[1]} <source|all>`,
+          message: `Usage: openwiki cron ${argv[1]} all`,
         };
       }
 
@@ -316,7 +316,7 @@ export function parseCommand(argv: string[]): CliCommand {
         kind: "error",
         exitCode: 1,
         message:
-          "Usage: openwiki cron list | pause <source|all> | resume <source|all> | delete <source|all>",
+          "Usage: openwiki cron list | pause all | resume all | delete all",
       };
     }
   }
@@ -580,9 +580,9 @@ export const helpContent: HelpContent = {
     "openwiki auth tools <provider>",
     "openwiki ingest <source|source-instance|all>",
     "openwiki cron list",
-    "openwiki cron pause <source|all>",
-    "openwiki cron resume <source|all>",
-    "openwiki cron delete <source|all>",
+    "openwiki cron pause all",
+    "openwiki cron resume all",
+    "openwiki cron delete all",
     "openwiki ngrok start [url] [--port <port>]",
   ],
   commands: [
@@ -625,17 +625,17 @@ export const helpContent: HelpContent = {
       description: "List saved connector schedules and local launchd status.",
     },
     {
-      label: "openwiki cron pause <source|all>",
+      label: "openwiki cron pause all",
       description:
         "Pause saved connector schedules and reconcile the Mac wake window.",
     },
     {
-      label: "openwiki cron resume <source|all>",
+      label: "openwiki cron resume all",
       description:
         "Resume paused connector schedules and reconcile the Mac wake window.",
     },
     {
-      label: "openwiki cron delete <source|all>",
+      label: "openwiki cron delete all",
       description:
         "Delete saved connector schedules and remove stale local schedule files.",
     },
@@ -692,9 +692,9 @@ export const helpContent: HelpContent = {
     "openwiki ingest web-search",
     "openwiki ingest web-search-2",
     "openwiki cron list",
-    "openwiki cron pause web-search",
-    "openwiki cron resume web-search",
-    "openwiki cron delete web-search",
+    "openwiki cron pause all",
+    "openwiki cron resume all",
+    "openwiki cron delete all",
     "openwiki auth slack",
     "openwiki auth gmail",
     "openwiki auth notion",

--- a/test/commands.test.ts
+++ b/test/commands.test.ts
@@ -325,6 +325,11 @@ describe("parseCommand — cron", () => {
     expect(result.kind).toBe("error");
   });
 
+  test("cron pause with a source id is rejected", () => {
+    const result = parseCommand(["cron", "pause", "web-search"]);
+    expect(result.kind).toBe("error");
+  });
+
   test("cron resume with a source instance id is rejected", () => {
     const result = parseCommand(["cron", "resume", "web-search-1"]);
     expect(result.kind).toBe("error");


### PR DESCRIPTION
## Summary
- make `openwiki cron pause|resume|delete` accept only `all`, matching the schedule mutation implementation
- update help text and examples so source-specific targets are not advertised
- add parser coverage for rejecting a source id

## Testing
- `corepack pnpm exec prettier --check src/commands.ts test/commands.test.ts`
- `corepack pnpm exec vitest run test/commands.test.ts`
- `corepack pnpm run lint:check`
- `corepack pnpm run typecheck`
Note: `corepack pnpm test` currently fails locally on Windows in `test/env-behavior.test.ts > writes the env file with 0600 permissions` (`mode & 0o077` receives `54`). Targeted tests above pass.