### PR TITLE
fix: point repository runtime note at openwiki docs

### DIFF
--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -393,12 +393,14 @@ function formatRuntimeRootLabel(outputMode: OpenWikiOutputMode): string {
   return outputMode === "local-wiki" ? "Local wiki root" : "Repository root";
 }
 
-function formatRuntimeRootInstruction(outputMode: OpenWikiOutputMode): string {
+export function formatRuntimeRootInstruction(
+  outputMode: OpenWikiOutputMode,
+): string {
   if (outputMode === "local-wiki") {
     return "Filesystem tools use a virtual root: / means the local wiki directory above. Write wiki pages directly under /, for example /quickstart.md, /sources/gmail.md, and /_plan.md. Do not create a nested /openwiki directory.";
   }
 
-  return "Treat the repository root above as source evidence only. The canonical generated wiki is ~/.openwiki/wiki, not a repository-local openwiki/ directory. Filesystem tools use a virtual root: / means the repository root for source inspection paths such as /README.md, /agent/agents/main.py, and /package.json.";
+  return "Filesystem tools use a virtual root: / means the repository root. The generated repository wiki lives under /openwiki, for example /openwiki/quickstart.md and /openwiki/architecture/overview.md. Inspect source files from repository-root paths such as /README.md, /src/agent/index.ts, and /package.json.";
 }
 
 async function createCheckpointer(

--- a/test/agent-runtime-root.test.ts
+++ b/test/agent-runtime-root.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, test } from "vitest";
+import { formatRuntimeRootInstruction } from "../src/agent/index.ts";
+
+describe("formatRuntimeRootInstruction", () => {
+  test("points repository runs at the repo-local openwiki directory", () => {
+    const instruction = formatRuntimeRootInstruction("repository");
+
+    expect(instruction).toContain("/openwiki");
+    expect(instruction).not.toContain("~/.openwiki/wiki");
+    expect(instruction).not.toContain("not a repository-local openwiki");
+  });
+
+  test("keeps local wiki runs rooted at the personal wiki virtual root", () => {
+    const instruction = formatRuntimeRootInstruction("local-wiki");
+
+    expect(instruction).toContain("local wiki directory");
+    expect(instruction).toContain("/quickstart.md");
+    expect(instruction).toContain("/_plan.md");
+  });
+});


### PR DESCRIPTION
## Summary

Updates the repository-mode runtime note appended to agent run messages so it points the agent at the repo-local `/openwiki` docs instead of the personal wiki path `~/.openwiki/wiki`.

## Why

PR #383 fixed the shared system prompt blocks, but `src/agent/index.ts` still appended a per-run runtime note that said the canonical generated wiki was `~/.openwiki/wiki` and not repository-local `openwiki/`. In repository runs that contradicts the actual virtual filesystem layout and can push the agent toward the wrong path.

Related to #368.

## Testing

- `corepack pnpm exec vitest run test/agent-runtime-root.test.ts test/prompt.test.ts`
- `corepack pnpm run format`
- `corepack pnpm run lint`
- `corepack pnpm run typecheck`

I also ran `corepack pnpm test`; it still fails on this Windows checkout in `test/env-behavior.test.ts` for the same 3 HOME/permission isolation assertions that also fail on a clean `origin/main@ac5007c` worktree.
