### PR TITLE
fix: avoid wrapping oauth urls in setup ui

### DIFF
--- a/src/credentials.tsx
+++ b/src/credentials.tsx
@@ -3470,6 +3470,7 @@ function Prompt({
         <Text>{selectedSource.displayName} authorization</Text>
         {sourceState.authUrl ? (
           <OAuthAuthorizationLink
+            authProvider={selectedSource.authProvider}
             copiedToClipboard={Boolean(sourceState.copiedAuthUrlToClipboard)}
             url={sourceState.authUrl}
           />
@@ -3790,9 +3791,11 @@ function SourceConnectionStatus({
 }
 
 function OAuthAuthorizationLink({
+  authProvider,
   copiedToClipboard,
   url,
 }: {
+  authProvider?: AuthProviderId;
   copiedToClipboard: boolean;
   url: string;
 }) {
@@ -3804,12 +3807,31 @@ function OAuthAuthorizationLink({
         </Text>
       </Text>
       <Text color={copiedToClipboard ? "green" : "gray"}>
-        {copiedToClipboard
-          ? "Full URL copied to clipboard. Use the link above if your terminal supports it."
-          : "Use the terminal link above. If it is not clickable, run this auth command in a plain terminal."}
+        {getOAuthAuthorizationStatusText({
+          authProvider,
+          copiedToClipboard,
+        })}
       </Text>
     </Box>
   );
+}
+
+export function getOAuthAuthorizationStatusText({
+  authProvider,
+  copiedToClipboard,
+}: {
+  authProvider?: AuthProviderId;
+  copiedToClipboard: boolean;
+}): string {
+  if (copiedToClipboard) {
+    return "Full URL copied to clipboard. Use the link above if your terminal supports it.";
+  }
+
+  const authCommand = authProvider
+    ? `openwiki auth ${authProvider}`
+    : "openwiki auth <provider>";
+
+  return `Use the terminal link above. If it is not clickable, cancel and run ${authCommand} in a plain terminal.`;
 }
 
 function OAuthLoginPrompt({

--- a/src/credentials.tsx
+++ b/src/credentials.tsx
@@ -3805,11 +3805,8 @@ function OAuthAuthorizationLink({
       </Text>
       <Text color={copiedToClipboard ? "green" : "gray"}>
         {copiedToClipboard
-          ? "Full URL copied to clipboard. It is also shown below."
-          : "Copy the full raw URL below if the link is not clickable."}
-      </Text>
-      <Text color="gray" wrap="wrap">
-        {url}
+          ? "Full URL copied to clipboard. Use the link above if your terminal supports it."
+          : "Use the terminal link above. If it is not clickable, run this auth command in a plain terminal."}
       </Text>
     </Box>
   );

--- a/test/credentials.test.ts
+++ b/test/credentials.test.ts
@@ -5,6 +5,7 @@ import { afterEach, describe, expect, test } from "vitest";
 import {
   ensureRunModeConfig,
   getInitialStep,
+  getOAuthAuthorizationStatusText,
   hydrateRunModeConfig,
   needsCredentialSetup,
   nextSetupStep,
@@ -218,5 +219,27 @@ describe("nextSetupStep", () => {
       null,
     );
     expect(nextSetupStep(null, "openai", "code", false)).toBe(null);
+  });
+});
+
+describe("getOAuthAuthorizationStatusText", () => {
+  test("uses a provider-specific fallback command when the URL is not copied", () => {
+    expect(
+      getOAuthAuthorizationStatusText({
+        authProvider: "gmail",
+        copiedToClipboard: false,
+      }),
+    ).toContain("openwiki auth gmail");
+  });
+
+  test("does not expose the raw authorization URL in fallback text", () => {
+    const rawUrl = "https://accounts.google.com/o/oauth2/v2/auth?state=abc";
+
+    expect(
+      getOAuthAuthorizationStatusText({
+        authProvider: "gmail",
+        copiedToClipboard: false,
+      }),
+    ).not.toContain(rawUrl);
   });
 });


### PR DESCRIPTION
## Summary
- remove the raw wrapped OAuth URL from the bordered setup UI
- keep the terminal hyperlink and clipboard status so copied URLs do not include Ink border characters
- show a provider-specific fallback command such as `openwiki auth gmail` when clipboard support is unavailable

Fixes #296.

## Testing
- `corepack pnpm exec prettier --check src/credentials.tsx test/credentials.test.ts`
- `corepack pnpm exec vitest run test/credentials.test.ts test/openai-chatgpt-credentials.test.ts`
- `corepack pnpm run typecheck`
- `corepack pnpm run lint:check`
Note: `corepack pnpm test` currently fails locally on Windows in `test/env-behavior.test.ts > writes the env file with 0600 permissions` (`mode & 0o077` receives `54`). Targeted tests above pass.