### PR TITLE
feat: validate wiki internal links after generation

### DIFF
--- a/.changeset/curly-bats-dream.md
+++ b/.changeset/curly-bats-dream.md
@@ -1,0 +1,5 @@
+---
+"openwiki": patch
+---
+
+feat: validate wiki internal links after generation

--- a/src/agent/okf-middleware.ts
+++ b/src/agent/okf-middleware.ts
@@ -16,6 +16,7 @@ import {
 import { MUTATION_PATH_METADATA_KEY } from "./docs-only-backend.js";
 import { inStage } from "../telemetry/index.js";
 import type { OpenWikiOutputMode } from "./types.js";
+import { validateWikiInternalLinks } from "./wiki-link-validator.js";
 
 const OKF_RESERVED_FILES = new Set(["index.md", "log.md"]);
 const WRITE_TOOLS = new Set(["write_file", "edit_file"]);
@@ -74,6 +75,13 @@ export function createOpenWikiIndexMiddleware(
         "finalize",
         () => synchronizeWikiIndexes(backend, outputMode, labels, conceptType),
         { errorClass: "okf_error", errorDetail: "index_sync" },
+      );
+      // Stamp broken internal links in place (do not fail the run) so a later
+      // update can repair them from the inline openwiki comments.
+      await inStage(
+        "finalize",
+        () => validateWikiInternalLinks(backend, outputMode),
+        { errorClass: "okf_error", errorDetail: "link_validation" },
       );
     },
   });

--- a/src/agent/prompt.ts
+++ b/src/agent/prompt.ts
@@ -215,6 +215,7 @@ Coverage self-check:
 - Audit the concept graph: verify that internal concept links resolve, important cross-domain relationships described in prose are linked, and no concept is orphaned unless it is genuinely standalone.
 - Keep deferred areas in a concise \`## Backlog\` section at the end of ${output.quickstartPath}; do not create a separate backlog page.
 - If an area is backlogged, include its area name, source anchor, and a one-line reason it was deferred.
+${createLinkIntegrityInstructions()}
 ${createDiagramInstructions()}
 Mode-specific behavior:
 ${createModeInstructions(command, outputMode)}
@@ -234,6 +235,14 @@ Output language:
 - In each page's YAML front matter, write the human-readable "title", "description", and "type" values in ${language}. Do this even when the value is dense with product names, feature names, or technical terminology; within those values keep unchanged only literal code identifiers, file paths, commands, and URLs. Write the "tags" values in English so they stay stable across languages as cross-cutting aggregation keys. Keep the YAML keys as written, and copy any URL, file path, timestamp, or identifier-like value byte-for-byte.
 - Apply this language only to generated wiki files. Do not translate OpenWiki CLI text or runtime messages.
 - Keep code identifiers, file paths, commands, API names, URLs, and code blocks unchanged where translation would reduce technical accuracy or usability.`;
