### PR TITLE
fix: cap retry-after delays for connector retries

### DIFF
--- a/src/connectors/http.ts
+++ b/src/connectors/http.ts
@@ -8,7 +8,7 @@
  * `fetchWithResilience` adds:
  *   - a per-request wall-clock timeout via `AbortSignal.timeout`,
  *   - bounded exponential backoff with jitter on 429 and 5xx responses,
- *     honoring a numeric or HTTP-date `Retry-After` header when present,
+ *     honoring a numeric or HTTP-date `Retry-After` header within the cap,
  *   - the same backoff on network errors (connection reset, DNS, timeout).
  *
  * Auth failures (401/403) and other 4xx are returned as-is: they are not
@@ -121,8 +121,10 @@ export async function fetchWithResilience(
           response.headers.get("retry-after"),
           Date.now(),
         );
-        const delay =
-          retryAfterMs ?? backoffDelayMs(attempt, baseDelayMs, random);
+        const delay = Math.min(
+          MAX_BACKOFF_DELAY_MS,
+          retryAfterMs ?? backoffDelayMs(attempt, baseDelayMs, random),
+        );
         // Discard the body so the connection can be reused before we retry.
         await response.body?.cancel();
         await sleep(delay);

--- a/test/fetch-with-resilience.test.ts
+++ b/test/fetch-with-resilience.test.ts
@@ -109,6 +109,33 @@ describe("fetchWithResilience", () => {
     expect(delays).toEqual([2000]);
   });
 
+  test("caps an oversized numeric Retry-After header", async () => {
+    stubFetchSequence([
+      () =>
+        new Response("slow down", {
+          headers: { "retry-after": "86400" },
+          status: 429,
+        }),
+      () => new Response("ok", { status: 200 }),
+    ]);
+
+    const delays: number[] = [];
+    const response = await fetchWithResilience(
+      "https://api.example.com/x",
+      {},
+      {
+        sleep: (ms) => {
+          delays.push(ms);
+          return Promise.resolve();
+        },
+        random: fixedRandom,
+      },
+    );
+
+    expect(response.status).toBe(200);
+    expect(delays).toEqual([20_000]);
+  });
+
   test("honors an HTTP-date Retry-After header relative to the current time", async () => {
     // The helper passes Date.now() into parseRetryAfterMs, so an HTTP-date
     // header must be turned into a real delay in production (not just in the
@@ -142,6 +169,40 @@ describe("fetchWithResilience", () => {
 
       expect(response.status).toBe(200);
       expect(delays).toEqual([5000]);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  test("caps an oversized HTTP-date Retry-After header", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-01-01T00:00:00Z"));
+
+    try {
+      stubFetchSequence([
+        () =>
+          new Response("slow down", {
+            headers: { "retry-after": "Fri, 02 Jan 2026 00:00:00 GMT" },
+            status: 429,
+          }),
+        () => new Response("ok", { status: 200 }),
+      ]);
+
+      const delays: number[] = [];
+      const response = await fetchWithResilience(
+        "https://api.example.com/x",
+        {},
+        {
+          sleep: (ms) => {
+            delays.push(ms);
+            return Promise.resolve();
+          },
+          random: fixedRandom,
+        },
+      );
+
+      expect(response.status).toBe(200);
+      expect(delays).toEqual([20_000]);
     } finally {
       vi.useRealTimers();
     }


### PR DESCRIPTION
Fixes #464

## Summary

- Cap connector retry delays at the existing 20-second maximum regardless of whether the delay comes from exponential jitter or a `Retry-After` header.
- Add regression coverage for oversized numeric and HTTP-date `Retry-After` values.

## Root Cause

`fetchWithResilience` capped only the fallback exponential backoff. A parsed `Retry-After` value bypassed `MAX_BACKOFF_DELAY_MS`, so an upstream response could suspend ingestion for hours or days.

## Verification

- `pnpm exec vitest run test/fetch-with-resilience.test.ts --no-color` — 15 tests passed.
- `pnpm run format:check` — passed.
- `pnpm run lint:check` — passed.
- `pnpm run typecheck` — passed.
- `pnpm run build` — passed.
- `OPENWIKI_DEV=1 node dist/cli.js code --dry-run --init` — passed.
- `pnpm test` — 54 files and 674 tests passed.
- `git diff --check` — passed.

## Notes for Reviewers

- Existing in-range `Retry-After` behavior is unchanged.
- This does not alter retry counts, retryable status codes, timeout behavior, or network-error backoff.
