### PR TITLE
fix: prune old checkpoints so chat sqlite storage doesn't grow unbounded

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,6 +81,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",
+    "@types/better-sqlite3": "^7.6.12",
     "@types/jsdom": "^28.0.3",
     "@types/node": "^22.10.2",
     "@types/react": "^18.3.17",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -84,6 +84,9 @@ importers:
       '@eslint/js':
         specifier: ^10.0.1
         version: 10.0.1(eslint@10.6.0)
+      '@types/better-sqlite3':
+        specifier: ^7.6.12
+        version: 7.6.13
       '@types/jsdom':
         specifier: ^28.0.3
         version: 28.0.3
@@ -811,6 +814,9 @@ packages:
 
   '@tybys/wasm-util@0.10.3':
     resolution: {integrity: sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==}
+
+  '@types/better-sqlite3@7.6.13':
+    resolution: {integrity: sha512-NMv9ASNARoKksWtsq/SHakpYAYnhBrQgGD8zkLYk/jaK8jUGn08CfEdTRgYhMypUQAfzSP8W6gNLe0q19/t4VA==}
 
   '@types/chai@5.2.3':
     resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
@@ -3228,6 +3234,10 @@ snapshots:
     dependencies:
       tslib: 2.8.1
     optional: true
+
+  '@types/better-sqlite3@7.6.13':
+    dependencies:
+      '@types/node': 22.20.0
 
   '@types/chai@5.2.3':
     dependencies:

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -351,12 +351,26 @@ async function runOpenWikiAgentCore(
       emitDebug(options, "metadata=writeFailed");
     }
 
+    prunePersistentCheckpointHistory(
+      checkpointTarget,
+      checkpointer,
+      threadId,
+      options,
+    );
+
     throw error;
   }
 
   if (checkpointTarget.persistent) {
     await chmodIfExists(checkpointTarget.connString, 0o600);
   }
+
+  prunePersistentCheckpointHistory(
+    checkpointTarget,
+    checkpointer,
+    threadId,
+    options,
+  );
 
   await cleanupTemporaryPlanFile(command, cwd, outputMode, options);
 
@@ -469,6 +483,66 @@ async function prepareCheckpointDirectory(filePath: string): Promise<void> {
     mode: 0o700,
   });
   await chmodIfExists(checkpointDir, 0o700);
+}
+
+// SqliteSaver.put() only ever inserts new checkpoint rows; nothing in the
+// checkpointer itself prunes older ones. A chat session reuses the same
+// thread_id for every turn, so the sqlite file grows by a full state
+// snapshot on every graph step for as long as the session runs. OpenWiki
+// never resumes a chat turn from anything but the latest checkpoint, so
+// history beyond that is pure waste and safe to discard here.
+export function pruneCheckpointHistory(
+  checkpointer: SqliteSaver,
+  threadId: string,
+): void {
+  checkpointer.db
+    .prepare(
+      `DELETE FROM checkpoints
+       WHERE thread_id = ?
+         AND (checkpoint_ns, checkpoint_id) NOT IN (
+           SELECT checkpoint_ns, checkpoint_id FROM (
+             SELECT checkpoint_ns, checkpoint_id,
+                    ROW_NUMBER() OVER (
+                      PARTITION BY checkpoint_ns ORDER BY checkpoint_id DESC
+                    ) AS rank
+             FROM checkpoints
+             WHERE thread_id = ?
+           )
+           WHERE rank = 1
+         )`,
+    )
+    .run(threadId, threadId);
+
+  checkpointer.db
+    .prepare(
+      `DELETE FROM writes
+       WHERE thread_id = ?
+         AND (checkpoint_ns, checkpoint_id) NOT IN (
+           SELECT checkpoint_ns, checkpoint_id FROM checkpoints WHERE thread_id = ?
+           UNION
+           SELECT checkpoint_ns, parent_checkpoint_id FROM checkpoints
+           WHERE thread_id = ? AND parent_checkpoint_id IS NOT NULL
+         )`,
+    )
+    .run(threadId, threadId, threadId);
+}
+
+function prunePersistentCheckpointHistory(
+  checkpointTarget: CheckpointTarget,
+  checkpointer: SqliteSaver,
+  threadId: string,
+  options: OpenWikiRunOptions,
+): void {
+  if (!checkpointTarget.persistent) {
+    return;
+  }
+
+  try {
+    pruneCheckpointHistory(checkpointer, threadId);
+    emitDebug(options, "checkpoint.pruned");
+  } catch {
+    emitDebug(options, "checkpoint.pruneFailed");
+  }
 }
 
 export function resolveCheckpointTarget(

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -351,26 +351,19 @@ async function runOpenWikiAgentCore(
       emitDebug(options, "metadata=writeFailed");
     }
 
+    throw error;
+  } finally {
     prunePersistentCheckpointHistory(
       checkpointTarget,
       checkpointer,
       threadId,
       options,
     );
-
-    throw error;
   }
 
   if (checkpointTarget.persistent) {
     await chmodIfExists(checkpointTarget.connString, 0o600);
   }
