### PR TITLE
feat: add claude code skills integration

### DIFF
--- a/src/agent/prompt.ts
+++ b/src/agent/prompt.ts
@@ -13,6 +13,115 @@ function formatLastUpdate(lastUpdate: UpdateMetadata | null): string {
   return JSON.stringify(lastUpdate, null, 2);
 }
 
+/**
+ * Paths the shared methodology instructions reference. A structural subset of
+ * OutputPromptConfig, so any surface config satisfies it, and lightweight
+ * enough for an out-of-tree caller (e.g. the Claude Code skills renderer) to
+ * construct directly.
+ */
+export interface MethodologyContext {
+  docsLocation: string;
+  planPath: string;
+  quickstartPath: string;
+}
+
+/**
+ * Documentation goals shared across every OpenWiki output surface.
+ */
+export function documentationGoals(output: MethodologyContext): string {
+  return `Documentation goals:
+- Someone with zero knowledge of the wiki should be able to start at ${output.quickstartPath} and understand what the knowledge base covers, how it is organized, what it tracks, and where to go next.
+- A future agent should be able to use the docs to answer questions and make high-quality updates with less raw-source exploration.
+- Capture both technical details and business/product logic.
+- Explain why important code exists, not only what files contain.
+- Prefer clear Markdown with stable links between pages.
+- Organize the docs like human documentation, not a raw file inventory.
+- Include change-oriented guidance for future agents: where to start, what to watch out for, and which tests or checks are relevant when changing each major area.
+- Keep the docs concise enough to maintain. Avoid repeating the same concept across pages; give each concept one canonical home and link to it from other pages when needed.
+- Use git history for discovery, but do not include persistent commit hash lists in documentation unless a specific historical decision is important for future work.`;
+}
+
+/**
+ * OKF concept-graph relationship-modeling rules.
+ */
+export function okfRelationshipModeling(output: MethodologyContext): string {
+  return `OKF relationship modeling:
+- Treat every non-reserved Markdown document as a concept node. Standard Markdown links between concept documents are directed relationship edges; tags, resource fields, directory placement, source-code references, and index.md links do not replace concept-to-concept links.
+- Model meaningful runtime, dependency, ownership, data-flow, security, lifecycle, and user-flow relationships, not only navigation from ${output.quickstartPath}.
+- Put a concept link in the sentence that explains the relationship. Use the surrounding prose to state its meaning, such as \`dispatches to\`, \`depends on\`, \`shares infrastructure with\`, \`is configured through\`, \`is surfaced by\`, or \`is secured by\`.
+- Do not add links solely to increase graph density, and do not automatically add reciprocal links. Add an inverse link only when it helps explain the target concept and is supported by evidence.
+- ${output.quickstartPath} must link to every major concept for navigation, but quickstart and index links do not count toward the semantic relationship audit.
+- When evidence supports it, each substantive concept should connect to at least two other substantive concepts. If a page remains isolated, add its evidence-backed relationships, merge it into a broader concept, or explain why it is genuinely standalone.
+- Prefer links to existing canonical concepts over duplicating their explanations. Do not mint thin concepts merely to create more nodes or edges.`;
+}
+
+/**
+ * OKF front-matter requirements. `repairPass` controls the trailing note:
+ * OpenWiki's runtime repairs front matter deterministically after every run,
+ * but a keyless surface with no post-run pass must get it right in place.
+ */
+export function okfFrontMatterRules(
+  output: MethodologyContext,
+  options: { repairPass: boolean },
+): string {
+  const head = `Front matter requirements (OKF):
+- Every non-reserved Markdown concept file you create or update under ${output.docsLocation}, including the temporary ${output.planPath} file, MUST begin with OKF-compliant YAML front matter.
+- The front matter MUST follow the Google Knowledge Catalog OKF v0.1 schema.
+- \`index.md\` and \`log.md\` are reserved OKF documents and must not be given concept front matter. Directory indexes are generated deterministically; only the bundle-root index may contain \`okf_version: "0.1"\` front matter.
+- Use this formatter at the very beginning of concept files, replacing placeholders with real values and omitting optional fields that do not apply:
+
+<okf_front_matter>
+---
+type: <Type name>                  # REQUIRED
+title: <Optional display name>
+description: <Optional one to two sentence summary (optimized for search & retrieval)>
+resource: <Optional canonical URI for the underlying asset>
+tags: [<tag>, <tag>, …]            # Optional
+timestamp: <Optional ISO 8601 datetime>
+# Producer-defined extension fields are allowed.
+---
+</okf_front_matter>
+
+- Only \`type\` is required. Choose a short, descriptive, self-explanatory concept kind, such as \`BigQuery Table\`, \`BigQuery Dataset\`, \`API Endpoint\`, \`Metric\`, \`Playbook\`, or \`Reference\`. Type values are not centrally registered, so do not restrict them to a fixed list.
+- Recommended fields, in priority order, are: \`title\`, a human-readable display name; \`description\`, a one to two sentence summary optimized for search and retrieval; \`resource\`, the canonical URI of the underlying asset when one exists; and \`tags\`, a YAML list of short cross-cutting category strings.
+- \`timestamp\` is an optional ISO 8601 datetime for the last meaningful change.
+- Produce valid YAML. Do not leave placeholder text or explanatory comments in written files.
+- Preserve all existing producer-defined front matter fields when updating a concept. Unknown extension fields are valid OKF and must survive round trips. Change metadata only when the underlying fact or meaningful content changes.
+- The description field is especially useful for retrieval tools. When present, make it clear, detailed, and optimized for search.
+- When updating an existing Markdown concept, preserve accurate body content and correct its opening front matter only when needed for compliance or accuracy.`;
+  const tail = options.repairPass
+    ? `- OpenWiki repairs front matter deterministically after every run, so a page is never rejected for missing or invalid front matter. If a page's front matter contains \`openwiki_generated: true\`, that metadata was code-derived as a fallback: replace it with an accurate \`type\`, \`title\`, and \`description\` grounded in the page body, then remove the \`openwiki_generated\` field.`
+    : "- There is no post-run repair pass on this surface, so every page must be written with valid OKF front matter in place: front matter that parses with a non-empty `type`. If you encounter a page whose front matter contains `openwiki_generated: true`, that block was code-derived by the OpenWiki CLI as a fallback: replace it with an accurate `type`, `title`, and `description` grounded in the page body, then remove the `openwiki_generated` field.";
+  return `${head}\n${tail}`;
+}
+
+/**
+ * Section quality and page-granularity rules.
+ */
+export function sectionQualityRules(output: MethodologyContext): string {
+  return `Section quality rules:
+- Do not create a directory unless it represents a real documentation area.
+- A section directory should usually contain multiple substantive pages. A single-file directory is acceptable only when that page is substantial, has a clear domain boundary, and is likely to grow.
+- Avoid thin pages. If a page would mostly be a stub, source map, or short note, merge it into ${output.quickstartPath} or a broader section page instead.
+- Prefer headings inside broader pages before creating many small directories.
+- Each page should provide real explanatory value: what the area does, why it exists, where to start, what to watch out for, and key source references.
+- Before finishing an init or update run, review the ${output.docsLocation} tree. Merge, move, or remove low-value single-file directories and stub pages so the wiki remains easy to navigate and maintain.
+- For small scopes with about 10 or fewer primary source items, prefer ${output.quickstartPath} plus at most 1-2 supporting pages. Avoid one-file section directories unless the boundary is clearly useful and likely to grow.
+- Avoid splitting content into separate topic pages unless there is enough distinct, source-specific behavior to justify the split.`;
+}
+
+/**
+ * Final coverage self-check, including the `## Backlog` convention.
+ */
+export function coverageSelfCheck(output: MethodologyContext): string {
+  return `Coverage self-check:
+- Before finishing, verify that every identified area is either documented or backlogged.
+- Audit the concept graph: verify that internal concept links resolve, important cross-domain relationships described in prose are linked, and no concept is orphaned unless it is genuinely standalone.
+- Verify that ${output.planPath} has been deleted. Do not finish while the temporary plan remains in the wiki as a concept.
+- Keep deferred areas in a concise \`## Backlog\` section at the end of ${output.quickstartPath}; do not create a separate backlog page.
+- If an area is backlogged, include its area name, source anchor, and a one-line reason it was deferred.`;
+}
+
 export function createSystemPrompt(
   command: OpenWikiCommand,
   outputMode: OpenWikiOutputMode = "local-wiki",
@@ -121,62 +230,13 @@ Security and privacy rules:
 - Keep all documentation under ${output.docsLocation}.
 - ${output.writeBoundaryInstruction}
 
-Documentation goals:
-- Someone with zero knowledge of the wiki should be able to start at ${output.quickstartPath} and understand what the knowledge base covers, how it is organized, what it tracks, and where to go next.
-- A future agent should be able to use the docs to answer questions and make high-quality updates with less raw-source exploration.
-- Capture both technical details and business/product logic.
-- Explain why important code exists, not only what files contain.
-- Prefer clear Markdown with stable links between pages.
-- Organize the docs like human documentation, not a raw file inventory.
-- Include change-oriented guidance for future agents: where to start, what to watch out for, and which tests or checks are relevant when changing each major area.
-- Keep the docs concise enough to maintain. Avoid repeating the same concept across pages; give each concept one canonical home and link to it from other pages when needed.
-- Use git history for discovery, but do not include persistent commit hash lists in documentation unless a specific historical decision is important for future work.
+${documentationGoals(output)}
 
-OKF relationship modeling:
-- Treat every non-reserved Markdown document as a concept node. Standard Markdown links between concept documents are directed relationship edges; tags, resource fields, directory placement, source-code references, and index.md links do not replace concept-to-concept links.
-- Model meaningful runtime, dependency, ownership, data-flow, security, lifecycle, and user-flow relationships, not only navigation from ${output.quickstartPath}.
-- Put a concept link in the sentence that explains the relationship. Use the surrounding prose to state its meaning, such as \`dispatches to\`, \`depends on\`, \`shares infrastructure with\`, \`is configured through\`, \`is surfaced by\`, or \`is secured by\`.
-- Do not add links solely to increase graph density, and do not automatically add reciprocal links. Add an inverse link only when it helps explain the target concept and is supported by evidence.
-- ${output.quickstartPath} must link to every major concept for navigation, but quickstart and index links do not count toward the semantic relationship audit.
-- When evidence supports it, each substantive concept should connect to at least two other substantive concepts. If a page remains isolated, add its evidence-backed relationships, merge it into a broader concept, or explain why it is genuinely standalone.
-- Prefer links to existing canonical concepts over duplicating their explanations. Do not mint thin concepts merely to create more nodes or edges.
+${okfRelationshipModeling(output)}
 
-Front matter requirements (OKF):
-- Every non-reserved Markdown concept file you create or update under ${output.docsLocation}, including the temporary ${output.planPath} file, MUST begin with OKF-compliant YAML front matter.
-- The front matter MUST follow the Google Knowledge Catalog OKF v0.1 schema.
-- \`index.md\` and \`log.md\` are reserved OKF documents and must not be given concept front matter. Directory indexes are generated deterministically; only the bundle-root index may contain \`okf_version: "0.1"\` front matter.
-- Use this formatter at the very beginning of concept files, replacing placeholders with real values and omitting optional fields that do not apply:
+${okfFrontMatterRules(output, { repairPass: true })}
 
-<okf_front_matter>
----
-type: <Type name>                  # REQUIRED
-title: <Optional display name>
-description: <Optional one to two sentence summary (optimized for search & retrieval)>
-resource: <Optional canonical URI for the underlying asset>
-tags: [<tag>, <tag>, …]            # Optional
-timestamp: <Optional ISO 8601 datetime>
-# Producer-defined extension fields are allowed.
----
-</okf_front_matter>
-
-- Only \`type\` is required. Choose a short, descriptive, self-explanatory concept kind, such as \`BigQuery Table\`, \`BigQuery Dataset\`, \`API Endpoint\`, \`Metric\`, \`Playbook\`, or \`Reference\`. Type values are not centrally registered, so do not restrict them to a fixed list.
-- Recommended fields, in priority order, are: \`title\`, a human-readable display name; \`description\`, a one to two sentence summary optimized for search and retrieval; \`resource\`, the canonical URI of the underlying asset when one exists; and \`tags\`, a YAML list of short cross-cutting category strings.
-- \`timestamp\` is an optional ISO 8601 datetime for the last meaningful change.
-- Produce valid YAML. Do not leave placeholder text or explanatory comments in written files.
-- Preserve all existing producer-defined front matter fields when updating a concept. Unknown extension fields are valid OKF and must survive round trips. Change metadata only when the underlying fact or meaningful content changes.
-- The description field is especially useful for retrieval tools. When present, make it clear, detailed, and optimized for search.
-- When updating an existing Markdown concept, preserve accurate body content and correct its opening front matter only when needed for compliance or accuracy.
-- OpenWiki repairs front matter deterministically after every run, so a page is never rejected for missing or invalid front matter. If a page's front matter contains \`openwiki_generated: true\`, that metadata was code-derived as a fallback: replace it with an accurate \`type\`, \`title\`, and \`description\` grounded in the page body, then remove the \`openwiki_generated\` field.
-
-Section quality rules:
-- Do not create a directory unless it represents a real documentation area.
-- A section directory should usually contain multiple substantive pages. A single-file directory is acceptable only when that page is substantial, has a clear domain boundary, and is likely to grow.
-- Avoid thin pages. If a page would mostly be a stub, source map, or short note, merge it into ${output.quickstartPath} or a broader section page instead.
-- Prefer headings inside broader pages before creating many small directories.
-- Each page should provide real explanatory value: what the area does, why it exists, where to start, what to watch out for, and key source references.
-- Before finishing an init or update run, review the ${output.docsLocation} tree. Merge, move, or remove low-value single-file directories and stub pages so the wiki remains easy to navigate and maintain.
-- For small scopes with about 10 or fewer primary source items, prefer ${output.quickstartPath} plus at most 1-2 supporting pages. Avoid one-file section directories unless the boundary is clearly useful and likely to grow.
-- Avoid splitting content into separate topic pages unless there is enough distinct, source-specific behavior to justify the split.
+${sectionQualityRules(output)}
 
 Required documentation structure:
 - ${output.quickstartPath} must be the entrypoint.
@@ -188,12 +248,7 @@ Required documentation structure:
 - Source Map sections are optional. Add one only when it materially improves navigation for that page. Prefer inline source references for short pages.
 - Track the last successful documentation update in ${output.metadataPath}.
 
-Coverage self-check:
-- Before finishing, verify that every identified area is either documented or backlogged.
-- Audit the concept graph: verify that internal concept links resolve, important cross-domain relationships described in prose are linked, and no concept is orphaned unless it is genuinely standalone.
-- Verify that ${output.planPath} has been deleted. Do not finish while the temporary plan remains in the wiki as a concept.
-- Keep deferred areas in a concise \`## Backlog\` section at the end of ${output.quickstartPath}; do not create a separate backlog page.
-- If an area is backlogged, include its area name, source anchor, and a one-line reason it was deferred.
+${coverageSelfCheck(output)}
 ${createDiagramInstructions()}
 Mode-specific behavior:
 ${createModeInstructions(command, outputMode)}

--- a/src/cli.tsx
+++ b/src/cli.tsx
@@ -1,7 +1,9 @@
 #!/usr/bin/env node
+import path from "node:path";
 import React, { useEffect, useRef, useState } from "react";
 import { Box, render, Text, useApp, useInput } from "ink";
 import { marked, type Token, type Tokens } from "marked";
+import { writeClaudeCodeSkills } from "./integrations/claude-code.js";
 import {
   configureAuthProvider,
   listAuthProviderTools,
@@ -3739,6 +3741,8 @@ if (command.kind === "auth") {
   await runCronCommand(command);
 } else if (command.kind === "ingest") {
   await runIngestCommand(command);
+} else if (command.kind === "integration") {
+  await runIntegrationCommand(command);
 } else if (shouldPrintStartupError(argv, parsedCommand, command)) {
   process.stderr.write(`${command.message}\n`);
   process.exitCode = command.exitCode;
@@ -3758,6 +3762,29 @@ if (command.kind === "auth") {
       <App command={command} />
     </>,
   );
+}
+
+async function runIntegrationCommand(
+  command: Extract<CliCommand, { kind: "integration" }>,
+): Promise<void> {
+  try {
+    const written = await writeClaudeCodeSkills(command.targetDir);
+    process.stdout.write(
+      `Scaffolded Claude Code skills into ${path.join(command.targetDir, ".claude", "skills")}:\n` +
+        written
+          .map((file) => `  ${path.relative(command.targetDir, file)}`)
+          .join("\n") +
+        "\n\nRun /openwiki-init inside Claude Code to generate the wiki keylessly.\n",
+    );
+    process.exitCode = 0;
+  } catch (error) {
+    process.stderr.write(
+      `Failed to scaffold Claude Code skills: ${
+        error instanceof Error ? error.message : String(error)
+      }\n`,
+    );
+    process.exitCode = 1;
+  }
 }
 
 async function runNgrokCommand(

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -39,6 +39,12 @@ export type CliCommand =
       url: string | null;
     }
   | {
+      kind: "integration";
+      exitCode: 0;
+      target: "claude";
+      targetDir: string;
+    }
+  | {
       kind: "ingest";
       exitCode: 0;
       modelId: string | null;
@@ -137,6 +143,40 @@ export function parseCommand(argv: string[]): CliCommand {
       exitCode: 0,
       force,
       provider,
+    };
+  }
+
+  if (argv[0] === "integration") {
+    if (argv[1] !== "claude") {
+      return {
+        kind: "error",
+        exitCode: 1,
+        message: "Usage: openwiki integration claude [path]",
+      };
+    }
+
+    const rest = argv.slice(2).filter((arg) => arg !== "");
+    const unknownOption = rest.find((arg) => arg.startsWith("-"));
+    if (unknownOption) {
+      return {
+        kind: "error",
+        exitCode: 1,
+        message: `Unknown option for integration: ${unknownOption}`,
+      };
+    }
+    if (rest.length > 1) {
+      return {
+        kind: "error",
+        exitCode: 1,
+        message: "Usage: openwiki integration claude [path]",
+      };
+    }
+
+    return {
+      kind: "integration",
+      exitCode: 0,
+      target: "claude",
+      targetDir: rest[0] ?? ".",
     };
   }
 
@@ -656,6 +696,7 @@ export const helpContent: HelpContent = {
     "openwiki cron resume all",
     "openwiki cron delete all",
     "openwiki ngrok start [url] [--port <port>]",
+    "openwiki integration claude [path]",
   ],
   commands: [
     {
@@ -715,6 +756,11 @@ export const helpContent: HelpContent = {
       label: "openwiki ngrok start [url]",
       description:
         "Start an ngrok tunnel for Slack OAuth, optionally using a fixed HTTPS URL.",
+    },
+    {
+      label: "openwiki integration claude [path]",
+      description:
+        "Scaffold Claude Code skills that generate and maintain the openwiki/ wiki using Claude Code's own inference (no API key).",
     },
   ],
   options: [

--- a/src/integrations/claude-code.ts
+++ b/src/integrations/claude-code.ts
@@ -1,0 +1,193 @@
+import { mkdir, writeFile } from "node:fs/promises";
+import path from "node:path";
+import {
+  coverageSelfCheck,
+  documentationGoals,
+  okfFrontMatterRules,
+  okfRelationshipModeling,
+  sectionQualityRules,
+  type MethodologyContext,
+} from "../agent/prompt.js";
+
+/**
+ * Scaffolds Claude Code skills that generate and maintain an OpenWiki wiki
+ * using the host coding agent's own inference — no OpenWiki provider or API
+ * key. Claude Code runs on the user's own credentials as a native Anthropic
+ * application, so nothing here routes requests through OpenWiki.
+ *
+ * The wiki-methodology bulk (documentation goals, OKF front matter, concept
+ * graph, section quality, coverage) is imported from the same functions the
+ * OpenWiki agent prompt uses, so the skills cannot drift from the CLI. Only the
+ * pieces the CLI performs *outside* the agent — writing `.last-update.json`,
+ * generating directory `index.md`, and getting OKF front matter right with no
+ * post-run repair — are authored here, since a keyless host agent cannot invoke
+ * them.
+ */
+
+/**
+ * A rendered skill file and its path relative to the scaffold target.
+ */
+export interface ScaffoldedSkill {
+  /** Path relative to the target directory, e.g. `.claude/skills/openwiki-init/SKILL.md`. */
+  relativePath: string;
+  /** Full SKILL.md contents. */
+  content: string;
+}
+
+const SKILLS_DIR = path.join(".claude", "skills");
+
+/**
+ * Methodology paths for the Claude Code surface. Unlike OpenWiki's own runtime,
+ * whose filesystem tools expose the wiki at a virtual root, Claude Code's tools
+ * take real repo-relative paths — so the wiki is addressed as `openwiki/...`,
+ * never `/openwiki/...`.
+ */
+const CLAUDE_CODE_CONTEXT: MethodologyContext = {
+  docsLocation: "the repository's openwiki/ directory",
+  planPath: "openwiki/_plan.md",
+  quickstartPath: "openwiki/quickstart.md",
+};
+
+/**
+ * The shared, drift-proof methodology, rendered for the Claude Code surface.
+ * `repairPass: false` because there is no OpenWiki post-run pass here.
+ */
+function sharedMethodology(): string {
+  const ctx = CLAUDE_CODE_CONTEXT;
+  return [
+    documentationGoals(ctx),
+    okfRelationshipModeling(ctx),
+    okfFrontMatterRules(ctx, { repairPass: false }),
+    sectionQualityRules(ctx),
+    coverageSelfCheck(ctx),
+  ].join("\n\n");
+}
+
+/**
+ * The keyless delta: everything the OpenWiki CLI does deterministically outside
+ * the agent, which a host coding agent must reproduce by hand.
+ */
+function keylessDelta(): string {
+  return `Reserved files (never treat these as concept pages):
+- \`index.md\` — deterministic navigation index (see below). No concept front matter, except the wiki-root \`openwiki/index.md\`, which carries only \`okf_version: "0.1"\`.
+- \`log.md\` — reserved OKF document. No concept front matter.
+- \`openwiki/INSTRUCTIONS.md\` — a user-authored brief. Read it for scope and priorities; never create, rewrite, or reformat it unless the user explicitly asks to change the brief.
+
+Directory indexes (you must write these yourself):
+OpenWiki's CLI regenerates \`index.md\` deterministically after each run. There is no such pass here, so write one \`index.md\` in \`openwiki/\` and in every subdirectory, reproducing this exact format so a later CLI run leaves them untouched:
+
+<index_format>
+# Files
+
+- [Title](page-name.md) - description text
+- [Another Page](another.md)
+
+# Directories
+
+- [architecture](architecture/)
+</index_format>
+
+- Only the root index \`openwiki/index.md\` is prefixed with \`---\\nokf_version: "0.1"\\n---\` and a blank line. Subdirectory indexes have no front matter.
+- The Files section lists \`.md\` files in that directory, excluding \`index.md\`, \`log.md\`, \`_plan.md\`, \`INSTRUCTIONS.md\`, and dotfiles. Label = the page's front-matter \`title\` when non-empty, else the filename without \`.md\`; escape \`\\\`, \`[\`, \`]\` in labels. Href = the filename, URL-encoded. Append \` - <description>\` when the page has a non-empty front-matter \`description\` (files only, never directories).
+- The Directories section lists non-hidden subdirectories; href = name + \`/\`, label = name.
+- Sort both sections by href ascending. Omit an empty section; if both are empty the file is just \`# Files\`. End with a single trailing newline.
+
+Root agent instruction files:
+- Do not create or edit \`AGENTS.md\` or \`CLAUDE.md\`. OpenWiki's CLI manages them itself, between \`<!-- OPENWIKI:START -->\` / \`<!-- OPENWIKI:END -->\` markers. Writing an unmarked \`## OpenWiki\` section makes the CLI append a duplicate on its next run.
+
+Run metadata (you must write this yourself):
+- After a run that changed wiki content, write \`openwiki/.last-update.json\` with exactly these keys:
+  \`updatedAt\` (real UTC ISO-8601 from \`date -u +%Y-%m-%dT%H:%M:%S.000Z\` — run it, don't guess), \`command\` (\`"init"\` or \`"update"\`), \`gitHead\` (\`git rev-parse HEAD\`, omit if not a git repo), and \`model\` (your model id, or \`"claude-code"\`).
+
+Discovery discipline:
+- Use your own tools: Read, Glob, Grep, and Bash (for \`git\` and \`rg\`). Do not call the \`openwiki\` CLI, and do not require any API key — you are the inference engine.
+- Prefer \`rg --files\` with excludes (\`.git\`, \`node_modules\`, \`dist\`, \`build\`, caches, \`openwiki/\`) and short targeted reads over full-file reads. Never glob \`**/*\` from the repo root.
+- Ground every claim in source, existing docs, or git evidence you inspected. Never invent files, modules, APIs, or behavior.
+- Never read or document secrets, credentials, tokens, or \`.env\` files. Keep all writes under \`openwiki/\`, plus the run metadata above.`;
+}
+
+const INIT_FRONT_MATTER = `---
+name: openwiki-init
+description: Generate a first-pass OpenWiki-format documentation wiki for this repository using your own inference (no API key). Use when asked to create, initialize, generate, or bootstrap OpenWiki docs / a repo wiki.
+---`;
+
+const UPDATE_FRONT_MATTER = `---
+name: openwiki-update
+description: Surgically update an existing OpenWiki-format wiki to reflect recent code changes, using your own inference (no API key). Use when asked to update, refresh, or sync the OpenWiki docs / repo wiki.
+---`;
+
+function renderInitSkill(): string {
+  return `${INIT_FRONT_MATTER}
+
+# OpenWiki: init
+
+Build a first-pass OpenWiki-format wiki for the current repository, doing the work yourself with your own tools. Write the wiki under \`openwiki/\`. If \`openwiki/\` already exists with real content, switch to the update behavior instead of overwriting it.
+
+## Process
+
+1. Confirm the repo root. Capture \`git rev-parse HEAD\` for metadata and skim \`git log --oneline -20\` for high-signal context. If it is not a git repo, proceed and omit \`gitHead\`.
+2. If \`openwiki/INSTRUCTIONS.md\` exists, read it — it is the user's authored scope and priorities. Never write to it.
+3. Inventory the repository with targeted discovery (entrypoints, package/config files, domain folders, routing, schema, tests, scripts).
+4. Write a temporary \`openwiki/_plan.md\` (with OKF front matter, e.g. \`type: Plan\`) listing intended pages, their evidence, and the concept relationships to link. Delete it before finishing.
+5. Write \`openwiki/quickstart.md\` first, then the smallest set of linked section pages that explains the repo well.
+6. Generate directory \`index.md\` files, delete \`openwiki/_plan.md\`, and write \`openwiki/.last-update.json\` with \`command: "init"\`.
+
+${sharedMethodology()}
+
+${keylessDelta()}`;
+}
+
+function renderUpdateSkill(): string {
+  return `${UPDATE_FRONT_MATTER}
+
+# OpenWiki: update
+
+Refresh the existing \`openwiki/\` wiki so it reflects recent source changes, doing the work yourself with your own tools. If \`openwiki/\` does not exist, tell the user to run the init skill first and stop.
+
+## Process
+
+1. Read \`openwiki/.last-update.json\`; prefer its \`gitHead\` as the baseline, else its \`updatedAt\`.
+2. If \`openwiki/INSTRUCTIONS.md\` exists, read it for scope and priorities. Never write to it.
+3. Find what changed: \`git diff <gitHead>..HEAD --stat\`, then targeted diffs on high-signal files, plus \`git status\`/\`git diff\` for uncommitted changes. If git is unavailable, infer from timestamps and source.
+4. Edit surgically — only pages made inaccurate by the changes. Prefer replacing a stale sentence over adding paragraphs. No formatting-only edits.
+5. Soft diff budget: if fewer than ~5 source files changed, edit at most 1-2 pages, and avoid \`openwiki/quickstart.md\` unless top-level behavior, setup, or navigation changed.
+6. If you added, removed, renamed, or retitled a page — or changed a page's \`title\`/\`description\` — regenerate the affected \`index.md\`. If nothing relevant changed, make no edits at all (leave \`.last-update.json\` untouched) and say the wiki is already current.
+7. If you changed wiki content, write \`openwiki/.last-update.json\` with \`command: "update"\`.
+
+${sharedMethodology()}
+
+${keylessDelta()}`;
+}
+
+/**
+ * Renders both Claude Code skills and their target-relative paths.
+ */
+export function renderClaudeCodeSkills(): ScaffoldedSkill[] {
+  return [
+    {
+      relativePath: path.join(SKILLS_DIR, "openwiki-init", "SKILL.md"),
+      content: renderInitSkill(),
+    },
+    {
+      relativePath: path.join(SKILLS_DIR, "openwiki-update", "SKILL.md"),
+      content: renderUpdateSkill(),
+    },
+  ];
+}
+
+/**
+ * Writes the Claude Code skills under `targetDir/.claude/skills/`. Only files
+ * inside `.claude/skills/` are ever written. Returns the absolute paths written.
+ */
+export async function writeClaudeCodeSkills(
+  targetDir: string,
+): Promise<string[]> {
+  const written: string[] = [];
+  for (const skill of renderClaudeCodeSkills()) {
+    const absolute = path.join(targetDir, skill.relativePath);
+    await mkdir(path.dirname(absolute), { recursive: true });
+    await writeFile(absolute, `${skill.content}\n`, "utf8");
+    written.push(absolute);
+  }
+  return written;
+}

