### PR TITLE
ci: fix repository posture checks

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,35 @@
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: monthly
+    groups:
+      minor-and-patch:
+        patterns:
+          - "*"
+        update-types:
+          - minor
+          - patch
+      major:
+        patterns:
+          - "*"
+        update-types:
+          - major
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: monthly
+    groups:
+      minor-and-patch:
+        patterns:
+          - "*"
+        update-types:
+          - minor
+          - patch
+      major:
+        patterns:
+          - "*"
+        update-types:
+          - major

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -1,6 +1,8 @@
 name: Checks
 
 on:
+  push:
+    branches: [main]
   pull_request:
 
 permissions:
@@ -63,8 +65,6 @@ jobs:
       matrix:
         include:
           - os: ubuntu-latest
-            node-version: "20"
-          - os: ubuntu-latest
             node-version: "22"
           - os: ubuntu-latest
             node-version: "24"
@@ -102,7 +102,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: ["20", "22", "24"]
+        node-version: ["22", "24"]
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
@@ -126,6 +126,9 @@ jobs:
 
   audit:
     name: Audit
+    permissions:
+      contents: read
+      security-events: write
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository
@@ -140,6 +143,14 @@ jobs:
           scan-type: fs
           scan-ref: .
           scanners: vuln
+          format: sarif
+          output: trivy-results.sarif
           severity: HIGH,CRITICAL
           exit-code: "1"
           ignore-unfixed: false
+
+      - name: Upload Trivy results to GitHub Security
+        if: always()
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: trivy-results.sarif

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "license": "MIT",
   "type": "module",
   "engines": {
-    "node": ">=20"
+    "node": ">=22"
   },
   "bin": {
     "openwiki": "./dist/cli.js"


### PR DESCRIPTION
## Summary
- add grouped monthly Dependabot updates for npm and GitHub Actions
- require and test supported Node.js versions only
- run Trivy on main pushes and upload SARIF results to code scanning

## Validation
- python YAML syntax and duplicate-key validation
- pnpm run format:check
- pnpm run typecheck

CodeQL is intentionally unchanged: GitHub default setup is configured with extended queries, weekly scans, and current successful analyses.