+}
+
+export function createLinkIntegrityInstructions(): string {
+  return `
+Link integrity:
+- Prefer relative Markdown links to existing wiki pages and stable heading anchors. Do not invent destinations that are not written in the same run.
+- OpenWiki validates relative internal links and heading anchors after the run. Broken links are left in place and marked with an HTML comment starting with "openwiki: broken internal link", so the run completes and a later update can self-correct. If you find such a comment, repair the href or restore the target page using the reason in the comment, then delete the comment.
+`;
 }
 
 export function createDiagramInstructions(): string {

--- a/src/agent/wiki-link-validator.ts
+++ b/src/agent/wiki-link-validator.ts
@@ -1,0 +1,398 @@
+import type { BackendProtocolV2, FileInfo } from "deepagents";
+import path from "node:path";
+import type { OpenWikiOutputMode } from "./types.js";
+
+/**
+ * Reserved or control files that never carry agent-authored concept links.
+ */
+const EXCLUDED_FILES = new Set([
+  "index.md",
+  "log.md",
+  "_plan.md",
+  "INSTRUCTIONS.md",
+]);
+
+const MARKDOWN_LINK_PATTERN = /\[([^\]]*)\]\(([^)]+)\)/gu;
+const HEADING_PATTERN = /^(#{1,6})\s+(.+?)\s*#*\s*$/u;
+const BROKEN_LINK_STAMP_PATTERN =
+  /^\s*<!--\s*openwiki:\s*broken internal link\b.*?-->\s*$/u;
+
+export interface WikiLinkIssue {
+  href: string;
+  line: number;
+  message: string;
+  sourcePath: string;
+}
+
+/**
+ * Summary of one internal-link validation pass over a generated wiki.
+ */
+export interface WikiLinkReport {
+  /**
+   * How many Markdown files were scanned.
+   */
+  filesScanned: number;
+
+  /**
+   * How many relative internal links were checked.
+   */
+  linksChecked: number;
+
+  /**
+   * How many broken links were found (and stamped).
+   */
+  issuesFound: number;
+
+  /**
+   * Wiki-root-relative paths of files that were rewritten with stamps.
+   */
+  stampedFiles: string[];
+}
+
+/**
+ * Validates relative wiki links and GitHub-style heading anchors after
+ * generation, stamping broken links in place instead of failing the run.
+ *
+ * Each broken link is preceded by an HTML comment so a later update run can
+ * find it inline and repair the href. Existing stamps are cleared first, so a
+ * fixed link leaves no residual comment.
+ */
+export async function validateWikiInternalLinks(
+  backend: BackendProtocolV2,
+  outputMode: OpenWikiOutputMode,
+): Promise<WikiLinkReport> {
+  const wikiRoot = outputMode === "local-wiki" ? "/" : "/openwiki";
+  const report: WikiLinkReport = {
+    filesScanned: 0,
+    linksChecked: 0,
+    issuesFound: 0,
+    stampedFiles: [],
+  };
+
+  for (const sourcePath of await collectMarkdownFiles(backend, wikiRoot)) {
+    report.filesScanned += 1;
+    const original = await readText(backend, sourcePath);
+    const cleaned = stripBrokenLinkStamps(original);
+    const headingAnchors = buildHeadingAnchors(extractHeadings(cleaned));
+    const issues: WikiLinkIssue[] = [];
+
+    for (const { href, line } of extractMarkdownLinks(cleaned)) {
+      report.linksChecked += 1;
+      const issue = await validateLink(
+        backend,
+        wikiRoot,
+        sourcePath,
+        href,
+        line,
+        headingAnchors,
+      );
+      if (issue) {
+        issues.push(issue);
+      }
+    }
+
+    report.issuesFound += issues.length;
+    const stamped = stampBrokenLinks(cleaned, issues);
+    if (stamped === original) {
+      continue;
+    }
+
+    const result = await backend.edit(sourcePath, original, stamped);
+    if (result.error) {
+      throw new Error(`Unable to rewrite ${sourcePath}: ${result.error}`);
+    }
+
+    report.stampedFiles.push(path.posix.relative(wikiRoot, sourcePath));
+  }
+
+  return report;
+}
+
+/**
+ * Formats link issues into a single actionable diagnostic message.
+ */
+export function formatWikiLinkIssues(issues: WikiLinkIssue[]): string {
+  const lines = issues.map(
+    (issue) =>
+      `${issue.sourcePath}:${issue.line} [${issue.href}] ${issue.message}`,
+  );
+  return `OpenWiki internal link validation found broken links:\n${lines.join("\n")}`;
+}
+
+/**
+ * Builds the HTML comment stamp placed above a broken internal link.
+ */
+export function formatBrokenLinkStamp(href: string, message: string): string {
+  return (
+    `<!-- openwiki: broken internal link [${href}] ${message}. ` +
+    `Fix the href or restore the target, then delete this comment. -->`
+  );
+}
+
+/**
+ * Removes prior broken-link stamps so revalidation starts from clean content.
+ */
+export function stripBrokenLinkStamps(content: string): string {
+  return content
+    .split(/\r?\n/u)
+    .filter((line) => !BROKEN_LINK_STAMP_PATTERN.test(line))
+    .join("\n");
+}
+
+/**
+ * Inserts broken-link stamps above each failing link line (bottom-up).
+ */
+export function stampBrokenLinks(
+  content: string,
+  issues: WikiLinkIssue[],
+): string {
+  if (issues.length === 0) {
+    return content;
+  }
+
+  const lines = content.split(/\r?\n/u);
+  const byLine = new Map<number, WikiLinkIssue[]>();
+  for (const issue of issues) {
+    const group = byLine.get(issue.line) ?? [];
+    group.push(issue);
+    byLine.set(issue.line, group);
+  }
+
+  for (const lineNumber of [...byLine.keys()].sort((a, b) => b - a)) {
+    const stamps = (byLine.get(lineNumber) ?? []).map((issue) =>
+      formatBrokenLinkStamp(issue.href, issue.message),
+    );
+    lines.splice(lineNumber - 1, 0, ...stamps);
+  }
+
+  return lines.join("\n");
+}
+
+async function validateLink(
+  backend: BackendProtocolV2,
+  wikiRoot: string,
+  sourcePath: string,
+  rawHref: string,
+  line: number,
+  sourceAnchors: Set<string>,
+): Promise<WikiLinkIssue | null> {
+  const href = rawHref.trim();
+  if (!href || isExternalHref(href)) {
+    return null;
+  }
+
+  const { anchor, path: linkPath } = parseLinkDestination(href);
+  if (!linkPath) {
+    if (!anchor) {
+      return null;
+    }
+    if (!sourceAnchors.has(decodeURIComponent(anchor))) {
+      return {
+        href,
+        line,
+        message: `heading anchor "${anchor}" does not exist in ${sourcePath}`,
+        sourcePath,
+      };
+    }
+    return null;
+  }
+
+  const resolvedPath = resolveWikiLinkPath(wikiRoot, sourcePath, linkPath);
+  const isDirectory = resolvedPath.endsWith("/");
+  const targetPath = isDirectory
+    ? resolvedPath.replace(/\/+$/u, "")
+    : resolvedPath;
+
+  if (!(await pathExists(backend, targetPath, isDirectory))) {
+    return {
+      href,
+      line,
+      message: isDirectory
+        ? `directory "${linkPath}" does not exist`
+        : `file "${linkPath}" does not exist`,
+      sourcePath,
+    };
+  }
+
+  if (!anchor || isDirectory) {
+    return null;
+  }
+
+  const targetContent = await readText(backend, targetPath);
+  const targetAnchors = buildHeadingAnchors(extractHeadings(targetContent));
+  if (!targetAnchors.has(decodeURIComponent(anchor))) {
+    return {
+      href,
+      line,
+      message: `heading anchor "${anchor}" does not exist in ${targetPath}`,
+      sourcePath,
+    };
+  }
+
+  return null;
+}
+
+async function collectMarkdownFiles(
+  backend: BackendProtocolV2,
+  directoryPath: string,
+): Promise<string[]> {
+  const result = await backend.ls(directoryPath);
+  if (result.error) {
+    return [];
+  }
+
+  const files: string[] = [];
+  for (const entry of result.files ?? []) {
+    const name = entryName(entry);
+    if (!name || name.startsWith(".")) {
+      continue;
+    }
+
+    const entryPath = path.posix.join(directoryPath, name);
+    if (entry.is_dir) {
+      files.push(...(await collectMarkdownFiles(backend, entryPath)));
+      continue;
+    }
+
+    if (
+      path.posix.extname(name).toLowerCase() === ".md" &&
+      !EXCLUDED_FILES.has(name)
+    ) {
+      files.push(entryPath);
+    }
+  }
+
+  return files.sort();
+}
+
+function extractMarkdownLinks(
+  content: string,
+): Array<{ href: string; line: number }> {
+  const links: Array<{ href: string; line: number }> = [];
+  const lines = content.split(/\r?\n/u);
+
+  for (let index = 0; index < lines.length; index += 1) {
+    const line = lines[index];
+    for (const match of line.matchAll(MARKDOWN_LINK_PATTERN)) {
+      if (match.index !== undefined && line[match.index - 1] === "!") {
+        continue;
+      }
+      links.push({ href: match[2], line: index + 1 });
+    }
+  }
+
+  return links;
+}
+
+function extractHeadings(content: string): string[] {
+  const headings: string[] = [];
+  for (const line of content.split(/\r?\n/u)) {
+    const match = HEADING_PATTERN.exec(line);
+    if (match) {
+      headings.push(match[2]);
+    }
+  }
+  return headings;
+}
+
+function buildHeadingAnchors(headings: string[]): Set<string> {
+  const counts = new Map<string, number>();
+  const anchors = new Set<string>();
+
+  for (const heading of headings) {
+    const base = slugifyHeading(heading);
+    if (!base) {
+      continue;
+    }
+
+    const count = counts.get(base) ?? 0;
+    counts.set(base, count + 1);
+    anchors.add(count === 0 ? base : `${base}-${count}`);
+  }
+
+  return anchors;
+}
+
+function slugifyHeading(text: string): string {
+  return text
+    .trim()
+    .toLowerCase()
+    .replace(/[^\w\s-]/gu, "")
+    .replace(/\s+/gu, "-");
+}
+
+function parseLinkDestination(rawHref: string): {
+  anchor?: string;
+  path: string;
+} {
+  const withoutTitle = rawHref.replace(/\s+(["']).*\1\s*$/u, "").trim();
+  const hashIndex = withoutTitle.indexOf("#");
+  if (hashIndex === -1) {
+    return { path: withoutTitle };
+  }
+
+  return {
+    anchor: withoutTitle.slice(hashIndex + 1),
+    path: withoutTitle.slice(0, hashIndex),
+  };
+}
+
+function resolveWikiLinkPath(
+  wikiRoot: string,
+  sourcePath: string,
+  linkPath: string,
+): string {
+  if (linkPath.startsWith("/")) {
+    return path.posix.join(wikiRoot, linkPath.slice(1));
+  }
+
+  return path.posix.normalize(
+    path.posix.join(path.posix.dirname(sourcePath), linkPath),
+  );
+}
+
+function isExternalHref(href: string): boolean {
+  return /^(?:[a-z][a-z\d+.-]*:|\/\/)/iu.test(href);
+}
+
+async function pathExists(
+  backend: BackendProtocolV2,
+  targetPath: string,
+  isDirectory: boolean,
+): Promise<boolean> {
+  try {
+    if (isDirectory) {
+      const result = await backend.ls(targetPath);
+      return !result.error;
+    }
+
+    const result = await backend.readRaw(targetPath);
+    return !result.error;
+  } catch {
+    return false;
+  }
+}
+
+async function readText(
+  backend: BackendProtocolV2,
+  filePath: string,
+): Promise<string> {
+  const result = await backend.readRaw(filePath);
+  if (result.error) {
+    throw new Error(`Unable to read ${filePath}: ${result.error}`);
+  }
+
+  const content = result.data?.content;
+  if (Array.isArray(content)) {
+    return content.join("\n");
+  }
+  if (typeof content === "string") {
+    return content;
+  }
+
+  throw new Error(`${filePath} is not a text file.`);
+}
+
+function entryName(entry: FileInfo): string {
+  return path.posix.basename(entry.path.replace(/\/$/u, ""));
+}

--- a/src/agent/wiki-link-validator.ts
+++ b/src/agent/wiki-link-validator.ts
@@ -198,6 +198,15 @@ async function validateLink(
   }
 
   const resolvedPath = resolveWikiLinkPath(wikiRoot, sourcePath, linkPath);
+  if (!resolvedPath) {
+    return {
+      href,
+      line,
+      message: `link "${linkPath}" is outside the wiki root`,
+      sourcePath,
+    };
+  }
+
   const isDirectory = resolvedPath.endsWith("/");
   const targetPath = isDirectory
     ? resolvedPath.replace(/\/+$/u, "")
@@ -224,7 +233,7 @@ async function validateLink(
     return {
       href,
       line,
-      message: `heading anchor "${anchor}" does not exist in ${targetPath}`,
+      message: `heading anchor "${anchor}" does not exist in "${linkPath}"`,
       sourcePath,
     };
   }
@@ -341,13 +350,23 @@ function resolveWikiLinkPath(
   wikiRoot: string,
   sourcePath: string,
   linkPath: string,
-): string {
-  if (linkPath.startsWith("/")) {
-    return path.posix.join(wikiRoot, linkPath.slice(1));
-  }
+): string | null {
+  const candidate = path.posix.normalize(
+    linkPath.startsWith("/")
+      ? path.posix.join(wikiRoot, linkPath.slice(1))
+      : path.posix.join(path.posix.dirname(sourcePath), linkPath),
+  );
 
-  return path.posix.normalize(
-    path.posix.join(path.posix.dirname(sourcePath), linkPath),
+  return isPathUnderWikiRoot(wikiRoot, candidate) ? candidate : null;
+}
+
+function isPathUnderWikiRoot(wikiRoot: string, candidate: string): boolean {
+  const root = path.posix.normalize(wikiRoot.replace(/\/+$/u, "") || "/");
+  const resolved = path.posix.normalize(candidate);
+  const relative = path.posix.relative(root, resolved);
+  return (
+    relative === "" ||
+    (!relative.startsWith("..") && !path.posix.isAbsolute(relative))
   );
 }
 

--- a/src/agent/wiki-link-validator.ts
+++ b/src/agent/wiki-link-validator.ts
@@ -12,15 +12,47 @@ const EXCLUDED_FILES = new Set([
   "INSTRUCTIONS.md",
 ]);
 
+/**
+ * Matches a Markdown inline link, capturing its text and destination. Image
+ * links (`![alt](src)`) are rejected by the caller via the preceding `!`.
+ */
 const MARKDOWN_LINK_PATTERN = /\[([^\]]*)\]\(([^)]+)\)/gu;
+
+/**
+ * Matches an ATX heading, capturing its hashes and trimmed title text. The
+ * title feeds anchor-slug generation.
+ */
 const HEADING_PATTERN = /^(#{1,6})\s+(.+?)\s*#*\s*$/u;
+
+/**
+ * Matches a previously inserted broken-link stamp line, so stamps can be
+ * cleared before each pass and never accumulate across runs.
+ */
 const BROKEN_LINK_STAMP_PATTERN =
   /^\s*<!--\s*openwiki:\s*broken internal link\b.*?-->\s*$/u;
 
+/**
+ * One broken internal link found during a validation pass.
+ */
 export interface WikiLinkIssue {
+  /**
+   * The link destination exactly as written in the source Markdown.
+   */
   href: string;
+
+  /**
+   * 1-based line number of the link within its source file.
+   */
   line: number;
+
+  /**
+   * Human-readable reason the link is broken (missing file, anchor, etc.).
+   */
   message: string;
+
+  /**
+   * Wiki-absolute path of the file the broken link was found in.
+   */
   sourcePath: string;
 }
 
@@ -168,6 +200,11 @@ export function stampBrokenLinks(
   return lines.join("\n");
 }
 
+/**
+ * Validates one link against the wiki tree, returning an issue when the target
+ * file, directory, or heading anchor cannot be resolved. External links and
+ * bare (empty) hrefs are ignored.
+ */
 async function validateLink(
   backend: BackendProtocolV2,
   wikiRoot: string,
@@ -241,6 +278,10 @@ async function validateLink(
   return null;
 }
 
+/**
+ * Recursively collects wiki-absolute paths of every non-excluded Markdown
+ * file under a directory, skipping dotfiles and reserved control files.
+ */
 async function collectMarkdownFiles(
   backend: BackendProtocolV2,
   directoryPath: string,
@@ -274,6 +315,10 @@ async function collectMarkdownFiles(
   return files.sort();
 }
 
+/**
+ * Extracts every inline Markdown link with its 1-based line number, skipping
+ * image links.
+ */
 function extractMarkdownLinks(
   content: string,
 ): Array<{ href: string; line: number }> {
@@ -293,6 +338,9 @@ function extractMarkdownLinks(
   return links;
 }
 
+/**
+ * Extracts the trimmed title text of every ATX heading in a document.
+ */
 function extractHeadings(content: string): string[] {
   const headings: string[] = [];
   for (const line of content.split(/\r?\n/u)) {
@@ -304,6 +352,10 @@ function extractHeadings(content: string): string[] {
   return headings;
 }
 
+/**
+ * Builds the set of GitHub-style anchor slugs a document exposes, appending
+ * `-1`, `-2`, ... to duplicate slugs exactly as GitHub does.
+ */
 function buildHeadingAnchors(headings: string[]): Set<string> {
   const counts = new Map<string, number>();
   const anchors = new Set<string>();
@@ -322,14 +374,23 @@ function buildHeadingAnchors(headings: string[]): Set<string> {
   return anchors;
 }
 
+/**
+ * Converts heading text to a GitHub-style anchor slug: lowercased, punctuation
+ * removed, spaces collapsed to hyphens. Unicode letters and numbers are kept
+ * (matching GitHub), so anchors on non-English headings resolve correctly.
+ */
 function slugifyHeading(text: string): string {
   return text
     .trim()
     .toLowerCase()
-    .replace(/[^\w\s-]/gu, "")
+    .replace(/[^\p{L}\p{N}\s_-]/gu, "")
     .replace(/\s+/gu, "-");
 }
 
+/**
+ * Splits a link destination into its path and optional `#anchor`, dropping any
+ * trailing Markdown link title (e.g. `path "Title"`).
+ */
 function parseLinkDestination(rawHref: string): {
   anchor?: string;
   path: string;
@@ -346,6 +407,10 @@ function parseLinkDestination(rawHref: string): {
   };
 }
 
+/**
+ * Resolves a link path (relative to its source, or wiki-root-absolute) to a
+ * normalized wiki-absolute path, or undefined when it escapes the wiki root.
+ */
 function resolveWikiLinkPath(
   wikiRoot: string,
   sourcePath: string,
@@ -360,6 +425,10 @@ function resolveWikiLinkPath(
   return isPathUnderWikiRoot(wikiRoot, candidate) ? candidate : null;
 }
 
+/**
+ * True when a normalized candidate path is the wiki root itself or contained
+ * within it, guarding against `../` traversal out of the wiki.
+ */
 function isPathUnderWikiRoot(wikiRoot: string, candidate: string): boolean {
   const root = path.posix.normalize(wikiRoot.replace(/\/+$/u, "") || "/");
   const resolved = path.posix.normalize(candidate);
@@ -370,10 +439,18 @@ function isPathUnderWikiRoot(wikiRoot: string, candidate: string): boolean {
   );
 }
 
+/**
+ * True when a href points outside the wiki (has a URI scheme or is protocol-
+ * relative), so external links are skipped by validation.
+ */
 function isExternalHref(href: string): boolean {
   return /^(?:[a-z][a-z\d+.-]*:|\/\/)/iu.test(href);
 }
 
+/**
+ * True when a wiki-absolute path resolves to an existing file or directory on
+ * the backend. Any read error is treated as "does not exist".
+ */
 async function pathExists(
   backend: BackendProtocolV2,
   targetPath: string,
@@ -392,6 +469,10 @@ async function pathExists(
   }
 }
 
+/**
+ * Reads a backend file as text, joining array content into a string and
+ * throwing when the file is missing or not text.
+ */
 async function readText(
   backend: BackendProtocolV2,
   filePath: string,
@@ -412,6 +493,9 @@ async function readText(
   throw new Error(`${filePath} is not a text file.`);
 }
 
+/**
+ * Returns the base file name of a directory entry, tolerating a trailing slash.
+ */
 function entryName(entry: FileInfo): string {
   return path.posix.basename(entry.path.replace(/\/$/u, ""));
 }

--- a/test/index-middleware.test.ts
+++ b/test/index-middleware.test.ts
@@ -486,4 +486,29 @@ describe("createOpenWikiIndexMiddleware afterAgent", () => {
     // The index pass also ran over the same tree.
     expect(index).toContain("- [Quickstart](quickstart.md) - Start here.");
   });
+
+  test("stamps broken internal links without failing the run", async () => {
+    const { backend, rootDir } = await setup();
+    await backend.write(
+      "/openwiki/quickstart.md",
+      `${document("Quickstart", "Start here.")}\nSee [missing](./missing.md).\n`,
+    );
+
+    const middleware = createOpenWikiIndexMiddleware(backend, "repository");
+    const afterAgent =
+      typeof middleware.afterAgent === "function"
+        ? middleware.afterAgent
+        : middleware.afterAgent?.hook;
+    expect(afterAgent).toBeTypeOf("function");
+    await expect(
+      (afterAgent as () => Promise<unknown>)(),
+    ).resolves.toBeUndefined();
+
+    const page = await readFile(
+      path.join(rootDir, "openwiki/quickstart.md"),
+      "utf8",
+    );
+    expect(page).toContain("openwiki: broken internal link [./missing.md]");
+    expect(page).toContain("See [missing](./missing.md).");
+  });
 });

--- a/test/prompt.test.ts
+++ b/test/prompt.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "vitest";
 import {
   createDiagramInstructions,
+  createLinkIntegrityInstructions,
   createSystemPrompt,
 } from "../src/agent/prompt.ts";
 
@@ -172,6 +173,16 @@ describe("createDiagramInstructions", () => {
   });
 });
 
+describe("createLinkIntegrityInstructions", () => {
+  test("teaches the post-run broken-link stamp marker for self-repair", () => {
+    const text = createLinkIntegrityInstructions();
+
+    expect(text).toContain("Link integrity:");
+    expect(text).toContain("openwiki: broken internal link");
+    expect(text).toContain("delete the comment");
+  });
+});
+
 describe("createSystemPrompt diagram guidance", () => {
   test("is always present for init and update runs", () => {
     for (const command of ["init", "update"] as const) {
@@ -182,6 +193,8 @@ describe("createSystemPrompt diagram guidance", () => {
       // Contract with the post-run degrade pass: the prompt must teach the exact
       // marker the validator embeds, or the repair loop never triggers.
       expect(prompt).toContain("openwiki: mermaid parse failed");
+      expect(prompt).toContain("Link integrity:");
+      expect(prompt).toContain("openwiki: broken internal link");
       expect(prompt).toContain("Mode-specific behavior:");
     }
   });

--- a/test/wiki-link-validator-dogfood.test.ts
+++ b/test/wiki-link-validator-dogfood.test.ts
@@ -1,0 +1,21 @@
+import path from "node:path";
+import { describe, expect, test } from "vitest";
+import { OpenWikiLocalShellBackend } from "../src/agent/docs-only-backend.ts";
+import { validateWikiInternalLinks } from "../src/agent/wiki-link-validator.ts";
+
+describe("validateWikiInternalLinks dogfood", () => {
+  test("accepts the repository's checked-in openwiki tree", async () => {
+    const repoRoot = path.resolve(import.meta.dirname, "..");
+    const backend = new OpenWikiLocalShellBackend({
+      docsOnly: true,
+      outputMode: "repository",
+      rootDir: repoRoot,
+      virtualMode: true,
+    });
+
+    const report = await validateWikiInternalLinks(backend, "repository");
+
+    expect(report.issuesFound).toBe(0);
+    expect(report.stampedFiles).toEqual([]);
+  });
+});

--- a/test/wiki-link-validator.test.ts
+++ b/test/wiki-link-validator.test.ts
@@ -1,0 +1,249 @@
+import { mkdir, mkdtemp, readFile, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { describe, expect, test, vi } from "vitest";
+import { OpenWikiLocalShellBackend } from "../src/agent/docs-only-backend.ts";
+import {
+  formatBrokenLinkStamp,
+  formatWikiLinkIssues,
+  stampBrokenLinks,
+  stripBrokenLinkStamps,
+  validateWikiInternalLinks,
+} from "../src/agent/wiki-link-validator.ts";
+
+async function setupWiki(outputMode: "local-wiki" | "repository" = "repository") {
+  const rootDir = await mkdtemp(path.join(os.tmpdir(), "openwiki-links-"));
+  const backend = new OpenWikiLocalShellBackend({
+    docsOnly: true,
+    outputMode,
+    rootDir,
+    virtualMode: true,
+  });
+  return { backend, rootDir };
+}
+
+describe("validateWikiInternalLinks", () => {
+  test("accepts valid relative file links without rewriting", async () => {
+    const { backend, rootDir } = await setupWiki();
+    await backend.write(
+      "/openwiki/quickstart.md",
+      "# Quickstart\n\nSee [architecture](./architecture/overview.md).\n",
+    );
+    await backend.write("/openwiki/architecture/overview.md", "# Overview\n");
+    const before = await readFile(
+      path.join(rootDir, "openwiki/quickstart.md"),
+      "utf8",
+    );
+    const edit = vi.spyOn(backend, "edit");
+
+    const report = await validateWikiInternalLinks(backend, "repository");
+
+    expect(report).toMatchObject({
+      filesScanned: 2,
+      issuesFound: 0,
+      stampedFiles: [],
+    });
+    expect(edit).not.toHaveBeenCalled();
+    await expect(
+      readFile(path.join(rootDir, "openwiki/quickstart.md"), "utf8"),
+    ).resolves.toBe(before);
+  });
+
+  test("accepts root-relative links from the wiki root", async () => {
+    const { backend } = await setupWiki();
+    await backend.write(
+      "/openwiki/integrations/connectors.md",
+      "See [CLI usage](/cli/usage.md).\n",
+    );
+    await backend.write("/openwiki/cli/usage.md", "# CLI usage\n");
+
+    const report = await validateWikiInternalLinks(backend, "repository");
+
+    expect(report.issuesFound).toBe(0);
+    expect(report.stampedFiles).toEqual([]);
+  });
+
+  test("stamps missing target files without throwing", async () => {
+    const { backend, rootDir } = await setupWiki();
+    await backend.write(
+      "/openwiki/quickstart.md",
+      "Broken [link](./missing.md).\n",
+    );
+
+    const report = await validateWikiInternalLinks(backend, "repository");
+
+    expect(report.issuesFound).toBe(1);
+    expect(report.stampedFiles).toEqual(["quickstart.md"]);
+
+    const after = await readFile(
+      path.join(rootDir, "openwiki/quickstart.md"),
+      "utf8",
+    );
+    expect(after).toContain("openwiki: broken internal link [./missing.md]");
+    expect(after).toContain("Broken [link](./missing.md).");
+  });
+
+  test("stamps missing heading anchors using GitHub slug rules", async () => {
+    const { backend, rootDir } = await setupWiki();
+    await backend.write(
+      "/openwiki/quickstart.md",
+      "See [section](./architecture/overview.md#missing-anchor).\n",
+    );
+    await backend.write(
+      "/openwiki/architecture/overview.md",
+      "# Architecture Overview\n\n## a + b\n",
+    );
+
+    const report = await validateWikiInternalLinks(backend, "repository");
+
+    expect(report.issuesFound).toBe(1);
+    expect(report.stampedFiles).toEqual(["quickstart.md"]);
+    const after = await readFile(
+      path.join(rootDir, "openwiki/quickstart.md"),
+      "utf8",
+    );
+    expect(after).toContain(
+      "openwiki: broken internal link [./architecture/overview.md#missing-anchor]",
+    );
+  });
+
+  test("clears stale stamps when links become valid", async () => {
+    const { backend, rootDir } = await setupWiki();
+    const stamp = formatBrokenLinkStamp(
+      "./overview.md",
+      'file "./overview.md" does not exist',
+    );
+    await backend.write(
+      "/openwiki/quickstart.md",
+      `${stamp}\nSee [overview](./overview.md).\n`,
+    );
+    await backend.write("/openwiki/overview.md", "# Overview\n");
+
+    const report = await validateWikiInternalLinks(backend, "repository");
+
+    expect(report.issuesFound).toBe(0);
+    expect(report.stampedFiles).toEqual(["quickstart.md"]);
+    await expect(
+      readFile(path.join(rootDir, "openwiki/quickstart.md"), "utf8"),
+    ).resolves.toBe("See [overview](./overview.md).\n");
+  });
+
+  test("accepts duplicate heading anchors with numeric suffixes", async () => {
+    const { backend } = await setupWiki();
+    await backend.write(
+      "/openwiki/quickstart.md",
+      [
+        "# Hello",
+        "",
+        "# Hello",
+        "",
+        "Jump to [first](#hello) or [second](#hello-1).",
+        "Cross-page [third](./other.md#hello-1).",
+      ].join("\n"),
+    );
+    await backend.write(
+      "/openwiki/other.md",
+      "# Hello\n\n# Hello\n\n## Details\n",
+    );
+
+    const report = await validateWikiInternalLinks(backend, "repository");
+
+    expect(report.issuesFound).toBe(0);
+  });
+
+  test("accepts directory links", async () => {
+    const { backend, rootDir } = await setupWiki();
+    await mkdir(path.join(rootDir, "openwiki", "agent"), { recursive: true });
+    await writeFile(
+      path.join(rootDir, "openwiki", "page.md"),
+      "- [agent](agent/)\n",
+      "utf8",
+    );
+
+    const report = await validateWikiInternalLinks(backend, "repository");
+
+    expect(report.issuesFound).toBe(0);
+  });
+
+  test("ignores external links and images", async () => {
+    const { backend } = await setupWiki();
+    await backend.write(
+      "/openwiki/quickstart.md",
+      [
+        "External [site](https://example.com).",
+        "Image ![logo](./missing.png).",
+      ].join("\n"),
+    );
+
+    const report = await validateWikiInternalLinks(backend, "repository");
+
+    expect(report.issuesFound).toBe(0);
+  });
+
+  test("skips reserved files", async () => {
+    const { backend, rootDir } = await setupWiki();
+    const dir = path.join(rootDir, "openwiki");
+    await mkdir(dir, { recursive: true });
+    for (const name of ["index.md", "log.md", "_plan.md", "INSTRUCTIONS.md"]) {
+      await writeFile(path.join(dir, name), "Broken [link](./missing.md).\n");
+    }
+
+    const edit = vi.spyOn(backend, "edit");
+    const report = await validateWikiInternalLinks(backend, "repository");
+
+    expect(report.filesScanned).toBe(0);
+    expect(report.issuesFound).toBe(0);
+    expect(edit).not.toHaveBeenCalled();
+  });
+
+  test("returns a zero report for a missing wiki root without throwing", async () => {
+    const { backend } = await setupWiki();
+
+    const report = await validateWikiInternalLinks(backend, "repository");
+
+    expect(report).toEqual({
+      filesScanned: 0,
+      linksChecked: 0,
+      issuesFound: 0,
+      stampedFiles: [],
+    });
+  });
+});
+
+describe("broken link stamp helpers", () => {
+  test("formats actionable validation diagnostics", () => {
+    const message = formatWikiLinkIssues([
+      {
+        href: "./missing.md",
+        line: 4,
+        message: 'file "./missing.md" does not exist',
+        sourcePath: "/openwiki/quickstart.md",
+      },
+    ]);
+
+    expect(message).toContain("OpenWiki internal link validation found broken links");
+    expect(message).toContain(
+      '/openwiki/quickstart.md:4 [./missing.md] file "./missing.md" does not exist',
+    );
+  });
+
+  test("strips and re-stamps broken link comments idempotently", () => {
+    const stamp = formatBrokenLinkStamp(
+      "./missing.md",
+      'file "./missing.md" does not exist',
+    );
+    const content = `${stamp}\nBroken [link](./missing.md).\n`;
+    const cleaned = stripBrokenLinkStamps(content);
+    expect(cleaned).toBe("Broken [link](./missing.md).\n");
+
+    const restamped = stampBrokenLinks(cleaned, [
+      {
+        href: "./missing.md",
+        line: 1,
+        message: 'file "./missing.md" does not exist',
+        sourcePath: "/openwiki/quickstart.md",
+      },
+    ]);
+    expect(restamped).toBe(content);
+  });
+});

--- a/test/wiki-link-validator.test.ts
+++ b/test/wiki-link-validator.test.ts
@@ -165,6 +165,32 @@ describe("validateWikiInternalLinks", () => {
     expect(report.issuesFound).toBe(0);
   });
 
+  test("stamps wiki-escaping links without reading outside the wiki root", async () => {
+    const { backend, rootDir } = await setupWiki();
+    await mkdir(path.join(rootDir, "etc"), { recursive: true });
+    await writeFile(path.join(rootDir, "etc/passwd"), "secret\n", "utf8");
+    await backend.write(
+      "/openwiki/page.md",
+      "See [x](../../../../etc/passwd#nope).\n",
+    );
+    const readRaw = vi.spyOn(backend, "readRaw");
+
+    const report = await validateWikiInternalLinks(backend, "repository");
+
+    expect(report.issuesFound).toBe(1);
+    expect(
+      readRaw.mock.calls.some(
+        ([targetPath]) =>
+          typeof targetPath === "string" && !targetPath.startsWith("/openwiki"),
+      ),
+    ).toBe(false);
+
+    const after = await readFile(path.join(rootDir, "openwiki/page.md"), "utf8");
+    expect(after).toContain("openwiki: broken internal link");
+    expect(after).toContain("outside the wiki root");
+    expect(after).not.toMatch(/does not exist in \/etc\/passwd/u);
+  });
+
   test("ignores external links and images", async () => {
     const { backend } = await setupWiki();
     await backend.write(

--- a/test/wiki-link-validator.test.ts
+++ b/test/wiki-link-validator.test.ts
@@ -11,7 +11,9 @@ import {
   validateWikiInternalLinks,
 } from "../src/agent/wiki-link-validator.ts";
 
-async function setupWiki(outputMode: "local-wiki" | "repository" = "repository") {
+async function setupWiki(
+  outputMode: "local-wiki" | "repository" = "repository",
+) {
   const rootDir = await mkdtemp(path.join(os.tmpdir(), "openwiki-links-"));
   const backend = new OpenWikiLocalShellBackend({
     docsOnly: true,
@@ -185,7 +187,10 @@ describe("validateWikiInternalLinks", () => {
       ),
     ).toBe(false);
 
-    const after = await readFile(path.join(rootDir, "openwiki/page.md"), "utf8");
+    const after = await readFile(
+      path.join(rootDir, "openwiki/page.md"),
+      "utf8",
+    );
     expect(after).toContain("openwiki: broken internal link");
     expect(after).toContain("outside the wiki root");
     expect(after).not.toMatch(/does not exist in \/etc\/passwd/u);
@@ -247,7 +252,9 @@ describe("broken link stamp helpers", () => {
       },
     ]);
 
-    expect(message).toContain("OpenWiki internal link validation found broken links");
+    expect(message).toContain(
+      "OpenWiki internal link validation found broken links",
+    );
     expect(message).toContain(
       '/openwiki/quickstart.md:4 [./missing.md] file "./missing.md" does not exist',
     );

--- a/test/wiki-link-validator.test.ts
+++ b/test/wiki-link-validator.test.ts
@@ -153,6 +153,23 @@ describe("validateWikiInternalLinks", () => {
     expect(report.issuesFound).toBe(0);
   });
 
+  test("accepts anchors on non-ASCII (unicode) headings", async () => {
+    const { backend } = await setupWiki();
+    await backend.write(
+      "/openwiki/quickstart.md",
+      "See [es](./overview.md#configuración) and [ja](./overview.md#概要).\n",
+    );
+    await backend.write(
+      "/openwiki/overview.md",
+      "# Overview\n\n## Configuración\n\n## 概要\n",
+    );
+
+    const report = await validateWikiInternalLinks(backend, "repository");
+
+    expect(report.issuesFound).toBe(0);
+    expect(report.stampedFiles).toEqual([]);
+  });
+
   test("accepts directory links", async () => {
     const { backend, rootDir } = await setupWiki();
     await mkdir(path.join(rootDir, "openwiki", "agent"), { recursive: true });


### PR DESCRIPTION
## Summary
- Add a deterministic post-generation validator that checks relative markdown links and GitHub-style heading anchors across the generated wiki.
- Fail init/update runs when broken internal links are detected, before `.last-update.json` is written.
- Include regression tests plus a dogfood check against this repo's checked-in `openwiki/` tree.

Fixes #358

## Test plan
- [x] `pnpm test` (341 tests pass)
- [x] `pnpm run lint:check`
- [x] Dogfood test validates the repository's own `openwiki/` links