### PR TITLE
fix: retry OpenAI streaming rate limits

### DIFF
--- a/.changeset/retry-openai-stream-rate-limits.md
+++ b/.changeset/retry-openai-stream-rate-limits.md
@@ -1,0 +1,5 @@
+---
+"openwiki": patch
+---
+
+Retry transient OpenAI streaming rate limit failures.

--- a/README.md
+++ b/README.md
@@ -356,7 +356,7 @@ OPENWIKI_OPENROUTER_MAX_TOKENS=8192
 
 A cap trades those hard 402 failures for possible truncation when a long wiki generation genuinely needs more output tokens, so prefer the largest value your balance allows.
 
-**Retry attempts.** OpenWiki uses LangChain's retry handling for transient provider errors. Override the retry count (default 3) with `OPENWIKI_PROVIDER_RETRY_ATTEMPTS=3` (a positive integer).
+**Retry attempts.** OpenWiki uses LangChain's retry handling for transient provider errors. For OpenAI and OpenAI-compatible transports, this also covers retryable streaming HTTP responses surfaced by the underlying SDK. Override the retry count (default 3) with `OPENWIKI_PROVIDER_RETRY_ATTEMPTS=3` (a positive integer).
 
 **Model output token limit.** Set `OPENWIKI_MAX_OUTPUT_TOKENS` (a positive integer) to override the maximum number of tokens generated in a model response, for example `OPENWIKI_MAX_OUTPUT_TOKENS=8192`. If unset, OpenWiki does not override the model client's output token limit. Provider and model limits still apply; unsupported values may be rejected, while very small values can truncate responses or tool calls.
 

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -7,7 +7,7 @@ import { ChatAnthropic } from "@langchain/anthropic";
 import { ChatBedrockConverse } from "@langchain/aws";
 import { ChatGoogle } from "@langchain/google/node";
 import { SqliteSaver } from "@langchain/langgraph-checkpoint-sqlite";
-import { ChatOpenAI } from "@langchain/openai";
+import { ChatOpenAI, type ClientOptions } from "@langchain/openai";
 import { ChatOpenRouter } from "@langchain/openrouter";
 import type { BaseChatModel } from "@langchain/core/language_models/chat_models";
 import type { Event as ProtocolEvent } from "@langchain/protocol";
