### PR TITLE
fix: name the code-mode update job after the detected Git host

### DIFF
--- a/.changeset/host-aware-code-mode-setup.md
+++ b/.changeset/host-aware-code-mode-setup.md
@@ -1,0 +1,5 @@
+---
+"openwiki": patch
+---
+
+fix: name the code-mode update job after the detected Git host instead of always claiming GitHub Actions

--- a/README.md
+++ b/README.md
@@ -66,6 +66,8 @@ Keep it current automatically by adding a scheduled CI job that opens a docs PR 
 - **GitLab CI:** copy [`openwiki-update.gitlab-ci.yml`](./examples/openwiki-update.gitlab-ci.yml) into `.gitlab-ci.yml` or include it from your pipeline.
 - **Bitbucket Pipelines:** copy [`openwiki-update.bitbucket-pipelines.yml`](./examples/openwiki-update.bitbucket-pipelines.yml) into `bitbucket-pipelines.yml`, then schedule the `openwiki-update` pipeline.
 
+`openwiki --init` writes the GitHub Actions workflow for you when the repository's remote is a GitHub host, and leaves a GitLab or Bitbucket repository to the examples above. The managed `AGENTS.md` block names the job for the detected host, so it never tells your agents about a GitHub Actions run the repository cannot perform. Set `OPENWIKI_CI_PROVIDER=github|gitlab|bitbucket|none` to override detection on a self-hosted instance whose hostname does not name its provider, or to `none` to keep OpenWiki from writing any workflow.
+
 > [!NOTE]
 > On Windows, install with a Node.js package manager (`npm install -g openwiki` or `pnpm add -g openwiki`). Installing with `bun` can fall back to compiling the `better-sqlite3` native dependency, which needs Visual Studio Build Tools with the Desktop development with C++ workload.
 
@@ -234,7 +236,7 @@ Locally the setup wizard saves this to `~/.openwiki/.env`. In CI, set it as a re
 
 Your wiki stays in the repository as plain Markdown you own, with OpenWiki-managed grounding and run metadata versioned alongside it.
 
-- **Agents read it as memory.** On each `code` run, OpenWiki maintains an `AGENTS.md` and `CLAUDE.md` at the repo root that point your coding agent at the wiki. It only rewrites its own `<!-- OPENWIKI:START -->…<!-- OPENWIKI:END -->` block and leaves the rest of each file untouched.
+- **Agents read it as memory.** On each `code` run, OpenWiki maintains an `AGENTS.md` and `CLAUDE.md` at the repo root that point your coding agent at the wiki. It only rewrites its own `<!-- OPENWIKI:START -->…<!-- OPENWIKI:END -->` block and leaves the rest of each file untouched, and names the scheduled update job after your detected Git host.
 - **Grounding stays with the wiki.** Versioned claim sidecars under `openwiki/.claims/` travel with the Markdown, so the evidence needed to maintain factual pages is inspectable and reviewable.
 - **You set the brief.** Repository-specific instructions live in `openwiki/INSTRUCTIONS.md`, a user-authored file OpenWiki reads for scope and priorities but never rewrites during normal runs.
 - **No-op runs do not churn docs.** A clean update skips model work and leaves wiki content untouched while refreshing `.last-update.json` to record that the check ran.

--- a/examples/openwiki-update.bitbucket-pipelines.yml
+++ b/examples/openwiki-update.bitbucket-pipelines.yml
@@ -18,15 +18,20 @@ pipelines:
             - npm install --global openwiki mermaid@11.16.0 jsdom@29.1.1
             - git config user.name "${BITBUCKET_USER_NAME:-OpenWiki Bot}"
             - git config user.email "${BITBUCKET_USER_EMAIL:-openwiki@example.com}"
+            # Keep the managed AGENTS.md block naming this pipeline instead
+            # of a GitHub Actions workflow, and keep `openwiki --init` from
+            # writing one. Detection from the git remote covers bitbucket.org;
+            # set it explicitly for a self-hosted host that is not named for it.
+            - export OPENWIKI_CI_PROVIDER=bitbucket
             - openwiki code --update --print
             - |
