### PR TITLE
fix: allow vertex claude client under the mermaid jsdom shim

### DIFF
--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -827,6 +827,17 @@ function createGeminiEnterpriseModel(
       // ANTHROPIC_API_KEY requirement. The env is neutralized around the
       // constructor so a stray ANTHROPIC_API_KEY/ANTHROPIC_AUTH_TOKEN cannot
       // clobber the Google OAuth token (see withAnthropicAuthEnvNeutralized).
+      //
+      // dangerouslyAllowBrowser: the Anthropic SDK (base of AnthropicVertex)
+      // refuses to construct when it detects `window`/`document`/`navigator` —
+      // its browser-credential-exposure guard. OpenWiki is always a Node CLI/CI
+      // process, but the optional Mermaid validation path installs jsdom DOM
+      // globals process-wide (see src/mermaid/dom-shim.ts), which trips that
+      // guard and aborts the whole run before any docs are generated. ChatAnthropic
+      // passes `dangerouslyAllowBrowser: true` into `createClient`, but this hook
+      // ignores its argument, so the flag is set explicitly here. It is forwarded
+      // to AnthropicVertex only — never the ANTHROPIC_* auth options LangChain
+      // also passes, which would defeat withAnthropicAuthEnvNeutralized.
       return new ChatAnthropic(stripPublisherPath(modelId), {
         createClient: () =>
           withAnthropicAuthEnvNeutralized(
@@ -834,6 +845,7 @@ function createGeminiEnterpriseModel(
               new AnthropicVertex({
                 projectId,
                 region: location,
+                dangerouslyAllowBrowser: true,
               }),
           ),
         ...retryOptions,

--- a/test/gemini-enterprise-claude.e2e.test.ts
+++ b/test/gemini-enterprise-claude.e2e.test.ts
@@ -1,25 +1,9 @@
-import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, test } from "vitest";
 import { ensureDomGlobals } from "../src/mermaid/dom-shim.ts";
 import { createModel } from "../src/agent/index.ts";
-
-// AnthropicVertex's constructor eagerly kicks off ADC resolution
-// (`new GoogleAuth().getClient()`), whose promise rejects with "Could not load
-// the default credentials" in an unauthenticated CI environment. That rejection
-// lands *after* this test resolves, so Vitest reports it as an unhandled
-// rejection and fails the run even though the test itself passes. Stub
-// google-auth-library so the eager auth lookup resolves to a dummy client. This
-// stubs *only* the credential lookup; the real AnthropicVertex is still
-// constructed, and its browser-environment guard still runs in the base-class
-// `super()` call — before any auth — so the fix remains exercised end-to-end.
-vi.mock("google-auth-library", () => ({
-  GoogleAuth: class {
-    getClient() {
-      return Promise.resolve({
-        getRequestHeaders: () => Promise.resolve({}),
-      });
-    }
-  },
-}));
 
 // End-to-end regression for issue #3, using the REAL Anthropic Vertex SDK (no
 // mock) and the REAL Mermaid DOM shim. The optional Mermaid validation path
@@ -28,31 +12,69 @@ vi.mock("google-auth-library", () => ({
 // "browser-like environment" at client construction, aborting the whole run.
 //
 // This test would FAIL (throw that error) if dangerouslyAllowBrowser were
-// removed from the AnthropicVertex construction — unlike the mocked unit test,
-// it exercises the actual SDK guard, so it guards against a base-SDK option
-// rename or a regression in the fix.
+// removed from the AnthropicVertex construction. Unlike the mocked unit test it
+// exercises the actual SDK guard, so it guards against a base-SDK option rename
+// or a regression in the fix.
+//
+// Suppressing the ADC unhandled rejection: AnthropicVertex's constructor eagerly
+// runs `new GoogleAuth().getClient()` and does not await the promise (it is only
+// awaited later, on the first request). In an unauthenticated CI environment that
+// promise rejects with "Could not load the default credentials" AFTER this test
+// resolves, so Vitest reports an unhandled rejection and fails the run even
+// though every test passes. Mocking google-auth-library does not help here:
+// @anthropic-ai/vertex-sdk is externalized CommonJS, so its internal
+// `require("google-auth-library")` never routes through Vitest's mock registry.
+// Instead we point GOOGLE_APPLICATION_CREDENTIALS at a throwaway `authorized_user`
+// credentials file so the eager lookup resolves offline: those creds build a
+// UserRefreshClient with no network call, and this test never triggers a token
+// refresh. The real GoogleAuth still runs, keeping the test genuinely end-to-end.
 const PROJECT_KEY = "GOOGLE_CLOUD_PROJECT";
 const LOCATION_KEY = "GOOGLE_CLOUD_LOCATION";
+const ADC_KEY = "GOOGLE_APPLICATION_CREDENTIALS";
+
+// Obviously-fake placeholder ADC. No real tokens, no private key; written to an
+// OS temp dir per test and removed in afterEach, never committed.
+const FAKE_AUTHORIZED_USER_ADC = JSON.stringify({
+  type: "authorized_user",
+  client_id: "test-client-id.apps.googleusercontent.com",
+  client_secret: "test-secret",
+  refresh_token: "test-refresh-token",
+});
 
 describe("gemini-enterprise Claude surface (real SDK + jsdom shim, issue #3)", () => {
   let saved: Record<string, string | undefined> = {};
+  let credsDir: string | undefined;
 
-  beforeEach(() => {
+  beforeEach(async () => {
     saved = {
       [PROJECT_KEY]: process.env[PROJECT_KEY],
       [LOCATION_KEY]: process.env[LOCATION_KEY],
+      [ADC_KEY]: process.env[ADC_KEY],
     };
     process.env[PROJECT_KEY] = "test-project";
     process.env[LOCATION_KEY] = "global";
+
+    credsDir = await mkdtemp(path.join(tmpdir(), "openwiki-vertex-adc-"));
+    const credsPath = path.join(
+      credsDir,
+      "application_default_credentials.json",
+    );
+    await writeFile(credsPath, FAKE_AUTHORIZED_USER_ADC, "utf8");
+    process.env[ADC_KEY] = credsPath;
   });
 
-  afterEach(() => {
+  afterEach(async () => {
     for (const [key, value] of Object.entries(saved)) {
       if (value === undefined) {
         delete process.env[key];
       } else {
         process.env[key] = value;
       }
+    }
+
+    if (credsDir !== undefined) {
+      await rm(credsDir, { force: true, recursive: true });
+      credsDir = undefined;
     }
   });
 

--- a/test/gemini-enterprise-claude.e2e.test.ts
+++ b/test/gemini-enterprise-claude.e2e.test.ts
@@ -1,6 +1,25 @@
-import { afterEach, beforeEach, describe, expect, test } from "vitest";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 import { ensureDomGlobals } from "../src/mermaid/dom-shim.ts";
 import { createModel } from "../src/agent/index.ts";
+
+// AnthropicVertex's constructor eagerly kicks off ADC resolution
+// (`new GoogleAuth().getClient()`), whose promise rejects with "Could not load
+// the default credentials" in an unauthenticated CI environment. That rejection
+// lands *after* this test resolves, so Vitest reports it as an unhandled
+// rejection and fails the run even though the test itself passes. Stub
+// google-auth-library so the eager auth lookup resolves to a dummy client. This
+// stubs *only* the credential lookup; the real AnthropicVertex is still
+// constructed, and its browser-environment guard still runs in the base-class
+// `super()` call — before any auth — so the fix remains exercised end-to-end.
+vi.mock("google-auth-library", () => ({
+  GoogleAuth: class {
+    getClient() {
+      return Promise.resolve({
+        getRequestHeaders: () => Promise.resolve({}),
+      });
+    }
+  },
+}));
 
 // End-to-end regression for issue #3, using the REAL Anthropic Vertex SDK (no
 // mock) and the REAL Mermaid DOM shim. The optional Mermaid validation path

--- a/test/gemini-enterprise-claude.e2e.test.ts
+++ b/test/gemini-enterprise-claude.e2e.test.ts
@@ -1,0 +1,56 @@
+import { afterEach, beforeEach, describe, expect, test } from "vitest";
+import { ensureDomGlobals } from "../src/mermaid/dom-shim.ts";
+import { createModel } from "../src/agent/index.ts";
+
+// End-to-end regression for issue #3, using the REAL Anthropic Vertex SDK (no
+// mock) and the REAL Mermaid DOM shim. The optional Mermaid validation path
+// installs jsdom's window/document globals process-wide; the Anthropic SDK's
+// browser guard (window && window.document && navigator all defined) then throws
+// "browser-like environment" at client construction, aborting the whole run.
+//
+// This test would FAIL (throw that error) if dangerouslyAllowBrowser were
+// removed from the AnthropicVertex construction — unlike the mocked unit test,
+// it exercises the actual SDK guard, so it guards against a base-SDK option
+// rename or a regression in the fix.
+const PROJECT_KEY = "GOOGLE_CLOUD_PROJECT";
+const LOCATION_KEY = "GOOGLE_CLOUD_LOCATION";
+
+describe("gemini-enterprise Claude surface (real SDK + jsdom shim, issue #3)", () => {
+  let saved: Record<string, string | undefined> = {};
+
+  beforeEach(() => {
+    saved = {
+      [PROJECT_KEY]: process.env[PROJECT_KEY],
+      [LOCATION_KEY]: process.env[LOCATION_KEY],
+    };
+    process.env[PROJECT_KEY] = "test-project";
+    process.env[LOCATION_KEY] = "global";
+  });
+
+  afterEach(() => {
+    for (const [key, value] of Object.entries(saved)) {
+      if (value === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = value;
+      }
+    }
+  });
+
+  test("constructs the Vertex Claude client with jsdom DOM globals present", async () => {
+    // Install the real DOM globals exactly as the Mermaid validation path does.
+    await ensureDomGlobals();
+    expect(typeof globalThis.window).toBe("object");
+    expect(typeof globalThis.document).toBe("object");
+
+    const model = createModel(
+      "gemini-enterprise",
+      "publishers/anthropic/models/claude-opus-4-8",
+      0,
+    );
+
+    // Must NOT throw "It looks like you're running in a browser-like environment".
+    const client = (model as { createClient: () => unknown }).createClient();
+    expect(client).toBeDefined();
+  });
+});

--- a/test/gemini-enterprise-claude.test.ts
+++ b/test/gemini-enterprise-claude.test.ts
@@ -6,7 +6,13 @@ import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 // Anthropic SDK can't send them as an Authorization header that clobbers the
 // Google OAuth token).
 type VertexCall = {
-  options: { projectId?: string; region?: string };
+  options: {
+    projectId?: string;
+    region?: string;
+    dangerouslyAllowBrowser?: boolean;
+    apiKey?: string;
+    authToken?: string;
+  };
   anthropicApiKeyVisible: boolean;
   anthropicAuthTokenVisible: boolean;
 };
@@ -15,7 +21,7 @@ const vertexCalls: VertexCall[] = [];
 
 vi.mock("@anthropic-ai/vertex-sdk", () => ({
   AnthropicVertex: class {
-    constructor(options: { projectId?: string; region?: string }) {
+    constructor(options: VertexCall["options"]) {
       vertexCalls.push({
         options,
         anthropicApiKeyVisible: process.env.ANTHROPIC_API_KEY !== undefined,
@@ -77,6 +83,27 @@ describe("gemini-enterprise Claude surface (createClient)", () => {
     // Project + region flow through.
     expect(call?.options.projectId).toBe("test-project");
     expect(call?.options.region).toBe("us-east5");
+  });
+
+  test("forwards dangerouslyAllowBrowser to AnthropicVertex, and only that flag (not the ANTHROPIC_* auth options)", () => {
+    // The Anthropic SDK refuses to construct once the Mermaid jsdom shim installs
+    // window/document globals unless dangerouslyAllowBrowser is set (that guard's
+    // suppression is proven end-to-end against the real SDK in
+    // gemini-enterprise-claude.e2e.test.ts). Here, with the SDK mocked, assert
+    // only that the flag is forwarded and — critically — that the ANTHROPIC_*
+    // auth options LangChain also hands the hook are NOT forwarded, since that
+    // would send an Authorization header clobbering the Google OAuth token.
+    const model = createModel(
+      "gemini-enterprise",
+      "publishers/anthropic/models/claude-sonnet-4-5@20250929",
+      0,
+    );
+    (model as { createClient?: () => unknown }).createClient?.();
+
+    expect(vertexCalls).toHaveLength(1);
+    expect(vertexCalls[0]?.options.dangerouslyAllowBrowser).toBe(true);
+    expect(vertexCalls[0]?.options.apiKey).toBeUndefined();
+    expect(vertexCalls[0]?.options.authToken).toBeUndefined();
   });
 
   test("restores ANTHROPIC_* env vars after construction", () => {


### PR DESCRIPTION
## Summary

Enabling the optional Mermaid validation path (`mermaid` + `jsdom`) breaks documentation runs on the Gemini Enterprise **Vertex "anthropic" surface** (Claude on Vertex): the Anthropic SDK refuses to construct with a "browser-like environment" error and the run aborts before any docs are generated. This makes Mermaid support and Claude-on-Vertex mutually exclusive.

Fixes #440.

## Root cause

- `src/mermaid/dom-shim.ts` installs jsdom's `window`/`document` as process-wide globals so DOMPurify can parse headless (by design, and before `mermaid` is first imported).
- The Anthropic SDK's `isRunningInBrowser()` returns true when `window`, `window.document`, and `navigator` are all defined. On Node ≥ 21 `navigator` is always present, so the shim trips the guard in the CLI/CI process, and the SDK constructor throws unless `dangerouslyAllowBrowser: true`.
- `ChatAnthropic` already passes `dangerouslyAllowBrowser: true` into its `createClient` hook for exactly this reason, but the Vertex `createClient` override in `createGeminiEnterpriseModel` is a zero-arg `() =>` that ignores the argument, dropping the flag before it reaches `AnthropicVertex`.

The non-Vertex `anthropic` provider (LangChain's default `createClient` forwards the flag) and all `ChatOpenAI`-family providers (flag set by default) were already immune.

## Fix

Set `dangerouslyAllowBrowser: true` on the `AnthropicVertex` construction inside the Vertex `createClient` hook. OpenWiki always runs as a Node CLI/CI process, so the guard is a false positive here; the flag's only runtime effect is an `anthropic-dangerous-direct-browser-access` header and it exposes no credential.

Only that flag is forwarded — deliberately **not** the `ANTHROPIC_*` auth options LangChain also hands the hook, which are neutralized on this surface (`withAnthropicAuthEnvNeutralized`) so they can't clobber the Google OAuth token.

## Testing

- New end-to-end regression test (`test/gemini-enterprise-claude.e2e.test.ts`) constructs the client with the **real** Anthropic Vertex SDK and the **real** jsdom shim active; it throws the "browser-like environment" error if the flag is removed, and passes with it.
- Existing unit test extended to assert the flag is forwarded and that the `ANTHROPIC_*` auth options are not.
- Full suite green (474 tests), typecheck + lint + build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
