### PR TITLE
fix: ground repository CI docs in checked-out config

### DIFF
--- a/.changeset/repository-ci-symlink-guard.md
+++ b/.changeset/repository-ci-symlink-guard.md
@@ -1,0 +1,5 @@
+---
+"openwiki": patch
+---
+
+Ignore symlinked repository CI files and workflow directories when building run context.

--- a/src/agent/prompt.ts
+++ b/src/agent/prompt.ts
@@ -67,6 +67,10 @@ export function createUserPrompt(
     .replace("{WIKI_GOAL}", context.wikiGoal?.trim() || "(not provided)")
     .replace("{LAST_UPDATE}", formatLastUpdate(context.lastUpdate))
     .replace(
+      "{REPOSITORY_CI_CONTEXT}",
+      formatRepositoryCiSummary(context.ciSummary),
+    )
+    .replace(
       "{ADDITIONAL_USER_REQUEST}",
       userMessage?.trim()
         ? `Additional user instruction:\n${userMessage.trim()}`
@@ -95,6 +99,10 @@ function formatLastUpdate(lastUpdate: UpdateMetadata | null): string {
   }
 
   return JSON.stringify(lastUpdate, null, 2);
+}
+
+function formatRepositoryCiSummary(ciSummary: string | undefined): string {
+  return ciSummary?.trim() || "(not applicable)";
 }
 
 function formatLanguageInstructions(language: string | undefined): string {

--- a/src/agent/prompts/code.ts
+++ b/src/agent/prompts/code.ts
@@ -28,6 +28,12 @@ Wiki-first question answering:
 Index discipline:
 - Directory index.md files are generated deterministically after the run. Do not create or edit them yourself.
 
+Repository evidence grounding discipline:
+- When documenting this repository's CI, scheduled jobs, or OpenWiki integration, read and cite the checked-out workflow/config files from this repository before changing those docs.
+- Treat this repository's workflow files, package scripts, configuration files, and existing user-authored briefs as the source of truth for this repository's actual automation.
+- The OpenWiki CLI reference and OpenWiki's own README/examples describe the tool's defaults and upstream examples; use them only for generic OpenWiki behavior, never as a substitute for this repository's checked-out configuration.
+- If the repository configuration conflicts with OpenWiki's defaults or examples, document the repository configuration and call the upstream default/example out only when that contrast is directly relevant.
+
 Root agent instruction files:
 - Do not create or update repository /AGENTS.md or /CLAUDE.md files during normal code wiki runs.
 - Keep generated wiki content under the repository /openwiki directory.
@@ -181,6 +187,12 @@ Do not draft wiki prose until every planned substantive page has an evidence bri
 - Once a canonical file is identified, read the complete relevant functions, types, and adjacent tests. Follow calls and data across at least one boundary in each direction. Do not merely collect filenames or test names: understand what behavior and invariant each test proves.
 - Only begin writing after this evidence gate is satisfied for the complete inventory. Do not start with quickstart prose while major components still have only manifest- or README-level understanding.
 
+Repository evidence grounding discipline:
+- When documenting this repository's CI, scheduled jobs, or OpenWiki integration, read and cite the checked-out workflow/config files from this repository before changing those docs.
+- Treat this repository's workflow files, package scripts, configuration files, and existing user-authored briefs as the source of truth for this repository's actual automation.
+- The OpenWiki CLI reference and OpenWiki's own README/examples describe the tool's defaults and upstream examples; use them only for generic OpenWiki behavior, never as a substitute for this repository's checked-out configuration.
+- If the repository configuration conflicts with OpenWiki's defaults or examples, document the repository configuration and call the upstream default/example out only when that contrast is directly relevant.
+
 Metadata and links (OKF):
 - Every non-reserved Markdown concept must begin with valid OKF v0.1 YAML front matter. index.md and log.md are reserved and must not receive concept front matter.
 - Use this shape, omitting optional or empty fields:
@@ -249,6 +261,12 @@ Existing documentation discipline:
 - Use README files, docs/ trees, root documentation, runbooks, and SKILL.md files to discover intended behavior, terminology, workflows, and historical rationale; verify important current claims against source code and tests.
 - Summarize and link to useful existing docs instead of duplicating them wholesale.
 - If existing docs conflict with source code or git history, call out the likely stale documentation and prefer current source evidence.
+
+Repository evidence grounding discipline:
+- When documenting this repository's CI, scheduled jobs, or OpenWiki integration, read and cite the checked-out workflow/config files from this repository before changing those docs.
+- Treat this repository's workflow files, package scripts, configuration files, and existing user-authored briefs as the source of truth for this repository's actual automation.
+- The OpenWiki CLI reference and OpenWiki's own README/examples describe the tool's defaults and upstream examples; use them only for generic OpenWiki behavior, never as a substitute for this repository's checked-out configuration.
+- If the repository configuration conflicts with OpenWiki's defaults or examples, document the repository configuration and call the upstream default/example out only when that contrast is directly relevant.
 
 Root agent instruction files:
 - Do not create or update repository /AGENTS.md or /CLAUDE.md files during normal code wiki runs.
@@ -410,6 +428,9 @@ export const CODE_USER_PROMPTS = {
 Wiki brief:
 {WIKI_GOAL}
 
+Repository automation context:
+{REPOSITORY_CI_CONTEXT}
+
 {ADDITIONAL_USER_REQUEST}
 
 {RUNTIME_CONTEXT}`,
@@ -419,6 +440,9 @@ Inspect the target repository's openwiki/ directory, read /openwiki/.last-update
 
 Wiki brief:
 {WIKI_GOAL}
+
+Repository automation context:
+{REPOSITORY_CI_CONTEXT}
 
 {ADDITIONAL_USER_REQUEST}
 

--- a/src/agent/types.ts
+++ b/src/agent/types.ts
@@ -55,6 +55,7 @@ export type UpdateMetadata = {
 };
 
 export type RunContext = {
+  ciSummary?: string;
   lastUpdate: UpdateMetadata | null;
   language?: string;
   wikiGoal?: string;

--- a/src/agent/utils.ts
+++ b/src/agent/utils.ts
@@ -129,6 +129,19 @@ async function findGitHubWorkflowPaths(cwd: string): Promise<string[]> {
   const workflowsDir = path.join(cwd, GITHUB_WORKFLOWS_DIR);
 
   try {
+    const workflowsDirStat = await lstat(workflowsDir);
+
+    if (!workflowsDirStat.isDirectory()) {
+      return [];
+    }
+
+    const realCwd = await realpath(cwd);
+    const realWorkflowsDir = await realpath(workflowsDir);
+
+    if (!isPathInsideDirectory(realWorkflowsDir, realCwd)) {
+      return [];
+    }
+
     const entries = await readdir(workflowsDir, { withFileTypes: true });
 
     return entries

--- a/src/agent/utils.ts
+++ b/src/agent/utils.ts
@@ -1,6 +1,14 @@
 import { execFile } from "node:child_process";
 import { createHash } from "node:crypto";
-import { mkdir, readdir, readFile, rm, writeFile } from "node:fs/promises";
+import {
+  lstat,
+  mkdir,
+  readdir,
+  readFile,
+  realpath,
+  rm,
+  writeFile,
+} from "node:fs/promises";
 import path from "node:path";
 import { promisify } from "node:util";
 import { OPEN_WIKI_DIR, UPDATE_METADATA_PATH } from "../config/constants.js";
@@ -27,6 +35,17 @@ import type { Dirent } from "node:fs";
 const execFileAsync = promisify(execFile);
 const LOCAL_WIKI_METADATA_PATH = ".last-update.json";
 const TEMPORARY_PLAN_FILE = "_plan.md";
+const GITHUB_WORKFLOWS_DIR = ".github/workflows";
+const YAML_EXTENSIONS = new Set([".yaml", ".yml"]);
+const REPOSITORY_CI_FILE_PATHS = [".gitlab-ci.yml", "bitbucket-pipelines.yml"];
+const REPOSITORY_CI_CONTEXT_HEADING =
+  "Repository automation context (checked-out CI configuration)";
+const NO_REPOSITORY_CI_CONFIG_MESSAGE =
+  "No checked-out CI configuration files were found in this repository.";
+const BYTES_PER_KIB = 1024;
+const REPOSITORY_CI_CONTEXT_MAX_BYTES = 64 * BYTES_PER_KIB;
+const TRUNCATED_CONTEXT_PREFIX = "[...truncated, ";
+const TRUNCATED_CONTEXT_SUFFIX = " more bytes]";
 
 export type OpenWikiContentSnapshot = string;
 
@@ -63,9 +82,129 @@ export async function createRunContext(
 
   return {
     lastUpdate,
+    // Only repository runs document this repo's automation; a local wiki run has
+    // no checked-out CI to ground, so it keeps ciSummary absent.
+    ...(outputMode === "repository"
+      ? { ciSummary: await createRepositoryCiSummary(cwd) }
+      : {}),
     ...languageContext,
     wikiGoal,
   };
+}
+
+async function createRepositoryCiSummary(cwd: string): Promise<string> {
+  const ciFilePaths = await findRepositoryCiFilePaths(cwd);
+
+  if (ciFilePaths.length === 0) {
+    return NO_REPOSITORY_CI_CONFIG_MESSAGE;
+  }
+
+  const fileBlocks = await Promise.all(
+    ciFilePaths.map(async (relativePath) => {
+      const content = await readFile(path.join(cwd, relativePath), "utf8");
+
+      return [`--- ${relativePath} ---`, content.trimEnd()].join("\n");
+    }),
+  );
+
+  return truncateTextByBytes(
+    [REPOSITORY_CI_CONTEXT_HEADING, ...fileBlocks].join("\n\n"),
+    REPOSITORY_CI_CONTEXT_MAX_BYTES,
+  );
+}
+
+async function findRepositoryCiFilePaths(cwd: string): Promise<string[]> {
+  const githubWorkflowPaths = await findGitHubWorkflowPaths(cwd);
+  const directCiPaths = await filterExistingFiles(
+    cwd,
+    REPOSITORY_CI_FILE_PATHS,
+  );
+
+  return [...githubWorkflowPaths, ...directCiPaths].sort((left, right) =>
+    left.localeCompare(right),
+  );
+}
+
+async function findGitHubWorkflowPaths(cwd: string): Promise<string[]> {
+  const workflowsDir = path.join(cwd, GITHUB_WORKFLOWS_DIR);
+
+  try {
+    const entries = await readdir(workflowsDir, { withFileTypes: true });
+
+    return entries
+      .filter((entry) => entry.isFile())
+      .map((entry) => entry.name)
+      .filter((fileName) => YAML_EXTENSIONS.has(path.extname(fileName)))
+      .map((fileName) => path.posix.join(GITHUB_WORKFLOWS_DIR, fileName));
+  } catch (error) {
+    if (isFileNotFoundError(error)) {
+      return [];
+    }
+
+    throw error;
+  }
+}
+
+async function filterExistingFiles(
+  cwd: string,
+  relativePaths: string[],
+): Promise<string[]> {
+  const realCwd = await realpath(cwd);
+  const existingPaths = await Promise.all(
+    relativePaths.map(async (relativePath) => {
+      try {
+        const filePath = path.join(cwd, relativePath);
+        const fileStat = await lstat(filePath);
+
+        if (!fileStat.isFile()) {
+          return null;
+        }
+
+        const realFilePath = await realpath(filePath);
+
+        return isPathInsideDirectory(realFilePath, realCwd)
+          ? relativePath
+          : null;
+      } catch (error) {
+        if (isFileNotFoundError(error)) {
+          return null;
+        }
+
+        throw error;
+      }
+    }),
+  );
+
+  return existingPaths.filter((relativePath) => relativePath !== null);
+}
+
+function isPathInsideDirectory(
+  filePath: string,
+  directoryPath: string,
+): boolean {
+  const relativePath = path.relative(directoryPath, filePath);
+
+  return (
+    relativePath.length > 0 &&
+    !relativePath.startsWith("..") &&
+    !path.isAbsolute(relativePath)
+  );
+}
+
+function truncateTextByBytes(text: string, maxBytes: number): string {
+  const buffer = Buffer.from(text, "utf8");
+
+  if (buffer.byteLength <= maxBytes) {
+    return text;
+  }
+
+  const remainingBytes = buffer.byteLength - maxBytes;
+  const truncatedText = buffer.subarray(0, maxBytes).toString("utf8").trimEnd();
+
+  return [
+    truncatedText,
+    `${TRUNCATED_CONTEXT_PREFIX}${remainingBytes}${TRUNCATED_CONTEXT_SUFFIX}`,
+  ].join("\n\n");
 }
 
 async function readRunWikiGoal(

--- a/test/agent/prompt.test.ts
+++ b/test/agent/prompt.test.ts
@@ -19,6 +19,11 @@ function emptyContext(overrides: Partial<RunContext> = {}): RunContext {
   };
 }
 
+const REPOSITORY_CI_GROUNDING_RULE =
+  "When documenting this repository's CI, scheduled jobs, or OpenWiki integration";
+const OPENWIKI_REFERENCE_BOUNDARY =
+  "The OpenWiki CLI reference and OpenWiki's own README/examples describe the tool's defaults";
+
 describe("createSystemPrompt output language", () => {
   test("instructs the agent to write wiki documentation in the selected language", () => {
     const prompt = createSystemPrompt("init", "repository", "zh-CN");
@@ -316,5 +321,20 @@ describe("createSystemPrompt diagram guidance", () => {
     // The carve-out is scoped to update runs, not repeated in init guidance.
     const init = createSystemPrompt("init");
     expect(init).not.toContain("adding one is a valuable improvement");
+  });
+});
+
+describe("createSystemPrompt repository evidence grounding", () => {
+  test("grounds repository update CI documentation in checked-out workflow files", () => {
+    const prompt = createSystemPrompt("update", "repository");
+
+    expect(prompt).toContain(REPOSITORY_CI_GROUNDING_RULE);
+    expect(prompt).toContain(OPENWIKI_REFERENCE_BOUNDARY);
+  });
+
+  test("does not add repository CI grounding rules to local wiki runs", () => {
+    const prompt = createSystemPrompt("update", "local-wiki");
+
+    expect(prompt).not.toContain(REPOSITORY_CI_GROUNDING_RULE);
   });
 });

--- a/test/repository-ci-context.test.ts
+++ b/test/repository-ci-context.test.ts
@@ -12,6 +12,7 @@ const OPENWIKI_WORKFLOW_FILE = "openwiki-update.yml";
 const OPENWIKI_WORKFLOW_PATH = `${GITHUB_WORKFLOW_DIR}/${OPENWIKI_WORKFLOW_FILE}`;
 const GITLAB_CI_PATH = ".gitlab-ci.yml";
 const BITBUCKET_PIPELINES_PATH = "bitbucket-pipelines.yml";
+const EXTERNAL_WORKFLOW_FILE = "leak.yml";
 const ANTHROPIC_PROVIDER_LINE = "OPENWIKI_PROVIDER: anthropic";
 const ANTHROPIC_MODEL_LINE = "OPENWIKI_MODEL_ID: claude-sonnet-5";
 const OPENROUTER_PROVIDER_LINE = "OPENWIKI_PROVIDER: openrouter";
@@ -42,6 +43,13 @@ async function createTempSecretFile(): Promise<string> {
   await writeFile(secretPath, SYMLINK_SECRET_CONTENT, "utf8");
 
   return secretPath;
+}
+
+async function createTempSecretDir(): Promise<string> {
+  const secretDir = await mkdtemp(path.join(tmpdir(), TEMP_SECRET_PREFIX));
+  tempSecretDirs.push(secretDir);
+
+  return secretDir;
 }
 
 afterEach(async () => {
@@ -157,5 +165,22 @@ jobs:
 
     expect(context.ciSummary).not.toContain(SYMLINK_SECRET_CONTENT);
     expect(context.ciSummary).not.toContain(GITLAB_CI_PATH);
+  });
+
+  test("does not follow symlinked GitHub workflows directories", async () => {
+    const repo = await createTempRepo();
+    const secretDir = await createTempSecretDir();
+    await writeFile(
+      path.join(secretDir, EXTERNAL_WORKFLOW_FILE),
+      SYMLINK_SECRET_CONTENT,
+      "utf8",
+    );
+    await mkdir(path.join(repo, ".github"), { recursive: true });
+    await symlink(secretDir, path.join(repo, GITHUB_WORKFLOW_DIR));
+
+    const context = await createRunContext("update", repo, "repository");
+
+    expect(context.ciSummary).not.toContain(SYMLINK_SECRET_CONTENT);
+    expect(context.ciSummary).not.toContain(EXTERNAL_WORKFLOW_FILE);
   });
 });

--- a/test/repository-ci-context.test.ts
+++ b/test/repository-ci-context.test.ts
@@ -1,0 +1,161 @@
+import { mkdtemp, mkdir, rm, symlink, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, test } from "vitest";
+import { createUserPrompt } from "../src/agent/prompt.ts";
+import { createRunContext } from "../src/agent/utils.ts";
+
+const TEMP_REPO_PREFIX = "openwiki-ci-context-";
+const TEMP_SECRET_PREFIX = "openwiki-ci-secret-";
+const GITHUB_WORKFLOW_DIR = ".github/workflows";
+const OPENWIKI_WORKFLOW_FILE = "openwiki-update.yml";
+const OPENWIKI_WORKFLOW_PATH = `${GITHUB_WORKFLOW_DIR}/${OPENWIKI_WORKFLOW_FILE}`;
+const GITLAB_CI_PATH = ".gitlab-ci.yml";
+const BITBUCKET_PIPELINES_PATH = "bitbucket-pipelines.yml";
+const ANTHROPIC_PROVIDER_LINE = "OPENWIKI_PROVIDER: anthropic";
+const ANTHROPIC_MODEL_LINE = "OPENWIKI_MODEL_ID: claude-sonnet-5";
+const OPENROUTER_PROVIDER_LINE = "OPENWIKI_PROVIDER: openrouter";
+const GITLAB_JOB_NAME = "gitlab_update_docs";
+const BITBUCKET_STEP_NAME = "Bitbucket OpenWiki refresh";
+const REPOSITORY_CI_CONTEXT_HEADING = "Repository automation context:";
+const NO_CI_CONFIG_MESSAGE =
+  "No checked-out CI configuration files were found in this repository.";
+const TRUNCATED_CONTEXT_MARKER = "[...truncated, ";
+const SYMLINK_SECRET_CONTENT = "SECRET_TOKEN=do-not-leak";
+const LARGE_WORKFLOW_COMMENT = "# repeated workflow context";
+const LARGE_WORKFLOW_REPEAT_COUNT = 3_500;
+
+const tempRepos: string[] = [];
+const tempSecretDirs: string[] = [];
+
+async function createTempRepo(): Promise<string> {
+  const repo = await mkdtemp(path.join(tmpdir(), TEMP_REPO_PREFIX));
+  tempRepos.push(repo);
+
+  return repo;
+}
+
+async function createTempSecretFile(): Promise<string> {
+  const secretDir = await mkdtemp(path.join(tmpdir(), TEMP_SECRET_PREFIX));
+  tempSecretDirs.push(secretDir);
+  const secretPath = path.join(secretDir, "secret.txt");
+  await writeFile(secretPath, SYMLINK_SECRET_CONTENT, "utf8");
+
+  return secretPath;
+}
+
+afterEach(async () => {
+  await Promise.all(
+    [...tempRepos.splice(0), ...tempSecretDirs.splice(0)].map((repo) =>
+      rm(repo, { force: true, recursive: true }),
+    ),
+  );
+});
+
+describe("repository CI context", () => {
+  test("injects checked-out workflow configuration into repository update prompts", async () => {
+    const repo = await createTempRepo();
+    await mkdir(path.join(repo, GITHUB_WORKFLOW_DIR), { recursive: true });
+    await writeFile(
+      path.join(repo, OPENWIKI_WORKFLOW_PATH),
+      `
+name: OpenWiki Update
+
+jobs:
+  update:
+    steps:
+      - run: openwiki --update --print
+        env:
+          ${ANTHROPIC_PROVIDER_LINE}
+          ${ANTHROPIC_MODEL_LINE}
+`.trimStart(),
+      "utf8",
+    );
+
+    const context = await createRunContext(repo, "repository");
+    const prompt = createUserPrompt("update", context, null, "repository");
+
+    expect(context.ciSummary).toBeDefined();
+    expect(context.ciSummary).toContain(OPENWIKI_WORKFLOW_PATH);
+    expect(context.ciSummary).toContain(ANTHROPIC_PROVIDER_LINE);
+    expect(prompt).toContain(ANTHROPIC_MODEL_LINE);
+    expect(prompt).not.toContain(OPENROUTER_PROVIDER_LINE);
+  });
+
+  test("includes GitLab CI and Bitbucket Pipelines files", async () => {
+    const repo = await createTempRepo();
+    await writeFile(
+      path.join(repo, GITLAB_CI_PATH),
+      `${GITLAB_JOB_NAME}:\n  script: openwiki --update --print\n`,
+      "utf8",
+    );
+    await writeFile(
+      path.join(repo, BITBUCKET_PIPELINES_PATH),
+      `pipelines:\n  default:\n    - step:\n        name: ${BITBUCKET_STEP_NAME}\n`,
+      "utf8",
+    );
+
+    const context = await createRunContext(repo, "repository");
+
+    expect(context.ciSummary).toContain(GITLAB_CI_PATH);
+    expect(context.ciSummary).toContain(GITLAB_JOB_NAME);
+    expect(context.ciSummary).toContain(BITBUCKET_PIPELINES_PATH);
+    expect(context.ciSummary).toContain(BITBUCKET_STEP_NAME);
+  });
+
+  test("reports when no checked-out CI configuration files exist", async () => {
+    const repo = await createTempRepo();
+
+    const context = await createRunContext(repo, "repository");
+    const prompt = createUserPrompt("update", context, null, "repository");
+
+    expect(context.ciSummary).toBe(NO_CI_CONFIG_MESSAGE);
+    expect(prompt).toContain(NO_CI_CONFIG_MESSAGE);
+  });
+
+  test("does not compute repository CI context for local wiki runs", async () => {
+    const repo = await createTempRepo();
+    await mkdir(path.join(repo, GITHUB_WORKFLOW_DIR), { recursive: true });
+    await writeFile(
+      path.join(repo, OPENWIKI_WORKFLOW_PATH),
+      `${ANTHROPIC_PROVIDER_LINE}\n`,
+      "utf8",
+    );
+
+    const context = await createRunContext(repo, "local-wiki");
+    const prompt = createUserPrompt("update", context, null, "local-wiki");
+
+    expect(context.ciSummary).toBeUndefined();
+    expect(prompt).not.toContain(REPOSITORY_CI_CONTEXT_HEADING);
+    expect(prompt).not.toContain(ANTHROPIC_PROVIDER_LINE);
+  });
+
+  test("truncates oversized repository CI context with an explicit byte count", async () => {
+    const repo = await createTempRepo();
+    await mkdir(path.join(repo, GITHUB_WORKFLOW_DIR), { recursive: true });
+    await writeFile(
+      path.join(repo, OPENWIKI_WORKFLOW_PATH),
+      Array.from(
+        { length: LARGE_WORKFLOW_REPEAT_COUNT },
+        () => LARGE_WORKFLOW_COMMENT,
+      ).join("\n"),
+      "utf8",
+    );
+
+    const context = await createRunContext(repo, "repository");
+
+    expect(context.ciSummary).toContain(OPENWIKI_WORKFLOW_PATH);
+    expect(context.ciSummary).toContain(TRUNCATED_CONTEXT_MARKER);
+  });
+
+  test("does not follow symlinks for direct CI config paths", async () => {
+    const repo = await createTempRepo();
+    const secretPath = await createTempSecretFile();
+    await symlink(secretPath, path.join(repo, GITLAB_CI_PATH));
+
+    const context = await createRunContext(repo, "repository");
+
+    expect(context.ciSummary).not.toContain(SYMLINK_SECRET_CONTENT);
+    expect(context.ciSummary).not.toContain(GITLAB_CI_PATH);
+  });
+});


### PR DESCRIPTION
## Summary

- preload checked-out repository CI configuration into the run context for repository init/update prompts
- include GitHub Actions, GitLab CI, and Bitbucket Pipelines files as deterministic source evidence before the model writes docs
- cap the injected CI context at 64 KiB with an explicit truncation marker, so large workflow sets do not silently bloat every prompt
- reject symlinked CI config paths and workflow directories before reading them, preventing prompt exfiltration through `.gitlab-ci.yml`, `bitbucket-pipelines.yml`, or `.github/workflows`
- keep repository-mode prompt guidance that OpenWiki defaults/examples must not override the host repo's actual workflow/config files
- add regression coverage for prompt boundaries, GitHub/GitLab/Bitbucket CI context, no-CI repos, local-wiki exclusion, truncation, and symlink exfiltration

Fixes #389

## Why this is not prompt-only

The prompt instruction is now a secondary guard. The runtime also reads the checked-out CI files before the LLM run and injects their contents into the user prompt as repository automation context, so the agent receives the repo's actual workflow provider/model values without needing to decide to inspect those files first.

## Security note

Direct root CI config paths and the `.github/workflows` directory are checked with `lstat()` before reading, so symlinks are ignored. Normal files and workflow directories are also checked with `realpath()` to ensure their resolved path remains inside the repository root before their contents can be injected into the LLM prompt.

## Test verification (RED → GREEN)

RED on upstream-base behavior with the prompt regression test:

```text
FAIL  test/prompt.test.ts > createSystemPrompt repository evidence grounding > grounds repository update CI documentation in checked-out workflow files
AssertionError: expected 'You are OpenWiki, an expert technical…' to contain 'When documenting this repository\'s C…'
Test Files  1 failed (1)
Tests  1 failed | 1 passed (2)
```

RED with the deterministic CI-context patch reverted, leaving only the earlier prompt-only change:

```text
FAIL  test/repository-ci-context.test.ts > repository CI context > injects checked-out workflow configuration into repository update prompts
AssertionError: the given combination of arguments (undefined and string) is invalid for this assertion.
Test Files  1 failed (1)
Tests  1 failed (1)
```

RED with only the CI-context cap/lookup code reverted while keeping the expanded tests:

```text
FAIL  test/repository-ci-context.test.ts > repository CI context > truncates oversized repository CI context with an explicit byte count
AssertionError: expected 'Repository automation context (checke…' to contain '[...truncated, '
Test Files  1 failed (1)
Tests  1 failed | 4 passed (5)
```

RED for Corridor's symlink exfiltration finding before the `lstat()` fix:

```text
FAIL  test/repository-ci-context.test.ts > repository CI context > does not follow symlinks for direct CI config paths
AssertionError: expected 'Repository automation context (checke…' not to contain 'SECRET_TOKEN=do-not-leak'
Test Files  1 failed (1)
Tests  1 failed | 5 passed (6)
```

RED for Corridor's symlinked GitHub workflows directory finding before the directory `lstat()`/`realpath()` fix:

```text
FAIL  test/repository-ci-context.test.ts > repository CI context > does not follow symlinked GitHub workflows directories
AssertionError: expected 'Repository automation context (checke…' not to contain 'SECRET_TOKEN=do-not-leak'
Test Files  1 failed (1)
Tests  1 failed | 6 skipped (7)
```

GREEN with the full fix:

```text
pnpm exec vitest run test/prompt.test.ts test/repository-ci-context.test.ts
Test Files  2 passed (2)
Tests  24 passed (24)
```

Full local verification:

```text
pnpm run typecheck
# passed

pnpm run lint:check
# passed

pnpm run format:check
All matched files use Prettier code style!

pnpm run test
Test Files  51 passed (51)
Tests  613 passed (613)

pnpm run build
# passed

OPENWIKI_DEV=1 node dist/cli.js code --dry-run --init
# passed; dry run writes no files or metadata
```