-              if git diff --quiet -- openwiki AGENTS.md CLAUDE.md .github/workflows/openwiki-update.yml; then
+              if git diff --quiet -- openwiki AGENTS.md CLAUDE.md; then
                 echo "OpenWiki is already up to date."
                 exit 0
               fi
             - export OPENWIKI_BRANCH="openwiki/update-${BITBUCKET_BUILD_NUMBER}"
             - git checkout -b "$OPENWIKI_BRANCH"
-            - git add openwiki AGENTS.md CLAUDE.md .github/workflows/openwiki-update.yml
+            - git add openwiki AGENTS.md CLAUDE.md
             - git commit -m "docs: update OpenWiki"
             - git push "https://x-token-auth:${OPENWIKI_BITBUCKET_TOKEN}@bitbucket.org/${BITBUCKET_WORKSPACE}/${BITBUCKET_REPO_SLUG}.git" "$OPENWIKI_BRANCH"
             - |

--- a/examples/openwiki-update.gitlab-ci.yml
+++ b/examples/openwiki-update.gitlab-ci.yml
@@ -13,13 +13,13 @@ openwiki_update:
   script:
     - openwiki code --update --print
     - |
-      if git diff --quiet -- openwiki AGENTS.md CLAUDE.md .github/workflows/openwiki-update.yml; then
+      if git diff --quiet -- openwiki AGENTS.md CLAUDE.md; then
         echo "OpenWiki is already up to date."
         exit 0
       fi
     - export OPENWIKI_BRANCH="openwiki/update-${CI_PIPELINE_ID}"
     - git checkout -b "$OPENWIKI_BRANCH"
-    - git add openwiki AGENTS.md CLAUDE.md .github/workflows/openwiki-update.yml
+    - git add openwiki AGENTS.md CLAUDE.md
     - git commit -m "docs: update OpenWiki"
     - git push "https://oauth2:${OPENWIKI_GITLAB_TOKEN}@${CI_SERVER_HOST}/${CI_PROJECT_PATH}.git" "$OPENWIKI_BRANCH"
     - |
@@ -35,6 +35,11 @@ openwiki_update:
     # it last documented; GitLab's default shallow clone hides that commit and
     # the update runs against an empty change summary.
     GIT_DEPTH: "0"
+    # Keep the managed AGENTS.md block naming this pipeline instead of a
+    # GitHub Actions workflow, and keep `openwiki --init` from writing one.
+    # Detection from the git remote covers gitlab.com and any host named
+    # `gitlab*`; set it explicitly for a self-hosted instance that is not.
+    OPENWIKI_CI_PROVIDER: gitlab
     OPENWIKI_PROVIDER: openrouter
     OPENWIKI_MODEL_ID: z-ai/glm-5.2
     LANGCHAIN_PROJECT: openwiki

--- a/src/ingestion/code-mode.ts
+++ b/src/ingestion/code-mode.ts
@@ -1,5 +1,7 @@
+import { execFile } from "node:child_process";
 import { mkdir, readFile, writeFile } from "node:fs/promises";
 import path from "node:path";