@@ -1141,6 +1141,7 @@ export function createModel(
     reasoningConfig?.transport === "chat-completions-reasoning-effort"
       ? { modelKwargs: { reasoning_effort: reasoningConfig.effort } }
       : {};
+  const fetchRetryOptions = { maxRetries: DISABLE_LANGCHAIN_FETCH_RETRIES };
 
   if (provider === "gemini") {
     return new ChatGoogle({
@@ -1213,8 +1214,8 @@ export function createModel(
       streaming: true,
       ...maxTokensOptions,
       ...responsesReasoningOptions,
-      ...retryOptions,
-      configuration: {
+      ...fetchRetryOptions,
+      configuration: withProviderRetryFetch(providerRetryAttempts, {
         baseURL: CODEX_RESPONSES_BASE_URL,
         defaultHeaders: {
           "chatgpt-account-id": tokens.accountId,
@@ -1222,7 +1223,7 @@ export function createModel(
           "OpenAI-Beta": "responses=experimental",
         },
         fetch: createCodexFetch(modelId),
-      },
+      }),
     });
   }
 
@@ -1256,11 +1257,14 @@ export function createModel(
 
   return new ChatOpenAI({
     apiKey: getProviderApiKey(provider),
-    configuration: baseURL
-      ? {
-          baseURL,
-        }
-      : undefined,
+    configuration: withProviderRetryFetch(
+      providerRetryAttempts,
+      baseURL
+        ? {
+            baseURL,
+          }
+        : undefined,
+    ),
     model: modelId,
     useResponsesApi: providerUsesResponsesApi(provider, modelId),
     ...maxTokensOptions,
@@ -1271,8 +1275,123 @@ export function createModel(
     // than assigning a boolean: `streaming: false` is not the same as omitting
     // the key, because LangChain turns it into `disableStreaming`.
     ...(providerUsesStreaming(provider) ? { streaming: true } : {}),
-    ...retryOptions,
+    ...fetchRetryOptions,
   });
+}
+
+type ProviderFetch = typeof globalThis.fetch;
+
+const HTTP_STATUS_REQUEST_TIMEOUT = 408;
+const HTTP_STATUS_CONFLICT = 409;
+const HTTP_STATUS_TOO_MANY_REQUESTS = 429;
+const HTTP_STATUS_INTERNAL_SERVER_ERROR = 500;
+const HTTP_STATUS_BAD_GATEWAY = 502;
+const HTTP_STATUS_SERVICE_UNAVAILABLE = 503;
+const HTTP_STATUS_GATEWAY_TIMEOUT = 504;
+const RETRY_AFTER_HEADER_NAME = "retry-after";
+const ABORT_ERROR_NAME = "AbortError";
+const MILLISECONDS_PER_SECOND = 1000;
+const DEFAULT_PROVIDER_RETRY_DELAY_MS = 1000;
+const MAX_PROVIDER_RETRY_DELAY_MS = 60_000;
+const DISABLE_LANGCHAIN_FETCH_RETRIES = 0;
+const PROVIDER_RETRYABLE_STATUSES = new Set<number>([
+  HTTP_STATUS_REQUEST_TIMEOUT,
+  HTTP_STATUS_CONFLICT,
+  HTTP_STATUS_TOO_MANY_REQUESTS,
+  HTTP_STATUS_INTERNAL_SERVER_ERROR,
+  HTTP_STATUS_BAD_GATEWAY,
+  HTTP_STATUS_SERVICE_UNAVAILABLE,
+  HTTP_STATUS_GATEWAY_TIMEOUT,
+]);
+
+function withProviderRetryFetch(
+  providerRetryAttempts: number,
+  configuration: ClientOptions | undefined,
+): ClientOptions {
+  return {
+    ...configuration,
+    fetch: createProviderRetryFetch(
+      providerRetryAttempts,
+      configuration?.fetch,
+    ),
+  };
+}
+
+function createProviderRetryFetch(
+  providerRetryAttempts: number,
+  fetchImpl: ProviderFetch = globalThis.fetch,
+): ProviderFetch {
+  return async (input, init) => {
+    for (let attempt = 0; ; attempt += 1) {
+      let response: Response;
+
+      try {
+        response = await fetchImpl(cloneFetchInput(input), init);
+      } catch (error) {
+        if (
+          attempt >= providerRetryAttempts ||
+          isProviderRetryAbortError(error)
+        ) {
+          throw error;
+        }
+
+        await sleep(DEFAULT_PROVIDER_RETRY_DELAY_MS);
+        continue;
+      }
+
+      if (
+        attempt >= providerRetryAttempts ||
+        !PROVIDER_RETRYABLE_STATUSES.has(response.status)
+      ) {
+        return response;
+      }
+
+      await sleep(resolveProviderRetryDelayMs(response));
+    }
+  };
+}
+
+function cloneFetchInput(input: Parameters<ProviderFetch>[0]) {
+  return input instanceof Request ? input.clone() : input;
+}
+
+function isProviderRetryAbortError(error: unknown): boolean {
+  return (
+    (error instanceof DOMException || error instanceof Error) &&
+    error.name === ABORT_ERROR_NAME
+  );
+}
+
+function resolveProviderRetryDelayMs(response: Response): number {
+  const retryAfter = response.headers.get(RETRY_AFTER_HEADER_NAME);
+
+  if (!retryAfter) {
+    return DEFAULT_PROVIDER_RETRY_DELAY_MS;
+  }
+
+  const retryAfterSeconds = Number(retryAfter);
+
+  if (Number.isFinite(retryAfterSeconds) && retryAfterSeconds >= 0) {
+    return Math.min(
+      retryAfterSeconds * MILLISECONDS_PER_SECOND,
+      MAX_PROVIDER_RETRY_DELAY_MS,
+    );
+  }
+
+  const retryAtMs = Date.parse(retryAfter);
+
+  if (!Number.isFinite(retryAtMs)) {
+    return DEFAULT_PROVIDER_RETRY_DELAY_MS;
+  }
+
+  return Math.min(
+    Math.max(retryAtMs - Date.now(), 0),
+    MAX_PROVIDER_RETRY_DELAY_MS,
+  );
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
 const CHATGPT_LOGIN_INCOMPLETE_MESSAGE =
@@ -1384,13 +1503,13 @@ function createGeminiEnterpriseModel(
       // `apiKey` is a placeholder because that header is overwritten.
       return new ChatOpenAI({
         apiKey: VERTEX_ADC_PLACEHOLDER_KEY,
-        configuration: {
+        configuration: withProviderRetryFetch(retryOptions.maxRetries, {
           baseURL: vertexOpenAIBaseUrl(projectId, location),
           fetch: createVertexAuthFetch(),
-        },
+        }),
         model: toVertexPublisherModel(modelId),
         ...maxTokensOptions,
-        ...retryOptions,
+        maxRetries: DISABLE_LANGCHAIN_FETCH_RETRIES,
       });
 
     default:

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -1290,6 +1290,8 @@ const HTTP_STATUS_SERVICE_UNAVAILABLE = 503;
 const HTTP_STATUS_GATEWAY_TIMEOUT = 504;
 const RETRY_AFTER_HEADER_NAME = "retry-after";
 const ABORT_ERROR_NAME = "AbortError";
+const ABORT_ERROR_MESSAGE = "The operation was aborted";
+const ABORT_EVENT_NAME = "abort";
 const MILLISECONDS_PER_SECOND = 1000;
 const DEFAULT_PROVIDER_RETRY_DELAY_MS = 1000;
 const MAX_PROVIDER_RETRY_DELAY_MS = 60_000;
@@ -1335,7 +1337,7 @@ function createProviderRetryFetch(
           throw error;
         }
 
-        await sleep(DEFAULT_PROVIDER_RETRY_DELAY_MS);
+        await sleep(DEFAULT_PROVIDER_RETRY_DELAY_MS, init?.signal);
         continue;
       }
 
@@ -1346,7 +1348,8 @@ function createProviderRetryFetch(
         return response;
       }
 
-      await sleep(resolveProviderRetryDelayMs(response));
+      await discardProviderResponse(response);
+      await sleep(resolveProviderRetryDelayMs(response), init?.signal);
     }
   };
 }
@@ -1390,8 +1393,38 @@ function resolveProviderRetryDelayMs(response: Response): number {
   );
 }
 
-function sleep(ms: number): Promise<void> {
-  return new Promise((resolve) => setTimeout(resolve, ms));
+async function discardProviderResponse(response: Response): Promise<void> {
+  if (response.body && !response.body.locked) {
+    try {
+      await response.body.cancel();
+    } catch {
+      // Cleanup is best-effort: the retryable HTTP response remains the
+      // actionable failure, and a stream cancellation error must not replace it.
+    }
+  }
+}
+
+function sleep(ms: number, signal?: AbortSignal | null): Promise<void> {
+  if (signal?.aborted) {
+    return Promise.reject(
+      new DOMException(ABORT_ERROR_MESSAGE, ABORT_ERROR_NAME),
+    );
+  }
+
+  let handleAbort: (() => void) | undefined;
+
+  return new Promise<void>((resolve, reject) => {
+    const timeout = setTimeout(resolve, ms);
+    handleAbort = () => {
+      clearTimeout(timeout);
+      reject(new DOMException(ABORT_ERROR_MESSAGE, ABORT_ERROR_NAME));
+    };
+    signal?.addEventListener(ABORT_EVENT_NAME, handleAbort, { once: true });
+  }).finally(() => {
+    if (handleAbort) {
+      signal?.removeEventListener(ABORT_EVENT_NAME, handleAbort);
+    }
+  });
 }
 
 const CHATGPT_LOGIN_INCOMPLETE_MESSAGE =

--- a/test/agent/gemini-retry.test.ts
+++ b/test/agent/gemini-retry.test.ts
@@ -8,6 +8,8 @@ const chatGoogleArgs: Array<Record<string, unknown>> = [];
 const chatAnthropicArgs: Array<[string, Record<string, unknown>]> = [];
 const chatOpenAIArgs: Array<Record<string, unknown>> = [];
 const chatOpenRouterArgs: Array<Record<string, unknown>> = [];
+const DISABLED_LANGCHAIN_RETRY_ATTEMPTS = 0;
+const FUNCTION_TYPE = "function";
 
 vi.mock("@langchain/google/node", () => ({
   ChatGoogle: class {
@@ -119,7 +121,7 @@ describe("createModel wires runtime options into provider clients", () => {
     expect(chatAnthropicArgs[0]?.[1].maxTokens).toBe(8192);
   });
 
-  test("gemini-enterprise MaaS surface passes runtime options to ChatOpenAI", () => {
+  test("gemini-enterprise MaaS surface uses fetch retry without stacking LangChain retries", () => {
     createModel(
       "gemini-enterprise",
       "publishers/meta/models/llama-3.3-70b-instruct-maas",
@@ -128,8 +130,14 @@ describe("createModel wires runtime options into provider clients", () => {
     );
 
     expect(chatOpenAIArgs).toHaveLength(1);
-    expect(chatOpenAIArgs[0]?.maxRetries).toBe(2);
+    expect(chatOpenAIArgs[0]?.maxRetries).toBe(
+      DISABLED_LANGCHAIN_RETRY_ATTEMPTS,
+    );
     expect(chatOpenAIArgs[0]?.maxTokens).toBe(8192);
+    expect(
+      (chatOpenAIArgs[0]?.configuration as { fetch?: unknown } | undefined)
+        ?.fetch,
+    ).toBeTypeOf(FUNCTION_TYPE);
   });
 
   test("passes maxTokens to direct non-Google clients", () => {

--- a/test/openai-provider-retry-fetch.test.ts
+++ b/test/openai-provider-retry-fetch.test.ts
@@ -1,0 +1,110 @@
+import { afterEach, describe, expect, test, vi } from "vitest";
+import { createModel } from "../src/agent/index.ts";
+
+const OPENAI_API_KEY_ENV_KEY = "OPENAI_API_KEY";
+const TEST_API_KEY = "test-openai-key";
+const TEST_MODEL_ID = "gpt-5.6-terra";
+const TEST_PROVIDER_RETRY_ATTEMPTS = 1;
+const DISABLED_LANGCHAIN_RETRY_ATTEMPTS = 0;
+const OPENAI_PROVIDER = "openai";
+const RATE_LIMIT_STATUS = 429;
+const SUCCESS_STATUS = 200;
+const FUNCTION_TYPE = "function";
+const RETRY_AFTER_HEADER_NAME = "retry-after";
+const ZERO_RETRY_AFTER_SECONDS = "0";
+const TEST_PROVIDER_URL = "https://api.example.test/responses";
+const TRANSIENT_FETCH_ERROR_MESSAGE = "fetch failed";
+const EXPECTED_PROVIDER_CALLS_AFTER_ONE_RETRY =
+  TEST_PROVIDER_RETRY_ATTEMPTS + 1;
+
+describe("createModel OpenAI provider retry fetch", () => {
+  let savedOpenAiApiKey: string | undefined;
+  let savedFetch: typeof globalThis.fetch;
+
+  afterEach(() => {
+    restoreEnv(OPENAI_API_KEY_ENV_KEY, savedOpenAiApiKey);
+    globalThis.fetch = savedFetch;
+    vi.restoreAllMocks();
+  });
+
+  test("retries provider rate-limit responses through the OpenAI SDK fetch", async () => {
+    savedOpenAiApiKey = process.env[OPENAI_API_KEY_ENV_KEY];
+    savedFetch = globalThis.fetch;
+    process.env[OPENAI_API_KEY_ENV_KEY] = TEST_API_KEY;
+
+    const providerFetch = vi
+      .fn<typeof globalThis.fetch>()
+      .mockResolvedValueOnce(
+        new Response(null, {
+          status: RATE_LIMIT_STATUS,
+          headers: { [RETRY_AFTER_HEADER_NAME]: ZERO_RETRY_AFTER_SECONDS },
+        }),
+      )
+      .mockResolvedValueOnce(new Response(null, { status: SUCCESS_STATUS }));
+    globalThis.fetch = providerFetch;
+
+    const model = createModel(
+      OPENAI_PROVIDER,
+      TEST_MODEL_ID,
+      TEST_PROVIDER_RETRY_ATTEMPTS,
+    ) as { clientConfig?: { fetch?: typeof globalThis.fetch } };
+
+    const retryFetch = model.clientConfig?.fetch;
+
+    expect(retryFetch).toBeTypeOf(FUNCTION_TYPE);
+
+    const response = await retryFetch?.(TEST_PROVIDER_URL);
+
+    expect(response?.status).toBe(SUCCESS_STATUS);
+    expect(providerFetch).toHaveBeenCalledTimes(
+      EXPECTED_PROVIDER_CALLS_AFTER_ONE_RETRY,
+    );
+  });
+
+  test("retries transient fetch rejections through the same retry budget", async () => {
+    savedOpenAiApiKey = process.env[OPENAI_API_KEY_ENV_KEY];
+    savedFetch = globalThis.fetch;
+    process.env[OPENAI_API_KEY_ENV_KEY] = TEST_API_KEY;
+
+    const providerFetch = vi
+      .fn<typeof globalThis.fetch>()
+      .mockRejectedValueOnce(new Error(TRANSIENT_FETCH_ERROR_MESSAGE))
+      .mockResolvedValueOnce(new Response(null, { status: SUCCESS_STATUS }));
+    globalThis.fetch = providerFetch;
+
+    const model = createModel(
+      OPENAI_PROVIDER,
+      TEST_MODEL_ID,
+      TEST_PROVIDER_RETRY_ATTEMPTS,
+    ) as { clientConfig?: { fetch?: typeof globalThis.fetch } };
+
+    const response = await model.clientConfig?.fetch?.(TEST_PROVIDER_URL);
+
+    expect(response?.status).toBe(SUCCESS_STATUS);
+    expect(providerFetch).toHaveBeenCalledTimes(
+      EXPECTED_PROVIDER_CALLS_AFTER_ONE_RETRY,
+    );
+  });
+
+  test("uses the fetch wrapper as the single retry budget", () => {
+    savedOpenAiApiKey = process.env[OPENAI_API_KEY_ENV_KEY];
+    savedFetch = globalThis.fetch;
+    process.env[OPENAI_API_KEY_ENV_KEY] = TEST_API_KEY;
+
+    const model = createModel(
+      OPENAI_PROVIDER,
+      TEST_MODEL_ID,
+      TEST_PROVIDER_RETRY_ATTEMPTS,
+    ) as { caller?: { maxRetries?: number } };
+
+    expect(model.caller?.maxRetries).toBe(DISABLED_LANGCHAIN_RETRY_ATTEMPTS);
+  });
+});
+
+function restoreEnv(key: string, value: string | undefined): void {
+  if (value === undefined) {
+    delete process.env[key];
+  } else {
+    process.env[key] = value;
+  }
+}

--- a/test/openai-provider-retry-fetch.test.ts
+++ b/test/openai-provider-retry-fetch.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, test, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 import { createModel } from "../src/agent/index.ts";
 
 const OPENAI_API_KEY_ENV_KEY = "OPENAI_API_KEY";
@@ -12,8 +12,13 @@ const SUCCESS_STATUS = 200;
 const FUNCTION_TYPE = "function";
 const RETRY_AFTER_HEADER_NAME = "retry-after";
 const ZERO_RETRY_AFTER_SECONDS = "0";
+const LONG_RETRY_AFTER_SECONDS = "60";
+const INVALID_RETRY_AFTER_VALUE = "not-a-delay";
+const PAST_RETRY_AFTER_DATE = "Thu, 01 Jan 1970 00:00:00 GMT";
+const ABORT_ERROR_NAME = "AbortError";
 const TEST_PROVIDER_URL = "https://api.example.test/responses";
 const TRANSIENT_FETCH_ERROR_MESSAGE = "fetch failed";
+const CANCEL_ERROR_MESSAGE = "cancel failed";
 const EXPECTED_PROVIDER_CALLS_AFTER_ONE_RETRY =
   TEST_PROVIDER_RETRY_ATTEMPTS + 1;
 
@@ -21,17 +26,20 @@ describe("createModel OpenAI provider retry fetch", () => {
   let savedOpenAiApiKey: string | undefined;
   let savedFetch: typeof globalThis.fetch;
 
+  beforeEach(() => {
+    savedOpenAiApiKey = process.env[OPENAI_API_KEY_ENV_KEY];
+    savedFetch = globalThis.fetch;
+    process.env[OPENAI_API_KEY_ENV_KEY] = TEST_API_KEY;
+  });
+
   afterEach(() => {
+    vi.useRealTimers();
     restoreEnv(OPENAI_API_KEY_ENV_KEY, savedOpenAiApiKey);
     globalThis.fetch = savedFetch;
     vi.restoreAllMocks();
   });
 
   test("retries provider rate-limit responses through the OpenAI SDK fetch", async () => {
-    savedOpenAiApiKey = process.env[OPENAI_API_KEY_ENV_KEY];
-    savedFetch = globalThis.fetch;
-    process.env[OPENAI_API_KEY_ENV_KEY] = TEST_API_KEY;
-
     const providerFetch = vi
       .fn<typeof globalThis.fetch>()
       .mockResolvedValueOnce(
@@ -62,10 +70,6 @@ describe("createModel OpenAI provider retry fetch", () => {
   });
 
   test("retries transient fetch rejections through the same retry budget", async () => {
-    savedOpenAiApiKey = process.env[OPENAI_API_KEY_ENV_KEY];
-    savedFetch = globalThis.fetch;
-    process.env[OPENAI_API_KEY_ENV_KEY] = TEST_API_KEY;
-
     const providerFetch = vi
       .fn<typeof globalThis.fetch>()
       .mockRejectedValueOnce(new Error(TRANSIENT_FETCH_ERROR_MESSAGE))
@@ -87,10 +91,6 @@ describe("createModel OpenAI provider retry fetch", () => {
   });
 
   test("uses the fetch wrapper as the single retry budget", () => {
-    savedOpenAiApiKey = process.env[OPENAI_API_KEY_ENV_KEY];
-    savedFetch = globalThis.fetch;
-    process.env[OPENAI_API_KEY_ENV_KEY] = TEST_API_KEY;
-
     const model = createModel(
       OPENAI_PROVIDER,
       TEST_MODEL_ID,
@@ -98,6 +98,171 @@ describe("createModel OpenAI provider retry fetch", () => {
     ) as { caller?: { maxRetries?: number } };
 
     expect(model.caller?.maxRetries).toBe(DISABLED_LANGCHAIN_RETRY_ATTEMPTS);
+  });
+
+  test("returns the final transient fetch rejection after exhausting retries", async () => {
+    const transientError = new Error(TRANSIENT_FETCH_ERROR_MESSAGE);
+    const providerFetch = vi
+      .fn<typeof globalThis.fetch>()
+      .mockRejectedValue(transientError);
+    globalThis.fetch = providerFetch;
+
+    const model = createModel(
+      OPENAI_PROVIDER,
+      TEST_MODEL_ID,
+      TEST_PROVIDER_RETRY_ATTEMPTS,
+    ) as { clientConfig?: { fetch?: typeof globalThis.fetch } };
+
+    await expect(model.clientConfig?.fetch?.(TEST_PROVIDER_URL)).rejects.toBe(
+      transientError,
+    );
+    expect(providerFetch).toHaveBeenCalledTimes(
+      EXPECTED_PROVIDER_CALLS_AFTER_ONE_RETRY,
+    );
+  });
+
+  test.each([
+    ["a missing Retry-After header", undefined],
+    ["an invalid Retry-After header", INVALID_RETRY_AFTER_VALUE],
+    ["an HTTP-date Retry-After header", PAST_RETRY_AFTER_DATE],
+  ])("retries after %s", async (_caseName, retryAfter) => {
+    vi.useFakeTimers();
+    const headers =
+      retryAfter === undefined
+        ? undefined
+        : { [RETRY_AFTER_HEADER_NAME]: retryAfter };
+    const providerFetch = vi
+      .fn<typeof globalThis.fetch>()
+      .mockResolvedValueOnce(
+        new Response(null, { status: RATE_LIMIT_STATUS, headers }),
+      )
+      .mockResolvedValueOnce(new Response(null, { status: SUCCESS_STATUS }));
+    globalThis.fetch = providerFetch;
+
+    const model = createModel(
+      OPENAI_PROVIDER,
+      TEST_MODEL_ID,
+      TEST_PROVIDER_RETRY_ATTEMPTS,
+    ) as { clientConfig?: { fetch?: typeof globalThis.fetch } };
+    const responsePromise = model.clientConfig?.fetch?.(TEST_PROVIDER_URL);
+
+    await vi.runAllTimersAsync();
+
+    await expect(responsePromise).resolves.toMatchObject({
+      status: SUCCESS_STATUS,
+    });
+    expect(providerFetch).toHaveBeenCalledTimes(
+      EXPECTED_PROVIDER_CALLS_AFTER_ONE_RETRY,
+    );
+  });
+
+  test("cancels a retryable response body before retrying", async () => {
+    const cancel = vi.fn();
+    const providerFetch = vi
+      .fn<typeof globalThis.fetch>()
+      .mockResolvedValueOnce(
+        new Response(new ReadableStream({ cancel }), {
+          status: RATE_LIMIT_STATUS,
+          headers: { [RETRY_AFTER_HEADER_NAME]: ZERO_RETRY_AFTER_SECONDS },
+        }),
+      )
+      .mockResolvedValueOnce(new Response(null, { status: SUCCESS_STATUS }));
+    globalThis.fetch = providerFetch;
+
+    const model = createModel(
+      OPENAI_PROVIDER,
+      TEST_MODEL_ID,
+      TEST_PROVIDER_RETRY_ATTEMPTS,
+    ) as { clientConfig?: { fetch?: typeof globalThis.fetch } };
+
+    await model.clientConfig?.fetch?.(TEST_PROVIDER_URL);
+
+    expect(cancel).toHaveBeenCalledTimes(1);
+  });
+
+  test("retries when discarding a response body fails", async () => {
+    const providerFetch = vi
+      .fn<typeof globalThis.fetch>()
+      .mockResolvedValueOnce(
+        new Response(
+          new ReadableStream({
+            cancel: () => Promise.reject(new Error(CANCEL_ERROR_MESSAGE)),
+          }),
+          {
+            status: RATE_LIMIT_STATUS,
+            headers: { [RETRY_AFTER_HEADER_NAME]: ZERO_RETRY_AFTER_SECONDS },
+          },
+        ),
+      )
+      .mockResolvedValueOnce(new Response(null, { status: SUCCESS_STATUS }));
+    globalThis.fetch = providerFetch;
+    const model = createModel(
+      OPENAI_PROVIDER,
+      TEST_MODEL_ID,
+      TEST_PROVIDER_RETRY_ATTEMPTS,
+    ) as { clientConfig?: { fetch?: typeof globalThis.fetch } };
+
+    await expect(
+      model.clientConfig?.fetch?.(TEST_PROVIDER_URL),
+    ).resolves.toMatchObject({ status: SUCCESS_STATUS });
+    expect(providerFetch).toHaveBeenCalledTimes(
+      EXPECTED_PROVIDER_CALLS_AFTER_ONE_RETRY,
+    );
+  });
+
+  test("aborts while waiting to retry a rate-limit response", async () => {
+    vi.useFakeTimers();
+    const providerFetch = vi.fn<typeof globalThis.fetch>().mockResolvedValue(
+      new Response(null, {
+        status: RATE_LIMIT_STATUS,
+        headers: {
+          [RETRY_AFTER_HEADER_NAME]: LONG_RETRY_AFTER_SECONDS,
+        },
+      }),
+    );
+    globalThis.fetch = providerFetch;
+    const abortController = new AbortController();
+    const model = createModel(
+      OPENAI_PROVIDER,
+      TEST_MODEL_ID,
+      TEST_PROVIDER_RETRY_ATTEMPTS,
+    ) as { clientConfig?: { fetch?: typeof globalThis.fetch } };
+    const responsePromise = model.clientConfig?.fetch?.(TEST_PROVIDER_URL, {
+      signal: abortController.signal,
+    });
+
+    await vi.advanceTimersByTimeAsync(0);
+    expect(vi.getTimerCount()).toBe(1);
+    abortController.abort();
+
+    await expect(responsePromise).rejects.toMatchObject({
+      name: ABORT_ERROR_NAME,
+    });
+    expect(providerFetch).toHaveBeenCalledTimes(1);
+  });
+
+  test("does not start a retry delay for an already-aborted signal", async () => {
+    const providerFetch = vi.fn<typeof globalThis.fetch>().mockResolvedValue(
+      new Response(null, {
+        status: RATE_LIMIT_STATUS,
+        headers: { [RETRY_AFTER_HEADER_NAME]: LONG_RETRY_AFTER_SECONDS },
+      }),
+    );
+    globalThis.fetch = providerFetch;
+    const abortController = new AbortController();
+    abortController.abort();
+    const model = createModel(
+      OPENAI_PROVIDER,
+      TEST_MODEL_ID,
+      TEST_PROVIDER_RETRY_ATTEMPTS,
+    ) as { clientConfig?: { fetch?: typeof globalThis.fetch } };
+
+    await expect(
+      model.clientConfig?.fetch?.(TEST_PROVIDER_URL, {
+        signal: abortController.signal,
+      }),
+    ).rejects.toMatchObject({ name: ABORT_ERROR_NAME });
+    expect(providerFetch).toHaveBeenCalledTimes(1);
   });
 });
 


### PR DESCRIPTION
## Summary

- add a retrying fetch wrapper for ChatOpenAI-backed providers so retryable HTTP responses from the OpenAI SDK transport are retried even on streaming runs
- keep one retry budget for OpenAI-backed transports by disabling the outer LangChain retry layer where the fetch wrapper owns retryable HTTP and transport failures
- preserve existing custom fetch transports for ChatGPT OAuth and Vertex MaaS by wrapping them instead of replacing them
- release discarded retry-response bodies and let request aborts interrupt retry delays
- document that OpenAI/OpenAI-compatible streaming HTTP responses are covered by provider retry attempts

Fixes #431

## Test verification (RED → GREEN)

RED on `origin/main` with the original regression test only:

```text
FAIL  retries provider rate-limit responses through the OpenAI SDK fetch
AssertionError: expected undefined to be type of 'function'
```

Additional RED checks on the rebased retry implementation:

```text
FAIL  cancels a retryable response body before retrying
expected cancel to be called 1 times, but got 0

FAIL  aborts while waiting to retry a rate-limit response
Test timed out in 2000ms

FAIL  retries when discarding a response body fails
promise rejected "Error: cancel failed" instead of resolving
```

GREEN on this branch:

```text
Test Files  182 passed | 2 skipped (184)
Tests       2443 passed | 3 skipped (2446)
Changed production lines covered: 55/55
```

Validation included frozen dependency install, formatting, lint, typecheck, build, CLI dry-run smoke test, full Vitest coverage, and changeset status.
