### PR TITLE
fix: clean up temporary openwiki plan files

### DIFF
--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -89,6 +89,7 @@ import {
   getUpdateNoopStatus,
   createRunContext,
   persistRunMetadataIfChanged,
+  removeTemporaryPlanFile,
   shouldCheckUpdateNoop,
 } from "./utils.js";
 import { classifyError, recordRunSafe } from "../telemetry/index.js";
@@ -302,6 +303,12 @@ async function runOpenWikiAgentCore(
     }
     emitDebug(options, "stream=completed");
   } catch (error) {
+    await cleanupTemporaryPlanFile(command, cwd, outputMode, options).catch(
+      () => {
+        emitDebug(options, "plan.cleanup=failed");
+      },
+    );
+
     // Persist metadata even when the stream fails late, so content that was
     // already generated stays diffable by future updates. Persistence errors
     // are swallowed here so the original run error propagates.
@@ -328,6 +335,8 @@ async function runOpenWikiAgentCore(
     await chmodIfExists(checkpointTarget.connString, 0o600);
   }
 
+  await cleanupTemporaryPlanFile(command, cwd, outputMode, options);
+
   const metadataWritten = await persistRunMetadataIfChanged(
     command,
     cwd,
@@ -351,6 +360,23 @@ async function runOpenWikiAgentCore(
     command,
     model: modelId,
   };
+}
+
+async function cleanupTemporaryPlanFile(
+  command: OpenWikiCommand,
+  cwd: string,
+  outputMode: OpenWikiOutputMode,
+  options: OpenWikiRunOptions,
+): Promise<void> {
+  if (command === "chat") {
+    return;
+  }
+
+  const removed = await removeTemporaryPlanFile(cwd, outputMode);
+  emitDebug(
+    options,
+    removed ? "plan.cleanup=removed" : "plan.cleanup=skipped missing",
+  );
 }
 
 const checkpointPath = path.join(openWikiEnvDir, "openwiki.sqlite");

--- a/src/agent/utils.ts
+++ b/src/agent/utils.ts
@@ -1,6 +1,6 @@
 import { execFile } from "node:child_process";
 import { createHash } from "node:crypto";
-import { mkdir, readdir, readFile, writeFile } from "node:fs/promises";
+import { mkdir, readdir, readFile, rm, writeFile } from "node:fs/promises";
 import path from "node:path";
 import { promisify } from "node:util";
 import { OPEN_WIKI_DIR, UPDATE_METADATA_PATH } from "../constants.js";
@@ -23,6 +23,7 @@ import type { Dirent } from "node:fs";
 
 const execFileAsync = promisify(execFile);
 const LOCAL_WIKI_METADATA_PATH = ".last-update.json";
+const TEMPORARY_PLAN_FILE = "_plan.md";
 
 export type OpenWikiContentSnapshot = string;
 
@@ -191,6 +192,27 @@ export async function persistRunMetadataIfChanged(
 }
 
 /**
+ * Removes the temporary planning file the agent creates during init/update runs.
+ */
+export async function removeTemporaryPlanFile(
+  cwd: string,
+  outputMode: OpenWikiOutputMode,
+): Promise<boolean> {
+  const planFile = getTemporaryPlanFilePath(cwd, outputMode);
+
+  try {
+    await rm(planFile);
+    return true;
+  } catch (error) {
+    if (isFileNotFoundError(error)) {
+      return false;
+    }
+
+    throw error;
+  }
+}
+
+/**
  * Hashes OpenWiki content, excluding run metadata, to detect real documentation changes.
  */
 export async function createOpenWikiContentSnapshot(
@@ -271,10 +293,7 @@ async function addDirectoryToSnapshot(
     const entryPath = path.join(directory, entry.name);
     const relativePath = path.join(relativeDirectory, entry.name);
 
-    if (
-      relativePath === path.basename(UPDATE_METADATA_PATH) ||
-      relativePath === LOCAL_WIKI_METADATA_PATH
-    ) {
+    if (isIgnoredSnapshotPath(relativePath)) {
       continue;
     }
 
@@ -307,6 +326,13 @@ function getWikiContentRoot(
   return outputMode === "local-wiki" ? cwd : path.join(cwd, OPEN_WIKI_DIR);
 }
 
+function getTemporaryPlanFilePath(
+  cwd: string,
+  outputMode: OpenWikiOutputMode,
+): string {
+  return path.join(getWikiContentRoot(cwd, outputMode), TEMPORARY_PLAN_FILE);
+}
+
 function getMetadataFilePath(
   cwd: string,
   outputMode: OpenWikiOutputMode,
@@ -314,6 +340,14 @@ function getMetadataFilePath(
   return outputMode === "local-wiki"
     ? path.join(cwd, LOCAL_WIKI_METADATA_PATH)
     : path.join(cwd, UPDATE_METADATA_PATH);
+}
+
+function isIgnoredSnapshotPath(relativePath: string): boolean {
+  return (
+    relativePath === path.basename(UPDATE_METADATA_PATH) ||
+    relativePath === LOCAL_WIKI_METADATA_PATH ||
+    relativePath === TEMPORARY_PLAN_FILE
+  );
 }
 
 /**

--- a/test/run-metadata.test.ts
+++ b/test/run-metadata.test.ts
@@ -5,7 +5,9 @@ import { describe, expect, test } from "vitest";
 import {
   createOpenWikiContentSnapshot,
   persistRunMetadataIfChanged,
+  removeTemporaryPlanFile,
 } from "../src/agent/utils.ts";
+import type { OpenWikiOutputMode } from "../src/agent/types.ts";
 
 async function createTempRepo(): Promise<string> {
   return mkdtemp(path.join(tmpdir(), "openwiki-run-metadata-"));
@@ -90,6 +92,33 @@ describe("persistRunMetadataIfChanged", () => {
     expect(await readMetadata(cwd, "openwiki/.last-update.json")).toBeNull();
   });
 
+  test("skips when only the temporary plan file changed", async () => {
+    const cwd = await createTempRepo();
+    await mkdir(path.join(cwd, "openwiki"), { recursive: true });
+    await writeFile(path.join(cwd, "openwiki", "index.md"), "# Docs\n", "utf8");
+    const snapshotBefore = await createOpenWikiContentSnapshot(
+      cwd,
+      "repository",
+    );
+
+    await writeFile(
+      path.join(cwd, "openwiki", "_plan.md"),
+      "# Temporary plan\n",
+      "utf8",
+    );
+
+    const written = await persistRunMetadataIfChanged(
+      "update",
+      cwd,
+      "test-model",
+      "repository",
+      snapshotBefore,
+    );
+
+    expect(written).toBe(false);
+    expect(await readMetadata(cwd, "openwiki/.last-update.json")).toBeNull();
+  });
+
   test("skips for chat runs", async () => {
     const cwd = await createTempRepo();
 
@@ -104,4 +133,27 @@ describe("persistRunMetadataIfChanged", () => {
     expect(written).toBe(false);
     expect(await readMetadata(cwd, "openwiki/.last-update.json")).toBeNull();
   });
+});
+
+describe("removeTemporaryPlanFile", () => {
+  test.each([
+    ["repository", path.join("openwiki", "_plan.md")],
+    ["local-wiki", "_plan.md"],
+  ] as const)(
+    "removes the temporary plan file in %s mode",
+    async (outputMode: OpenWikiOutputMode, relativePlanPath: string) => {
+      const cwd = await createTempRepo();
+      const planPath = path.join(cwd, relativePlanPath);
+      await mkdir(path.dirname(planPath), { recursive: true });
+      await writeFile(planPath, "# Temporary plan\n", "utf8");
+
+      await expect(removeTemporaryPlanFile(cwd, outputMode)).resolves.toBe(
+        true,
+      );
+      await expect(readFile(planPath, "utf8")).rejects.toThrow();
+      await expect(removeTemporaryPlanFile(cwd, outputMode)).resolves.toBe(
+        false,
+      );
+    },
+  );
 });


### PR DESCRIPTION
## Summary

Adds host-side cleanup for the temporary `_plan.md` file that OpenWiki asks the agent to create during init/update runs.

## Why

The prompt already tells the agent to delete `_plan.md` before finishing, but issue #368 shows that a run can still leave `openwiki/_plan.md` behind and include it in the generated PR. Since the plan is scratch state rather than final documentation, the runtime should clean it up deterministically.

Related to #368.

## What changed

- Removes the mode-specific temporary plan file after init/update streams finish, before metadata persistence.
- Attempts the same cleanup before late-failure metadata persistence without masking the original run error.
- Excludes the root `_plan.md` from OpenWiki content snapshots so a leftover temporary plan alone does not look like a documentation change.

## Testing

- `corepack pnpm exec vitest run test/run-metadata.test.ts test/update-noop.test.ts --no-file-parallelism`
- `corepack pnpm run format`
- `corepack pnpm run lint`
- `corepack pnpm run typecheck`

I also ran `corepack pnpm test`; it still fails on this Windows checkout in `test/env-behavior.test.ts` for the same 3 HOME/permission isolation assertions that also fail on a clean `origin/main@ac5007c` worktree.
