### PR TITLE
feat: support the AWS SDK credential chain for Bedrock

### DIFF
--- a/README.md
+++ b/README.md
@@ -302,8 +302,8 @@ Some local servers ignore the API key value, but OpenWiki still requires
 ### AWS Bedrock
 
 The `bedrock` provider calls foundation models hosted on AWS Bedrock using IAM
-credentials rather than a single vendor API key. It authenticates with an AWS
-access key ID, a secret access key, and a region:
+credentials rather than a single vendor API key. Existing installations can
+continue to provide an AWS access key ID, secret access key, and region:
 
 ```bash
 OPENWIKI_PROVIDER=bedrock
@@ -312,6 +312,11 @@ BEDROCK_AWS_SECRET_ACCESS_KEY=your-secret-access-key
 BEDROCK_AWS_REGION=us-east-1
 OPENWIKI_MODEL_ID=anthropic.claude-sonnet-5
 ```
+
+When the explicit Bedrock credentials are not set, OpenWiki uses the AWS SDK
+default credential provider chain, including OIDC/web identity, IAM roles,
+AWS profiles, and ECS/EC2 credentials. The region is resolved from
+`BEDROCK_AWS_REGION`, `AWS_REGION`, or `AWS_DEFAULT_REGION`.
 
 Which model IDs are available depends on your AWS account and region (which
 foundation models you've enabled in the Bedrock console), so there is no

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -55,7 +55,10 @@ import type {
 import {
   ANTHROPIC_BASE_URL_ENV_KEY,
   BASETEN_BASE_URL_ENV_KEY,
+  BEDROCK_AWS_ACCESS_KEY_ID_ENV_KEY,
   BEDROCK_AWS_REGION_ENV_KEY,
+  BEDROCK_AWS_SECRET_ACCESS_KEY_ENV_KEY,
+  BEDROCK_AWS_SESSION_TOKEN_ENV_KEY,
   getDefaultModelId,
   getMissingProviderEnvKey,
   getProviderApiKeyEnvKey,
@@ -64,8 +67,8 @@ import {
   getProviderLabel,
   getProviderBaseUrlWarnings,
   getProviderModelOptions,
-  getProviderRegionEnvKey,
   FIREWORKS_BASE_URL_ENV_KEY,
+  getProviderRegionEnvKeys,
   getProviderSecretKeyEnvKey,
   getProvidersForKnownModelId,
   isModelIdForOtherProvider,
@@ -84,6 +87,7 @@ import {
   providerRequiresBaseUrl,
   providerRequiresRegion,
   providerRequiresSecretKey,
+  providerUsesAwsSdkCredentials,
   resolveConfiguredProvider,
   resolveOpenRouterProviderOnly,
   resolveProviderBaseUrl,
@@ -168,7 +172,12 @@ export async function runOpenWikiAgent(
       );
     }
     ensureProviderCredentials(provider);
-    emitDebug(options, `credentials=${provider} present`);
+    emitDebug(
+      options,
+      providerUsesAwsSdkCredentials(provider)
+        ? `credentials=${provider} delegated-to-aws-sdk`
+        : `credentials=${provider} present`,
+    );
     ensureProviderBaseUrl(provider);
     ensureProviderSecretKey(provider);
     ensureProviderRegion(provider);
@@ -568,10 +577,12 @@ function ensureProviderRegion(provider: OpenWikiProvider): void {
   }
 
   if (!resolveProviderRegion(provider)) {
-    const regionEnvKey = getProviderRegionEnvKey(provider) ?? "region";
+    const regionEnvKeys = getProviderRegionEnvKeys(provider);
+    const regionRequirement =
+      regionEnvKeys.length > 0 ? regionEnvKeys.join(", ") : "region";
 
     throw new Error(
-      `${regionEnvKey} is required to run OpenWiki with ${getProviderLabel(provider)}.`,
+      `One of ${regionRequirement} is required to run OpenWiki with ${getProviderLabel(provider)}.`,
     );
   }
 }
@@ -733,15 +744,7 @@ export function createModel(
   }
 
   if (provider === "bedrock") {
-    const secretKeyEnvKey = getProviderSecretKeyEnvKey(provider);
-
     return new ChatBedrockConverse({
-      credentials: {
-        accessKeyId: getProviderApiKey(provider) ?? "",
-        secretAccessKey: secretKeyEnvKey
-          ? (process.env[secretKeyEnvKey] ?? "")
-          : "",
-      },
       model: modelId,
       region: resolveProviderRegion(provider),
       ...retryOptions,
@@ -1656,11 +1659,14 @@ function formatOpenRouterDebugUrl(value: string): string {
 
 function formatEnvironmentDebug(): string {
   return DEBUG_ENV_KEYS.map(
-    (key) => `${key}:${formatDebugValue(key, process.env[key])}`,
+    (key) => `${key}:${formatEnvironmentDebugValue(key, process.env[key])}`,
   ).join(" ");
 }
 
-function formatDebugValue(key: string, value: string | undefined): string {
+export function formatEnvironmentDebugValue(
+  key: string,
+  value: string | undefined,
+): string {
   if (value === undefined) {
     return "unset";
   }
@@ -1677,7 +1683,12 @@ function formatDebugValue(key: string, value: string | undefined): string {
     return formatUrlDebugValue(value);
   }
 
-  if (key.endsWith("_API_KEY")) {
+  if (
+    key.endsWith("_API_KEY") ||
+    key === BEDROCK_AWS_ACCESS_KEY_ID_ENV_KEY ||
+    key === BEDROCK_AWS_SECRET_ACCESS_KEY_ENV_KEY ||
+    key === BEDROCK_AWS_SESSION_TOKEN_ENV_KEY
+  ) {
     return `set(length=${value.length})`;
   }
 

--- a/src/cli.tsx
+++ b/src/cli.tsx
@@ -78,6 +78,7 @@ import {
   normalizeProvider,
   OPENWIKI_PROVIDER_ENV_KEY,
   OPENWIKI_MODEL_ID_ENV_KEY,
+  providerUsesAwsSdkCredentials,
   resolveConfiguredProvider,
   SELECTABLE_OPENWIKI_PROVIDERS,
   OPENWIKI_VERSION,
@@ -164,6 +165,7 @@ type ErrorDiagnostic = {
 type AuthFix = {
   apiKeyEnvKey: string | undefined;
   keyFromShell: boolean;
+  provider: OpenWikiProvider;
 };
 
 type AppProps = {
@@ -1125,6 +1127,17 @@ function CredentialDiagnosticsPanel({
 function getAuthFixSteps(authFix: AuthFix): string[] {
   const steps: string[] = [];
 
+  if (providerUsesAwsSdkCredentials(authFix.provider)) {
+    steps.push(
+      "Verify the selected AWS identity with `aws sts get-caller-identity` in the same environment.",
+      "Configure the AWS SDK credential chain (OIDC/workload role, AWS_PROFILE/SSO, or standard AWS credentials) and a Bedrock region, then retry.",
+      "Unset AWS_BEARER_TOKEN_BEDROCK for OIDC/IAM runs; a bearer token takes precedence when present.",
+      "A complete BEDROCK_AWS_ACCESS_KEY_ID/BEDROCK_AWS_SECRET_ACCESS_KEY pair takes precedence; unset both in the shell and remove both from ~/.openwiki/.env to use ambient AWS credentials.",
+    );
+
+    return steps;
+  }
+
   if (authFix.keyFromShell && authFix.apiKeyEnvKey) {
     steps.push(
       `${authFix.apiKeyEnvKey} came from your shell, not ~/.openwiki/.env. ` +
@@ -1978,6 +1991,13 @@ function ChatInput({
         return;
       }
 
+      if (providerUsesAwsSdkCredentials(currentProvider)) {
+        setError(
+          `${getProviderLabel(currentProvider)} uses the AWS SDK credential chain; /api-key cannot safely configure an access-key pair. ${getProviderCredentialHint(currentProvider) ?? ""} Legacy BEDROCK_AWS_ACCESS_KEY_ID and BEDROCK_AWS_SECRET_ACCESS_KEY values must be configured or removed together in the shell and ~/.openwiki/.env.`.trim(),
+        );
+        return;
+      }
+
       const apiKeyEnvKey = getProviderApiKeyEnvKey(currentProvider);
 
       if (!apiKeyEnvKey) {
@@ -2125,9 +2145,12 @@ function ChatInput({
       await onProviderSelect(provider);
       resetInput();
       const apiKeyEnvKey = getProviderApiKeyEnvKey(provider);
-      const requirement = apiKeyEnvKey
-        ? `Ensure ${apiKeyEnvKey} is set.`
-        : `Ensure ${getProviderProjectEnvKey(provider)} is set. ${getProviderCredentialHint(provider) ?? ""}`.trim();
+      const requirement = providerUsesAwsSdkCredentials(provider)
+        ? (getProviderCredentialHint(provider) ??
+          "Configure AWS SDK credentials.")
+        : apiKeyEnvKey
+          ? `Ensure ${apiKeyEnvKey} is set.`
+          : `Ensure ${getProviderProjectEnvKey(provider)} is set. ${getProviderCredentialHint(provider) ?? ""}`.trim();
       const modelNotice =
         getProviderModelOptions(provider).length > 0
           ? ` with model ${getDefaultModelId(provider)}`
@@ -3315,6 +3338,7 @@ function getAuthFix(
     keyFromShell:
       apiKeyEnvKey !== undefined &&
       getShellEnvValue(apiKeyEnvKey) !== undefined,
+    provider,
   };
 }
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -737,7 +737,7 @@ export function resolveConfiguredProvider(
                     : hasNonEmptyEnvValue(
                           env,
                           BEDROCK_AWS_ACCESS_KEY_ID_ENV_KEY,
-                        ) &&
+                        ) ||
                         hasNonEmptyEnvValue(
                           env,
                           BEDROCK_AWS_SECRET_ACCESS_KEY_ENV_KEY,

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -28,7 +28,17 @@ export const OPENWIKI_OPENROUTER_PROVIDER_ONLY_ENV_KEY =
 export const BEDROCK_AWS_ACCESS_KEY_ID_ENV_KEY = "BEDROCK_AWS_ACCESS_KEY_ID";
 export const BEDROCK_AWS_SECRET_ACCESS_KEY_ENV_KEY =
   "BEDROCK_AWS_SECRET_ACCESS_KEY";
+export const BEDROCK_AWS_SESSION_TOKEN_ENV_KEY = "BEDROCK_AWS_SESSION_TOKEN";
 export const BEDROCK_AWS_REGION_ENV_KEY = "BEDROCK_AWS_REGION";
+export const AWS_ACCESS_KEY_ID_ENV_KEY = "AWS_ACCESS_KEY_ID";
+export const AWS_SECRET_ACCESS_KEY_ENV_KEY = "AWS_SECRET_ACCESS_KEY";
+export const AWS_SESSION_TOKEN_ENV_KEY = "AWS_SESSION_TOKEN";
+export const AWS_REGION_ENV_KEY = "AWS_REGION";
+export const AWS_DEFAULT_REGION_ENV_KEY = "AWS_DEFAULT_REGION";
+export const AWS_ROLE_ARN_ENV_KEY = "AWS_ROLE_ARN";
+export const AWS_WEB_IDENTITY_TOKEN_FILE_ENV_KEY =
+  "AWS_WEB_IDENTITY_TOKEN_FILE";
+export const AWS_BEARER_TOKEN_BEDROCK_ENV_KEY = "AWS_BEARER_TOKEN_BEDROCK";
 export const GEMINI_API_KEY_ENV_KEY = "GEMINI_API_KEY";
 export const GOOGLE_CLOUD_PROJECT_ENV_KEY = "GOOGLE_CLOUD_PROJECT";
 export const GOOGLE_CLOUD_LOCATION_ENV_KEY = "GOOGLE_CLOUD_LOCATION";
@@ -89,9 +99,10 @@ export type OpenWikiProvider =
 /**
  * How a provider authenticates. Providers default to `"api-key"` (a pasted
  * secret persisted to a `*_API_KEY` env var); `"oauth"` providers instead run a
- * browser login flow and persist short-lived access/refresh tokens.
+ * browser login flow and persist short-lived access/refresh tokens. `"aws-sdk"`
+ * providers delegate authentication to the AWS SDK credential provider chain.
  */
-export type ProviderAuthMethod = "api-key" | "oauth";
+export type ProviderAuthMethod = "api-key" | "aws-sdk" | "oauth";
 
 export type SelectableOpenWikiProvider = OpenWikiProvider;
 
@@ -130,9 +141,9 @@ const GEMINI_MODELS: ProviderModelOption[] = [
 
 type ProviderConfig = {
   /**
-   * Environment variable holding the provider's API key. Absent when the
-   * provider authenticates without an API key (e.g. Google Application
-   * Default Credentials for Vertex AI).
+   * Environment variable holding the provider's API key, or a legacy access
+   * key override retained by a provider that otherwise delegates credentials.
+   * Absent when the provider has no corresponding environment setting.
    */
   apiKeyEnvKey?: string;
   /**
@@ -166,9 +177,9 @@ type ProviderConfig = {
   label: string;
   modelOptions: ProviderModelOption[];
   /**
-   * Environment variable holding a second required secret (e.g. an AWS secret
-   * access key paired with {@link ProviderConfig.apiKeyEnvKey} as an access key
-   * ID). Omitted for providers authenticated by a single API key.
+   * Environment variable holding a paired secret (e.g. an AWS secret access
+   * key paired with {@link ProviderConfig.apiKeyEnvKey}). Whether the pair is
+   * required depends on the provider's authentication method.
    */
   secretKeyEnvKey?: string;
   /**
@@ -176,9 +187,11 @@ type ProviderConfig = {
    * Only relevant when {@link ProviderConfig.requiresRegion} is true.
    */
   regionEnvKey?: string;
+  /** Additional region variables checked after {@link regionEnvKey}. */
+  regionFallbackEnvKeys?: readonly string[];
   /**
-   * When true, the provider has no default region and requires one to be
-   * supplied via {@link ProviderConfig.regionEnvKey}.
+   * When true, the provider has no default region and requires one of its
+   * supported region environment variables.
    */
   requiresRegion?: boolean;
 };
@@ -211,6 +224,7 @@ export const PROVIDER_CONFIGS: Record<OpenWikiProvider, ProviderConfig> = {
   },
   bedrock: {
     apiKeyEnvKey: BEDROCK_AWS_ACCESS_KEY_ID_ENV_KEY,
+    authMethod: "aws-sdk",
     label: "AWS Bedrock",
     // Available model IDs are account- and region-specific (they depend on
     // which foundation models are enabled in Bedrock), so there is no safe
@@ -219,6 +233,7 @@ export const PROVIDER_CONFIGS: Record<OpenWikiProvider, ProviderConfig> = {
     modelOptions: [],
     secretKeyEnvKey: BEDROCK_AWS_SECRET_ACCESS_KEY_ENV_KEY,
     regionEnvKey: BEDROCK_AWS_REGION_ENV_KEY,
+    regionFallbackEnvKeys: [AWS_REGION_ENV_KEY, AWS_DEFAULT_REGION_ENV_KEY],
     requiresRegion: true,
   },
   fireworks: {
@@ -362,8 +377,17 @@ export function providerUsesOAuth(provider: OpenWikiProvider): boolean {
   return getProviderAuthMethod(provider) === "oauth";
 }
 
+export function providerUsesAwsSdkCredentials(
+  provider: OpenWikiProvider,
+): boolean {
+  return getProviderAuthMethod(provider) === "aws-sdk";
+}
+
 export function providerRequiresApiKey(provider: OpenWikiProvider): boolean {
-  return getProviderConfig(provider).apiKeyEnvKey !== undefined;
+  return (
+    getProviderAuthMethod(provider) === "api-key" &&
+    getProviderConfig(provider).apiKeyEnvKey !== undefined
+  );
 }
 
 export function getProviderProjectEnvKey(
@@ -379,16 +403,53 @@ export function getProviderLocationEnvKey(
 }
 
 /**
- * Returns the first required-but-unset environment variable for a provider
- * (its API key, or its cloud project for providers that authenticate without
- * one), or `null` when the provider has everything it needs to run. Base URL
- * requirements are checked separately via {@link providerRequiresBaseUrl}.
+ * Returns the first required-but-unset environment variable for a provider, or
+ * `null` when the provider can proceed. AWS SDK providers accept an absent
+ * legacy key pair, but reject partial or blank legacy and standard AWS key
+ * pairs before credential-chain resolution. Base URL requirements are checked
+ * separately via {@link providerRequiresBaseUrl}.
  */
 export function getMissingProviderEnvKey(
   provider: OpenWikiProvider,
   env: NodeJS.ProcessEnv = process.env,
 ): string | null {
   const config = getProviderConfig(provider);
+
+  if (providerUsesAwsSdkCredentials(provider)) {
+    // @langchain/aws gives the Bedrock bearer token precedence over both
+    // legacy keys and SigV4 credentials. Preserve that existing behavior.
+    if (env[AWS_BEARER_TOKEN_BEDROCK_ENV_KEY]?.trim()) {
+      return null;
+    }
+
+    const legacyPairState = inspectCredentialPair(
+      env,
+      config.apiKeyEnvKey,
+      config.secretKeyEnvKey,
+    );
+
+    if (legacyPairState.missingEnvKey) {
+      return legacyPairState.missingEnvKey;
+    }
+
+    // A complete legacy pair takes precedence inside @langchain/aws, so
+    // unrelated standard AWS env variables cannot affect this provider run.
+    if (legacyPairState.complete) {
+      return null;
+    }
+
+    const standardPairState = inspectCredentialPair(
+      env,
+      AWS_ACCESS_KEY_ID_ENV_KEY,
+      AWS_SECRET_ACCESS_KEY_ENV_KEY,
+    );
+
+    if (standardPairState.missingEnvKey) {
+      return standardPairState.missingEnvKey;
+    }
+
+    return null;
+  }
 
   if (config.apiKeyEnvKey && !env[config.apiKeyEnvKey]) {
     return config.apiKeyEnvKey;
@@ -438,6 +499,13 @@ export function getProviderCredentialHint(
     );
   }
 
+  if (providerUsesAwsSdkCredentials(provider)) {
+    return (
+      "Configure the AWS SDK credential chain with OIDC/web identity, an IAM " +
+      "role, AWS_PROFILE/SSO, or standard AWS environment credentials."
+    );
+  }
+
   return null;
 }
 
@@ -479,7 +547,10 @@ export function getProviderSecretKeyEnvKey(
 }
 
 export function providerRequiresSecretKey(provider: OpenWikiProvider): boolean {
-  return getProviderConfig(provider).secretKeyEnvKey !== undefined;
+  return (
+    !providerUsesAwsSdkCredentials(provider) &&
+    getProviderConfig(provider).secretKeyEnvKey !== undefined
+  );
 }
 
 export function getProviderRegionEnvKey(
@@ -488,23 +559,35 @@ export function getProviderRegionEnvKey(
   return getProviderConfig(provider).regionEnvKey;
 }
 
+export function getProviderRegionEnvKeys(provider: OpenWikiProvider): string[] {
+  const config = getProviderConfig(provider);
+
+  return [config.regionEnvKey, ...(config.regionFallbackEnvKeys ?? [])].filter(
+    (key): key is string => key !== undefined,
+  );
+}
+
 export function providerRequiresRegion(provider: OpenWikiProvider): boolean {
   return getProviderConfig(provider).requiresRegion === true;
 }
 
 /**
- * Resolves the configured region for a provider from its region environment
- * variable. Returns `undefined` when unset, so callers fall back to the SDK's
- * own region resolution (e.g. `~/.aws/config`).
+ * Resolves the configured region for a provider from its supported region
+ * environment variables, in provider-defined precedence order.
  */
 export function resolveProviderRegion(
   provider: OpenWikiProvider,
   env: NodeJS.ProcessEnv = process.env,
 ): string | undefined {
-  const regionEnvKey = getProviderRegionEnvKey(provider);
-  const region = regionEnvKey ? env[regionEnvKey]?.trim() : undefined;
+  for (const regionEnvKey of getProviderRegionEnvKeys(provider)) {
+    const region = env[regionEnvKey]?.trim();
 
-  return region ? region : undefined;
+    if (region) {
+      return region;
+    }
+  }
+
+  return undefined;
 }
 
 export function isValidBaseUrl(value: string): boolean {
@@ -651,10 +734,57 @@ export function resolveConfiguredProvider(
                   ? "nebius"
                   : env[NVIDIA_API_KEY_ENV_KEY]
                     ? "nvidia"
-                    : env[BEDROCK_AWS_ACCESS_KEY_ID_ENV_KEY]
+                    : hasNonEmptyEnvValue(
+                          env,
+                          BEDROCK_AWS_ACCESS_KEY_ID_ENV_KEY,
+                        ) &&
+                        hasNonEmptyEnvValue(
+                          env,
+                          BEDROCK_AWS_SECRET_ACCESS_KEY_ENV_KEY,
+                        )
                       ? "bedrock"
                       : DEFAULT_PROVIDER)
   );
+}
+
+function hasNonEmptyEnvValue(
+  env: NodeJS.ProcessEnv,
+  key: string | undefined,
+): boolean {
+  return key !== undefined && Boolean(env[key]?.trim());
+}
+
+function inspectCredentialPair(
+  env: NodeJS.ProcessEnv,
+  accessKeyEnvKey: string | undefined,
+  secretKeyEnvKey: string | undefined,
+): { complete: boolean; missingEnvKey: string | null } {
+  if (!accessKeyEnvKey || !secretKeyEnvKey) {
+    return { complete: false, missingEnvKey: null };
+  }
+
+  const accessKey = env[accessKeyEnvKey];
+  const secretKey = env[secretKeyEnvKey];
+  const hasAccessKey = Boolean(accessKey?.trim());
+  const hasSecretKey = Boolean(secretKey?.trim());
+
+  if (accessKey !== undefined && !hasAccessKey) {
+    return { complete: false, missingEnvKey: accessKeyEnvKey };
+  }
+
+  if (secretKey !== undefined && !hasSecretKey) {
+    return { complete: false, missingEnvKey: secretKeyEnvKey };
+  }
+
+  if (hasAccessKey && !hasSecretKey) {
+    return { complete: false, missingEnvKey: secretKeyEnvKey };
+  }
+
+  if (hasSecretKey && !hasAccessKey) {
+    return { complete: false, missingEnvKey: accessKeyEnvKey };
+  }
+
+  return { complete: hasAccessKey && hasSecretKey, missingEnvKey: null };
 }
 
 export function resolveProviderRetryAttempts(

--- a/src/credentials.tsx
+++ b/src/credentials.tsx
@@ -7,6 +7,12 @@ import { Box, Text, useInput, useStdout } from "ink";
 import { configureAuthProvider } from "./auth/configure.js";
 import { runOAuthAuth } from "./auth/oauth.js";
 import {
+  AWS_ACCESS_KEY_ID_ENV_KEY,
+  AWS_BEARER_TOKEN_BEDROCK_ENV_KEY,
+  AWS_SECRET_ACCESS_KEY_ENV_KEY,
+  AWS_SESSION_TOKEN_ENV_KEY,
+  BEDROCK_AWS_ACCESS_KEY_ID_ENV_KEY,
+  BEDROCK_AWS_SECRET_ACCESS_KEY_ENV_KEY,
   DEFAULT_PROVIDER,
   DEFAULT_VERTEX_LOCATION,
   getDefaultModelId,
@@ -19,6 +25,7 @@ import {
   getProviderModelOptions,
   getProviderProjectEnvKey,
   getProviderRegionEnvKey,
+  getProviderRegionEnvKeys,
   getProviderSecretKeyEnvKey,
   providerRequiresApiKey,
   isValidModelId,
@@ -36,8 +43,10 @@ import {
   providerRequiresBaseUrl,
   providerRequiresRegion,
   providerRequiresSecretKey,
+  providerUsesAwsSdkCredentials,
   providerUsesOAuth,
   resolveConfiguredProvider,
+  resolveProviderRegion,
   SELECTABLE_OPENWIKI_PROVIDERS,
 } from "./constants.js";
 import {
@@ -440,6 +449,7 @@ export function needsCredentialSetup(
 
   const needsCredentials =
     !hasValidConfiguredProvider() ||
+    needsAwsCredentialRepair(provider) ||
     needsCredentialStep(provider) ||
     needsSecretKeyStep(provider) ||
     needsBaseUrlStep(provider) ||
@@ -457,6 +467,35 @@ export function needsCredentialSetup(
     : !isOpenWikiOnboardingCompleteSync();
 }
 
+function needsAwsCredentialRepair(provider: OpenWikiProvider): boolean {
+  return (
+    providerUsesAwsSdkCredentials(provider) &&
+    getMissingProviderEnvKey(provider) !== null
+  );
+}
+
+function getAwsCredentialRepairMessage(
+  provider: OpenWikiProvider,
+): string | null {
+  if (!providerUsesAwsSdkCredentials(provider)) {
+    return null;
+  }
+
+  const missingEnvKey = getMissingProviderEnvKey(provider);
+
+  if (!missingEnvKey) {
+    return null;
+  }
+
+  const pair =
+    missingEnvKey === BEDROCK_AWS_ACCESS_KEY_ID_ENV_KEY ||
+    missingEnvKey === BEDROCK_AWS_SECRET_ACCESS_KEY_ENV_KEY
+      ? `${BEDROCK_AWS_ACCESS_KEY_ID_ENV_KEY} and ${BEDROCK_AWS_SECRET_ACCESS_KEY_ENV_KEY}`
+      : `${AWS_ACCESS_KEY_ID_ENV_KEY} and ${AWS_SECRET_ACCESS_KEY_ENV_KEY}`;
+
+  return `${missingEnvKey} is missing or blank. Set both ${pair}, or unset both in your shell and ${openWikiEnvPath}, then restart OpenWiki.`;
+}
+
 /**
  * Whether the provider still needs its primary credential collected. For
  * `oauth` providers this is a valid, non-expired stored token; for API-key
@@ -464,18 +503,31 @@ export function needsCredentialSetup(
  * the required GCP project id.
  */
 function needsCredentialStep(provider: OpenWikiProvider): boolean {
-  return providerUsesOAuth(provider)
-    ? !hasValidStoredToken()
-    : getMissingProviderEnvKey(provider) !== null;
+  if (providerUsesOAuth(provider)) {
+    return !hasValidStoredToken();
+  }
+
+  return (
+    getMissingProviderEnvKey(provider) !== null &&
+    credentialStep(provider) !== null
+  );
 }
 
 /** The step that collects the provider's primary credential. */
-function credentialStep(provider: OpenWikiProvider): PromptStep {
+function credentialStep(provider: OpenWikiProvider): PromptStep | null {
   if (providerUsesOAuth(provider)) {
     return "oauth-login";
   }
 
-  return providerRequiresApiKey(provider) ? "api-key" : "gcp-project";
+  if (providerUsesAwsSdkCredentials(provider)) {
+    return null;
+  }
+
+  if (providerRequiresApiKey(provider)) {
+    return "api-key";
+  }
+
+  return getProviderProjectEnvKey(provider) ? "gcp-project" : null;
 }
 
 /**
@@ -521,7 +573,9 @@ export function orderedSetupSteps(
   steps.push("provider");
 
   const primary = credentialStep(provider);
-  steps.push(primary);
+  if (primary) {
+    steps.push(primary);
+  }
 
   if (providerRequiresSecretKey(provider)) {
     steps.push("secret-key");
@@ -641,9 +695,7 @@ export function needsLangSmithStep(
 }
 
 function isRegionConfigured(provider: OpenWikiProvider): boolean {
-  const regionEnvKey = getProviderRegionEnvKey(provider);
-
-  return regionEnvKey ? Boolean(process.env[regionEnvKey]) : false;
+  return resolveProviderRegion(provider) !== undefined;
 }
 
 function isCredentialConfigured(provider: OpenWikiProvider): boolean {
@@ -667,6 +719,53 @@ function getCredentialSetupDetail(
     );
 
     return account ? `signed in as ${account}` : "signed in with ChatGPT";
+  }
+
+  if (providerUsesAwsSdkCredentials(provider)) {
+    if (process.env[AWS_BEARER_TOKEN_BEDROCK_ENV_KEY]?.trim()) {
+      return "Bedrock bearer token (takes precedence)";
+    }
+
+    const missingEnvKey = getMissingProviderEnvKey(provider);
+
+    if (missingEnvKey) {
+      if (
+        missingEnvKey === BEDROCK_AWS_ACCESS_KEY_ID_ENV_KEY ||
+        missingEnvKey === BEDROCK_AWS_SECRET_ACCESS_KEY_ENV_KEY
+      ) {
+        return "incomplete legacy Bedrock keys; set both or clear both";
+      }
+
+      if (
+        missingEnvKey === AWS_ACCESS_KEY_ID_ENV_KEY ||
+        missingEnvKey === AWS_SECRET_ACCESS_KEY_ENV_KEY
+      ) {
+        return "incomplete standard AWS credentials; set the full set or unset it";
+      }
+
+      return `incomplete AWS credential configuration (${missingEnvKey})`;
+    }
+
+    const legacyApiKey = getProviderApiKeyEnvKey(provider);
+    const legacySecretKey = getProviderSecretKeyEnvKey(provider);
+    const usesLegacyKeys = Boolean(
+      legacyApiKey &&
+      legacySecretKey &&
+      process.env[legacyApiKey]?.trim() &&
+      process.env[legacySecretKey]?.trim(),
+    );
+
+    const ignoresOrphanSessionToken = Boolean(
+      process.env[AWS_SESSION_TOKEN_ENV_KEY]?.trim() &&
+      !process.env[AWS_ACCESS_KEY_ID_ENV_KEY]?.trim() &&
+      !process.env[AWS_SECRET_ACCESS_KEY_ENV_KEY]?.trim(),
+    );
+
+    return usesLegacyKeys
+      ? "legacy Bedrock keys (take precedence)"
+      : ignoresOrphanSessionToken
+        ? "AWS SDK default credential chain (orphan AWS_SESSION_TOKEN ignored)"
+        : "AWS SDK default credential chain";
   }
 
   const apiKeyEnvKey = getProviderApiKeyEnvKey(provider);
@@ -1845,15 +1944,27 @@ export function InitSetup({
 
     if (step === "region") {
       const trimmedInput = input.trim();
+      const configuredRegion = resolveProviderRegion(provider);
+      const credentialRepairMessage = getAwsCredentialRepairMessage(provider);
 
-      if (trimmedInput.length === 0) {
+      if (credentialRepairMessage) {
+        setError(credentialRepairMessage);
+        return;
+      }
+
+      if (trimmedInput.length === 0 && !configuredRegion) {
+        const regionEnvKeys = getProviderRegionEnvKeys(provider);
         setError(
-          `${getProviderRegionEnvKey(provider) ?? "Region"} is required.`,
+          `Set one of ${regionEnvKeys.join(", ") || "the supported region variables"}.`,
         );
         return;
       }
 
-      setRegion(trimmedInput);
+      const nextRegion = trimmedInput.length > 0 ? trimmedInput : region;
+
+      if (trimmedInput.length > 0) {
+        setRegion(trimmedInput);
+      }
       setInput("");
       const nextStep =
         nextSetupStep("region", provider, selectedMode, allowModeSelection) ??
@@ -1878,7 +1989,7 @@ export function InitSetup({
         nextApiKey: apiKey,
         nextBaseUrl: baseUrl,
         nextSecretKey: secretKey,
-        nextRegion: trimmedInput,
+        nextRegion,
         nextGcpLocation: gcpLocation,
         nextGcpProject: gcpProject,
         nextLangSmithKey: langSmithKey,
@@ -3032,6 +3143,7 @@ export function InitSetup({
 
   const needsCredentialPrompt =
     !hasValidConfiguredProvider() ||
+    needsAwsCredentialRepair(provider) ||
     needsCredentialStep(provider) ||
     needsSecretKeyStep(provider) ||
     needsBaseUrlStep(provider) ||
@@ -3040,6 +3152,7 @@ export function InitSetup({
       process.env[OPENWIKI_MODEL_ID_ENV_KEY] === undefined) ||
     needsLangSmithStep();
   const apiKeyEnvKey = getProviderApiKeyEnvKey(provider);
+  const primaryCredentialStep = credentialStep(provider);
   const projectEnvKey = getProviderProjectEnvKey(provider);
   const locationEnvKey = getProviderLocationEnvKey(provider);
 
@@ -3105,13 +3218,21 @@ export function InitSetup({
             )}
             detail={getProviderLabel(provider)}
           />
-          {providerUsesOAuth(provider) || apiKeyEnvKey ? (
+          {providerUsesAwsSdkCredentials(provider) ? (
+            <SetupStep
+              label="AWS credentials"
+              state={
+                getMissingProviderEnvKey(provider) === null ? "done" : "pending"
+              }
+              detail={getCredentialSetupDetail(provider)}
+            />
+          ) : providerUsesOAuth(provider) || primaryCredentialStep ? (
             <SetupStep
               label={
                 providerUsesOAuth(provider) ? "ChatGPT login" : "Provider key"
               }
               state={resolveStepStatus(
-                credentialStep(provider),
+                primaryCredentialStep ?? "provider",
                 step,
                 apiKey !== null ||
                   isCredentialConfigured(provider) ||
@@ -3566,14 +3687,26 @@ function Prompt({
   }
 
   if (step === "region") {
+    const resolvedRegion = resolveProviderRegion(provider);
+    const credentialRepairMessage = getAwsCredentialRepairMessage(provider);
+
     return (
       <Box flexDirection="column">
-        <Text>Enter the {getProviderLabel(provider)} region.</Text>
+        {credentialRepairMessage ? (
+          <Text color="yellow">⚠ {credentialRepairMessage}</Text>
+        ) : null}
+        <Text>
+          Enter the {getProviderLabel(provider)} region
+          {resolvedRegion ? `, or press Enter to keep ${resolvedRegion}` : ""}.
+        </Text>
         <Text>
           <Text color="gray">$</Text> {getProviderRegionEnvKey(provider)}={" "}
           <Text color="yellow">{input}</Text>
         </Text>
-        <Text color="gray">For example us-east-1. Press Enter to save it.</Text>
+        <Text color="gray">
+          Uses {getProviderRegionEnvKeys(provider).join(", ")}. For example
+          us-east-1.
+        </Text>
       </Box>
     );
   }
@@ -4593,8 +4726,14 @@ export function getInitialStep(
     return "provider";
   }
 
-  if (needsCredentialStep(provider)) {
-    return credentialStep(provider);
+  if (needsAwsCredentialRepair(provider)) {
+    return "region";
+  }
+
+  const nextCredentialStep = credentialStep(provider);
+
+  if (needsCredentialStep(provider) && nextCredentialStep) {
+    return nextCredentialStep;
   }
 
   if (needsSecretKeyStep(provider)) {
@@ -4654,8 +4793,14 @@ export function getNextStepAfterProvider(
   mode: OpenWikiRunMode = "code",
   forceModelStep = false,
 ): PromptStep | null {
-  if (needsCredentialStep(provider)) {
-    return credentialStep(provider);
+  if (needsAwsCredentialRepair(provider)) {
+    return "region";
+  }
+
+  const nextCredentialStep = credentialStep(provider);
+
+  if (needsCredentialStep(provider) && nextCredentialStep) {
+    return nextCredentialStep;
   }
 
   return getNextStepAfterApiKey(

--- a/src/diagnostics.ts
+++ b/src/diagnostics.ts
@@ -1,8 +1,14 @@
 import {
   ANTHROPIC_API_KEY_ENV_KEY,
+  AWS_ACCESS_KEY_ID_ENV_KEY,
+  AWS_BEARER_TOKEN_BEDROCK_ENV_KEY,
+  AWS_SECRET_ACCESS_KEY_ENV_KEY,
+  AWS_SESSION_TOKEN_ENV_KEY,
+  AWS_WEB_IDENTITY_TOKEN_FILE_ENV_KEY,
   BASETEN_API_KEY_ENV_KEY,
   BEDROCK_AWS_ACCESS_KEY_ID_ENV_KEY,
   BEDROCK_AWS_SECRET_ACCESS_KEY_ENV_KEY,
+  BEDROCK_AWS_SESSION_TOKEN_ENV_KEY,
   FIREWORKS_API_KEY_ENV_KEY,
   GEMINI_API_KEY_ENV_KEY,
   NEBIUS_API_KEY_ENV_KEY,
@@ -26,8 +32,14 @@ export function sanitizeDiagnosticText(value: string): string {
 
   for (const key of [
     BASETEN_API_KEY_ENV_KEY,
+    AWS_ACCESS_KEY_ID_ENV_KEY,
+    AWS_BEARER_TOKEN_BEDROCK_ENV_KEY,
+    AWS_SECRET_ACCESS_KEY_ENV_KEY,
+    AWS_SESSION_TOKEN_ENV_KEY,
+    AWS_WEB_IDENTITY_TOKEN_FILE_ENV_KEY,
     BEDROCK_AWS_ACCESS_KEY_ID_ENV_KEY,
     BEDROCK_AWS_SECRET_ACCESS_KEY_ENV_KEY,
+    BEDROCK_AWS_SESSION_TOKEN_ENV_KEY,
     FIREWORKS_API_KEY_ENV_KEY,
     GEMINI_API_KEY_ENV_KEY,
     NEBIUS_API_KEY_ENV_KEY,
@@ -127,6 +139,7 @@ export function isAuthError(error: unknown, message: string): boolean {
   const status = isRecord(error)
     ? (error.statusCode ?? error.status)
     : undefined;
+  const name = isRecord(error) ? error.name : undefined;
 
   if (
     status === 401 ||
@@ -137,7 +150,16 @@ export function isAuthError(error: unknown, message: string): boolean {
     return true;
   }
 
-  return /\b40[13]\b|incorrect api key|invalid api key|unauthorized|forbidden|authentication|permission denied|not authorized/iu.test(
+  if (
+    name === "CredentialsProviderError" ||
+    name === "InvalidIdentityTokenException" ||
+    name === "ExpiredTokenException" ||
+    name === "IDPRejectedClaimException"
+  ) {
+    return true;
+  }
+
+  return /\b40[13]\b|incorrect api key|invalid api key|unauthorized|forbidden|authentication|permission denied|not authorized|could not load credentials from any providers|invalid identity token|expired token|web identity token.+(?:expired|invalid|not valid)|security token.+invalid/iu.test(
     message,
   );
 }

--- a/test/bedrock-credentials-integration.test.ts
+++ b/test/bedrock-credentials-integration.test.ts
@@ -1,0 +1,74 @@
+import { afterEach, beforeEach, describe, expect, test } from "vitest";
+import { ChatBedrockConverse } from "@langchain/aws";
+import { createModel } from "../src/agent/index.ts";
+
+const ENV_KEYS = [
+  "AWS_ACCESS_KEY_ID",
+  "AWS_SECRET_ACCESS_KEY",
+  "AWS_SESSION_TOKEN",
+  "BEDROCK_AWS_ACCESS_KEY_ID",
+  "BEDROCK_AWS_SECRET_ACCESS_KEY",
+  "BEDROCK_AWS_SESSION_TOKEN",
+  "AWS_REGION",
+] as const;
+
+const originalEnv = new Map(
+  ENV_KEYS.map((key) => [key, process.env[key]] as const),
+);
+
+beforeEach(() => {
+  for (const key of ENV_KEYS) {
+    delete process.env[key];
+  }
+  process.env.AWS_REGION = "us-east-1";
+});
+
+afterEach(() => {
+  for (const [key, value] of originalEnv) {
+    if (value === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = value;
+    }
+  }
+});
+
+describe("Bedrock AWS SDK credential integration", () => {
+  test("resolves standard temporary AWS environment credentials", async () => {
+    process.env.AWS_ACCESS_KEY_ID = "standard-access";
+    process.env.AWS_SECRET_ACCESS_KEY = "standard-secret";
+    process.env.AWS_SESSION_TOKEN = "standard-session";
+
+    const model = createModel(
+      "bedrock",
+      "anthropic.claude-sonnet-5",
+      0,
+    ) as ChatBedrockConverse;
+    const credentials = await model.client.config.credentials();
+
+    expect(credentials).toMatchObject({
+      accessKeyId: "standard-access",
+      secretAccessKey: "standard-secret",
+      sessionToken: "standard-session",
+    });
+  });
+
+  test("preserves the legacy Bedrock session token", async () => {
+    process.env.BEDROCK_AWS_ACCESS_KEY_ID = "legacy-access";
+    process.env.BEDROCK_AWS_SECRET_ACCESS_KEY = "legacy-secret";
+    process.env.BEDROCK_AWS_SESSION_TOKEN = "legacy-session";
+
+    const model = createModel(
+      "bedrock",
+      "anthropic.claude-sonnet-5",
+      0,
+    ) as ChatBedrockConverse;
+    const credentials = await model.client.config.credentials();
+
+    expect(credentials).toMatchObject({
+      accessKeyId: "legacy-access",
+      secretAccessKey: "legacy-secret",
+      sessionToken: "legacy-session",
+    });
+  });
+});

--- a/test/bedrock-model.test.ts
+++ b/test/bedrock-model.test.ts
@@ -1,0 +1,78 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+
+const bedrockConstructorArgs = vi.hoisted(
+  () => [] as Array<Record<string, unknown>>,
+);
+
+vi.mock("@langchain/aws", () => ({
+  ChatBedrockConverse: class {
+    constructor(options: Record<string, unknown>) {
+      bedrockConstructorArgs.push(options);
+    }
+  },
+}));
+
+const { createModel } = await import("../src/agent/index.ts");
+
+const ENV_KEYS = [
+  "AWS_DEFAULT_REGION",
+  "AWS_REGION",
+  "AWS_ROLE_ARN",
+  "AWS_WEB_IDENTITY_TOKEN_FILE",
+  "BEDROCK_AWS_ACCESS_KEY_ID",
+  "BEDROCK_AWS_REGION",
+  "BEDROCK_AWS_SECRET_ACCESS_KEY",
+] as const;
+
+const originalEnv = new Map(
+  ENV_KEYS.map((key) => [key, process.env[key]] as const),
+);
+
+beforeEach(() => {
+  bedrockConstructorArgs.length = 0;
+  for (const key of ENV_KEYS) {
+    delete process.env[key];
+  }
+});
+
+afterEach(() => {
+  for (const [key, value] of originalEnv) {
+    if (value === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = value;
+    }
+  }
+});
+
+describe("createModel Bedrock credentials", () => {
+  test("delegates OIDC credentials to the AWS SDK provider chain", () => {
+    process.env.AWS_ROLE_ARN = "arn:aws:iam::123456789012:role/openwiki";
+    process.env.AWS_WEB_IDENTITY_TOKEN_FILE = "/path/that/must/not/be/read";
+    process.env.AWS_REGION = "us-east-1";
+
+    createModel("bedrock", "anthropic.claude-sonnet-5", 4);
+
+    expect(bedrockConstructorArgs).toHaveLength(1);
+    expect(bedrockConstructorArgs[0]).toMatchObject({
+      maxRetries: 4,
+      model: "anthropic.claude-sonnet-5",
+      region: "us-east-1",
+    });
+    expect(bedrockConstructorArgs[0]).not.toHaveProperty("credentials");
+  });
+
+  test("lets LangChain preserve complete legacy credentials and session tokens", () => {
+    process.env.BEDROCK_AWS_ACCESS_KEY_ID = "legacy-access";
+    process.env.BEDROCK_AWS_SECRET_ACCESS_KEY = "legacy-secret";
+    process.env.BEDROCK_AWS_REGION = "us-west-2";
+
+    createModel("bedrock", "anthropic.claude-sonnet-5", 0);
+
+    expect(bedrockConstructorArgs[0]).toMatchObject({
+      maxRetries: 0,
+      region: "us-west-2",
+    });
+    expect(bedrockConstructorArgs[0]).not.toHaveProperty("credentials");
+  });
+});

--- a/test/constants.test.ts
+++ b/test/constants.test.ts
@@ -9,6 +9,7 @@ import {
   getProviderBaseUrlWarnings,
   getMissingProviderEnvKey,
   getProviderApiKeyEnvKey,
+  getProviderAuthMethod,
   getProviderModelOptions,
   getProviderRegionEnvKey,
   FIREWORKS_BASE_URL_ENV_KEY,
@@ -26,6 +27,7 @@ import {
   providerRequiresApiKey,
   providerRequiresRegion,
   providerRequiresSecretKey,
+  providerUsesAwsSdkCredentials,
   resolveConfiguredProvider,
   resolveOpenRouterProviderOnly,
   resolveProviderBaseUrl,
@@ -136,10 +138,25 @@ describe("resolveConfiguredProvider", () => {
     expect(resolveConfiguredProvider({ NVIDIA_API_KEY: "x" })).toBe("nvidia");
   });
 
-  test("falls back to bedrock when only a Bedrock access key is present", () => {
-    expect(resolveConfiguredProvider({ BEDROCK_AWS_ACCESS_KEY_ID: "x" })).toBe(
-      "bedrock",
-    );
+  test("falls back to bedrock when a complete legacy key pair is present", () => {
+    expect(
+      resolveConfiguredProvider({
+        BEDROCK_AWS_ACCESS_KEY_ID: "access",
+        BEDROCK_AWS_SECRET_ACCESS_KEY: "secret",
+      }),
+    ).toBe("bedrock");
+  });
+
+  test("does not auto-select bedrock from partial or ambient AWS config", () => {
+    expect(
+      resolveConfiguredProvider({ BEDROCK_AWS_ACCESS_KEY_ID: "access" }),
+    ).toBe(DEFAULT_PROVIDER);
+    expect(
+      resolveConfiguredProvider({
+        AWS_ROLE_ARN: "arn:aws:iam::123456789012:role/openwiki",
+        AWS_WEB_IDENTITY_TOKEN_FILE: "/var/run/secrets/aws/token",
+      }),
+    ).toBe(DEFAULT_PROVIDER);
   });
 
   test("falls back to the default provider when nothing is configured", () => {
@@ -330,25 +347,49 @@ describe("getProviderModelOptions", () => {
   });
 });
 
-describe("bedrock provider (IAM access key + secret key + region)", () => {
-  test("requires a secret key and a region, unlike API-key providers", () => {
-    expect(providerRequiresSecretKey("bedrock")).toBe(true);
+describe("bedrock provider (AWS SDK credentials + region)", () => {
+  test("uses the AWS SDK credential chain instead of required static keys", () => {
+    expect(getProviderAuthMethod("bedrock")).toBe("aws-sdk");
+    expect(providerUsesAwsSdkCredentials("bedrock")).toBe(true);
+    expect(providerRequiresApiKey("bedrock")).toBe(false);
+    expect(providerRequiresSecretKey("bedrock")).toBe(false);
     expect(providerRequiresRegion("bedrock")).toBe(true);
+    expect(providerUsesAwsSdkCredentials("anthropic")).toBe(false);
     expect(providerRequiresSecretKey("anthropic")).toBe(false);
     expect(providerRequiresRegion("anthropic")).toBe(false);
   });
 
-  test("exposes the AWS-flavored env keys", () => {
+  test("retains the legacy AWS env-key metadata for compatibility", () => {
+    expect(getProviderApiKeyEnvKey("bedrock")).toBe(
+      "BEDROCK_AWS_ACCESS_KEY_ID",
+    );
     expect(getProviderSecretKeyEnvKey("bedrock")).toBe(
       "BEDROCK_AWS_SECRET_ACCESS_KEY",
     );
     expect(getProviderRegionEnvKey("bedrock")).toBe("BEDROCK_AWS_REGION");
   });
 
-  test("resolveProviderRegion reads the region env key and trims it", () => {
+  test("resolves and trims Bedrock region env vars in precedence order", () => {
     expect(
-      resolveProviderRegion("bedrock", { BEDROCK_AWS_REGION: " us-east-1 " }),
+      resolveProviderRegion("bedrock", {
+        BEDROCK_AWS_REGION: " us-east-1 ",
+        AWS_REGION: "us-west-2",
+        AWS_DEFAULT_REGION: "eu-west-1",
+      }),
     ).toBe("us-east-1");
+    expect(
+      resolveProviderRegion("bedrock", {
+        BEDROCK_AWS_REGION: "   ",
+        AWS_REGION: " us-west-2 ",
+        AWS_DEFAULT_REGION: "eu-west-1",
+      }),
+    ).toBe("us-west-2");
+    expect(
+      resolveProviderRegion("bedrock", {
+        AWS_REGION: "   ",
+        AWS_DEFAULT_REGION: " eu-west-1 ",
+      }),
+    ).toBe("eu-west-1");
     expect(resolveProviderRegion("bedrock", {})).toBeUndefined();
   });
 
@@ -394,6 +435,103 @@ describe("getMissingProviderEnvKey", () => {
       getMissingProviderEnvKey("gemini-enterprise", {
         GOOGLE_CLOUD_PROJECT: "proj",
         GOOGLE_CLOUD_LOCATION: undefined,
+      }),
+    ).toBeNull();
+  });
+
+  test("allows Bedrock to delegate credentials to the AWS SDK", () => {
+    expect(getMissingProviderEnvKey("bedrock", {})).toBeNull();
+    expect(
+      getMissingProviderEnvKey("bedrock", {
+        AWS_ROLE_ARN: "arn:aws:iam::123456789012:role/openwiki",
+        AWS_WEB_IDENTITY_TOKEN_FILE: "/var/run/secrets/aws/token",
+      }),
+    ).toBeNull();
+    expect(
+      getMissingProviderEnvKey("bedrock", {
+        BEDROCK_AWS_ACCESS_KEY_ID: "access",
+        BEDROCK_AWS_SECRET_ACCESS_KEY: "secret",
+      }),
+    ).toBeNull();
+  });
+
+  test("rejects either half of a legacy Bedrock key pair", () => {
+    expect(
+      getMissingProviderEnvKey("bedrock", {
+        BEDROCK_AWS_ACCESS_KEY_ID: "access",
+      }),
+    ).toBe("BEDROCK_AWS_SECRET_ACCESS_KEY");
+    expect(
+      getMissingProviderEnvKey("bedrock", {
+        BEDROCK_AWS_SECRET_ACCESS_KEY: "secret",
+      }),
+    ).toBe("BEDROCK_AWS_ACCESS_KEY_ID");
+  });
+
+  test("treats blank legacy Bedrock values as incomplete configuration", () => {
+    expect(
+      getMissingProviderEnvKey("bedrock", {
+        BEDROCK_AWS_ACCESS_KEY_ID: "   ",
+        BEDROCK_AWS_SECRET_ACCESS_KEY: "   ",
+      }),
+    ).toBe("BEDROCK_AWS_ACCESS_KEY_ID");
+    expect(
+      getMissingProviderEnvKey("bedrock", {
+        BEDROCK_AWS_ACCESS_KEY_ID: "access",
+        BEDROCK_AWS_SECRET_ACCESS_KEY: "   ",
+      }),
+    ).toBe("BEDROCK_AWS_SECRET_ACCESS_KEY");
+  });
+
+  test("rejects partial standard AWS environment credentials", () => {
+    expect(
+      getMissingProviderEnvKey("bedrock", {
+        AWS_ACCESS_KEY_ID: "access",
+      }),
+    ).toBe("AWS_SECRET_ACCESS_KEY");
+    expect(
+      getMissingProviderEnvKey("bedrock", {
+        AWS_SECRET_ACCESS_KEY: "secret",
+      }),
+    ).toBe("AWS_ACCESS_KEY_ID");
+    expect(
+      getMissingProviderEnvKey("bedrock", {
+        AWS_ACCESS_KEY_ID: "access",
+        AWS_SECRET_ACCESS_KEY: "secret",
+        AWS_SESSION_TOKEN: "session",
+      }),
+    ).toBeNull();
+  });
+
+  test("rejects blank standard credentials but ignores an orphan session token", () => {
+    expect(
+      getMissingProviderEnvKey("bedrock", {
+        AWS_ACCESS_KEY_ID: "   ",
+        AWS_SECRET_ACCESS_KEY: "secret",
+      }),
+    ).toBe("AWS_ACCESS_KEY_ID");
+    expect(
+      getMissingProviderEnvKey("bedrock", {
+        AWS_SESSION_TOKEN: "session",
+      }),
+    ).toBeNull();
+  });
+
+  test("preserves Bedrock bearer-token precedence", () => {
+    expect(
+      getMissingProviderEnvKey("bedrock", {
+        AWS_BEARER_TOKEN_BEDROCK: "bearer-token",
+        BEDROCK_AWS_ACCESS_KEY_ID: "partial-legacy-access",
+      }),
+    ).toBeNull();
+  });
+
+  test("ignores partial standard AWS credentials when legacy keys take precedence", () => {
+    expect(
+      getMissingProviderEnvKey("bedrock", {
+        BEDROCK_AWS_ACCESS_KEY_ID: "legacy-access",
+        BEDROCK_AWS_SECRET_ACCESS_KEY: "legacy-secret",
+        AWS_ACCESS_KEY_ID: "ambient-access-without-secret",
       }),
     ).toBeNull();
   });

--- a/test/constants.test.ts
+++ b/test/constants.test.ts
@@ -147,10 +147,16 @@ describe("resolveConfiguredProvider", () => {
     ).toBe("bedrock");
   });
 
-  test("does not auto-select bedrock from partial or ambient AWS config", () => {
+  test("auto-selects bedrock from partial legacy config for repair", () => {
     expect(
       resolveConfiguredProvider({ BEDROCK_AWS_ACCESS_KEY_ID: "access" }),
-    ).toBe(DEFAULT_PROVIDER);
+    ).toBe("bedrock");
+    expect(
+      resolveConfiguredProvider({ BEDROCK_AWS_SECRET_ACCESS_KEY: "secret" }),
+    ).toBe("bedrock");
+  });
+
+  test("does not auto-select bedrock from ambient AWS config", () => {
     expect(
       resolveConfiguredProvider({
         AWS_ROLE_ARN: "arn:aws:iam::123456789012:role/openwiki",

--- a/test/credentials.test.ts
+++ b/test/credentials.test.ts
@@ -16,6 +16,17 @@ import {
 import type { OpenWikiOnboardingConfig } from "../src/onboarding.ts";
 
 const ENV_KEYS = [
+  "AWS_ACCESS_KEY_ID",
+  "AWS_DEFAULT_REGION",
+  "AWS_REGION",
+  "AWS_ROLE_ARN",
+  "AWS_SECRET_ACCESS_KEY",
+  "AWS_SESSION_TOKEN",
+  "AWS_WEB_IDENTITY_TOKEN_FILE",
+  "AWS_BEARER_TOKEN_BEDROCK",
+  "BEDROCK_AWS_ACCESS_KEY_ID",
+  "BEDROCK_AWS_REGION",
+  "BEDROCK_AWS_SECRET_ACCESS_KEY",
   "LANGSMITH_API_KEY",
   "OPENROUTER_API_KEY",
   "OPENWIKI_MODEL_ID",
@@ -194,12 +205,17 @@ describe("orderedSetupSteps", () => {
     );
   });
 
-  test("bedrock adds secret-key and region before model", () => {
-    const spine = orderedSetupSteps("bedrock", "code", false);
-    expect(spine).toContain("secret-key");
-    expect(spine).toContain("region");
-    expect(spine.indexOf("secret-key")).toBeLessThan(spine.indexOf("model"));
-    expect(spine.indexOf("region")).toBeLessThan(spine.indexOf("model"));
+  test("bedrock delegates AWS credentials and only prompts for region", () => {
+    delete process.env.BEDROCK_AWS_ACCESS_KEY_ID;
+    delete process.env.BEDROCK_AWS_SECRET_ACCESS_KEY;
+
+    expect(orderedSetupSteps("bedrock", "code", false)).toEqual([
+      "provider",
+      "region",
+      "model",
+      "langsmith",
+      "code-repo-confirm",
+    ]);
   });
 
   test("personal mode ends at langsmith with no template chooser or code tail", () => {
@@ -236,12 +252,61 @@ describe("getInitialStep", () => {
       "run-mode",
     );
   });
+
+  test("bedrock accepts ambient OIDC credentials and a standard AWS region", () => {
+    process.env.OPENWIKI_PROVIDER = "bedrock";
+    process.env.AWS_ROLE_ARN = "arn:aws:iam::123456789012:role/openwiki";
+    process.env.AWS_WEB_IDENTITY_TOKEN_FILE = "/var/run/secrets/aws/token";
+    process.env.AWS_REGION = "us-east-1";
+    delete process.env.AWS_DEFAULT_REGION;
+    delete process.env.AWS_ACCESS_KEY_ID;
+    delete process.env.AWS_SECRET_ACCESS_KEY;
+    delete process.env.AWS_SESSION_TOKEN;
+    delete process.env.AWS_BEARER_TOKEN_BEDROCK;
+    delete process.env.BEDROCK_AWS_ACCESS_KEY_ID;
+    delete process.env.BEDROCK_AWS_SECRET_ACCESS_KEY;
+    delete process.env.BEDROCK_AWS_REGION;
+    delete process.env.OPENWIKI_MODEL_ID;
+
+    expect(getInitialStep(null, "bedrock")).toBe("model");
+  });
+
+  test("bedrock routes incomplete legacy credentials to the repair gate", () => {
+    process.env.OPENWIKI_PROVIDER = "bedrock";
+    process.env.BEDROCK_AWS_ACCESS_KEY_ID = "partial-access";
+    delete process.env.BEDROCK_AWS_SECRET_ACCESS_KEY;
+    process.env.AWS_REGION = "us-east-1";
+    process.env.OPENWIKI_MODEL_ID = "anthropic.claude-sonnet-5";
+    process.env.LANGSMITH_API_KEY = "lsv2_placeholder";
+
+    expect(getInitialStep(null, "bedrock")).toBe("region");
+  });
+
+  test("bedrock routes incomplete standard credentials to the repair gate", () => {
+    process.env.OPENWIKI_PROVIDER = "bedrock";
+    delete process.env.BEDROCK_AWS_ACCESS_KEY_ID;
+    delete process.env.BEDROCK_AWS_SECRET_ACCESS_KEY;
+    process.env.AWS_ACCESS_KEY_ID = "partial-access";
+    delete process.env.AWS_SECRET_ACCESS_KEY;
+    process.env.AWS_REGION = "us-east-1";
+    process.env.OPENWIKI_MODEL_ID = "anthropic.claude-sonnet-5";
+    process.env.LANGSMITH_API_KEY = "lsv2_placeholder";
+
+    expect(getInitialStep(null, "bedrock")).toBe("region");
+  });
 });
 
 describe("nextSetupStep", () => {
   test("walks forward through the spine", () => {
     expect(nextSetupStep("provider", "openai", "code", false)).toBe("api-key");
     expect(nextSetupStep("api-key", "openai", "code", false)).toBe("model");
+  });
+
+  test("moves from bedrock provider selection directly to region", () => {
+    delete process.env.BEDROCK_AWS_ACCESS_KEY_ID;
+    delete process.env.BEDROCK_AWS_SECRET_ACCESS_KEY;
+
+    expect(nextSetupStep("provider", "bedrock", "code", false)).toBe("region");
   });
 
   test("no-op at the end and for null", () => {

--- a/test/redaction.test.ts
+++ b/test/redaction.test.ts
@@ -1,11 +1,15 @@
 import { afterEach, beforeEach, describe, expect, test } from "vitest";
 import {
   getErrorMessage,
+  isAuthError,
   isOpenRouterServerError,
   isSecretLikeKey,
   sanitizeDiagnosticText,
 } from "../src/diagnostics.ts";
-import { sanitizeOpenRouterResponseBody } from "../src/agent/index.ts";
+import {
+  formatEnvironmentDebugValue,
+  sanitizeOpenRouterResponseBody,
+} from "../src/agent/index.ts";
 
 describe("isSecretLikeKey", () => {
   // The shared predicate must be the union of every term the three former
@@ -201,6 +205,46 @@ describe("sanitizeDiagnosticText", () => {
       }
     }
   });
+
+  test.each([
+    ["AWS_ACCESS_KEY_ID", "standard-access-id-123"],
+    ["AWS_SECRET_ACCESS_KEY", "standard-aws-secret-abcdef123456"],
+    ["AWS_SESSION_TOKEN", "standard-aws-session-token-abcdef123456"],
+    ["BEDROCK_AWS_SESSION_TOKEN", "bedrock-session-token-abcdef123456"],
+    ["AWS_WEB_IDENTITY_TOKEN_FILE", "/var/run/secrets/aws/identity-token"],
+  ])("redacts the exact value of %s", (envKey, secretValue) => {
+    const originalValue = process.env[envKey];
+    process.env[envKey] = secretValue;
+
+    try {
+      const result = sanitizeDiagnosticText(
+        `provider error exposed ${secretValue}`,
+      );
+
+      expect(result).not.toContain(secretValue);
+      expect(result).toContain(`[REDACTED:${envKey}]`);
+    } finally {
+      if (originalValue === undefined) {
+        delete process.env[envKey];
+      } else {
+        process.env[envKey] = originalValue;
+      }
+    }
+  });
+});
+
+describe("formatEnvironmentDebugValue", () => {
+  test.each([
+    ["BEDROCK_AWS_ACCESS_KEY_ID", "bedrock-access-id-123"],
+    ["BEDROCK_AWS_SECRET_ACCESS_KEY", "bedrock-secret-abcdef123456"],
+    ["BEDROCK_AWS_SESSION_TOKEN", "bedrock-session-abcdef123456"],
+  ])("does not preview %s", (envKey, secretValue) => {
+    const result = formatEnvironmentDebugValue(envKey, secretValue);
+
+    expect(result).toBe(`set(length=${secretValue.length})`);
+    expect(result).not.toContain(secretValue.slice(0, 6));
+    expect(result).not.toContain(secretValue.slice(-4));
+  });
 });
 
 describe("isOpenRouterServerError", () => {
@@ -247,6 +291,41 @@ describe("getErrorMessage", () => {
   test("redacts secrets in the underlying error message", () => {
     expect(getErrorMessage(new Error("bad token sk-abcDEF123"))).toContain(
       "[REDACTED:API_KEY]",
+    );
+  });
+});
+
+describe("isAuthError", () => {
+  test("recognizes AWS SDK credential-chain exhaustion by error name", () => {
+    const error = Object.assign(
+      new Error("Could not load credentials from any providers"),
+      { name: "CredentialsProviderError" },
+    );
+
+    expect(isAuthError(error, error.message)).toBe(true);
+  });
+
+  test.each([
+    "Could not load credentials from any providers",
+    "The web identity token that was passed is expired or is not valid",
+    "The security token included in the request is invalid",
+  ])("recognizes AWS credential failure: %s", (message) => {
+    expect(isAuthError(new Error(message), message)).toBe(true);
+  });
+
+  test.each([
+    "InvalidIdentityTokenException",
+    "ExpiredTokenException",
+    "IDPRejectedClaimException",
+  ])("recognizes AWS identity error name %s", (name) => {
+    const error = Object.assign(new Error("AWS identity failed"), { name });
+
+    expect(isAuthError(error, error.message)).toBe(true);
+  });
+
+  test("does not classify unrelated provider failures as authentication errors", () => {
+    expect(isAuthError(new Error("model overloaded"), "model overloaded")).toBe(
+      false,
     );
   });
 });

--- a/test/startup.test.ts
+++ b/test/startup.test.ts
@@ -7,6 +7,15 @@ import { afterEach, beforeEach, describe, expect, test } from "vitest";
 import { resolveStartupCommand } from "../src/startup.ts";
 import type { CliCommand } from "../src/commands.ts";
 import {
+  AWS_ACCESS_KEY_ID_ENV_KEY,
+  AWS_DEFAULT_REGION_ENV_KEY,
+  AWS_REGION_ENV_KEY,
+  AWS_ROLE_ARN_ENV_KEY,
+  AWS_SECRET_ACCESS_KEY_ENV_KEY,
+  AWS_SESSION_TOKEN_ENV_KEY,
+  AWS_WEB_IDENTITY_TOKEN_FILE_ENV_KEY,
+  BEDROCK_AWS_ACCESS_KEY_ID_ENV_KEY,
+  BEDROCK_AWS_SECRET_ACCESS_KEY_ENV_KEY,
   OPENAI_CHATGPT_ACCESS_TOKEN_ENV_KEY,
   OPENAI_CHATGPT_ACCOUNT_ID_ENV_KEY,
   OPENAI_CHATGPT_EXPIRES_AT_ENV_KEY,
@@ -17,6 +26,15 @@ import {
 
 const execFileAsync = promisify(execFile);
 const MANAGED_ENV_KEYS = [
+  AWS_ACCESS_KEY_ID_ENV_KEY,
+  AWS_DEFAULT_REGION_ENV_KEY,
+  AWS_REGION_ENV_KEY,
+  AWS_ROLE_ARN_ENV_KEY,
+  AWS_SECRET_ACCESS_KEY_ENV_KEY,
+  AWS_SESSION_TOKEN_ENV_KEY,
+  AWS_WEB_IDENTITY_TOKEN_FILE_ENV_KEY,
+  BEDROCK_AWS_ACCESS_KEY_ID_ENV_KEY,
+  BEDROCK_AWS_SECRET_ACCESS_KEY_ENV_KEY,
   OPENWIKI_PROVIDER_ENV_KEY,
   OPENROUTER_API_KEY_ENV_KEY,
   OPENAI_CHATGPT_ACCESS_TOKEN_ENV_KEY,
@@ -102,6 +120,15 @@ beforeEach(() => {
   delete process.env[OPENAI_CHATGPT_REFRESH_TOKEN_ENV_KEY];
   delete process.env[OPENAI_CHATGPT_EXPIRES_AT_ENV_KEY];
   delete process.env[OPENAI_CHATGPT_ACCOUNT_ID_ENV_KEY];
+  delete process.env[AWS_DEFAULT_REGION_ENV_KEY];
+  delete process.env[AWS_ACCESS_KEY_ID_ENV_KEY];
+  delete process.env[AWS_REGION_ENV_KEY];
+  delete process.env[AWS_ROLE_ARN_ENV_KEY];
+  delete process.env[AWS_SECRET_ACCESS_KEY_ENV_KEY];
+  delete process.env[AWS_SESSION_TOKEN_ENV_KEY];
+  delete process.env[AWS_WEB_IDENTITY_TOKEN_FILE_ENV_KEY];
+  delete process.env[BEDROCK_AWS_ACCESS_KEY_ID_ENV_KEY];
+  delete process.env[BEDROCK_AWS_SECRET_ACCESS_KEY_ENV_KEY];
 });
 
 afterEach(() => {
@@ -215,6 +242,73 @@ describe("resolveStartupCommand", () => {
 
     expect(result).toBe(command);
   });
+
+  test("allows non-interactive Bedrock startup with OIDC credentials", async () => {
+    process.env[OPENWIKI_PROVIDER_ENV_KEY] = "bedrock";
+    process.env[AWS_ROLE_ARN_ENV_KEY] =
+      "arn:aws:iam::123456789012:role/openwiki";
+    process.env[AWS_WEB_IDENTITY_TOKEN_FILE_ENV_KEY] =
+      "/var/run/secrets/aws/token";
+    process.env[AWS_REGION_ENV_KEY] = "us-east-1";
+
+    const command = updatePrintCommand({ userMessage: "refresh API docs" });
+    const result = await resolveStartupCommand(command, { isStdinTTY: false });
+
+    expect(result).toBe(command);
+  });
+
+  test.each([
+    [
+      BEDROCK_AWS_ACCESS_KEY_ID_ENV_KEY,
+      "access",
+      BEDROCK_AWS_SECRET_ACCESS_KEY_ENV_KEY,
+    ],
+    [
+      BEDROCK_AWS_SECRET_ACCESS_KEY_ENV_KEY,
+      "secret",
+      BEDROCK_AWS_ACCESS_KEY_ID_ENV_KEY,
+    ],
+  ])(
+    "rejects partial legacy Bedrock credentials when only %s is set",
+    async (configuredKey, configuredValue, missingKey) => {
+      process.env[OPENWIKI_PROVIDER_ENV_KEY] = "bedrock";
+      process.env[configuredKey] = configuredValue;
+
+      const result = await resolveStartupCommand(
+        updatePrintCommand({ userMessage: "refresh API docs" }),
+        { isStdinTTY: false },
+      );
+
+      expect(result.kind).toBe("error");
+      if (result.kind === "error") {
+        expect(result.message).toContain(`${missingKey} is required`);
+        expect(result.message).not.toContain(configuredValue);
+      }
+    },
+  );
+
+  test.each([
+    [AWS_ACCESS_KEY_ID_ENV_KEY, "access", AWS_SECRET_ACCESS_KEY_ENV_KEY],
+    [AWS_SECRET_ACCESS_KEY_ENV_KEY, "secret", AWS_ACCESS_KEY_ID_ENV_KEY],
+  ])(
+    "rejects incomplete standard AWS credentials when only %s is set",
+    async (configuredKey, configuredValue, missingKey) => {
+      process.env[OPENWIKI_PROVIDER_ENV_KEY] = "bedrock";
+      process.env[AWS_REGION_ENV_KEY] = "us-east-1";
+      process.env[configuredKey] = configuredValue;
+
+      const result = await resolveStartupCommand(
+        updatePrintCommand({ userMessage: "refresh API docs" }),
+        { isStdinTTY: false },
+      );
+
+      expect(result.kind).toBe("error");
+      if (result.kind === "error") {
+        expect(result.message).toContain(`${missingKey} is required`);
+        expect(result.message).not.toContain(configuredValue);
+      }
+    },
+  );
 
   test("leaves expired complete ChatGPT OAuth tokens to the agent refresh path", async () => {
     process.env[OPENWIKI_PROVIDER_ENV_KEY] = "openai-chatgpt";


### PR DESCRIPTION
> [!NOTE]
> #384 and #400 pursue the same Bedrock credential-chain goal. This PR is an independent implementation based on current `main`, with the behavioral contract and regression coverage made explicit for comparison. I am happy to adapt or consolidate whichever implementation the maintainers prefer.

## Summary

- let the Bedrock provider use the [AWS SDK default credential provider chain](https://docs.aws.amazon.com/sdk-for-javascript/v3/developer-guide/setting-credentials-node.html) when a legacy `BEDROCK_*` key pair is absent
- preserve complete legacy Bedrock key pairs, including `BEDROCK_AWS_SESSION_TOKEN`
- resolve the region from `BEDROCK_AWS_REGION`, `AWS_REGION`, then `AWS_DEFAULT_REGION`
- keep onboarding, startup validation, diagnostics, and redaction consistent with SDK-managed credentials

## Why

Addresses #397.

OpenWiki currently requires explicit Bedrock access keys during setup and injects them when constructing `ChatBedrockConverse`. That prevents deployments from using temporary credentials already supplied through GitHub Actions OIDC/web identity, IAM roles, AWS profiles/SSO, ECS, or EC2.

This change delegates credential discovery and refresh to `@langchain/aws` and the AWS SDK instead of implementing a separate credential resolver.

## Credential behavior

| Configuration | Behavior |
| --- | --- |
| `AWS_BEARER_TOKEN_BEDROCK` | Preserve the existing LangChain precedence |
| Complete legacy Bedrock key pair | Continue using it, including an optional session token |
| No legacy Bedrock key pair | Use the AWS SDK default chain, including standard `AWS_*` credentials |
| Partial legacy or standard AWS access/secret pair | Fail early with the missing environment variable instead of silently falling back |
| Region configuration | Prefer `BEDROCK_AWS_REGION`, then `AWS_REGION`, then `AWS_DEFAULT_REGION` |

The model-selection and cross-region inference behavior introduced in #327 is unchanged.

## Scope and review guide

This is one Bedrock-authentication change. It does not modify dependencies, generated workflow templates, model selection, or generated `openwiki/` documentation. The README change only notes that the credential chain is supported. Of the 953 added lines, 551 are regression tests.

- `src/constants.ts`: represent SDK-managed authentication explicitly and centralize credential-pair and region resolution
- `src/agent/index.ts`: omit the explicit `credentials` option so the SDK owns resolution and refresh, while retaining the existing model, region, and retry configuration
- onboarding, CLI, and diagnostics: skip static-key collection for SDK credentials, reject incomplete pairs, provide AWS-specific remediation, and redact AWS credential/token values
- tests: cover SDK delegation, temporary environment credentials, legacy compatibility, startup/onboarding behavior, region precedence, auth-error classification, and redaction

A generated GitHub Actions workflow is intentionally out of scope: this PR makes OpenWiki consume credentials already supplied to the process, such as those exported by `aws-actions/configure-aws-credentials`.

## Validation

- [x] `pnpm run format:check`
- [x] `pnpm run lint:check`
- [x] `pnpm run typecheck`
- [x] `pnpm run build`
- [x] `pnpm test` — 40 files, 478 tests
- [x] `pnpm run coverage`
- [x] `pnpm audit --prod`
- [x] `git diff --check`

Manual smoke test: ran OpenWiki from this branch with Bedrock and confirmed a repository run completes successfully through the AWS SDK credential chain. The automated tests additionally exercise model construction and temporary environment credentials without network access; credential exchange and refresh remain AWS SDK responsibilities.