+import { promisify } from "node:util";
 import {
   getProviderAuthMethod,
   getProviderConfig,
@@ -15,13 +17,33 @@ import { UPDATE_METADATA_PATH } from "../config/constants.js";
 import { createConnectorSynthesisGuidance } from "./ingestion.js";
 import type { OpenWikiRunEvent } from "../agent/types.js";
 
+const execFileAsync = promisify(execFile);
+
 const OPENWIKI_AGENTS_SNIPPET_START = "<!-- OPENWIKI:START -->";
 const OPENWIKI_AGENTS_SNIPPET_END = "<!-- OPENWIKI:END -->";
 const DEFAULT_CODE_MODE_CRON = "0 8 * * *";
 
+// Host detection is a nicety, not a dependency: a hung git must not stall setup.
+const GIT_TIMEOUT_MS = 10_000;
+
 // Root agent-instruction files OpenWiki keeps pointed at the generated wiki.
 // Each is created when missing and refreshed in place when already present.
 const CODE_MODE_AGENT_FILES = ["AGENTS.md", "CLAUDE.md"];
+
+/**
+ * The git host OpenWiki tailors its generated code-mode artifacts to. Only
+ * `github` has a workflow OpenWiki can commit (GitHub Actions); the other hosts
+ * ship as `examples/` the operator wires up, so all OpenWiki owes them is
+ * managed-snippet wording that names the right thing. `none` opts out of both.
+ */
+export type CodeModeCiProvider = "github" | "gitlab" | "bitbucket" | "none";
+
+/**
+ * Overrides host detection. Needed for a self-hosted instance whose hostname
+ * does not advertise its provider, and for opting out entirely
+ * (`OPENWIKI_CI_PROVIDER=none`) in a pipeline that manages its own pull requests.
+ */
+export const CI_PROVIDER_ENV_KEY = "OPENWIKI_CI_PROVIDER";
 
 /** Controls which parts of the repo OpenWiki sets up for code mode. */
 export interface CodeModeRepoSetupOptions {
@@ -35,30 +57,158 @@ export interface CodeModeRepoSetupOptions {
   /** Cron expression for a freshly created workflow. Defaults to {@link DEFAULT_CODE_MODE_CRON}. */
   cronExpression?: string;
   /**
-   * Environment the generated workflow's provider block is derived from.
-   * Defaults to `process.env`, which by this point holds the credentials setup
-   * resolved for this run.
+   * Environment the generated workflow's provider block and the
+   * {@link CI_PROVIDER_ENV_KEY} override are read from. Defaults to
+   * `process.env`, which by this point holds the credentials setup resolved for
+   * this run.
    */
   env?: NodeJS.ProcessEnv;
 }
 
 /**
  * Ensure the repo is set up for code mode: refresh the managed agent-instruction
- * snippets, and, when `options.createWorkflow` is set, create the scheduled-update
- * workflow if it does not already exist.
+ * snippets, and, when `options.createWorkflow` is set and the repository is
+ * hosted on GitHub, create the scheduled-update workflow if it does not already
+ * exist.
+ *
+ * Both halves are host-aware. A GitLab or Bitbucket repository has no use for a
+ * GitHub Actions workflow, and telling its agents that "the scheduled OpenWiki
+ * GitHub Actions workflow refreshes the repository wiki" states something the
+ * repo cannot do -- a correction that never sticks, because the managed block is
+ * rewritten on the next run.
  */
 export async function ensureCodeModeRepoSetup(
   cwd: string,
   options: CodeModeRepoSetupOptions = {},
 ): Promise<void> {
-  if (options.createWorkflow) {
+  const env = options.env ?? process.env;
+  const provider = await detectCiProvider(cwd, env);
+
+  if (options.createWorkflow && provider === "github") {
     await ensureCodeModeWorkflow(
       cwd,
       options.cronExpression ?? DEFAULT_CODE_MODE_CRON,
-      options.env ?? process.env,
+      env,
     );
   }
-  await writeCodeModeAgentSnippets(cwd);
+  await writeCodeModeAgentSnippets(cwd, provider);
+}
+
+/**
+ * Resolves the host OpenWiki generates for: the {@link CI_PROVIDER_ENV_KEY}
+ * override when it names a known one, otherwise the repository remote's host.
+ */
+async function detectCiProvider(
+  cwd: string,
+  env: NodeJS.ProcessEnv,
+): Promise<CodeModeCiProvider> {
+  return (
+    normalizeCiProvider(env[CI_PROVIDER_ENV_KEY]) ??
+    classifyRemoteHost(await readGitRemoteUrl(cwd))
+  );
+}
+
+/** The named provider, or null when the value is absent or unrecognized. */
+function normalizeCiProvider(
+  value: string | undefined,
+): CodeModeCiProvider | null {
+  switch (value?.trim().toLowerCase()) {
+    case "github":
+      return "github";
+    case "gitlab":
+      return "gitlab";
+    case "bitbucket":
+      return "bitbucket";
+    case "none":
+      return "none";
+    default:
+      // An unrecognized value falls through to detection rather than failing
+      // setup: a typo in a pipeline variable must not break the docs run.
+      return null;
+  }
+}
+
+/**
+ * The repository's remote URL, preferring `origin` and falling back to whichever
+ * remote exists. Null when this is not a git repository or has no remote.
+ */
+async function readGitRemoteUrl(cwd: string): Promise<string | null> {
+  const originUrl = await runGitQuietly(cwd, ["remote", "get-url", "origin"]);
+  if (originUrl) {
+    return originUrl;
+  }
+
+  const firstRemote = (await runGitQuietly(cwd, ["remote"]))
+    ?.split(/\r?\n/u)
+    .map((line) => line.trim())
+    .find(Boolean);
+
+  return firstRemote
+    ? runGitQuietly(cwd, ["remote", "get-url", firstRemote])
+    : null;
+}
+
+/** Git stdout, or null for any failure -- an undetectable host, never a throw. */
+async function runGitQuietly(
+  cwd: string,
+  args: string[],
+): Promise<string | null> {
+  try {
+    const { stdout } = await execFileAsync("git", args, {
+      cwd,
+      maxBuffer: 1024 * 1024,
+      timeout: GIT_TIMEOUT_MS,
+    });
+    return stdout.trim() || null;
+  } catch {
+    // No git binary, not a repository, or no such remote.
+    return null;
+  }
+}
+
+/**
+ * Classifies a remote by its **hostname only**. Matching the whole URL would
+ * misread a repository path -- `git@github.com:acme/gitlab-importer.git` is a
+ * GitHub repo -- while a hostname substring still catches the self-hosted
+ * instances that keep the product name in their host (`gitlab.acme.com`).
+ *
+ * An unrecognized host falls back to `github`, preserving the behavior every
+ * existing repo was set up under; {@link CI_PROVIDER_ENV_KEY} covers the rest.
+ */
+function classifyRemoteHost(remoteUrl: string | null): CodeModeCiProvider {
+  const host = remoteUrl === null ? null : parseRemoteHost(remoteUrl);
+  if (host === null) {
+    return "github";
+  }
+  if (host.includes("gitlab")) {
+    return "gitlab";
+  }
+  if (host.includes("bitbucket")) {
+    return "bitbucket";
+  }
+  return "github";
+}
+
+/**
+ * The lowercased hostname of a git remote URL, covering both the URL form
+ * (`https://host/owner/repo.git`, `ssh://git@host:22/owner/repo`) and the
+ * scp-like form (`git@host:owner/repo.git`), which is not a parseable URL.
+ * Null for a local path or anything else with no host to read.
+ */
+function parseRemoteHost(remoteUrl: string): string | null {
+  const trimmed = remoteUrl.trim();
+
+  // scp-like: an optional user, a host, then a colon that is not a port.
+  const scpLike = /^(?:[^@/]+@)?([^/:]+):(?!\/)/u.exec(trimmed);
+  if (scpLike?.[1] !== undefined) {
+    return scpLike[1].toLowerCase();
+  }
+
+  try {
+    return new URL(trimmed).hostname.toLowerCase() || null;
+  } catch {
+    return null;
+  }
 }
 
 /**
@@ -188,8 +338,11 @@ async function readLastUpdatedAt(
   }
 }
 
-async function writeCodeModeAgentSnippets(cwd: string): Promise<void> {
-  const agentsSnippet = createCodeModeAgentsSnippet();
+async function writeCodeModeAgentSnippets(
+  cwd: string,
+  provider: CodeModeCiProvider,
+): Promise<void> {
+  const agentsSnippet = createCodeModeAgentsSnippet(provider);
   const claudeSnippet = createCodeModeClaudeSnippet();
   const snippetByFile: Record<string, string> = {
     "AGENTS.md": agentsSnippet,
@@ -402,7 +555,7 @@ jobs:
 `;
 }
 
-function createCodeModeAgentsSnippet(): string {
+function createCodeModeAgentsSnippet(provider: CodeModeCiProvider): string {
   return `${OPENWIKI_AGENTS_SNIPPET_START}
 
 ## OpenWiki
@@ -412,9 +565,29 @@ This repository has a generated \`openwiki/\` evidence index. It is optional jus
 - Treat source code and tests as authoritative. A brief's unknowns and review items are verification gaps, not automatic requirements.
 - Prefer the narrowest quiet validation that proves the changed behavior. Preserve complete failure output.
 
-The scheduled OpenWiki GitHub Actions workflow refreshes the repository wiki. Do not hand-edit generated OpenWiki pages unless explicitly asked; prefer updating source code/docs and letting OpenWiki regenerate.
+The ${describeCodeModeUpdateJob(provider)} refreshes the repository wiki. Do not hand-edit generated OpenWiki pages unless explicitly asked; prefer updating source code/docs and letting OpenWiki regenerate.
 
 ${OPENWIKI_AGENTS_SNIPPET_END}`;
+}
+
+/**
+ * Names the recurring job in the managed block after the detected host, so the
+ * sentence is true on GitLab and Bitbucket instead of asserting a GitHub Actions
+ * run the repository has no way to perform.
+ */
+function describeCodeModeUpdateJob(provider: CodeModeCiProvider): string {
+  switch (provider) {
+    case "gitlab":
+      return "scheduled OpenWiki GitLab pipeline";
+    case "bitbucket":
+      return "scheduled OpenWiki Bitbucket pipeline";
+    case "github":
+      return "scheduled OpenWiki GitHub Actions workflow";
+    default:
+      // `none`, and any provider added later without a phrasing of its own: say
+      // only what holds for every host rather than naming the wrong one.
+      return "scheduled OpenWiki update job";
+  }
 }
 
 /**

--- a/test/ingestion/code-mode.test.ts
+++ b/test/ingestion/code-mode.test.ts
@@ -1,6 +1,8 @@
+import { execFile } from "node:child_process";
 import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
+import { promisify } from "node:util";
 import { afterEach, describe, expect, test } from "vitest";
 import { parse } from "yaml";
 import {
@@ -8,6 +10,8 @@ import {
   runCodeModeConnectors,
 } from "../../src/ingestion/code-mode.ts";
 import type { OpenWikiRunEvent } from "../../src/agent/types.ts";
+
+const execFileAsync = promisify(execFile);
 
 const SNIPPET_START = "<!-- OPENWIKI:START -->";
 const SNIPPET_END = "<!-- OPENWIKI:END -->";
@@ -550,5 +554,146 @@ describe("runCodeModeConnectors", () => {
     );
 
     expect(await runCodeModeConnectors(repo, "keep me")).toBe("keep me");
+  });
+});
+
+describe("ensureCodeModeRepoSetup host awareness", () => {
+  const WORKFLOW_RELATIVE_PATH = path.join(
+    ".github",
+    "workflows",
+    "openwiki-update.yml",
+  );
+
+  async function createTempRepoWithRemote(remoteUrl: string): Promise<string> {
+    const repo = await createTempRepo();
+    await execFileAsync("git", ["init", "--quiet"], { cwd: repo });
+    await execFileAsync("git", ["remote", "add", "origin", remoteUrl], {
+      cwd: repo,
+    });
+    return repo;
+  }
+
+  test.each([
+    { host: "gitlab", job: "scheduled OpenWiki GitLab pipeline" },
+    { host: "bitbucket", job: "scheduled OpenWiki Bitbucket pipeline" },
+    { host: "none", job: "scheduled OpenWiki update job" },
+  ])(
+    "skips the GitHub workflow and names the $host job in AGENTS.md",
+    async ({ host, job }) => {
+      const repo = await createTempRepo();
+
+      await ensureCodeModeRepoSetup(repo, {
+        createWorkflow: true,
+        env: { OPENWIKI_CI_PROVIDER: host },
+      });
+
+      // A GitHub Actions workflow this host cannot run is committed noise that
+      // the repo's own pipeline then has to scrub on every update.
+      expect(
+        await readIfPresent(path.join(repo, WORKFLOW_RELATIVE_PATH)),
+      ).toBeNull();
+      const agents = await readIfPresent(path.join(repo, "AGENTS.md"));
+      expect(agents).toContain(`The ${job} refreshes the repository wiki.`);
+      expect(agents).not.toContain("GitHub Actions");
+    },
+  );
+
+  test("detects the host from the repository remote", async () => {
+    const repo = await createTempRepoWithRemote(
+      "git@bitbucket.org:acme/widgets.git",
+    );
+
+    await ensureCodeModeRepoSetup(repo, { createWorkflow: true, env: {} });
+
+    expect(
+      await readIfPresent(path.join(repo, WORKFLOW_RELATIVE_PATH)),
+    ).toBeNull();
+    expect(await readIfPresent(path.join(repo, "AGENTS.md"))).toContain(
+      "scheduled OpenWiki Bitbucket pipeline",
+    );
+  });
+
+  test("reads the host, not the repository path, from the remote", async () => {
+    // `gitlab` in the project name says nothing about where the repo is hosted;
+    // matching the whole remote URL would mistake this GitHub repo for GitLab.
+    const repo = await createTempRepoWithRemote(
+      "git@github.com:acme/gitlab-importer.git",
+    );
+
+    await ensureCodeModeRepoSetup(repo, { createWorkflow: true, env: {} });
+
+    expect(
+      await readIfPresent(path.join(repo, WORKFLOW_RELATIVE_PATH)),
+    ).not.toBeNull();
+    expect(await readIfPresent(path.join(repo, "AGENTS.md"))).toContain(
+      "scheduled OpenWiki GitHub Actions workflow",
+    );
+  });
+
+  test("detects a self-hosted instance from its hostname", async () => {
+    const repo = await createTempRepoWithRemote(
+      "https://gitlab.acme.example/platform/widgets.git",
+    );
+
+    await ensureCodeModeRepoSetup(repo, { createWorkflow: true, env: {} });
+
+    expect(
+      await readIfPresent(path.join(repo, WORKFLOW_RELATIVE_PATH)),
+    ).toBeNull();
+    expect(await readIfPresent(path.join(repo, "AGENTS.md"))).toContain(
+      "scheduled OpenWiki GitLab pipeline",
+    );
+  });
+
+  test("prefers the environment override over the detected host", async () => {
+    const repo = await createTempRepoWithRemote(
+      "git@github.com:acme/widgets.git",
+    );
+
+    await ensureCodeModeRepoSetup(repo, {
+      createWorkflow: true,
+      env: { OPENWIKI_CI_PROVIDER: "none" },
+    });
+
+    expect(
+      await readIfPresent(path.join(repo, WORKFLOW_RELATIVE_PATH)),
+    ).toBeNull();
+    expect(await readIfPresent(path.join(repo, "AGENTS.md"))).toContain(
+      "scheduled OpenWiki update job",
+    );
+  });
+
+  test("falls back to GitHub when the host cannot be detected", async () => {
+    // The historical default: an unrecognized or absent remote keeps generating
+    // exactly what every repo set up before host detection already had.
+    const repo = await createTempRepoWithRemote(
+      "https://git.acme.example/platform/widgets.git",
+    );
+
+    await ensureCodeModeRepoSetup(repo, { createWorkflow: true, env: {} });
+
+    expect(
+      await readIfPresent(path.join(repo, WORKFLOW_RELATIVE_PATH)),
+    ).not.toBeNull();
+    expect(await readIfPresent(path.join(repo, "AGENTS.md"))).toContain(
+      "scheduled OpenWiki GitHub Actions workflow",
+    );
+  });
+
+  test("ignores an unrecognized override and detects instead", async () => {
+    const repo = await createTempRepoWithRemote(
+      "git@bitbucket.org:acme/widgets.git",
+    );
+
+    // A typo in a pipeline variable must not fail setup, nor silently pin the
+    // wording to the wrong host.
+    await ensureCodeModeRepoSetup(repo, {
+      createWorkflow: true,
+      env: { OPENWIKI_CI_PROVIDER: "bitbuckets" },
+    });
+
+    expect(await readIfPresent(path.join(repo, "AGENTS.md"))).toContain(
+      "scheduled OpenWiki Bitbucket pipeline",
+    );
   });
 });


### PR DESCRIPTION
## What and why

Fixes #341. Rebased onto current `main` and narrowed to what `main` does not already cover.

`main` has since fixed most of the workflow half by another route: `createWorkflow` is now gated on `mode === "init"`, and `ensureCodeModeWorkflow` returns early when the file exists, so `code --update` no longer reintroduces `.github/workflows/openwiki-update.yml`. What is left is what this PR fixes:

1. `code --init` still writes the GitHub Actions workflow on a GitLab or Bitbucket repository, which cannot run it.
2. The managed `<!-- OPENWIKI:START -->…<!-- OPENWIKI:END -->` block still says "The scheduled OpenWiki **GitHub Actions workflow** refreshes the repository wiki" on every host. On a non-GitHub repo that is false, and since the block is rewritten each run, a manual correction never survives (also reported independently in #820).

## What changed

- **`src/ingestion/code-mode.ts`**: resolve the host from the repository remote (`origin`, else any remote), overridable with `OPENWIKI_CI_PROVIDER=github|gitlab|bitbucket|none`.
  - Create the GitHub Actions workflow only when the host is GitHub — `--init` on GitLab/Bitbucket now leaves `.github/` alone.
  - Name the recurring job after the detected host: GitHub Actions workflow / GitLab pipeline / Bitbucket pipeline / a neutral "scheduled OpenWiki update job".
  - Detection reads the remote's **hostname only**, so `git@github.com:acme/gitlab-importer.git` stays GitHub while `gitlab.acme.com` is still recognized. An unrecognized host, an absent remote, an unrecognized override value, and a failed or timed-out `git` all fall back to GitHub — the behavior every existing repo was set up under. Detection never throws and is bounded by a 10s timeout.
- **`examples/`**: the GitLab and Bitbucket pipelines set `OPENWIKI_CI_PROVIDER` explicitly and stop tracking the GitHub workflow path OpenWiki no longer writes for them.
- **`README.md`**: documents detection and the override.

## Review comments from the previous round

- *"is it safe to match on the entire url?"* — no, and it is now fixed: `parseRemoteHost` extracts the hostname (URL form and scp-like `git@host:path` form) and only that is matched. `git@github.com:acme/gitlab-importer.git` is covered by a test.
- *"does this need a default case?"* — added. `describeCodeModeUpdateJob` falls through to the provider-neutral phrasing for `none` and for any host added later without wording of its own, so a new provider can never inherit the wrong name.

## Relationship to #835 and #742

#835 proposes **omitting** the sentence unless a `.github` workflow with an `on.schedule` trigger can be confirmed. That is strictly better than asserting something false, but a Bitbucket repo driven by a scheduled pipeline does have a schedule — it is just not visible under `.github` — so it ends up with no statement rather than a correct one. This PR keeps the claim and makes it true. The two are compatible: host detection here can render the sentence, with #835's workflow check deciding whether to state it at all, and either can fold into #742's persistent config shape. Happy to converge on whichever direction a maintainer prefers.

## Testing

- `test/ingestion/code-mode.test.ts`: workflow skipped and matching wording for gitlab/bitbucket/none; detection from a real git remote; hostname-not-path matching; self-hosted `gitlab.*` host; env override beating detection; unrecognized override falling through to detection; unknown host defaulting to GitHub.
- `pnpm run format:check`, `pnpm run lint:check`, `pnpm run typecheck` all clean.
- `pnpm test`: 3041 passed. The 6 failures are pre-existing on `main` in this environment (mermaid render timeouts and the openai-compatible transport tests) and reproduce with the branch's changes reverted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
