### PR TITLE
Add claude-cli provider write guard

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,4 +1,25 @@
-## OpenWiki
+# argus-wiki
+
+Light-touch fork of [langchain-ai/openwiki](https://github.com/langchain-ai/openwiki), retargeted at the CONTEXT/CORTEX Obsidian vaults instead of a fresh `~/.openwiki` tree.
+
+## Remotes
+
+- `origin` → `deanjstone/argus-wiki` (this fork)
+- `upstream` → `langchain-ai/openwiki` (pull periodically: `git fetch upstream && git merge upstream/main`)
+
+## Local divergence from upstream
+
+- `src/constants.ts` / `src/openwiki-home.ts` — `OPEN_WIKI_DIR` and `openWikiHomeDir` are env-overridable (`OPENWIKI_OUTPUT_DIR`, `OPENWIKI_HOME`), defaulting to upstream's original paths when unset. Kept small to stay low-conflict against future upstream merges.
+
+## Not yet done
+
+- Wire `OPENWIKI_HOME`/`OPENWIKI_OUTPUT_DIR` at CONTEXT/CORTEX and validate a real run.
+- Structural-vs-routine-write split in the scheduled update → PR workflow (`examples/openwiki-update.yml`, `src/code-mode.ts`) — upstream treats all doc changes as PR-worthy; this fork needs an additive rule so only structural changes go through review.
+- Disable telemetry by default (`OPENWIKI_TELEMETRY_DISABLED=1`) given vault content is personal.
+
+---
+
+## OpenWiki (upstream, self-generated)
 
 This repository has documentation located in the /openwiki directory.
 

--- a/src/agent/claude-cli/write-guard-hook.ts
+++ b/src/agent/claude-cli/write-guard-hook.ts
@@ -1,0 +1,84 @@
+#!/usr/bin/env node
+import { evaluateWritePath } from "./write-guard.js";
+
+/**
+ * Claude Code PreToolUse hook entrypoint for the claude-cli provider.
+ *
+ * Wired via a generated `.claude/settings.json` with a "Write|Edit" matcher.
+ * Reads the standard PreToolUse JSON payload from stdin and exits 2 (which
+ * Claude Code treats as "deny, feed stderr back to the model") for any write
+ * outside CLAUDE_CLI_ALLOWED_DIR. Any malformed input or missing config fails
+ * closed (deny) rather than silently allowing the write through.
+ */
+
+interface PreToolUseHookInput {
+  cwd?: string;
+  tool_name?: string;
+  tool_input?: {
+    file_path?: string;
+  };
+}
+
+async function readStdin(): Promise<string> {
+  const chunks: Buffer[] = [];
+  for await (const chunk of process.stdin as AsyncIterable<Buffer | string>) {
+    chunks.push(typeof chunk === "string" ? Buffer.from(chunk) : chunk);
+  }
+  return Buffer.concat(chunks).toString("utf8");
+}
+
+function deny(reason: string): never {
+  process.stderr.write(`${reason}\n`);
+  process.exit(2);
+}
+
+async function main(): Promise<void> {
+  const repoRoot = process.env.CLAUDE_CLI_REPO_ROOT;
+  if (!repoRoot) {
+    deny(
+      "claude-cli write guard misconfigured: CLAUDE_CLI_REPO_ROOT is not set.",
+    );
+  }
+  const allowedRelativeDir = process.env.CLAUDE_CLI_ALLOWED_DIR ?? "openwiki";
+
+  const raw = await readStdin();
+  let input: PreToolUseHookInput;
+  try {
+    input = JSON.parse(raw) as PreToolUseHookInput;
+  } catch {
+    deny("claude-cli write guard: could not parse PreToolUse hook payload.");
+    return;
+  }
+
+  if (input.tool_name !== "Write" && input.tool_name !== "Edit") {
+    process.exit(0);
+    return;
+  }
+
+  const filePath = input.tool_input?.file_path;
+  if (!filePath) {
+    deny(
+      `claude-cli write guard: ${input.tool_name} call had no file_path in tool_input.`,
+    );
+    return;
+  }
+
+  const decision = evaluateWritePath({
+    repoRoot,
+    allowedRelativeDir,
+    filePath,
+    cwd: input.cwd,
+  });
+
+  if (!decision.allowed) {
+    deny(decision.reason ?? "claude-cli write guard: write refused.");
+    return;
+  }
+
+  process.exit(0);
+}
+
+main().catch((error: unknown) => {
+  const message = error instanceof Error ? error.message : String(error);
+  deny(`claude-cli write guard crashed: ${message}`);
+});

--- a/src/agent/claude-cli/write-guard.ts
+++ b/src/agent/claude-cli/write-guard.ts
@@ -1,0 +1,59 @@
+import path from "node:path";
+
+/**
+ * Path-based write guard for the claude-cli provider.
+ *
+ * The `claude` CLI backend bypasses DeepAgents entirely (see docs-only-backend.ts),
+ * so the docs-only restriction has to be re-enforced out of band via a PreToolUse
+ * hook instead of a LocalShellBackend subclass. This module holds the pure
+ * decision logic so it can be unit tested without spawning a real hook process.
+ */
+export interface WriteGuardDecision {
+  allowed: boolean;
+  reason?: string;
+}
+
+export interface EvaluateWritePathOptions {
+  /** Absolute path to the repository root the claude-cli agent was launched against. */
+  repoRoot: string;
+  /** Path, relative to repoRoot, that writes/edits must stay within (e.g. "openwiki"). */
+  allowedRelativeDir: string;
+  /** The file_path the tool call wants to write/edit, as reported by Claude Code. */
+  filePath: string;
+  /** cwd reported by the hook payload, used to resolve relative filePath values. */
+  cwd?: string;
+}
+
+export function evaluateWritePath(
+  options: EvaluateWritePathOptions,
+): WriteGuardDecision {
+  const { repoRoot, allowedRelativeDir, filePath, cwd } = options;
+
+  if (!filePath || filePath.trim() === "") {
+    return { allowed: false, reason: "Refused: empty file path." };
+  }
+
+  const resolvedRepoRoot = path.resolve(repoRoot);
+  const allowedDir = path.resolve(resolvedRepoRoot, allowedRelativeDir);
+  const resolvedFilePath = path.resolve(cwd ?? resolvedRepoRoot, filePath);
+
+  if (!isWithinDir(resolvedRepoRoot, resolvedFilePath)) {
+    return {
+      allowed: false,
+      reason: `Refused path: ${filePath} is outside the repository (${resolvedRepoRoot}).`,
+    };
+  }
+
+  if (!isWithinDir(allowedDir, resolvedFilePath)) {
+    return {
+      allowed: false,
+      reason: `claude-cli init/update runs may only write under ${allowedRelativeDir}/. Refused path: ${filePath}`,
+    };
+  }
+
+  return { allowed: true };
+}
+
+function isWithinDir(dir: string, target: string): boolean {
+  return target === dir || target.startsWith(`${dir}${path.sep}`);
+}

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,4 +1,4 @@
-export const OPEN_WIKI_DIR = "openwiki";
+export const OPEN_WIKI_DIR = process.env.OPENWIKI_OUTPUT_DIR ?? "openwiki";
 export const UPDATE_METADATA_PATH = `${OPEN_WIKI_DIR}/.last-update.json`;
 export const BASETEN_API_KEY_ENV_KEY = "BASETEN_API_KEY";
 export const FIREWORKS_API_KEY_ENV_KEY = "FIREWORKS_API_KEY";

--- a/src/env.ts
+++ b/src/env.ts
@@ -53,7 +53,8 @@ import {
 } from "./constants.js";
 import { isFileNotFoundError } from "./fs-errors.js";
 
-export const openWikiEnvDir = path.join(os.homedir(), ".openwiki");
+export const openWikiEnvDir =
+  process.env.OPENWIKI_HOME ?? path.join(os.homedir(), ".openwiki");
 export const openWikiEnvPath = path.join(openWikiEnvDir, ".env");
 
 type EnvMap = Record<string, string>;

--- a/src/openwiki-home.ts
+++ b/src/openwiki-home.ts
@@ -2,7 +2,8 @@ import { chmod, mkdir } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 
-export const openWikiHomeDir = path.join(os.homedir(), ".openwiki");
+export const openWikiHomeDir =
+  process.env.OPENWIKI_HOME ?? path.join(os.homedir(), ".openwiki");
 export const openWikiConnectorsDir = path.join(openWikiHomeDir, "connectors");
 export const openWikiLocalWikiDir = path.join(openWikiHomeDir, "wiki");
 export const openWikiSkillsDir = path.join(openWikiHomeDir, "skills");

--- a/test/write-guard.test.ts
+++ b/test/write-guard.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, test } from "vitest";
+import { evaluateWritePath } from "../src/agent/claude-cli/write-guard.ts";
+
+describe("evaluateWritePath", () => {
+  const repoRoot = "/home/deanj/projects/argus-wiki";
+
+  test("allows writes inside the allowed directory", () => {
+    const decision = evaluateWritePath({
+      repoRoot,
+      allowedRelativeDir: "openwiki",
+      filePath: "/home/deanj/projects/argus-wiki/openwiki/architecture.md",
+    });
+    expect(decision).toEqual({ allowed: true });
+  });
+
+  test("allows writes at the allowed directory root itself", () => {
+    const decision = evaluateWritePath({
+      repoRoot,
+      allowedRelativeDir: "openwiki",
+      filePath: "/home/deanj/projects/argus-wiki/openwiki",
+    });
+    expect(decision.allowed).toBe(true);
+  });
+
+  test("refuses writes elsewhere in the repo", () => {
+    const decision = evaluateWritePath({
+      repoRoot,
+      allowedRelativeDir: "openwiki",
+      filePath: "/home/deanj/projects/argus-wiki/AGENTS.md",
+    });
+    expect(decision.allowed).toBe(false);
+    expect(decision.reason).toContain("Refused path: /home/deanj");
+  });
+
+  test("refuses a sibling directory that merely shares a prefix", () => {
+    const decision = evaluateWritePath({
+      repoRoot,
+      allowedRelativeDir: "openwiki",
+      filePath: "/home/deanj/projects/argus-wiki/openwiki-fake/notes.md",
+    });
+    expect(decision.allowed).toBe(false);
+  });
+
+  test("refuses writes outside the repository entirely", () => {
+    const decision = evaluateWritePath({
+      repoRoot,
+      allowedRelativeDir: "openwiki",
+      filePath: "/etc/passwd",
+    });
+    expect(decision.allowed).toBe(false);
+    expect(decision.reason).toContain("outside the repository");
+  });
+
+  test("refuses path traversal back out of the allowed directory", () => {
+    const decision = evaluateWritePath({
+      repoRoot,
+      allowedRelativeDir: "openwiki",
+      filePath:
+        "/home/deanj/projects/argus-wiki/openwiki/../../../etc/passwd",
+    });
+    expect(decision.allowed).toBe(false);
+  });
+
+  test("resolves relative file paths against the hook's reported cwd", () => {
+    const decision = evaluateWritePath({
+      repoRoot,
+      allowedRelativeDir: "openwiki",
+      filePath: "architecture.md",
+      cwd: "/home/deanj/projects/argus-wiki/openwiki",
+    });
+    expect(decision.allowed).toBe(true);
+  });
+
+  test("refuses an empty file path", () => {
+    const decision = evaluateWritePath({
+      repoRoot,
+      allowedRelativeDir: "openwiki",
+      filePath: "",
+    });
+    expect(decision.allowed).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- First piece of the `claude-cli` provider design: since a bare `claude -p` subprocess can't be handed a DeepAgents `LocalShellBackend` subclass (the mechanism `docs-only-backend.ts` uses today), this adds the equivalent write restriction as an out-of-band Claude Code `PreToolUse` hook.
- `src/agent/claude-cli/write-guard.ts` — pure, unit-tested path decision logic (`evaluateWritePath`), covering directory containment, prefix-collision (`openwiki-fake` vs `openwiki`), traversal, and repo-boundary checks.
- `src/agent/claude-cli/write-guard-hook.ts` — thin CLI entrypoint invoked by Claude Code itself: parses the PreToolUse stdin payload, only inspects `Write`/`Edit` calls, and exits 2 (block, stderr fed back to the model) for any file path outside `CLAUDE_CLI_ALLOWED_DIR` (default `openwiki`) under `CLAUDE_CLI_REPO_ROOT`. Fails closed on missing config or malformed input.

Not wired into the agent runtime yet — the `claude-cli-backend.ts` module that spawns `claude -p` with this hook configured via a generated `.claude/settings.json` is a follow-up PR.

## Test plan
- [x] `pnpm test` — 340/340 passing (8 new tests in `test/write-guard.test.ts`)
- [x] `pnpm run typecheck` / `pnpm run lint:check` — clean
- [x] `pnpm run build`, then manually piped real PreToolUse-shaped JSON at the compiled hook for an allow case (write inside `openwiki/`), a deny case (write to `AGENTS.md`), and a non-matching tool case (`Bash`) — exit codes 0/2/0 as expected