### PR TITLE
fix: stop code-mode runs from targeting ~/.openwiki/wiki and bump deepagents to prevent crashes

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "ci-info": "^4.4.0",
     "cron-parser": "5.6.1",
     "cronstrue": "3.24.0",
-    "deepagents": "^1.11.0",
+    "deepagents": "^1.11.1",
     "google-auth-library": "^10.9.0",
     "ink": "^5.1.0",
     "langchain": "^1.5.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -51,8 +51,8 @@ importers:
         specifier: 3.24.0
         version: 3.24.0
       deepagents:
-        specifier: ^1.11.0
-        version: 1.11.0(258c1430434a32ce8e1dc2c77a7040b8)
+        specifier: ^1.11.1
+        version: 1.11.1(258c1430434a32ce8e1dc2c77a7040b8)
       google-auth-library:
         specifier: ^10.9.0
         version: 10.9.0
@@ -993,8 +993,8 @@ packages:
   deep-is@0.1.4:
     resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
 
-  deepagents@1.11.0:
-    resolution: {integrity: sha512-HPKLmOoi23fRykXpJgrhYNhjm+Yrd3qVmvwm7mvJ2DeTcJBKu1mc+VYbYeHunIVfi9F05GgjZa9JjdWwuAVuPQ==}
+  deepagents@1.11.1:
+    resolution: {integrity: sha512-qBdQ+rmQteHsGgDjqubbBEaY6qcCyQdhKHYKs3f4G7FMnfGMWo/OvbzGncDGIjQLqSl1pF7tD/XkQmfVCU/fhQ==}
     peerDependencies:
       '@langchain/core': ^1.2.0
       '@langchain/langgraph': ^1.4.4
@@ -2897,7 +2897,7 @@ snapshots:
 
   deep-is@0.1.4: {}
 
-  deepagents@1.11.0(258c1430434a32ce8e1dc2c77a7040b8):
+  deepagents@1.11.1(258c1430434a32ce8e1dc2c77a7040b8):
     dependencies:
       '@langchain/core': 1.2.1(openai@6.45.0(@aws-sdk/credential-provider-node@3.972.63)(@smithy/signature-v4@5.6.2)(ws@8.21.0)(zod@4.4.3))(ws@8.21.0)
       '@langchain/langgraph': 1.4.7(@langchain/core@1.2.1(openai@6.45.0(@aws-sdk/credential-provider-node@3.972.63)(@smithy/signature-v4@5.6.2)(ws@8.21.0)(zod@4.4.3))(ws@8.21.0))(react@18.3.1)(zod@4.4.3)

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -13,7 +13,7 @@ minimumReleaseAgeExclude:
   - "@vitest/snapshot@4.1.10"
   - "@vitest/spy@4.1.10"
   - "@vitest/utils@4.1.10"
-  - "deepagents@1.11.0"
+  - "deepagents@1.11.1"
   - "langchain@1.5.3"
   - "node-abi@3.94.0"
   - "picomatch@4.0.5"

--- a/src/agent/prompt.ts
+++ b/src/agent/prompt.ts
@@ -24,11 +24,7 @@ You are OpenWiki, an expert technical writer, software architect, and product an
 
 Your job is to inspect the relevant source evidence and local OpenWiki knowledge sources, then produce documentation in ${output.docsLocation} that is excellent for both humans and future agents. OpenWiki can maintain a local general-purpose knowledge wiki from connector raw dumps under ~/.openwiki.
 
-Canonical wiki location:
-- The generated OpenWiki knowledge base always lives in ~/.openwiki/wiki.
-- When reading the wiki to answer questions, inspect ~/.openwiki/wiki first. Do not assume the repository-local openwiki/ directory is the current wiki.
-- In local-wiki runs, filesystem tools are rooted at ~/.openwiki/wiki and virtual path / means the wiki root. Use paths such as /quickstart.md, /sources/gmail.md, and /topics/ai-research.md.
-- If a runtime is ever rooted somewhere else, use shell execute narrowly against ~/.openwiki/wiki for wiki reads instead of reading a repo-local openwiki/ directory.
+${output.canonicalLocationInstruction}
 
 Use only the tools available to you. Prefer built-in filesystem discovery tools such as ls, glob, grep, read_file, write_file, and edit_file for targeted reads. Use git through shell execute when it provides useful history. Do not invent files, modules, APIs, business rules, or behavior. Ground every important claim in source files, existing docs, or git evidence you have inspected.
 
@@ -64,11 +60,7 @@ Connector ingestion discipline:
 
 ${output.localWikiSynthesisInstruction}
 
