### PR TITLE
fix: reject invalid hackernews feed configs

### DIFF
--- a/src/connectors/sources/hackernews.ts
+++ b/src/connectors/sources/hackernews.ts
@@ -17,11 +17,11 @@ import type {
 
 type HackerNewsConfig = {
   enabled?: boolean;
-  feeds?: HackerNewsFeed[];
+  feeds?: unknown;
   maxItemsPerFeed?: number;
   maxResultsPerQuery?: number;
-  queries?: string[];
-  queryTags?: string[];
+  queries?: unknown;
+  queryTags?: unknown;
 };
 
 type HackerNewsFeed = "ask" | "best" | "job" | "new" | "show" | "top";
@@ -63,6 +63,20 @@ type AlgoliaResponse = {
 const HN_FIREBASE_BASE_URL = "https://hacker-news.firebaseio.com/v0";
 const HN_ALGOLIA_SEARCH_URL = "https://hn.algolia.com/api/v1/search_by_date";
 const DEFAULT_FEEDS: HackerNewsFeed[] = ["top", "new"];
+const VALID_FEEDS: readonly HackerNewsFeed[] = [
+  "ask",
+  "best",
+  "job",
+  "new",
+  "show",
+  "top",
+];
+
+type FeedSelection = {
+  feeds: HackerNewsFeed[];
+  invalidFeeds: string[];
+  source: "configured" | "default" | "requested";
+};
 
 const definition: ConnectorDefinition = {
   backend: "direct-api",
@@ -120,7 +134,25 @@ async function ingest(
     config.maxResultsPerQuery,
     100,
   );
-  const feeds = normalizeFeeds(options.streams, config.feeds);
+  const feedSelection = normalizeFeeds(options.streams, config.feeds);
+  const feeds = feedSelection.feeds;
+  const invalidFeedsWarning = getInvalidFeedsWarning(feedSelection);
+  if (invalidFeedsWarning) {
+    warnings.push(invalidFeedsWarning);
+  }
+  const queries = normalizeStringArray(config.queries);
+  if (feeds.length === 0 && queries.length === 0) {
+    return await finishHackerNewsRun({
+      message:
+        "No valid Hacker News feeds were configured or requested, and no Hacker News search queries are configured. Add at least one valid feed or query.",
+      rawFiles,
+      runId,
+      state,
+      status: "error",
+      warnings,
+    });
+  }
+
   const windowHours = normalizeWindowHours(options.windowHours);
   const earliestUnixTime =
     windowHours === null
@@ -154,7 +186,6 @@ async function ingest(
   }
 
   const queryResults = [];
-  const queries = normalizeStringArray(config.queries);
   const tags = normalizeStringArray(config.queryTags);
   for (const query of queries) {
     try {
@@ -181,26 +212,51 @@ async function ingest(
     }),
   );
 
+  return await finishHackerNewsRun({
+    message: `Fetched ${feedResults.length} Hacker News feed(s) and ${queryResults.length} search quer${
+      queryResults.length === 1 ? "y" : "ies"
+    }.`,
+    rawFiles,
+    runId,
+    state,
+    status: rawFiles.length > 0 ? "success" : "skipped",
+    warnings,
+  });
+}
+
+async function finishHackerNewsRun({
+  message,
+  rawFiles,
+  runId,
+  state,
+  status,
+  warnings,
+}: {
+  message: string;
+  rawFiles: string[];
+  runId: string;
+  state: Awaited<ReturnType<typeof readConnectorState>>;
+  status: ConnectorIngestResult["status"];
+  warnings: string[];
+}): Promise<ConnectorIngestResult> {
   await writeConnectorState(
     "hackernews",
     updateStateWithRun(state, {
       at: new Date().toISOString(),
       rawFiles,
       runId,
-      status: rawFiles.length > 0 ? "success" : "skipped",
+      status,
       warnings,
     }),
   );
 
   return {
     connectorId: "hackernews",
-    message: `Fetched ${feedResults.length} Hacker News feed(s) and ${queryResults.length} search quer${
-      queryResults.length === 1 ? "y" : "ies"
-    }.`,
+    message,
     rawFiles,
     runId,
     statePath: "~/.openwiki/connectors/hackernews/state.json",
-    status: rawFiles.length > 0 ? "success" : "skipped",
+    status,
     warnings,
   };
 }
@@ -252,22 +308,75 @@ async function searchHackerNews(
 }
 
 function normalizeFeeds(
-  optionFeeds: string[] | undefined,
+  optionFeeds: unknown,
   configFeeds: HackerNewsConfig["feeds"],
-): HackerNewsFeed[] {
-  const feeds = optionFeeds?.length ? optionFeeds : configFeeds;
-  return (feeds?.length ? feeds : DEFAULT_FEEDS).filter(isHackerNewsFeed);
+): FeedSelection {
+  const requestedFeeds = normalizeExplicitFeeds(optionFeeds);
+  if (requestedFeeds) {
+    return {
+      ...requestedFeeds,
+      source: "requested",
+    };
+  }
+
+  const configuredFeeds = normalizeExplicitFeeds(configFeeds);
+  if (configuredFeeds) {
+    return {
+      ...configuredFeeds,
+      source: "configured",
+    };
+  }
+
+  return {
+    feeds: DEFAULT_FEEDS,
+    invalidFeeds: [],
+    source: "default",
+  };
+}
+
+function normalizeExplicitFeeds(
+  value: unknown,
+): Pick<FeedSelection, "feeds" | "invalidFeeds"> | null {
+  if (value === undefined || (Array.isArray(value) && value.length === 0)) {
+    return null;
+  }
+
+  const values = normalizeStringArray(value);
+  const feeds: HackerNewsFeed[] = [];
+  const invalidFeeds: string[] = [];
+
+  for (const feed of values) {
+    if (isHackerNewsFeed(feed)) {
+      feeds.push(feed);
+    } else {
+      invalidFeeds.push(feed);
+    }
+  }
+
+  if (!Array.isArray(value)) {
+    invalidFeeds.push(`non-array ${typeof value}`);
+  } else if (values.length < value.length) {
+    invalidFeeds.push("non-string or blank value");
+  }
+
+  return {
+    feeds,
+    invalidFeeds,
+  };
+}
+
+function getInvalidFeedsWarning(selection: FeedSelection): string | null {
+  if (selection.invalidFeeds.length === 0) {
+    return null;
+  }
+
+  return `Ignored invalid Hacker News ${selection.source} feed(s): ${selection.invalidFeeds.join(
+    ", ",
+  )}. Valid feeds are: ${VALID_FEEDS.join(", ")}.`;
 }
 
 function isHackerNewsFeed(value: string): value is HackerNewsFeed {
-  return (
-    value === "ask" ||
-    value === "best" ||
-    value === "job" ||
-    value === "new" ||
-    value === "show" ||
-    value === "top"
-  );
+  return (VALID_FEEDS as readonly string[]).includes(value);
 }
 
 function isWithinWindow(

--- a/test/hackernews.test.ts
+++ b/test/hackernews.test.ts
@@ -1,0 +1,244 @@
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, test, vi } from "vitest";
+
+const originalHome = process.env.HOME;
+const originalUserProfile = process.env.USERPROFILE;
+const tempHomes: string[] = [];
+
+type HackerNewsDump = {
+  feeds: { feed: string }[];
+  queryResults: unknown[];
+};
+
+type ConnectorStateDump = {
+  runs: {
+    rawFiles: string[];
+    runId: string;
+    status: string;
+    warnings: string[];
+  }[];
+};
+
+async function createTempHome(): Promise<string> {
+  const home = await mkdtemp(path.join(tmpdir(), "openwiki-hackernews-"));
+  tempHomes.push(home);
+  return home;
+}
+
+async function writeHackerNewsConfig(
+  home: string,
+  config: unknown,
+): Promise<void> {
+  const dir = path.join(home, ".openwiki", "connectors", "hackernews");
+  await mkdir(dir, { recursive: true });
+  await writeFile(
+    path.join(dir, "config.json"),
+    `${JSON.stringify(config, null, 2)}\n`,
+    "utf8",
+  );
+}
+
+function setConnectorTestHome(home: string): void {
+  process.env.HOME = home;
+  process.env.USERPROFILE = home;
+}
+
+async function loadHackerNewsConnector(home: string) {
+  vi.resetModules();
+  setConnectorTestHome(home);
+  const { createHackerNewsConnector } =
+    await import("../src/connectors/sources/hackernews.ts");
+  return createHackerNewsConnector();
+}
+
+function getRequestUrl(input: string | URL | Request): string {
+  return input instanceof Request ? input.url : String(input);
+}
+
+afterEach(async () => {
+  vi.resetModules();
+  vi.unstubAllGlobals();
+
+  if (originalHome === undefined) {
+    delete process.env.HOME;
+  } else {
+    process.env.HOME = originalHome;
+  }
+  if (originalUserProfile === undefined) {
+    delete process.env.USERPROFILE;
+  } else {
+    process.env.USERPROFILE = originalUserProfile;
+  }
+
+  await Promise.all(
+    tempHomes
+      .splice(0)
+      .map((home) => rm(home, { force: true, recursive: true })),
+  );
+});
+
+describe("hackernews connector feed configuration", () => {
+  test("uses the default feeds when no feeds are configured", async () => {
+    const home = await createTempHome();
+    const paths: string[] = [];
+    vi.stubGlobal(
+      "fetch",
+      vi.fn((input: string | URL | Request) => {
+        const requestPath = new URL(getRequestUrl(input)).pathname;
+        paths.push(requestPath);
+
+        if (requestPath === "/v0/topstories.json") {
+          return Promise.resolve(jsonResponse([101]));
+        }
+        if (requestPath === "/v0/newstories.json") {
+          return Promise.resolve(jsonResponse([202]));
+        }
+        if (requestPath === "/v0/item/101.json") {
+          return Promise.resolve(
+            jsonResponse({ id: 101, time: 1, title: "Top story" }),
+          );
+        }
+        if (requestPath === "/v0/item/202.json") {
+          return Promise.resolve(
+            jsonResponse({ id: 202, time: 1, title: "New story" }),
+          );
+        }
+
+        return Promise.resolve(jsonResponse({}));
+      }),
+    );
+    const connector = await loadHackerNewsConnector(home);
+
+    const result = await connector.ingest({ limit: 1 });
+
+    expect(result.status).toBe("success");
+    expect(result.warnings).toEqual([]);
+    expect(paths).toEqual([
+      "/v0/topstories.json",
+      "/v0/item/101.json",
+      "/v0/newstories.json",
+      "/v0/item/202.json",
+    ]);
+
+    const dump = JSON.parse(
+      await readFile(result.rawFiles[0] ?? "", "utf8"),
+    ) as HackerNewsDump;
+    expect(dump.feeds.map((feed) => feed.feed)).toEqual(["top", "new"]);
+  });
+
+  test("errors without writing raw results when configured feeds are invalid and there are no queries", async () => {
+    const home = await createTempHome();
+    await writeHackerNewsConfig(home, {
+      enabled: true,
+      feeds: ["frontpage", "popular"],
+      queries: [],
+    });
+    const fetchMock = vi.fn(() => {
+      throw new Error("fetch should not be called");
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    const connector = await loadHackerNewsConnector(home);
+
+    const result = await connector.ingest();
+
+    expect(result.status).toBe("error");
+    expect(result.rawFiles).toEqual([]);
+    expect(result.message).toContain("No valid Hacker News feeds");
+    expect(result.warnings).toEqual([
+      "Ignored invalid Hacker News configured feed(s): frontpage, popular. Valid feeds are: ask, best, job, new, show, top.",
+    ]);
+    expect(fetchMock).not.toHaveBeenCalled();
+
+    const statePath = path.join(
+      home,
+      ".openwiki",
+      "connectors",
+      "hackernews",
+      "state.json",
+    );
+    const state = JSON.parse(
+      await readFile(statePath, "utf8"),
+    ) as ConnectorStateDump;
+    expect(state.runs[0]).toMatchObject({
+      rawFiles: [],
+      runId: result.runId,
+      status: "error",
+      warnings: result.warnings,
+    });
+  });
+
+  test("errors without writing raw results when requested feeds are invalid and there are no queries", async () => {
+    const home = await createTempHome();
+    const fetchMock = vi.fn(() => {
+      throw new Error("fetch should not be called");
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    const connector = await loadHackerNewsConnector(home);
+
+    const result = await connector.ingest({
+      connectorConfig: { queries: [] },
+      streams: ["frontpage"],
+    });
+
+    expect(result.status).toBe("error");
+    expect(result.rawFiles).toEqual([]);
+    expect(result.warnings).toEqual([
+      "Ignored invalid Hacker News requested feed(s): frontpage. Valid feeds are: ask, best, job, new, show, top.",
+    ]);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  test("preserves search failure warnings when invalid feeds leave query work", async () => {
+    const home = await createTempHome();
+    await writeHackerNewsConfig(home, {
+      enabled: true,
+      feeds: ["frontpage"],
+      queries: ["openwiki"],
+    });
+    const urls: string[] = [];
+    vi.stubGlobal(
+      "fetch",
+      vi.fn((input: string | URL | Request) => {
+        const url = getRequestUrl(input);
+        urls.push(url);
+
+        return Promise.resolve(
+          new Response(JSON.stringify({ error: "unavailable" }), {
+            headers: { "Content-Type": "application/json" },
+            status: 503,
+            statusText: "Service Unavailable",
+          }),
+        );
+      }),
+    );
+    const connector = await loadHackerNewsConnector(home);
+
+    const result = await connector.ingest();
+
+    expect(result.status).toBe("success");
+    expect(result.rawFiles).toHaveLength(1);
+    expect(result.warnings).toEqual([
+      "Ignored invalid Hacker News configured feed(s): frontpage. Valid feeds are: ask, best, job, new, show, top.",
+      "openwiki: Hacker News search request failed: 503 Service Unavailable",
+    ]);
+    expect(urls.length).toBeGreaterThan(0);
+    expect(
+      urls.every((url) => new URL(url).pathname === "/api/v1/search_by_date"),
+    ).toBe(true);
+
+    const dump = JSON.parse(
+      await readFile(result.rawFiles[0] ?? "", "utf8"),
+    ) as HackerNewsDump;
+    expect(dump.feeds).toEqual([]);
+    expect(dump.queryResults).toEqual([]);
+  });
+});
+
+function jsonResponse(value: unknown): Response {
+  return new Response(JSON.stringify(value), {
+    headers: { "Content-Type": "application/json" },
+    status: 200,
+  });
+}


### PR DESCRIPTION
﻿## Summary
- warn when configured or requested Hacker News feeds are invalid
- stop with `status: "error"` and no raw result when there are no valid feeds and no query work
- preserve the default feed behavior when no feeds are explicitly configured

## Why
Explicitly invalid Hacker News feed config could previously produce an empty raw file and report success. This makes the failed configuration visible and avoids recording a successful ingest when no Hacker News work ran.

No dedicated issue; found during connector config hardening.

## Testing
- `corepack pnpm exec vitest run test/hackernews.test.ts` passed
- `corepack pnpm run format:check` passed
- `corepack pnpm run lint:check` passed
- `corepack pnpm run typecheck` passed
- `git diff --check` passed
- `corepack pnpm test` was attempted on Windows and still fails outside this change in existing `test/env-behavior.test.ts` HOME/permission assertions plus Mermaid/jsdom timeout tests