-
-  prunePersistentCheckpointHistory(
-    checkpointTarget,
-    checkpointer,
-    threadId,
-    options,
-  );
 
   await cleanupTemporaryPlanFile(command, cwd, outputMode, options);
 
@@ -495,36 +488,40 @@ export function pruneCheckpointHistory(
   checkpointer: SqliteSaver,
   threadId: string,
 ): void {
-  checkpointer.db
-    .prepare(
-      `DELETE FROM checkpoints
-       WHERE thread_id = ?
-         AND (checkpoint_ns, checkpoint_id) NOT IN (
-           SELECT checkpoint_ns, checkpoint_id FROM (
-             SELECT checkpoint_ns, checkpoint_id,
-                    ROW_NUMBER() OVER (
-                      PARTITION BY checkpoint_ns ORDER BY checkpoint_id DESC
-                    ) AS rank
-             FROM checkpoints
-             WHERE thread_id = ?
-           )
-           WHERE rank = 1
-         )`,
-    )
-    .run(threadId, threadId);
+  const prune = checkpointer.db.transaction((id: string) => {
+    checkpointer.db
+      .prepare(
+        `DELETE FROM checkpoints
+         WHERE thread_id = ?
+           AND (checkpoint_ns, checkpoint_id) NOT IN (
+             SELECT checkpoint_ns, checkpoint_id FROM (
+               SELECT checkpoint_ns, checkpoint_id,
+                      ROW_NUMBER() OVER (
+                        PARTITION BY checkpoint_ns ORDER BY checkpoint_id DESC
+                      ) AS rank
+               FROM checkpoints
+               WHERE thread_id = ?
+             )
+             WHERE rank = 1
+           )`,
+      )
+      .run(id, id);
 
-  checkpointer.db
-    .prepare(
-      `DELETE FROM writes
-       WHERE thread_id = ?
-         AND (checkpoint_ns, checkpoint_id) NOT IN (
-           SELECT checkpoint_ns, checkpoint_id FROM checkpoints WHERE thread_id = ?
-           UNION
-           SELECT checkpoint_ns, parent_checkpoint_id FROM checkpoints
-           WHERE thread_id = ? AND parent_checkpoint_id IS NOT NULL
-         )`,
-    )
-    .run(threadId, threadId, threadId);
+    checkpointer.db
+      .prepare(
+        `DELETE FROM writes
+         WHERE thread_id = ?
+           AND (checkpoint_ns, checkpoint_id) NOT IN (
+             SELECT checkpoint_ns, checkpoint_id FROM checkpoints WHERE thread_id = ?
+             UNION
+             SELECT checkpoint_ns, parent_checkpoint_id FROM checkpoints
+             WHERE thread_id = ? AND parent_checkpoint_id IS NOT NULL
+           )`,
+      )
+      .run(id, id, id);
+  });
+
+  prune(threadId);
 }
 
 function prunePersistentCheckpointHistory(

--- a/test/checkpoint-pruning.test.ts
+++ b/test/checkpoint-pruning.test.ts
@@ -1,0 +1,77 @@
+import { SqliteSaver } from "@langchain/langgraph-checkpoint-sqlite";
+import { describe, expect, test } from "vitest";
+import { pruneCheckpointHistory } from "../src/agent/index.ts";
+
+describe("pruneCheckpointHistory", () => {
+  test("keeps only the latest checkpoint per thread/namespace and leaves other threads untouched", async () => {
+    const checkpointer = SqliteSaver.fromConnString(":memory:");
+
+    // Trigger the checkpointer's lazy table creation.
+    await checkpointer.getTuple({
+      configurable: { thread_id: "thread-a", checkpoint_ns: "" },
+    });
+
+    const insertCheckpoint = checkpointer.db.prepare(
+      `INSERT INTO checkpoints
+         (thread_id, checkpoint_ns, checkpoint_id, parent_checkpoint_id, type, checkpoint, metadata)
+       VALUES (?, ?, ?, ?, 'json', '{}', '{}')`,
+    );
+    const insertWrite = checkpointer.db.prepare(
+      `INSERT INTO writes
+         (thread_id, checkpoint_ns, checkpoint_id, task_id, idx, channel, type, value)
+       VALUES (?, ?, ?, 'task', 0, 'messages', 'json', '{}')`,
+    );
+
+    insertCheckpoint.run("thread-a", "", "c1", null);
+    insertCheckpoint.run("thread-a", "", "c2", "c1");
+    insertCheckpoint.run("thread-a", "", "c3", "c2");
+    insertCheckpoint.run("thread-a", "sub:1", "s1", null);
+    insertCheckpoint.run("thread-a", "sub:1", "s2", "s1");
+    insertCheckpoint.run("thread-b", "", "b1", null);
+    insertCheckpoint.run("thread-b", "", "b2", "b1");
+
+    for (const [threadId, ns, checkpointId] of [
+      ["thread-a", "", "c1"],
+      ["thread-a", "", "c2"],
+      ["thread-a", "", "c3"],
+      ["thread-a", "sub:1", "s1"],
+      ["thread-a", "sub:1", "s2"],
+      ["thread-b", "", "b1"],
+      ["thread-b", "", "b2"],
+    ]) {
+      insertWrite.run(threadId, ns, checkpointId);
+    }
+
+    pruneCheckpointHistory(checkpointer, "thread-a");
+
+    const remainingCheckpoints = checkpointer.db
+      .prepare(
+        "SELECT thread_id, checkpoint_ns, checkpoint_id FROM checkpoints ORDER BY thread_id, checkpoint_ns, checkpoint_id",
+      )
+      .all();
+
+    expect(remainingCheckpoints).toEqual([
+      { thread_id: "thread-a", checkpoint_ns: "", checkpoint_id: "c3" },
+      { thread_id: "thread-a", checkpoint_ns: "sub:1", checkpoint_id: "s2" },
+      { thread_id: "thread-b", checkpoint_ns: "", checkpoint_id: "b1" },
+      { thread_id: "thread-b", checkpoint_ns: "", checkpoint_id: "b2" },
+    ]);
+
+    const remainingWrites = checkpointer.db
+      .prepare(
+        "SELECT thread_id, checkpoint_ns, checkpoint_id FROM writes ORDER BY thread_id, checkpoint_ns, checkpoint_id",
+      )
+      .all();
+
+    expect(remainingWrites).toEqual([
+      // c2's and s1's write rows survive because the retained checkpoints
+      // (c3 and s2) each point back to them as their parent_checkpoint_id.
+      { thread_id: "thread-a", checkpoint_ns: "", checkpoint_id: "c2" },
+      { thread_id: "thread-a", checkpoint_ns: "", checkpoint_id: "c3" },
+      { thread_id: "thread-a", checkpoint_ns: "sub:1", checkpoint_id: "s1" },
+      { thread_id: "thread-a", checkpoint_ns: "sub:1", checkpoint_id: "s2" },
+      { thread_id: "thread-b", checkpoint_ns: "", checkpoint_id: "b1" },
+      { thread_id: "thread-b", checkpoint_ns: "", checkpoint_id: "b2" },
+    ]);
+  });
+});


### PR DESCRIPTION
Fixes #360.

In chat mode, OpenWiki keeps one thread_id for the whole session and persists checkpoints in a sqlite file (`~/.openwiki/openwiki.sqlite`). The checkpointer (`SqliteSaver` from `@langchain/langgraph-checkpoint-sqlite`) only inserts new rows; each graph step writes the full state, and nothing prunes the old ones. Since OpenWiki only ever resumes from the latest checkpoint, that history just accumulates forever. In a long chat session, the file grows without bound. The reporter hit roughly 890GB.

I've added a `pruneCheckpointHistory` step that runs after each chat turn (success or error) and keeps only the latest checkpoint per thread/namespace, discarding write rows we don't need anymore. Both deletes run in a single transaction, so a crash mid-prune can't leave the tables in an inconsistent state. This only touches the persistent (chat) checkpoint target; the in-memory init/update checkpointer stays untouched.

How I tested it:
- `pnpm run typecheck`, `pnpm run lint:check`, and `pnpm run format:check` all pass.
- Added `test/checkpoint-pruning.test.ts`. It builds a checkpointer with synthetic checkpoint/write rows across two threads and two namespaces, including a parent-checkpoint chain. Tests confirm that pruning keeps only the latest checkpoint per thread/namespace, leaves the other thread alone, and retains the write rows needed to look up the retained checkpoint's parent.
- `pnpm test`: 670 passing. The 3 failures (all in `test/env-behavior.test.ts`) reproduce identically on main without this change; I stashed my changes and reran to confirm. CI runs on ubuntu-latest only, so these Windows-specific failures won't show up there.
- Added `@types/better-sqlite3` as a devDependency. `checkpointer.db` was untyped because `better-sqlite3` ships no bundled types and `@types/better-sqlite3` was only a transitive devDependency. Once code touches `checkpointer.db` directly, ESLint's type-aware rules flag every call as unsafe without the types.