### PR TITLE
docs: document local openai-compatible llms

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,6 +248,41 @@ OPENAI_COMPATIBLE_BASE_URL=https://your-gateway.example.com/v1
 OPENWIKI_MODEL_ID=your-gateway-model-name
 ```
 
+Local LLM servers that expose OpenAI-compatible chat completions use the same
+provider. The model ID must match a model available from that local server:
+
+```bash
+# Ollama, after `ollama serve` and `ollama pull llama3.2`
+OPENWIKI_PROVIDER=openai-compatible
+OPENAI_COMPATIBLE_API_KEY=ollama
+OPENAI_COMPATIBLE_BASE_URL=http://localhost:11434/v1
+OPENWIKI_MODEL_ID=llama3.2
+openwiki --init
+```
+
+```bash
+# LM Studio, after starting the local server from the Developer tab
+OPENWIKI_PROVIDER=openai-compatible
+OPENAI_COMPATIBLE_API_KEY=lm-studio
+OPENAI_COMPATIBLE_BASE_URL=http://localhost:1234/v1
+OPENWIKI_MODEL_ID=your-loaded-model-id
+openwiki --init
+```
+
+For local gateways such as 9Router, use the OpenAI-compatible endpoint URL,
+API key, and model ID shown by the gateway:
+
+```bash
+OPENWIKI_PROVIDER=openai-compatible
+OPENAI_COMPATIBLE_API_KEY=your-local-gateway-key
+OPENAI_COMPATIBLE_BASE_URL=http://localhost:20128/v1
+OPENWIKI_MODEL_ID=your-routed-model-id
+openwiki --init
+```
+
+Some local servers ignore the API key value, but OpenWiki still requires
+`OPENAI_COMPATIBLE_API_KEY` because the OpenAI-compatible client expects one.
+
 ### AWS Bedrock
 
 The `bedrock` provider calls foundation models hosted on AWS Bedrock using IAM


### PR DESCRIPTION
## Summary

Documents how to use local LLM servers through the existing `openai-compatible` provider.

## Why

Issue #120 asks for local LLM support or at least clear documentation. OpenWiki already has the provider plumbing for OpenAI-compatible chat completions, but the README only showed a generic remote gateway example.

This PR keeps the scope docs-only and avoids adding another provider. It adds examples for:

- Ollama
- LM Studio
- local OpenAI-compatible gateways such as 9Router

## Testing

- `corepack pnpm run format`
- `corepack pnpm run lint`
- `corepack pnpm run typecheck`

I also ran `corepack pnpm test`; it still fails on this Windows checkout in `test/env-behavior.test.ts` for the same 3 HOME/permission isolation assertions that also fail on a clean `origin/main@ac5007c` worktree.

Fixes #120 for the documentation-only path.