-Wiki-first question answering:
-- For ordinary chat questions, inspect the generated wiki at ~/.openwiki/wiki first. Use quickstart/index pages, section pages, and targeted grep/glob over the wiki before looking at raw connector dumps.
-- If the user asks you to "look at the wiki", answer "based on the wiki", report "what the wiki says", or otherwise frames the request around the wiki, use only wiki pages unless the wiki cannot support the answer.
-- Assume the synthesized wiki contains the answer most of the time. Do not inspect raw connector data just because it exists.
-- Never treat a repository-local openwiki/ directory as the canonical generated wiki unless the user explicitly asks about that repository documentation directory.
+${output.wikiFirstAnsweringInstruction}
 - Use raw connector data only when the wiki is missing the needed detail, clearly stale, ambiguous, contradicted, the user explicitly asks for source-level evidence, or the question is specifically about the latest uncompiled data since the last wiki update.
 - If a wiki-framed question cannot be answered from the wiki, say what important context is missing before deciding whether raw data is necessary. When appropriate, suggest or run a targeted connector ingestion/update instead of browsing broad raw dumps.
 - When the wiki answers the question, do not inspect or mention raw connector data.
@@ -314,6 +306,7 @@ function formatWikiGoal(wikiGoal: string | undefined): string {
 }
 
 type OutputPromptConfig = {
+  canonicalLocationInstruction: string;
   docsLocation: string;
   filesystemRootInstruction: string;
   gitDisciplineInstruction: string;
@@ -329,6 +322,7 @@ type OutputPromptConfig = {
   sectionDirectoryInstruction: string;
   subjectLabel: string;
   updateEvidenceInstruction: string;
+  wikiFirstAnsweringInstruction: string;
   writeBoundaryInstruction: string;
   writePathExample: string;
 };
@@ -338,6 +332,10 @@ function getOutputPromptConfig(
 ): OutputPromptConfig {
   if (outputMode === "local-wiki") {
     return {
+      canonicalLocationInstruction: `Canonical wiki location:
+- The generated OpenWiki knowledge base lives in ~/.openwiki/wiki, which the filesystem tools expose as the virtual root /. Reference wiki files by /-rooted virtual paths such as /quickstart.md, /sources/gmail.md, and /topics/ai-research.md.
+- Never type ~, ~/.openwiki/wiki, or host paths like /Users/... into filesystem tools (ls, read_file, write_file, edit_file, glob, grep). Those host paths are only valid with shell execute, and only when a source-specific instruction requires it.
+- When reading the wiki to answer questions, inspect the wiki root / first.`,
       docsLocation: "~/.openwiki/wiki (the current virtual filesystem root /)",
       filesystemRootInstruction:
         "Filesystem tools are rooted at ~/.openwiki/wiki. Use virtual paths such as /quickstart.md, /sources/gmail.md, /topics/ai-research.md, and /_plan.md. Do not create a nested /openwiki directory.",
@@ -417,6 +415,11 @@ function getOutputPromptConfig(
       subjectLabel: "the local knowledge wiki",
       updateEvidenceInstruction:
         "Use newly ingested connector raw files, connector tools, source-specific instructions, existing wiki pages, and relevant configured local repository evidence to understand what changed.",
+      wikiFirstAnsweringInstruction: `Wiki-first question answering:
+- For ordinary chat questions, inspect the generated wiki under the virtual root / first. Use quickstart/index pages, section pages, and targeted grep/glob over the wiki before looking at raw connector dumps.
+- If the user asks you to "look at the wiki", answer "based on the wiki", report "what the wiki says", or otherwise frames the request around the wiki, use only wiki pages unless the wiki cannot support the answer.
+- Assume the synthesized wiki contains the answer most of the time. Do not inspect raw connector data just because it exists.
+- Never treat a repository-local openwiki/ directory as the canonical generated wiki unless the user explicitly asks about that repository documentation directory.`,
       writeBoundaryInstruction:
         "Do not modify files outside ~/.openwiki/wiki with filesystem tools. The only source data outside this root that may be inspected is connector raw data through constrained connector tools or explicit shell reads requested by the source-specific prompt.",
       writePathExample:
@@ -425,6 +428,11 @@ function getOutputPromptConfig(
   }
 
   return {
+    canonicalLocationInstruction: `Canonical wiki location:
+- The generated OpenWiki knowledge base lives in the target repository's openwiki/ directory, which the filesystem tools expose under the virtual path /openwiki. Reference wiki files by /-rooted virtual paths such as /openwiki/quickstart.md and /openwiki/architecture/overview.md.
+- In repository runs the wiki is this repo-local /openwiki directory, not ~/.openwiki/wiki.
+- Never type ~, ~/.openwiki/wiki, or host paths like /Users/... into filesystem tools (ls, read_file, write_file, edit_file, glob, grep).
+- When reading the wiki to answer questions, inspect /openwiki first.`,
     docsLocation: "the target repository's openwiki/ directory",
     filesystemRootInstruction:
       "Filesystem tools are rooted at the target repository. Create and update generated wiki pages under /openwiki, such as /openwiki/quickstart.md, /openwiki/architecture/overview.md, or /openwiki/source-map.md.",
@@ -452,6 +460,10 @@ function getOutputPromptConfig(
     subjectLabel: "this repository",
     updateEvidenceInstruction:
       "Always use git-oriented repository evidence to understand recent changes. Inspect commits added since the previous successful run using the recorded gitHead when available. If shell execution is unavailable, use filesystem timestamps, source inspection, and existing docs to infer what changed.",
+    wikiFirstAnsweringInstruction: `Wiki-first question answering:
+- For ordinary chat questions, inspect the generated wiki under /openwiki first. Use quickstart/index pages, section pages, and targeted grep/glob over the wiki before looking at source files.
+- If the user asks you to "look at the wiki", answer "based on the wiki", report "what the wiki says", or otherwise frames the request around the wiki, use only /openwiki pages unless the wiki cannot support the answer.
+- Assume the generated wiki contains the answer most of the time. Do not exhaustively read source files just because they exist.`,
     writeBoundaryInstruction:
       "Do not modify source code. Write generated wiki pages only under the repository /openwiki directory.",
     writePathExample:

--- a/test/prompt.test.ts
+++ b/test/prompt.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, test } from "vitest";
+import { createSystemPrompt } from "../src/agent/prompt.ts";
+
+/**
+ * Guards against the 0.2 regression where the shared "Canonical wiki location"
+ * and "Wiki-first question answering" blocks hardcoded ~/.openwiki/wiki and
+ * leaked into repository (code) mode. In code mode the filesystem virtual root
+ * maps to the repo, so instructing the model to use ~/.openwiki/wiki made it
+ * type non-absolute host paths into filesystem tools and crash the run.
+ */
+describe("createSystemPrompt filesystem path guidance", () => {
+  const commands = ["init", "update", "chat"] as const;
+
+  describe("repository mode", () => {
+    for (const command of commands) {
+      test(`${command}: does not point the wiki at ~/.openwiki/wiki`, () => {
+        const prompt = createSystemPrompt(command, "repository");
+
+        // The canonical location must be the repo-local /openwiki, never the
+        // personal-brain home dir.
+        expect(prompt).not.toMatch(/lives in ~\/\.openwiki\/wiki/);
+        expect(prompt).not.toMatch(/inspect ~\/\.openwiki\/wiki first/);
+        expect(prompt).toContain("/openwiki");
+      });
+    }
+  });
+
+  describe("local-wiki mode", () => {
+    for (const command of commands) {
+      test(`${command}: roots the wiki at ~/.openwiki/wiki via virtual /`, () => {
+        const prompt = createSystemPrompt(command, "local-wiki");
+
+        expect(prompt).toContain("~/.openwiki/wiki");
+        expect(prompt).toContain("/quickstart.md");
+      });
+    }
+  });
+
+  test("both modes forbid typing host/tilde paths into filesystem tools", () => {
+    for (const outputMode of ["repository", "local-wiki"] as const) {
+      const prompt = createSystemPrompt("update", outputMode);
+      expect(prompt).toMatch(
+        /Never type ~, ~\/\.openwiki\/wiki, or host paths/,
+      );
+    }
+  });
+});


### PR DESCRIPTION
### Summary

Code mode runs were crashing with error `path must be absolute: "~/.openwiki/wiki"`.

Two shared prompt blocks ("Canonical wiki location" and "Wiki-first question answering") told **every** run the wiki lives at `~/.openwiki/wiki`. In code mode the filesystem root maps to the repo  so that path is unreachable, the model typed the literal `~/.openwiki/wiki` into filesystem tools, and deepagents rejected it causing a crash.

This PR separates the prompts into code specific and personal specific domains and bumps the deepagents version to pick up an upstream fix that no longer crashes the agent and, instead, returns a tool message allowing the agent to recover.

### Tests
- Unit tests
- Manually verified openwiki with deepagents v1.11.1 no longer throws on a `~` path.