### PR TITLE
fix: stop env-behavior tests from overwriting the real ~/.openwiki/.env

### DIFF
--- a/test/env-behavior.test.ts
+++ b/test/env-behavior.test.ts
@@ -8,13 +8,7 @@ import {
 } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
-import { afterEach, beforeEach, describe, expect, test } from "vitest";
-import {
-  getCredentialDiagnostics,
-  loadOpenWikiEnv,
-  openWikiEnvPath,
-  saveOpenWikiEnv,
-} from "../src/env.ts";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 import {
   ANTHROPIC_API_KEY_ENV_KEY,
   ANTHROPIC_BASE_URL_ENV_KEY,
@@ -25,14 +19,25 @@ import {
 } from "../src/constants.ts";
 
 // `loadOpenWikiEnv`, `saveOpenWikiEnv`, and `getCredentialDiagnostics` all read
-// from / write to a fixed `~/.openwiki/.env` path derived from `os.homedir()`.
-// Pointing HOME at a throwaway temp directory keeps these tests fully isolated
-// from the developer's real credentials and machine.
+// from / write to `~/.openwiki/.env`, and `src/env.ts` resolves that path from
+// `os.homedir()` **at module load time** (`openWikiEnvPath` is a module-level
+// const). A static `import` of `../src/env.ts` would therefore bind the path
+// to the developer's real home before any hook can point HOME elsewhere — and
+// every save in this file would overwrite the developer's real credentials
+// with test fixtures.
+//
+// So, like `test/onboarding.test.ts`, this file must reset the module registry
+// and set HOME **before** dynamically importing the module under test. That
+// way each test gets a module instance whose paths are bound to a throwaway
+// temp directory, keeping these tests fully isolated from the developer's
+// real credentials and machine.
 //
 // The existing `test/env.test.ts` covers the pure `parseEnv`/`formatEnv`
 // serializers. This file covers the runtime behavior of the three functions
 // above — the deprecation-dropping, source resolution, file permissions, and
 // secret masking — which previously had no coverage.
+
+type EnvModule = typeof import("../src/env.ts");
 
 const KEYS_UNDER_TEST = [
   ANTHROPIC_API_KEY_ENV_KEY,
@@ -51,11 +56,18 @@ const KEYS_UNDER_TEST = [
 
 let originalHome: string | undefined;
 let tempHome: string;
+let env: EnvModule;
 
 beforeEach(async () => {
   originalHome = process.env.HOME;
   tempHome = await mkdtemp(path.join(tmpdir(), "openwiki-env-behavior-"));
+
+  // Order matters: HOME must point at the temp directory before the module
+  // evaluates, because `openWikiEnvPath` is computed from `os.homedir()` when
+  // `src/env.ts` first loads.
+  vi.resetModules();
   process.env.HOME = tempHome;
+  env = await import("../src/env.ts");
 
   for (const key of KEYS_UNDER_TEST) {
     delete process.env[key];
@@ -63,6 +75,8 @@ beforeEach(async () => {
 });
 
 afterEach(async () => {
+  vi.resetModules();
+
   for (const key of KEYS_UNDER_TEST) {
     delete process.env[key];
   }
@@ -76,23 +90,32 @@ afterEach(async () => {
   await rm(tempHome, { recursive: true, force: true });
 });
 
+describe("test isolation", () => {
+  test("resolves the env file inside the test HOME, never the real home", () => {
+    // Regression guard: if `../src/env.ts` is ever imported statically again
+    // (binding `os.homedir()` before the HOME swap), this fails loudly instead
+    // of letting the suite overwrite the developer's real ~/.openwiki/.env.
+    expect(env.openWikiEnvPath.startsWith(tempHome + path.sep)).toBe(true);
+  });
+});
+
 describe("loadOpenWikiEnv", () => {
   test("loads a saved managed key into process.env", async () => {
-    await saveOpenWikiEnv({ [OPENROUTER_API_KEY_ENV_KEY]: "sk-or-test" });
+    await env.saveOpenWikiEnv({ [OPENROUTER_API_KEY_ENV_KEY]: "sk-or-test" });
 
     delete process.env[OPENROUTER_API_KEY_ENV_KEY];
 
-    await loadOpenWikiEnv();
+    await env.loadOpenWikiEnv();
 
     expect(process.env[OPENROUTER_API_KEY_ENV_KEY]).toBe("sk-or-test");
   });
 
   test("does not overwrite a key already present in process.env", async () => {
-    await saveOpenWikiEnv({ [OPENROUTER_API_KEY_ENV_KEY]: "from-file" });
+    await env.saveOpenWikiEnv({ [OPENROUTER_API_KEY_ENV_KEY]: "from-file" });
 
     process.env[OPENROUTER_API_KEY_ENV_KEY] = "from-process-env";
 
-    await loadOpenWikiEnv();
+    await env.loadOpenWikiEnv();
 
     expect(process.env[OPENROUTER_API_KEY_ENV_KEY]).toBe("from-process-env");
   });
@@ -101,9 +124,9 @@ describe("loadOpenWikiEnv", () => {
     // OPENAI_BASE_URL was un-deprecated (PR #90): it is now loaded from
     // ~/.openwiki/.env like any other key, so proxy/gateway setups survive.
     // OPENAI_ORG_ID and OPENAI_PROJECT remain deprecated and are still dropped.
-    await mkdir(path.dirname(openWikiEnvPath), { recursive: true });
+    await mkdir(path.dirname(env.openWikiEnvPath), { recursive: true });
     await writeFile(
-      openWikiEnvPath,
+      env.openWikiEnvPath,
       [
         "OPENAI_BASE_URL=https://gateway.example.com/v1",
         "OPENAI_ORG_ID=org-123",
@@ -113,7 +136,7 @@ describe("loadOpenWikiEnv", () => {
       "utf8",
     );
 
-    await loadOpenWikiEnv();
+    await env.loadOpenWikiEnv();
 
     expect(process.env.OPENAI_BASE_URL).toBe("https://gateway.example.com/v1");
     expect(process.env.OPENAI_ORG_ID).toBeUndefined();
@@ -124,7 +147,7 @@ describe("loadOpenWikiEnv", () => {
 
 describe("saveOpenWikiEnv", () => {
   test("persists a value that loadOpenWikiEnv can round-trip", async () => {
-    await saveOpenWikiEnv({
+    await env.saveOpenWikiEnv({
       [OPENWIKI_PROVIDER_ENV_KEY]: "openrouter",
       [OPENROUTER_API_KEY_ENV_KEY]: "sk-or-roundtrip",
     });
@@ -132,16 +155,16 @@ describe("saveOpenWikiEnv", () => {
     delete process.env[OPENWIKI_PROVIDER_ENV_KEY];
     delete process.env[OPENROUTER_API_KEY_ENV_KEY];
 
-    await loadOpenWikiEnv();
+    await env.loadOpenWikiEnv();
 
     expect(process.env[OPENWIKI_PROVIDER_ENV_KEY]).toBe("openrouter");
     expect(process.env[OPENROUTER_API_KEY_ENV_KEY]).toBe("sk-or-roundtrip");
   });
 
   test("writes the env file with 0600 permissions", async () => {
-    await saveOpenWikiEnv({ [OPENAI_API_KEY_ENV_KEY]: "sk-test" });
+    await env.saveOpenWikiEnv({ [OPENAI_API_KEY_ENV_KEY]: "sk-test" });
 
-    const mode = (await stat(openWikiEnvPath)).mode & 0o777;
+    const mode = (await stat(env.openWikiEnvPath)).mode & 0o777;
 
     // Owner read/write only; no group/other bits.
     expect(mode & 0o077).toBe(0);
@@ -151,19 +174,19 @@ describe("saveOpenWikiEnv", () => {
   test("strips deprecated keys from the persisted file", async () => {
     // A deprecated key written by an older OpenWiki version must not survive a
     // subsequent save, so stale deprecated values can't linger in the file.
-    await mkdir(path.dirname(openWikiEnvPath), { recursive: true });
-    await writeFile(openWikiEnvPath, "OPENAI_ORG_ID=stale-org\n", "utf8");
+    await mkdir(path.dirname(env.openWikiEnvPath), { recursive: true });
+    await writeFile(env.openWikiEnvPath, "OPENAI_ORG_ID=stale-org\n", "utf8");
 
-    await saveOpenWikiEnv({ [OPENAI_API_KEY_ENV_KEY]: "sk-fresh" });
+    await env.saveOpenWikiEnv({ [OPENAI_API_KEY_ENV_KEY]: "sk-fresh" });
 
-    const contents = await readFile(openWikiEnvPath, "utf8");
+    const contents = await readFile(env.openWikiEnvPath, "utf8");
 
     expect(contents).not.toContain("OPENAI_ORG_ID");
     expect(contents).toContain("OPENAI_API_KEY=");
   });
 
   test("seeds process.env with the saved value immediately", async () => {
-    await saveOpenWikiEnv({ [OPENAI_API_KEY_ENV_KEY]: "sk-immediate" });
+    await env.saveOpenWikiEnv({ [OPENAI_API_KEY_ENV_KEY]: "sk-immediate" });
 
     expect(process.env[OPENAI_API_KEY_ENV_KEY]).toBe("sk-immediate");
   });
@@ -171,7 +194,7 @@ describe("saveOpenWikiEnv", () => {
 
 describe("getCredentialDiagnostics", () => {
   test("includes the provider and each credential key in display order", async () => {
-    const diagnostics = await getCredentialDiagnostics();
+    const diagnostics = await env.getCredentialDiagnostics();
     const keys = diagnostics.map((entry) => entry.key);
 
     expect(keys[0]).toBe(OPENWIKI_PROVIDER_ENV_KEY);
@@ -183,9 +206,9 @@ describe("getCredentialDiagnostics", () => {
   });
 
   test("reports an unset key as unset with no warnings", async () => {
-    await rm(openWikiEnvPath, { force: true });
+    await rm(env.openWikiEnvPath, { force: true });
 
-    const diagnostics = await getCredentialDiagnostics();
+    const diagnostics = await env.getCredentialDiagnostics();
     const entry = diagnostics.find(
       (item) => item.key === OPENROUTER_API_KEY_ENV_KEY,
     );
@@ -197,9 +220,9 @@ describe("getCredentialDiagnostics", () => {
   });
 
   test("masks a secret value rather than echoing it", async () => {
-    await saveOpenWikiEnv({ [OPENAI_API_KEY_ENV_KEY]: "sk-secret-12345" });
+    await env.saveOpenWikiEnv({ [OPENAI_API_KEY_ENV_KEY]: "sk-secret-12345" });
 
-    const diagnostics = await getCredentialDiagnostics();
+    const diagnostics = await env.getCredentialDiagnostics();
     const entry = diagnostics.find(
       (item) => item.key === OPENAI_API_KEY_ENV_KEY,
     );
@@ -209,11 +232,11 @@ describe("getCredentialDiagnostics", () => {
   });
 
   test("surfaces a non-secret base URL verbatim, not masked", async () => {
-    await saveOpenWikiEnv({
+    await env.saveOpenWikiEnv({
       [ANTHROPIC_BASE_URL_ENV_KEY]: "https://gateway.example.com/anthropic",
     });
 
-    const diagnostics = await getCredentialDiagnostics();
+    const diagnostics = await env.getCredentialDiagnostics();
     const entry = diagnostics.find(
       (item) => item.key === ANTHROPIC_BASE_URL_ENV_KEY,
     );
@@ -222,9 +245,9 @@ describe("getCredentialDiagnostics", () => {
   });
 
   test("flags an invalid model ID with a warning", async () => {
-    await saveOpenWikiEnv({ [OPENWIKI_MODEL_ID_ENV_KEY]: "bad model id" });
+    await env.saveOpenWikiEnv({ [OPENWIKI_MODEL_ID_ENV_KEY]: "bad model id" });
 
-    const diagnostics = await getCredentialDiagnostics();
+    const diagnostics = await env.getCredentialDiagnostics();
     const entry = diagnostics.find(
       (item) => item.key === OPENWIKI_MODEL_ID_ENV_KEY,
     );
@@ -233,9 +256,11 @@ describe("getCredentialDiagnostics", () => {
   });
 
   test("flags an invalid provider with a warning", async () => {
-    await saveOpenWikiEnv({ [OPENWIKI_PROVIDER_ENV_KEY]: "not-a-provider" });
+    await env.saveOpenWikiEnv({
+      [OPENWIKI_PROVIDER_ENV_KEY]: "not-a-provider",
+    });
 
-    const diagnostics = await getCredentialDiagnostics();
+    const diagnostics = await env.getCredentialDiagnostics();
     const entry = diagnostics.find(
       (item) => item.key === OPENWIKI_PROVIDER_ENV_KEY,
     );
@@ -244,12 +269,12 @@ describe("getCredentialDiagnostics", () => {
   });
 
   test("prefers process.env over the file when both are set", async () => {
-    await saveOpenWikiEnv({ [OPENROUTER_API_KEY_ENV_KEY]: "from-file" });
+    await env.saveOpenWikiEnv({ [OPENROUTER_API_KEY_ENV_KEY]: "from-file" });
 
     // Override process.env after the save seeds it.
     process.env[OPENROUTER_API_KEY_ENV_KEY] = "from-process-env";
 
-    const diagnostics = await getCredentialDiagnostics();
+    const diagnostics = await env.getCredentialDiagnostics();
     const entry = diagnostics.find(
       (item) => item.key === OPENROUTER_API_KEY_ENV_KEY,
     );


### PR DESCRIPTION
## What

`test/env-behavior.test.ts` imports `../src/env.ts` statically, but `src/env.ts` resolves `openWikiEnvPath` from `os.homedir()` **at module load time**. The `beforeEach` hook's `HOME` swap therefore happens *after* the path is already bound to the developer's real home directory — so every `saveOpenWikiEnv()` call in the file writes test fixtures (`sk-secret-12345`, `bad model id`, `https://gateway.example.com/anthropic`, …) straight into the developer's **real `~/.openwiki/.env`**, silently destroying their saved provider credentials and connector tokens. The file's own header comment claims the tests are "fully isolated from the developer's real credentials" — this PR makes that true.

This bit me for real: one `pnpm test` run replaced my configured provider, model ID, Google OAuth client, and Gmail tokens with fixtures, and I had to re-authenticate everything.

## Why this fix

`test/onboarding.test.ts` already solves the identical problem correctly: `vi.resetModules()` + set `HOME` + dynamically `import()` the module under test. This PR applies the same pattern to `env-behavior.test.ts`, and adds a regression test asserting that the resolved `openWikiEnvPath` lives inside the test's temp `HOME` — so a future return to static imports fails loudly instead of silently clobbering real credentials.

One PR = one change: only the test file is touched. (A follow-up could make `src/env.ts` / `src/openwiki-home.ts` resolve paths lazily so the footgun disappears at the source — happy to open that separately if wanted.)

## How I tested it

Repro before the fix (on `main`):

```sh
sha256sum ~/.openwiki/.env          # note hash
pnpm exec vitest run test/env-behavior.test.ts
sha256sum ~/.openwiki/.env          # hash CHANGED; file now contains test fixtures
```

After the fix:

- `pnpm exec vitest run test/env-behavior.test.ts` — 15/15 pass (14 existing + 1 new regression test)
- `pnpm test` — full suite 224/224 pass
- `sha256sum ~/.openwiki/.env` before/after the full suite — **unchanged**
- `pnpm run lint:check` / `pnpm run format:check` — clean on the changed file

🤖 Generated with [Claude Code](https://claude.com/claude-code)
