### PR TITLE
fix: preserve contested local-wiki claims

### DIFF
--- a/src/agent/prompt.ts
+++ b/src/agent/prompt.ts
@@ -410,8 +410,14 @@ function getOutputPromptConfig(
 - Apply confidence labels consistently:
   - confirmed: directly supported by authoritative evidence or repeated high-quality evidence.
   - source-backed: supported by one credible source but not yet independently confirmed.
+  - contested: incompatible claims from credible sources that current evidence does not settle.
   - watchlist: weak, low-signal, early, or potentially transient evidence worth checking again.
   - saved-context: useful context intentionally saved by the user or found in bookmarks, without implying it is true or important.
+- Contested knowledge discipline:
+  - When credible personal-mode sources disagree and no ground truth settles the conflict, preserve both claims in a ## Contested section on the canonical page. Include each claim's source and date when available.
+  - Label the disputed fact contested wherever it appears, including /themes.md Confidence cells. Never present either side as confirmed or source-backed while the conflict remains unsettled.
+  - Add an /open-questions.md entry only when the unresolved conflict would impair future assistance, and link that question to the canonical Contested entry instead of restating both claims.
+  - Never resolve a contested fact by recency alone. Resolve it only when new evidence settles the conflict or shows that a source is stale, then keep a short resolution note with the resolution date, deciding evidence, and superseded claim source.
 - Classify email-like evidence before writing it to the wiki. Use these labels: action_required, scheduled_commitment, decision_or_approval, direct_request, important_update, people_or_org_signal, project_context, security_or_account_notice, newsletter_or_digest, transaction_or_receipt, promotion_or_marketing, personal_logistics, noise.
 - For email-like evidence, also assign priority high, medium, low, or ignore, and durability ephemeral, durable, or recurring. Write only high/medium durable items, action items, scheduled commitments, approvals, personal logistics, and recurring patterns. Keep receipts, promotions, generic newsletters, routine security notices, and noise out of the wiki unless they are actionable, recurrent, or explicitly requested.
 - Route work commitments and follow-ups to /commitments.md with Owner when inferable; route personal logistics to /personal-logistics.md with date/time/location/status when available.

--- a/src/ingestion.ts
+++ b/src/ingestion.ts
@@ -333,7 +333,8 @@ Instructions:
 function createSourceSynthesisPolicy(connector: ConnectorRuntime): string {
   return `
 - Synthesize into canonical cross-source files when relevant: /open-questions.md for unresolved memory/wiki questions, /themes.md for recurring trends, /commitments.md for work tasks/follow-ups, /personal-logistics.md for non-work life-admin items, /quickstart.md for high-level navigation/current status, and /sources/${connector.id}.md for compact source evidence.
-- Apply confidence labels: confirmed, source-backed, watchlist, or saved-context. Keep weak/watchlist items out of /quickstart.md unless they materially affect current status.
+- Apply confidence labels: confirmed, source-backed, contested, watchlist, or saved-context. Keep weak/watchlist items out of /quickstart.md unless they materially affect current status.
+- When credible sources disagree and no ground truth settles it, label the fact contested and preserve both claims with source and date in a ## Contested section on the canonical page instead of overwriting one side. Never resolve a contested fact by recency alone.
 - Deduplicate with stable topic keys. Update existing themes, open questions, and commitments instead of repeating the same fact in several source pages.
 - Keep /themes.md as a compact index: prefer table rows or one short fielded entry per theme, cap prose at 1-2 short sentences, and move details/examples into source pages.
 - If /open-questions.md exists, read it at the start so known open questions shape evidence review. At the end, return to it to add real newly discovered questions and move answered questions from Active to Answered.

--- a/test/prompt.test.ts
+++ b/test/prompt.test.ts
@@ -48,6 +48,22 @@ describe("createSystemPrompt filesystem path guidance", () => {
         );
       });
     }
+
+    test("preserves unresolved source conflicts as contested knowledge", () => {
+      const prompt = createSystemPrompt("update", "local-wiki");
+
+      expect(prompt).toContain("contested:");
+      expect(prompt).toContain("## Contested section");
+      expect(prompt).toContain(
+        "Never resolve a contested fact by recency alone",
+      );
+      expect(prompt).toContain(
+        "Never present either side as confirmed or source-backed while the conflict remains unsettled",
+      );
+      expect(prompt).toContain(
+        "Add an /open-questions.md entry only when the unresolved conflict would impair future assistance",
+      );
+    });
   });
 
   test("both modes forbid typing host/tilde paths into filesystem tools", () => {


### PR DESCRIPTION
## Summary

Fix #380

Local-wiki synthesis now has an explicit `contested` confidence label and a contested-knowledge discipline. When credible personal-mode sources disagree and current evidence does not settle the conflict, the prompt tells the agent to preserve both claims with source/date provenance in a canonical `## Contested` section instead of silently overwriting one side.

The guidance is scoped to local-wiki mode; repository mode keeps the existing prompt behavior.

## Test verification (RED → GREEN)

RED on upstream-base behavior with the new prompt regression test:

```text
FAIL  test/prompt.test.ts > createSystemPrompt filesystem path guidance > local-wiki mode > preserves unresolved source conflicts as contested knowledge
AssertionError: expected 'You are OpenWiki, an expert technical…' to contain 'contested:'
Test Files  1 failed (1)
Tests  1 failed | 15 skipped (16)
```

GREEN with the fix:

```text
pnpm exec vitest run test/prompt.test.ts --testNamePattern 'preserves unresolved source conflicts as contested knowledge'
Test Files  1 passed (1)
Tests  1 passed | 15 skipped (16)
```

## Local validation

```text
pnpm run format:check
All matched files use Prettier code style!

pnpm run lint:check
# passed

pnpm run typecheck
# passed

pnpm test
Test Files  44 passed (44)
Tests  512 passed (512)

pnpm run build
# passed

OPENWIKI_DEV=1 node dist/cli.js code --dry-run --init
# passed; printed the dry-run execution plan and did not invoke the agent
```