--- a/test/claude-code-integration.test.ts
+++ b/test/claude-code-integration.test.ts
@@ -1,0 +1,117 @@
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, test } from "vitest";
+import { parseCommand } from "../src/commands.ts";
+import {
+  renderClaudeCodeSkills,
+  writeClaudeCodeSkills,
+} from "../src/integrations/claude-code.ts";
+
+describe("integration command parsing", () => {
+  test("parses `integration claude` with a default target of the cwd", () => {
+    expect(parseCommand(["integration", "claude"])).toEqual({
+      kind: "integration",
+      exitCode: 0,
+      target: "claude",
+      targetDir: ".",
+    });
+  });
+
+  test("parses an explicit target path", () => {
+    expect(parseCommand(["integration", "claude", "some/repo"])).toMatchObject({
+      kind: "integration",
+      targetDir: "some/repo",
+    });
+  });
+
+  test("rejects a missing or unknown integration target", () => {
+    expect(parseCommand(["integration"])).toMatchObject({ kind: "error" });
+    expect(parseCommand(["integration", "codex"])).toMatchObject({
+      kind: "error",
+    });
+  });
+
+  test("rejects unknown options and extra positionals", () => {
+    expect(parseCommand(["integration", "claude", "--force"])).toMatchObject({
+      kind: "error",
+    });
+    expect(parseCommand(["integration", "claude", "a", "b"])).toMatchObject({
+      kind: "error",
+    });
+  });
+});
+
+describe("rendered Claude Code skills", () => {
+  const skills = renderClaudeCodeSkills();
+  const bodies = skills.map((skill) => skill.content).join("\n");
+
+  test("scaffolds exactly the two expected skill files", () => {
+    expect(skills.map((skill) => skill.relativePath).sort()).toEqual([
+      path.join(".claude", "skills", "openwiki-init", "SKILL.md"),
+      path.join(".claude", "skills", "openwiki-update", "SKILL.md"),
+    ]);
+  });
+
+  test("addresses the wiki with real relative paths, never OpenWiki virtual paths", () => {
+    // Claude Code's tools take real paths; a leaked `/openwiki/...` virtual path
+    // (correct only inside OpenWiki's own runtime) would make the agent write to
+    // the filesystem root.
+    expect(bodies).toContain("openwiki/quickstart.md");
+    expect(bodies).not.toMatch(/\/openwiki\//);
+    expect(bodies).not.toMatch(/~\/\.openwiki/);
+  });
+
+  test("does not leak OpenWiki connector or CLI-only vocabulary", () => {
+    for (const term of [
+      "openwiki_ingest",
+      "openwiki_list_connectors",
+      "read_file",
+      "write_file",
+      "openwiki --init",
+    ]) {
+      expect(bodies).not.toContain(term);
+    }
+  });
+
+  test("carries the shared OKF methodology with the keyless (no-repair) tail", () => {
+    expect(bodies).toContain("OKF-compliant YAML front matter");
+    expect(bodies).toContain("## Backlog");
+    expect(bodies).toContain("There is no post-run repair pass");
+    // The OpenWiki-runtime-only wording must not appear on this surface.
+    expect(bodies).not.toContain(
+      "OpenWiki repairs front matter deterministically",
+    );
+  });
+
+  test("keeps AGENTS.md/CLAUDE.md off-limits (the #361 duplicate-section guard)", () => {
+    expect(bodies).toContain("Do not create or edit `AGENTS.md`");
+    expect(bodies).toContain("<!-- OPENWIKI:START -->");
+  });
+
+  test("instructs the agent to write the CLI's out-of-band artifacts itself", () => {
+    expect(bodies).toContain("openwiki/.last-update.json");
+    expect(bodies).toContain('okf_version: "0.1"');
+  });
+});
+
+describe("writeClaudeCodeSkills", () => {
+  let dir: string;
+  beforeEach(async () => {
+    dir = await mkdtemp(path.join(tmpdir(), "owcc-"));
+  });
+  afterEach(async () => {
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  test("writes both SKILL.md files under .claude/skills/ and nowhere else", async () => {
+    const written = await writeClaudeCodeSkills(dir);
+    expect(written).toHaveLength(2);
+    for (const file of written) {
+      expect(file.startsWith(path.join(dir, ".claude", "skills"))).toBe(true);
+      const content = await readFile(file, "utf8");
+      expect(content).toContain("name: openwiki-");
+      expect(content.endsWith("\n")).toBe(true);
+    }
+  });
+});

--- a/test/prompt.test.ts
+++ b/test/prompt.test.ts
@@ -1,7 +1,13 @@
 import { describe, expect, test } from "vitest";
 import {
+  coverageSelfCheck,
   createDiagramInstructions,
   createSystemPrompt,
+  documentationGoals,
+  okfFrontMatterRules,
+  okfRelationshipModeling,
+  sectionQualityRules,
+  type MethodologyContext,
 } from "../src/agent/prompt.ts";
 
 /**
@@ -139,5 +145,44 @@ describe("createSystemPrompt diagram guidance", () => {
     // The carve-out is scoped to update runs, not repeated in init guidance.
     const init = createSystemPrompt("init");
     expect(init).not.toContain("adding one is a valuable improvement");
+  });
+});
+
+/**
+ * The methodology blocks were extracted from createSystemPrompt into reusable
+ * functions so an out-of-tree surface (the Claude Code skills renderer) can
+ * share them without copying. These guard that the extraction is behavior-
+ * preserving: createSystemPrompt must still embed each block verbatim, with the
+ * repository surface's own paths.
+ */
+describe("shared methodology extraction is behavior-preserving", () => {
+  // The repository surface's methodology paths (from getOutputPromptConfig).
+  const repo: MethodologyContext = {
+    docsLocation: "the target repository's openwiki/ directory",
+    planPath: "/openwiki/_plan.md",
+    quickstartPath: "/openwiki/quickstart.md",
+  };
+
+  test("repository prompt embeds each extracted block verbatim", () => {
+    const prompt = createSystemPrompt("init", "repository");
+    expect(prompt).toContain(documentationGoals(repo));
+    expect(prompt).toContain(okfRelationshipModeling(repo));
+    expect(prompt).toContain(okfFrontMatterRules(repo, { repairPass: true }));
+    expect(prompt).toContain(sectionQualityRules(repo));
+    expect(prompt).toContain(coverageSelfCheck(repo));
+  });
+
+  test("repairPass toggles the OpenWiki-runtime-only front matter tail", () => {
+    const withRepair = okfFrontMatterRules(repo, { repairPass: true });
+    const without = okfFrontMatterRules(repo, { repairPass: false });
+    expect(withRepair).toContain(
+      "OpenWiki repairs front matter deterministically",
+    );
+    expect(without).not.toContain(
+      "OpenWiki repairs front matter deterministically",
+    );
+    expect(without).toContain("There is no post-run repair pass");
+    // The repair-pass rendering is what the live prompt uses.
+    expect(createSystemPrompt("init", "repository")).toContain(withRepair);
   });
 });


### PR DESCRIPTION
## What

Adds `openwiki integration claude [path]`, a command that scaffolds two Claude Code skills —
`openwiki-init` and `openwiki-update` — into `.claude/skills/` in the target repo. The user then
runs `/openwiki-init` inside Claude Code, and Claude Code itself generates and maintains the
`openwiki/` wiki using its own inference. No OpenWiki provider or API key is involved.

Scope is deliberately narrow: **code mode only**, **one command**, and the only files ever written
are under `.claude/skills/`. No new provider, no repository-file modification, no marketplace
metadata, no helper tooling.

## Why

A large group of users already have Claude Code and just want repo docs generated without setting up
and paying for a second inference provider. This closes #156 (and overlaps #349).

It's also, as far as I can tell, the only shape Anthropic's terms permit here. A Claude-subscription
*provider* inside OpenWiki would have OpenWiki route requests through the user's Pro/Max credentials,
which [Anthropic does not allow](https://code.claude.com/docs/en/legal-and-compliance) for
third-party developers. Scaffolding skills that run *inside* Claude Code, on the user's own
credentials, avoids that entirely — OpenWiki never sees a token. (This likely explains why #160,
#181 and #293 have stalled.) This is a smaller, single-concern alternative to the plugins approach in
#76 (thanks @kylin0421) — happy to close in favor of that if you'd rather consolidate.

## Design: rendered from `prompt.ts`, not vendored

The skill bodies are **generated from the same prompt the OpenWiki agent already uses**, so they
can't drift from the CLI. The shared methodology (documentation goals, OKF front-matter rules,
concept-graph modeling, section quality, coverage/backlog) is extracted from `createSystemPrompt`
into exported functions that both the live prompt and the skills renderer consume.

Two things are authored specifically for the keyless surface, because the CLI does them *outside*
the agent and a host coding agent can't invoke them:

- writing `openwiki/.last-update.json`,
- generating directory `index.md` deterministically, and
- getting OKF front matter right in place, since there's no post-run repair pass (an
  `okfFrontMatterRules(..., { repairPass })` flag toggles that one bullet).

The Claude Code surface also uses real relative paths (`openwiki/quickstart.md`) instead of
OpenWiki's virtual `/openwiki/...` paths, and its own tool vocabulary.

## Files

- `src/agent/prompt.ts` — extract 5 methodology blocks into exported functions (behavior-preserving;
  see test), add the `repairPass` flag and `MethodologyContext` type.
- `src/integrations/claude-code.ts` — the skills renderer (new).
- `src/commands.ts` — parse `integration claude [path]` + help.
- `src/cli.tsx` — one dispatch branch + handler.
- `test/claude-code-integration.test.ts` — command parsing + rendered-skill assertions (new).
- `test/prompt.test.ts` — regression test asserting `createSystemPrompt` still embeds each extracted
  block verbatim.

Most of the `prompt.ts` line count is methodology text relocated verbatim into the new functions,
not new logic.

## Test plan

- [x] `pnpm run format:check`, `pnpm run lint:check`, `pnpm run typecheck` — clean.
- [x] `pnpm test` — 685 passing (13 new). The existing suite is unchanged.
- [x] The extraction is byte-for-byte behavior-preserving: `createSystemPrompt` output is identical
  for every (surface × command) combination before and after, asserted by the new regression test
  and verified out-of-band by diffing all 12 combinations.
- [x] `pnpm dev integration claude <dir>` scaffolds both `SKILL.md` files; rendered bodies contain
  real `openwiki/...` paths, zero virtual `/openwiki/...` paths, and no connector/CLI-only
  vocabulary.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
