### PR TITLE
fix: open oauth urls on windows via rundll32 (cmd /c start truncates at '&')

### DIFF
--- a/src/auth/oauth.ts
+++ b/src/auth/oauth.ts
@@ -559,7 +559,11 @@ async function openBrowser(url: string): Promise<boolean> {
     }
 
     if (platform === "win32") {
-      await execFilePromise("cmd", ["/c", "start", "", url]);
+      // "cmd /c start" re-parses the reconstructed command line, so "&" in a
+      // URL acts as a command separator and truncates the authorization URL
+      // at the first query parameter. rundll32's FileProtocolHandler receives
+      // the URL as a verbatim argument and avoids start's title-arg quirk.
+      await execFilePromise("rundll32", ["url.dll,FileProtocolHandler", url]);
       return true;
     }
 


### PR DESCRIPTION
## Summary

Closes #425

On Windows, `openBrowser()` used `cmd /c start "" <url>`. `cmd.exe` re-parses the reconstructed command line and treats `&` as a command separator, so every OAuth authorization URL was truncated at the first query parameter — the provider received only `client_id`, Notion showed **"Missing redirect_uri in OAuth request"**, and the CLI hung forever waiting for a callback.

## Change

Replace the `cmd /c start` invocation with:

```ts
await execFilePromise("rundll32", ["url.dll,FileProtocolHandler", url]);
```

as suggested in the issue. `rundll32` passes the URL through verbatim (no shell re-parsing), avoids `start`'s title-argument quirk, and requires no quoting gymnastics. macOS/Linux paths are untouched, and the existing `try/catch` fallback (printing the URL for manual open) still applies if `rundll32` is unavailable.

One-line behavioral change, scoped to the `win32` branch of `openBrowser()` in `src/auth/oauth.ts`.