### PR TITLE
chore: replace retired pnpm audit endpoint with Trivy lockfile scan in ci

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -131,19 +131,15 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@v4
 
-      - name: Set up pnpm
-        uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
-        with:
-          run_install: false
-
-      - name: Set up Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: "22"
-          cache: pnpm
-
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
-
+      # `pnpm audit` calls npm's retired quick-audit endpoint (HTTP 410), so we
+      # scan the lockfile with Trivy instead. `severity: HIGH,CRITICAL` +
+      # `exit-code: 1` preserves the previous `--audit-level=high` gate.
       - name: Audit dependencies
-        run: pnpm audit --audit-level=high
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
+        with:
+          scan-type: fs
+          scan-ref: .
+          scanners: vuln
+          severity: HIGH,CRITICAL
+          exit-code: "1"
+          ignore-unfixed: false


### PR DESCRIPTION
### Summary

Audit is failing in CI:
```
ERR_PNPM_AUDIT_BAD_RESPONSE  The audit endpoint (at https://registry.npmjs.org/-/npm/v1/security/audits/quick) responded with 410: {"error":"This endpoint is being retired. Use the bulk advisory endpoint instead. See the following docs for more info: https://api-docs.npmjs.com/#tag/Audit"}. Fallback endpoint (at https://registry.npmjs.org/-/npm/v1/security/audits) responded with 410: {"error":"This endpoint is being retired. Use the bulk advisory endpoint instead. See the following docs for more info: https://api-docs.npmjs.com/#tag/Audit"}
```

This is a good catch and why we added audit.

This PR replaces the step with a Trivy filesystem scan of the lockfile. `severity: HIGH,CRITICAL` + `exit-code: 1` keeps the same gate as the old `--audit-level=high so what CI blocks is unchanged.