### PR TITLE
fix: keep scheduled OpenWiki updates opt-in on forks

### DIFF
--- a/.github/workflows/openwiki-update.yml
+++ b/.github/workflows/openwiki-update.yml
@@ -11,6 +11,12 @@ permissions:
 
 jobs:
   update:
+    # Scheduled runs only fire in the origin repo by default, so contributor
+    # forks do not silently arm a daily job that requires a provider secret.
+    # Fork owners can opt in without editing this file by setting the
+    # OPENWIKI_ENABLE_SCHEDULED_UPDATE repository variable to "true". Manual
+    # dispatch remains available for intentional runs and testing.
+    if: github.event_name == 'workflow_dispatch' || github.repository == 'langchain-ai/openwiki' || vars.OPENWIKI_ENABLE_SCHEDULED_UPDATE == 'true'
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository


### PR DESCRIPTION
Closes #369

## Summary

Restore the fork protection for scheduled OpenWiki updates that was introduced in #303 and removed by #179.

Scheduled runs now:

- Run normally in `langchain-ai/openwiki`.
- Skip on forks by default.
- Run on forks when `OPENWIKI_ENABLE_SCHEDULED_UPDATE=true`.

Manual `workflow_dispatch` runs remain available on both the upstream repository and forks.

## Why

Contributor forks usually do not have the `OPENROUTER_API_KEY` secret required by this workflow.

Without the guard, enabling Actions for contribution CI can also enable a daily OpenWiki update that repeatedly fails, even though the fork owner did not opt in to scheduled updates.

A manual run reproduced the execution path on my fork:

https://github.com/jyje/openwiki/actions/runs/29509927346

The manual dispatch itself is expected behavior. It demonstrates the failure that the scheduled job reaches on a fork without the required provider secret.

## Testing

- `actionlint .github/workflows/openwiki-update.yml`
- Prettier formatting check
- `git diff --check`

If explicitly allowing manual runs with `github.event_name == 'workflow_dispatch' ||` is not the preferred approach, please let me know and I will adjust it.
