### PR TITLE
fix: return connector tool errors as tool results instead of throwing

### DIFF
--- a/src/connectors/tools.ts
+++ b/src/connectors/tools.ts
@@ -198,7 +198,30 @@ export function createOpenWikiConnectorTools(): StructuredToolInterface[] {
           ),
         ),
     }),
-  ];
+  ].map(wrapToolErrors);
+}
+
+/**
+ * Wraps a connector tool's func so thrown errors are returned to the model as
+ * a `Tool error: <message>` result instead of propagating. Thrown tool errors
+ * abort the whole agent run before the model can read the (often
+ * model-directed) error message and self-correct — e.g. retrying
+ * openwiki_call_mcp_tool with an exact discovered tool name.
+ */
+function wrapToolErrors<
+  T extends { func: (...args: any[]) => Promise<unknown> },
+>(tool: T): T {
+  const originalFunc = tool.func;
+  tool.func = (async (...args: any[]) => {
+    try {
+      return await originalFunc(...args);
+    } catch (error) {
+      return `Tool error: ${
+        error instanceof Error ? error.message : String(error)
+      }`;
+    }
+  }) as T["func"];
+  return tool;
 }
 
 async function listConnectors() {


### PR DESCRIPTION
## Summary

Closes #427

Every `func` in `createOpenWikiConnectorTools()` currently lets errors propagate. A thrown tool error aborts the whole agent run, so the model never sees the error messages that were written *for* it — e.g. the `openwiki_call_mcp_tool` guidance to run `openwiki_list_mcp_tools` first and retry with an exact discovered tool name. A single hallucinated tool name or one expired connector token kills the entire wiki-build instead of letting the agent self-correct or continue with other connectors.

## Change

Added a small `wrapToolErrors` helper in `src/connectors/tools.ts` and applied it to all seven connector tools via `.map(wrapToolErrors)` on the returned array, following the approach suggested (and verified with a local patch) in the issue:

```ts
function wrapToolErrors<
  T extends { func: (...args: any[]) => Promise<unknown> },
>(tool: T): T {
  const originalFunc = tool.func;
  tool.func = (async (...args: any[]) => {
    try {
      return await originalFunc(...args);
    } catch (error) {
      return `Tool error: ${
        error instanceof Error ? error.message : String(error)
      }`;
    }
  }) as T["func"];
  return tool;
}
```

## Behavior

- Tool failures now return `Tool error: <message>` as the tool result, matching how LangChain's own `ToolNode` reports errors, so the agent can retry with corrected input or move on
- Bad tool name → model retries after discovery; expired token → model skips that connector and continues; the run completes with partial results instead of crashing
- No behavior change on the success path; internal helper `throw`s (input validation, MCP-backed checks) are preserved and simply surface through the wrapper

Kept the scope minimal per the issue; making `ingestAllConnectors` collect per-connector failures individually could be a follow-up.