### PR TITLE
feature: graceful fallback to timestamp based diff on unreachable gitHead

### DIFF
--- a/src/agent/utils.ts
+++ b/src/agent/utils.ts
@@ -115,6 +115,13 @@ export async function getUpdateNoopStatus(
   }
 
   if (head !== lastUpdate.gitHead) {
+    if (!(await commitExists(cwd, lastUpdate.gitHead))) {
+      return {
+        shouldSkip: false,
+        reason: `recorded git head ${lastUpdate.gitHead} not found (history rewritten or shallow clone)`,
+      };
+    }
+
     const committedPaths = await getChangedPathsSinceLastUpdate(
       cwd,
       lastUpdate.gitHead,
@@ -380,7 +387,12 @@ async function createGitSummary(
   sections.push(formatGitSection("git status --short", status));
   sections.push(formatGitSection("git rev-parse HEAD", head ?? "(unknown)"));
 
-  if (command === "update" && lastUpdate?.gitHead) {
+  const hasUsableGitHead =
+    command === "update" &&
+    lastUpdate?.gitHead !== undefined &&
+    (await commitExists(cwd, lastUpdate.gitHead));
+
+  if (hasUsableGitHead && lastUpdate?.gitHead) {
     const logSinceLastHead = await runGit(cwd, [
       "log",
       `${lastUpdate.gitHead}..HEAD`,
@@ -395,6 +407,12 @@ async function createGitSummary(
       ),
     );
   } else if (command === "update" && lastUpdate?.updatedAt) {
+    if (lastUpdate.gitHead) {
+      sections.push(
+        `Note: recorded git head ${lastUpdate.gitHead} is no longer present (history was rewritten or commit was amended/rebased away). Falling back to time-based change evidence.`,
+      );
+    }
+
     const logSinceLastUpdate = await runGit(cwd, [
       "log",
       "--since",
@@ -439,6 +457,23 @@ async function getGitHead(cwd: string): Promise<string | undefined> {
   const head = await runGit(cwd, ["rev-parse", "HEAD"]);
 
   return head.length > 0 ? head : undefined;
+}
+
+/**
+ * Returns true when the given commit SHA exists in the local object database.
+ * Uses `git cat-file -e <sha>^{commit}` which exits 0 only when the object is
+ * present and is a commit (or resolves to one).  A missing or rewritten commit
+ * (amend/rebase + gc, or a narrow shallow clone) exits non-zero.
+ */
+async function commitExists(cwd: string, sha: string): Promise<boolean> {
+  try {
+    await execFileAsync("git", ["--no-pager", "cat-file", "-e", `${sha}^{commit}`], {
+      cwd,
+    });
+    return true;
+  } catch {
+    return false;
+  }
 }
 
 /**

--- a/test/update-noop.test.ts
+++ b/test/update-noop.test.ts
@@ -5,6 +5,7 @@ import { execFile } from "node:child_process";
 import { promisify } from "node:util";
 import { describe, expect, test } from "vitest";
 import {
+  createRunContext,
   getUpdateNoopStatus,
   shouldCheckUpdateNoop,
 } from "../src/agent/utils.ts";
@@ -14,6 +15,14 @@ const execFileAsync = promisify(execFile);
 async function git(cwd: string, args: string[]): Promise<string> {
   const { stdout } = await execFileAsync("git", args, { cwd });
   return stdout.trim();
+}
+
+/** Removes dangling objects by expiring the reflog and running gc --prune=now. */
+async function gcPrune(repo: string): Promise<void> {
+  await execFileAsync("git", ["reflog", "expire", "--expire=now", "--all"], {
+    cwd: repo,
+  });
+  await execFileAsync("git", ["gc", "--prune=now", "-q"], { cwd: repo });
 }
 
 async function createRepoWithOpenWiki(): Promise<string> {
@@ -33,11 +42,15 @@ async function createRepoWithOpenWiki(): Promise<string> {
   return repo;
 }
 
-async function writeLastUpdate(repo: string, gitHead: string): Promise<void> {
+async function writeLastUpdate(
+  repo: string,
+  gitHead: string,
+  updatedAt?: string,
+): Promise<void> {
   await writeFile(
     path.join(repo, "openwiki", ".last-update.json"),
     `${JSON.stringify({
-      updatedAt: new Date().toISOString(),
+      updatedAt: updatedAt ?? new Date().toISOString(),
       command: "update",
       gitHead,
       model: "test-model",
@@ -117,5 +130,140 @@ describe("shouldCheckUpdateNoop", () => {
   test("checks for update no-op when no update message is provided", () => {
     expect(shouldCheckUpdateNoop({ userMessage: null })).toBe(true);
     expect(shouldCheckUpdateNoop({ userMessage: "   " })).toBe(true);
+  });
+});
+
+describe("getUpdateNoopStatus — missing base commit (rewrite/amend scenario)", () => {
+  test("does not skip update when the recorded gitHead no longer exists", async () => {
+    const repo = await createRepoWithOpenWiki();
+    const absentSha = "0000000000000000000000000000000000000000";
+    await writeLastUpdate(repo, absentSha);
+
+    const status = await getUpdateNoopStatus(repo);
+
+    expect(status.shouldSkip).toBe(false);
+    expect(status.reason).toMatch(/not found/);
+    expect(status.reason).toContain(absentSha);
+  });
+
+  test("does not skip update when the recorded gitHead was amended and gc'd away", async () => {
+    const repo = await createRepoWithOpenWiki();
+    const originalHead = await git(repo, ["rev-parse", "HEAD"]);
+
+    // Amend the commit so the original SHA becomes dangling.
+    await writeFile(
+      path.join(repo, "README.md"),
+      "# Test Repo\nAmended\n",
+      "utf8",
+    );
+    await git(repo, ["add", "README.md"]);
+    await git(repo, ["commit", "--amend", "--no-edit"]);
+
+    // Remove the dangling object so commitExists definitely returns false.
+    await gcPrune(repo);
+
+    await writeLastUpdate(repo, originalHead);
+
+    const status = await getUpdateNoopStatus(repo);
+
+    expect(status.shouldSkip).toBe(false);
+    expect(status.reason).toMatch(/not found/);
+    expect(status.reason).toContain(originalHead);
+  });
+
+  test("does not skip when missing gitHead in metadata", async () => {
+    const repo = await createRepoWithOpenWiki();
+    // Write metadata with gitHead omitted (e.g., older format or local-wiki metadata).
+    await writeFile(
+      path.join(repo, "openwiki", ".last-update.json"),
+      `${JSON.stringify({
+        updatedAt: new Date().toISOString(),
+        command: "update",
+        model: "test-model",
+      })}\n`,
+      "utf8",
+    );
+
+    const status = await getUpdateNoopStatus(repo);
+
+    expect(status.shouldSkip).toBe(false);
+    expect(status.reason).toContain("missing previous update git head");
+  });
+});
+
+describe("createRunContext git summary — present base commit (happy path)", () => {
+  test("uses precise gitHead..HEAD range when recorded commit exists", async () => {
+    const repo = await createRepoWithOpenWiki();
+    const baseHead = await git(repo, ["rev-parse", "HEAD"]);
+    await writeLastUpdate(repo, baseHead);
+
+    // Add a source commit after the recorded head.
+    await writeFile(
+      path.join(repo, "README.md"),
+      "# Test Repo\nChanged\n",
+      "utf8",
+    );
+    await git(repo, ["add", "README.md"]);
+    await git(repo, ["commit", "-m", "change readme"]);
+
+    const context = await createRunContext("update", repo, "repository");
+
+    // Should use the exact gitHead..HEAD diff, not the time-based fallback.
+    expect(context.gitSummary).toContain(
+      `git log ${baseHead}..HEAD --name-status --oneline`,
+    );
+    // The "no longer present" note must NOT appear.
+    expect(context.gitSummary).not.toMatch(/no longer present/i);
+  });
+});
+
+describe("createRunContext git summary — missing base commit (rewrite/amend scenario)", () => {
+  test("does not include a fatal git error in gitSummary when recorded gitHead is absent", async () => {
+    const repo = await createRepoWithOpenWiki();
+    const absentSha = "0000000000000000000000000000000000000000";
+    await writeLastUpdate(repo, absentSha);
+
+    const context = await createRunContext("update", repo, "repository");
+
+    expect(context.gitSummary).not.toMatch(/^fatal:/m);
+    expect(context.gitSummary).not.toContain("Invalid revision range");
+  });
+
+  test("includes a note and time-based fallback evidence when recorded gitHead is absent", async () => {
+    const repo = await createRepoWithOpenWiki();
+    const absentSha = "0000000000000000000000000000000000000000";
+    await writeLastUpdate(repo, absentSha);
+
+    const context = await createRunContext("update", repo, "repository");
+
+    expect(context.gitSummary).toContain(absentSha);
+    expect(context.gitSummary).toMatch(/no longer present/i);
+    // Falls back to git log --since which should appear in the evidence.
+    expect(context.gitSummary).toContain("git log --since");
+  });
+
+  test("uses time-based fallback after a gc'd amend, no fatal error", async () => {
+    const repo = await createRepoWithOpenWiki();
+    const originalHead = await git(repo, ["rev-parse", "HEAD"]);
+
+    // Amend and gc so the original commit is truly gone.
+    await writeFile(
+      path.join(repo, "README.md"),
+      "# Test Repo\nAmended\n",
+      "utf8",
+    );
+    await git(repo, ["add", "README.md"]);
+    await git(repo, ["commit", "--amend", "--no-edit"]);
+    await gcPrune(repo);
+
+    await writeLastUpdate(repo, originalHead);
+
+    const context = await createRunContext("update", repo, "repository");
+
+    expect(context.gitSummary).not.toMatch(/^fatal:/m);
+    expect(context.gitSummary).not.toContain("Invalid revision range");
+    expect(context.gitSummary).toMatch(/no longer present/i);
+    expect(context.gitSummary).toContain(originalHead);
+    expect(context.gitSummary).toContain("git log --since");
   });
 });


### PR DESCRIPTION
### Problem
After each run, OpenWiki records the HEAD SHA in `openwiki/.last-update.json` and diffs `git log <gitHead>..HEAD` to find what changed since the last update. When git history is rewritten with **squash or rebase**, the recorded SHA becomes **orphaned** (no longer reachable from HEAD) — or is absent entirely on a fresh/shallow clone.

When that happens, OpenWiki silently misbehaves:
- `runGit()` swallows git's non-zero exit and returns the `fatal: Invalid revision range …` text as if it were normal output.
- **No-op check** (`getUpdateNoopStatus`) only "worked" by accident — it misinterpreted the error string as a changed path.
- **Agent evidence** (`createGitSummary`) fed the model the `fatal:` string as its diff, and the timestamp fallback was structurally unreachable: the `if/else-if` was keyed on *whether `gitHead` was present*, not on whether the git command succeeded.

Net effect: incremental updates run blind (under-update or hallucinate) with no signal that anything went wrong.

### Solution
Detect an unreachable baseline explicitly and degrade gracefully:
- Add `commitExists(cwd, sha)` (`git cat-file -e <sha>^{commit}`).
- `getUpdateNoopStatus`: if the recorded `gitHead` isn't reachable, return "not a no-op" with a clear reason instead of parsing git's error text — safe default is to run the update.
- `createGitSummary`: guard the `gitHead..HEAD` branch with `commitExists`. If the commit is gone, fall through to the existing time-based `git log --since <updatedAt>` evidence and prepend an explicit note. The model never receives a `fatal:` string again.


### Alternatives considered
1. **Repair the orphaned SHA to the last commit that modified `.last-update.json`** (the approach in our CI workaround). `git log -1 --format=%H -- .last-update.json` is always reachable (log only walks HEAD's ancestors) and is a *more precise* incremental baseline than a timestamp. Not chosen for the core fix because of too much added complexity.
2. **Make `runGit` fail loudly / distinguish "empty diff" from "command failed."** Correct as defense-in-depth, but larger blast radius across all git calls; the `commitExists` guards prevent the bad range from ever running, so it's deferred.

### Notes

Before this is merged, my team is using below to "repair" the gitHead in our CI setup. 
```yaml
    # Orphaned-baseline repair: OpenWiki records the HEAD SHA in
    # ${OPENWIKI_DOCS_PATH}/.last-update.json after each run and diffs
    # `git log <gitHead>..HEAD` to find what changed. When a merge uses
    # squash/rebase the recorded SHA is orphaned (no longer reachable from
    # HEAD), and OpenWiki silently treats it as "no changes" — its `runGit`
    # helper swallows the non-zero exit, and the timestamp fallback is
    # structurally unreachable when gitHead is present (if/else-if keyed on
    # the input, not the git-command result).
    # Fix: if the recorded gitHead is unreachable, replace it with the last
    # commit that actually *modified* .last-update.json. That commit is always
    # reachable (git-log only walks ancestors of HEAD), and it represents the
    # true incremental baseline even after squash/rebase rewrites.
    - |
      LAST_UPDATE_FILE="${OPENWIKI_DOCS_PATH}/.last-update.json"
      if [ -f "$LAST_UPDATE_FILE" ]; then
        RECORDED=$(jq -r '.gitHead // empty' "$LAST_UPDATE_FILE" 2>/dev/null || true)
        if [ -n "$RECORDED" ] && ! git cat-file -e "${RECORDED}^{commit}" 2>/dev/null; then
          REPAIR=$(git log -1 --format=%H -- "$LAST_UPDATE_FILE" 2>/dev/null || true)
          if [ -n "$REPAIR" ]; then
            echo "Recorded gitHead ${RECORDED} is unreachable (squash/rebase merge) — resetting to last reachable baseline ${REPAIR}."
            tmp=$(mktemp)
            jq --arg h "$REPAIR" '.gitHead = $h' "$LAST_UPDATE_FILE" > "$tmp" && mv "$tmp" "$LAST_UPDATE_FILE"
          else
            echo "No reachable baseline found for ${LAST_UPDATE_FILE} — OpenWiki will fall back to its timestamp/recent-commits path."
          fi
        fi
      fi
```