### PR TITLE
feat: add native Z.AI provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,7 +219,26 @@ notes.
 
 ## Customizing
 
-OpenWiki supports OpenAI (with an API key or a ChatGPT login), OpenRouter, Gemini (AI Studio), Gemini Enterprise (Vertex AI), Nebius Token Factory, Fireworks, Baseten, NVIDIA NIM, an OpenAI-compatible provider, AWS Bedrock, and Anthropic out of the box. The onboarding default is OpenAI with `gpt-5.6-terra`, and each inference provider also includes pre-defined model options plus support for custom model IDs.
+OpenWiki supports OpenAI (with an API key or a ChatGPT login), OpenRouter, Z.AI, Gemini (AI Studio), Gemini Enterprise (Vertex AI), Nebius Token Factory, Fireworks, Baseten, NVIDIA NIM, an OpenAI-compatible provider, AWS Bedrock, and Anthropic out of the box. The onboarding default is OpenAI with `gpt-5.6-terra`, and each inference provider also includes pre-defined model options plus support for custom model IDs.
+
+### Z.AI
+
+The native `zai` provider calls Z.AI directly; it does not route through
+OpenRouter or the generic `openai-compatible` provider. Set `ZAI_API_KEY` and,
+optionally, a custom coding endpoint. The default model is `glm-5.2` and the
+default endpoint is `https://api.z.ai/api/coding/paas/v4`:
+
+```bash
+OPENWIKI_PROVIDER=zai
+ZAI_API_KEY=your-zai-api-key
+# Optional; overrides the default Z.AI coding endpoint.
+ZAI_BASE_URL=https://api.z.ai/api/coding/paas/v4
+OPENWIKI_MODEL_ID=glm-5.2
+```
+
+Z.AI requests normalize file-content blocks for the Z.AI API only and retry
+HTTP 429 responses up to three times by default. Set
+`ZAI_RATE_LIMIT_MAX_RETRIES=0` to disable those retries.
 
 ### Alternative base URLs
 

--- a/docs/superpowers/plans/2026-07-27-native-zai-provider.md
+++ b/docs/superpowers/plans/2026-07-27-native-zai-provider.md
@@ -1,0 +1,297 @@
+# Native Z.AI Provider Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add Z.AI as an independent, credential-isolated OpenWiki provider, replacing the wrapper-only request handling and operational safety in upstream TypeScript code.
+
+**Architecture:** `zai` is a normal `OpenWikiProvider` with its own `ZAI_*` configuration and a provider-local `ChatOpenAI` fetch adapter. A reusable PID-symlink lock module owns execution and bundled-skill synchronization; it is invoked from the OpenWiki runtime rather than a launcher or preload hook. The adapter and locking layer accept time/fetch/filesystem boundaries as dependencies so all behavioral tests run without real Z.AI credentials or network access.
+
+**Tech Stack:** Node.js 22, TypeScript ESM, Vitest, `@langchain/openai`, Node `fs/promises`.
+
+## Global Constraints
+
+- `OPENWIKI_PROVIDER=zai` is a distinct provider; it uses only `ZAI_API_KEY`, `ZAI_BASE_URL`, and `ZAI_RATE_LIMIT_*` settings.
+- The default Z.AI API root is `https://api.z.ai/api/coding/paas/v4`; its default model is `glm-5.2`.
+- Never modify `node_modules`, install a preload hook, replace `globalThis.fetch`, print a credential, or place a credential in source, tests, or docs.
+- Preserve OpenAI-compatible, OpenRouter, and every other provider's current request and credential behavior.
+- Do not hand-edit generated `openwiki/` pages. Update only source-controlled product docs such as `README.md` if provider usage documentation is needed.
+- The existing upstream Mermaid baseline timeouts are outside this change; record them separately when running the final suite.
+
+---
+
+### Task 1: Register the independent provider and its configuration surface
+
+**Files:**
+
+- Modify: `src/constants.ts:1-852`
+- Modify: `src/env.ts:1-566`
+- Modify: `src/credentials.tsx:500-3700`
+- Modify: `src/cli.tsx:400-720`
+- Modify: `test/constants.test.ts:1-679`
+- Modify: `test/env-behavior.test.ts:1-446`
+- Modify: `test/credentials.test.ts:1-340`
+- Modify: `test/startup.test.ts:1-322`
+
+**Interfaces:**
+
+- Produces `OpenWikiProvider = ... | "zai"`, `ZAI_API_KEY_ENV_KEY`, `ZAI_BASE_URL_ENV_KEY`, and rate-limit env-key constants.
+- Produces `providerOffersOptionalBaseUrl(provider)` so Z.AI setup can accept an empty base URL and retain the built-in root.
+- Produces `getCredentialDiagnostics({ provider?: OpenWikiProvider })`, where a selected provider returns universal config fields plus that provider's credential family, never unrelated provider secrets.
+
+- [ ] **Step 1: Write the provider contract tests before adding production values.**
+
+```ts
+expect(normalizeProvider(" ZAI ")).toBe("zai");
+expect(resolveConfiguredProvider({ OPENWIKI_PROVIDER: "zai" })).toBe("zai");
+expect(getDefaultModelId("zai")).toBe("glm-5.2");
+expect(resolveProviderBaseUrl("zai", {})).toBe(
+  "https://api.z.ai/api/coding/paas/v4",
+);
+expect(
+  getMissingProviderEnvKey("zai", {
+    OPENROUTER_API_KEY: "not-a-zai-key",
+    OPENAI_COMPATIBLE_API_KEY: "not-a-zai-key",
+  }),
+).toBe("ZAI_API_KEY");
+```
+
+Add environment and startup tests that save/select `zai`, prove `ZAI_API_KEY` is masked, and prove a non-interactive run with an explicit Z.AI provider fails with `ZAI_API_KEY` before agent/network creation. Add a diagnostics test that selects `zai` and asserts `ZAI_API_KEY`/`ZAI_BASE_URL` are present while `OPENROUTER_API_KEY` and `OPENAI_COMPATIBLE_API_KEY` are absent.
+
+- [ ] **Step 2: Run the focused red tests.**
+
+Run: `pnpm exec vitest run test/constants.test.ts test/env-behavior.test.ts test/credentials.test.ts test/startup.test.ts`
+
+Expected: new Z.AI assertions fail because `zai` and the `ZAI_*` configuration surface do not yet exist; unrelated existing tests remain green.
+
+- [ ] **Step 3: Add the minimal provider metadata and generic setup/diagnostic hooks.**
+
+```ts
+zai: {
+  apiKeyEnvKey: ZAI_API_KEY_ENV_KEY,
+  baseURL: ZAI_DEFAULT_BASE_URL,
+  baseUrlEnvKey: ZAI_BASE_URL_ENV_KEY,
+  optionalBaseUrl: true,
+  label: "Z.AI",
+  modelOptions: [{ id: "glm-5.2", label: "GLM 5.2" }],
+}
+```
+
+Add `zai` to the explicit selectable list and key-based provider detection. Extend `MANAGED_ENV_KEYS`, non-secret base-URL handling, base-URL validation dispatch, and provider-filtered credential diagnostics. Make the wizard show an optional Z.AI base URL step: blank input advances without saving a key; a non-empty valid root saves `ZAI_BASE_URL`. Keep `OPENWIKI_PROVIDER` and `OPENWIKI_MODEL_ID` as universal setup fields, but never read, copy, display, or fall back to OpenRouter/OpenAI-compatible credentials while Z.AI is active.
+
+- [ ] **Step 4: Run the focused provider tests to green.**
+
+Run: `pnpm exec vitest run test/constants.test.ts test/env-behavior.test.ts test/credentials.test.ts test/startup.test.ts`
+
+Expected: Z.AI is selectable, defaults to GLM 5.2 and the Coding API root, requires `ZAI_API_KEY` independently, and diagnostics redact only the selected provider's credential family.
+
+### Task 2: Build the provider-local Z.AI request transport
+
+**Files:**
+
+- Create: `src/agent/zai-transport.ts`
+- Modify: `src/agent/index.ts:650-760`
+- Create: `test/zai-transport.test.ts`
+
+**Interfaces:**
+
+- Produces `createZaiFetch(dependencies?)`, a `fetch`-compatible function used only by the Z.AI `ChatOpenAI` client.
+- Produces `normalizeZaiRequestBody(body)` and `resolveZaiRateLimitConfig(env)` for direct, network-free behavior tests.
+- `ZaiTransportDependencies` contains injected `fetch`, `sleep`, `now`, and `env` values; production defaults are `globalThis.fetch`, `setTimeout`, `Date.now`, and `process.env`.
+
+- [ ] **Step 1: Write failing transport behavior tests.**
+
+```ts
+const fetch = createZaiFetch({ env, fetch: fetchStub, sleep, now: () => now });
+await fetch("https://api.z.ai/api/coding/paas/v4/chat/completions", {
+  body: JSON.stringify({
+    messages: [{ content: [{ type: "file", data: "aGVsbG8=" }] }],
+  }),
+});
+expect(JSON.parse(String(fetchStub.mock.calls[0]?.[1]?.body))).toMatchObject({
+  messages: [{ content: [{ type: "text", text: "hello" }] }],
+});
+```
+
+Cover the complete file matrix: base64 UTF-8, ordinary string, invalid UTF-8 binary (`[binary file content omitted]`), empty/missing data (`[file content omitted]`), non-file blocks, malformed JSON, and non-Z.AI adapter isolation. Cover 429 delay precedence for integer seconds and HTTP-date `Retry-After`, exponential fallback/cap, disabled retries (`ZAI_RATE_LIMIT_MAX_RETRIES=0`), and exhaustion returning the final original 429. Assert recorded delays and returned responses, not mock call counts alone.
+
+- [ ] **Step 2: Run the new test file and observe the red state.**
+
+Run: `pnpm exec vitest run test/zai-transport.test.ts`
+
+Expected: FAIL because the transport module and factory do not exist.
+
+- [ ] **Step 3: Implement the isolated adapter and wire it only into Z.AI model construction.**
+
+```ts
+if (provider === "zai") {
+  return new ChatOpenAI({
+    apiKey: getProviderApiKey(provider),
+    configuration: {
+      baseURL: resolveProviderBaseUrl(provider),
+      fetch: createZaiFetch(),
+    },
+    model: modelId,
+    ...retryOptions,
+  });
+}
+```
+
+The adapter parses only JSON string bodies emitted by this Z.AI client. It maps only `messages[].content[]` blocks where `type === "file"`; all other body fields, non-file blocks, and malformed/non-JSON bodies retain their original representation. It retries only `response.status === 429`, uses `Retry-After` before exponential delay, caps all waits at `ZAI_RATE_LIMIT_MAX_DELAY_MS`, and never uses a process-wide patch.
+
+- [ ] **Step 4: Verify the adapter and existing provider isolation.**
+
+Run: `pnpm exec vitest run test/zai-transport.test.ts test/constants.test.ts test/startup.test.ts`
+
+Expected: PASS; Z.AI behavior is fully deterministic with injected dependencies and no OpenRouter/OpenAI-compatible credential is read for an explicit `zai` provider.
+
+### Task 3: Move scoped execution locking into the native runtime
+
+**Files:**
+
+- Create: `src/execution-lock.ts`
+- Modify: `src/openwiki-home.ts:1-78`
+- Modify: `src/agent/index.ts:109-224`
+- Modify: `src/cli.tsx:710-720,4169-4176`
+- Create: `test/execution-lock.test.ts`
+
+**Interfaces:**
+
+- Produces `withOpenWikiExecutionLock(scope, run, dependencies?)` and `OpenWikiLockError` with `exitCode = 73` for a malformed/non-symlink lock path.
+- `ExecutionLockScope` is `{ command, cwd, outputMode }`; repository scopes derive their key from `realpath(cwd)`, personal scopes share one key, and `init` also acquires the shared-home setup lock.
+- Production lock paths live under `~/.openwiki/locks/`; callers release only their own PID symlink in reverse acquisition order.
+
+- [ ] **Step 1: Write red lock-manager tests using temporary lock directories.**
+
+```ts
+await Promise.all([
+  withOpenWikiExecutionLock(repositoryScope(repoA), () => hold("first"), deps),
+  withOpenWikiExecutionLock(repositoryScope(repoB), () => hold("second"), deps),
+]);
+expect(events.slice(0, 2)).toEqual(["first:start", "second:start"]);
+```
+
+Add separate tests proving same repository serializes, an on-disk directory symlink resolves to that same repository key, personal runs serialize, `init` waits only on another home-setup operation while an unrelated normal repository run overlaps, a dead numeric PID symlink is recovered, and a regular file/non-numeric symlink rejects with `OpenWikiLockError` exit code 73.
+
+- [ ] **Step 2: Run the lock tests and observe the red state.**
+
+Run: `pnpm exec vitest run test/execution-lock.test.ts`
+
+Expected: FAIL because the native lock manager does not exist.
+
+- [ ] **Step 3: Implement the PID-symlink manager and runtime/CLI integration.**
+
+```ts
+await withOpenWikiExecutionLock(
+  { command, cwd: runtimeCwd, outputMode: options.outputMode ?? "local-wiki" },
+  async () => runOpenWikiAgentUnlocked(command, runtimeCwd, options),
+);
+```
+
+Create `openWikiLocksDir`; acquire with an atomic `symlink(String(process.pid), lockPath)`, validate a conflicting path with `lstat`/`readlink`, remove only dead numeric PID owners, and wait for live owners. Use SHA-256 of the physical repository path for a code lock filename. Convert `OpenWikiLockError` to exit 73 in both non-interactive print and auto-exiting interactive error handling; all other errors retain exit 1.
+
+- [ ] **Step 4: Verify lock behavior.**
+
+Run: `pnpm exec vitest run test/execution-lock.test.ts test/startup.test.ts`
+
+Expected: PASS; normal code repositories overlap, contended physical repositories/personal runs serialize, and unsafe lock files never get deleted or treated as valid locks.
+
+### Task 4: Make bundled-skill synchronization race-safe with the same native lock discipline
+
+**Files:**
+
+- Modify: `src/agent/skills.ts:1-32`
+- Modify: `test/skills.test.ts:1-88`
+
+**Interfaces:**
+
+- `syncBundledSkills()` remains the production API and becomes in-process single-flight.
+- `replaceSkillDirectories(sourceDir, targetDir, dependencies?)` accepts test-only-injected copy/sleep operations and retries only `EEXIST`/`ENOENT` copy races at 250ms, 500ms, and 750ms.
+- The cross-process bundled-skill lock is a PID symlink under `~/.openwiki/locks/bundled-skills.lock` and shares malformed/stale-owner semantics with Task 3.
+
+- [ ] **Step 1: Add failing race and preservation tests.**
+
+```ts
+await expect(
+  replaceSkillDirectories(source, target, {
+    copy: vi
+      .fn()
+      .mockRejectedValueOnce(
+        Object.assign(new Error("race"), { code: "EEXIST" }),
+      )
+      .mockResolvedValue(undefined),
+    sleep,
+  }),
+).resolves.toBeUndefined();
+expect(delays).toEqual([250]);
+```
+
+Add a complementary `ENOENT` retry test, an `EACCES` immediate-failure test, and concurrent `syncBundledSkills` coverage that proves bundled directories update while a user-created unrelated skill remains untouched.
+
+- [ ] **Step 2: Run the skills tests and observe the red state.**
+
+Run: `pnpm exec vitest run test/skills.test.ts`
+
+Expected: new race/single-flight assertions fail because current synchronization copies directories concurrently without retry or cross-process ownership.
+
+- [ ] **Step 3: Implement in-process serialization, cross-process locking, and bounded retries.**
+
+```ts
+const sync = pendingSkillSync.then(() =>
+  withBundledSkillLock(syncBundledSkillsOnce),
+);
+pendingSkillSync = sync.catch(() => undefined);
+return sync;
+```
+
+Copy bundled skill directories one at a time, remove only the matching bundled target, preserve unrelated target entries, and retry only transient destination races. Reuse Task 3's owner validation and release behavior rather than duplicating PID-lock parsing.
+
+- [ ] **Step 4: Verify the focused safety suite.**
+
+Run: `pnpm exec vitest run test/skills.test.ts test/execution-lock.test.ts`
+
+Expected: PASS; synchronization is safe within one process and across lock owners, preserves user skills, and propagates non-transient filesystem errors.
+
+### Task 5: Run product checks and an opt-in credential-redacted Z.AI smoke test
+
+**Files:**
+
+- Modify only if the preceding checks reveal a tested defect.
+
+- [ ] **Step 1: Run static and formatting checks.**
+
+Run: `pnpm typecheck && pnpm lint:check && pnpm format:check`
+
+Expected: exit 0 with no formatter or TypeScript errors.
+
+- [ ] **Step 2: Run all focused provider and safety tests.**
+
+Run: `pnpm exec vitest run test/constants.test.ts test/env-behavior.test.ts test/credentials.test.ts test/startup.test.ts test/zai-transport.test.ts test/execution-lock.test.ts test/skills.test.ts`
+
+Expected: exit 0.
+
+- [ ] **Step 3: Run the complete Vitest suite and separate known baseline failures.**
+
+Run: `pnpm test`
+
+Expected: all Z.AI and safety suites pass. If `test/index-middleware.test.ts` and `test/mermaid-validate.test.ts` still exceed their 5-second timeout, report them as the pre-existing baseline failures approved as separate work; do not modify them in this branch.
+
+- [ ] **Step 4: Execute an opt-in smoke test only when an externally supplied key is present.**
+
+```sh
+if [ -n "${ZAI_API_KEY:-}" ]; then
+  ZAI_API_KEY="$ZAI_API_KEY" \
+  OPENWIKI_PROVIDER=zai \
+  OPENWIKI_MODEL_ID=glm-5.2 \
+  pnpm dev -- --print "Report the active provider and model only."
+else
+  echo "Z.AI smoke skipped: ZAI_API_KEY was not supplied."
+fi
+```
+
+Run it from a disposable temporary repository, capture only provider/model/exit evidence, and never echo the key, full environment, request authorization, or generated content. Expected live evidence when opted in: `provider: Z.AI` and `model: glm-5.2`, with no OpenRouter request. If no external key is present, record the smoke as deliberately skipped rather than fabricated.
+
+## Plan Self-Review
+
+- Coverage: Tasks 1-2 cover the independent Z.AI identity, credential boundary, transport normalization, retry contract, setup, and diagnostics. Tasks 3-4 migrate the wrapper's execution and bundled-skill safety. Task 5 covers required static, suite, and opt-in live verification.
+- Placeholder scan: every production boundary, test file, command, expected outcome, and required injected dependency is named.
+- Consistency: `zai`, `ZAI_API_KEY`, `ZAI_BASE_URL`, `glm-5.2`, and the Coding API root are used consistently; only the Z.AI transport receives the custom fetch adapter.

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -15,6 +15,7 @@ import {
   FilesystemBackend,
 } from "deepagents";
 import { createOpenWikiConnectorTools } from "../connectors/tools.js";
+import { withOpenWikiExecutionLock } from "../execution-lock.js";
 import {
   DEBUG_ENV_KEYS,
   loadOpenWikiEnv,
@@ -36,7 +37,9 @@ import {
   refreshChatGptTokens,
 } from "./openai-chatgpt-oauth.js";
 import { createSystemPrompt, createUserPrompt } from "./prompt.js";
+import { getOpenWikiExecutionLockScope } from "./runtime-lock.js";
 import { syncBundledSkills } from "./skills.js";
+import { createZaiFetch } from "./zai-transport.js";
 import {
   createVertexAuthFetch,
   resolveVertexSurface,
@@ -111,8 +114,18 @@ export async function runOpenWikiAgent(
   cwd = openWikiLocalWikiDir,
   options: OpenWikiRunOptions = {},
 ): Promise<OpenWikiRunResult> {
-  const runtimeCwd = options.outputMode ? cwd : openWikiLocalWikiDir;
+  const lockScope = getOpenWikiExecutionLockScope(command, cwd, options);
 
+  return withOpenWikiExecutionLock(lockScope, () =>
+    runOpenWikiAgentUnlocked(command, lockScope.cwd, options),
+  );
+}
+
+async function runOpenWikiAgentUnlocked(
+  command: OpenWikiCommand,
+  runtimeCwd: string,
+  options: OpenWikiRunOptions,
+): Promise<OpenWikiRunResult> {
   emitDebug(options, `command=${command}`);
   emitDebug(options, `cwd=${runtimeCwd}`);
   emitDebug(
@@ -128,7 +141,7 @@ export async function runOpenWikiAgent(
   emitDebug(options, `env.afterLoad ${formatEnvironmentDebug()}`);
 
   if (command === "update" && shouldCheckUpdateNoop(options)) {
-    const noopStatus = await getUpdateNoopStatus(cwd);
+    const noopStatus = await getUpdateNoopStatus(runtimeCwd);
 
     if (noopStatus.shouldSkip) {
       const message =
@@ -153,7 +166,8 @@ export async function runOpenWikiAgent(
     emitDebug(options, "update.noop=false reason=user message provided");
   }
 
-  const debugFetchCapture = installOpenRouterDebugFetch(options);
+  let debugFetchCapture: OpenRouterFetchCapture =
+    createNoopOpenRouterFetchCapture();
 
   // Resolved inside the try so a failure during resolution (missing key,
   // invalid model, missing base URL) is still recorded. They may be undefined
@@ -163,6 +177,9 @@ export async function runOpenWikiAgent(
 
   try {
     provider = resolveConfiguredProvider();
+    if (shouldInstallOpenRouterDebugFetch(provider)) {
+      debugFetchCapture = installOpenRouterDebugFetch(options);
+    }
     const providerBaseUrl = resolveProviderBaseUrl(provider);
     emitDebug(options, `provider=${provider}`);
     if (providerBaseUrl) {
@@ -742,6 +759,20 @@ export function createModel(
       model: modelId,
       provider: providerOnly ? { only: providerOnly } : undefined,
       siteName: "OpenWiki",
+      ...retryOptions,
+    });
+  }
+
+  if (provider === "zai") {
+    const baseURL = resolveProviderBaseUrl(provider);
+
+    return new ChatOpenAI({
+      apiKey: getProviderApiKey(provider),
+      configuration: {
+        baseURL,
+        fetch: createZaiFetch({ baseUrl: baseURL }),
+      },
+      model: modelId,
       ...retryOptions,
     });
   }
@@ -1425,6 +1456,20 @@ type OpenRouterResponseSummary = {
 
 const OPENROUTER_DEBUG_PROPERTY = "openRouterDebug";
 const OPENROUTER_DEBUG_BODY_LIMIT = 4_000;
+
+export function shouldInstallOpenRouterDebugFetch(
+  provider: OpenWikiProvider,
+): boolean {
+  return provider === "openrouter";
+}
+
+function createNoopOpenRouterFetchCapture(): OpenRouterFetchCapture {
+  return {
+    clearLastFailure: () => undefined,
+    getLastFailure: () => null,
+    restore: () => undefined,
+  };
+}
 
 function installOpenRouterDebugFetch(
   options: OpenWikiRunOptions,

--- a/src/agent/runtime-lock.ts
+++ b/src/agent/runtime-lock.ts
@@ -1,0 +1,22 @@
+import type { ExecutionLockScope } from "../execution-lock.js";
+import { openWikiLocalWikiDir } from "../openwiki-home.js";
+import type { OpenWikiCommand, OpenWikiRunOptions } from "./types.js";
+
+/**
+ * Maps a user-facing agent invocation to its physical output scope before any
+ * shared OpenWiki state is touched. Keeping this mapping separate makes the
+ * locking boundary explicit and independently testable.
+ */
+export function getOpenWikiExecutionLockScope(
+  command: OpenWikiCommand,
+  cwd: string,
+  options: Pick<OpenWikiRunOptions, "outputMode">,
+): ExecutionLockScope {
+  const outputMode = options.outputMode ?? "local-wiki";
+
+  return {
+    command,
+    cwd: outputMode === "repository" ? cwd : openWikiLocalWikiDir,
+    outputMode,
+  };
+}

--- a/src/agent/skills.ts
+++ b/src/agent/skills.ts
@@ -1,32 +1,123 @@
 import { cp, readdir, rm } from "node:fs/promises";
 import { fileURLToPath } from "node:url";
 import path from "node:path";
-import { ensureOpenWikiHome, openWikiSkillsDir } from "../openwiki-home.js";
+import {
+  withPidSymlinkLock,
+  type ExecutionLockDependencies,
+} from "../execution-lock.js";
+import {
+  ensureOpenWikiHome,
+  openWikiLocksDir,
+  openWikiSkillsDir,
+} from "../openwiki-home.js";
 
 const bundledSkillsDir = fileURLToPath(
   new URL("../../skills", import.meta.url),
+);
+const bundledSkillsLockPath = path.join(
+  openWikiLocksDir,
+  "bundled-skills.lock",
+);
+const MAX_SKILL_COPY_RETRIES = 3;
+const SKILL_COPY_RETRY_DELAY_MS = 25;
+
+type CopyDirectory = (source: string, target: string) => Promise<void>;
+
+export type SkillSyncDependencies = {
+  copyDirectory?: CopyDirectory;
+  lock?: ExecutionLockDependencies;
+  sleep?: (delayMs: number) => Promise<void>;
+};
+
+const synchronizeBundledSkills = createBundledSkillsSynchronizer(
+  bundledSkillsDir,
+  openWikiSkillsDir,
+  bundledSkillsLockPath,
 );
 
 /** Copies bundled skills into the OpenWiki home while preserving other skills. */
 export async function syncBundledSkills(): Promise<void> {
   await ensureOpenWikiHome();
-  await replaceSkillDirectories(bundledSkillsDir, openWikiSkillsDir);
+  await synchronizeBundledSkills();
+}
+
+/**
+ * Builds an in-process queue around a cross-process PID lock. A single Node
+ * process cannot wait on its own PID symlink, so both layers are required.
+ */
+export function createBundledSkillsSynchronizer(
+  sourceDir: string,
+  targetDir: string,
+  lockPath: string,
+  dependencies: SkillSyncDependencies = {},
+): () => Promise<void> {
+  let pending = Promise.resolve();
+
+  return () => {
+    const current = pending.then(() =>
+      withPidSymlinkLock(
+        lockPath,
+        () => replaceSkillDirectories(sourceDir, targetDir, dependencies),
+        dependencies.lock,
+      ),
+    );
+
+    // Let the next synchronization proceed after a failed copy rather than
+    // permanently poisoning this process's queue.
+    pending = current.catch(() => undefined);
+    return current;
+  };
 }
 
 /** Replaces bundled skill directories without removing unrelated skills. */
 export async function replaceSkillDirectories(
   sourceDir: string,
   targetDir: string,
+  dependencies: Omit<SkillSyncDependencies, "lock"> = {},
 ): Promise<void> {
   const skills = (await readdir(sourceDir, { withFileTypes: true })).filter(
     (entry) => entry.isDirectory(),
   );
 
-  await Promise.all(
-    skills.map(async ({ name }) => {
-      const target = path.join(targetDir, name);
-      await rm(target, { force: true, recursive: true });
-      await cp(path.join(sourceDir, name), target, { recursive: true });
-    }),
+  for (const { name } of skills) {
+    const target = path.join(targetDir, name);
+    const source = path.join(sourceDir, name);
+
+    for (let attempt = 0; ; attempt += 1) {
+      try {
+        await rm(target, { force: true, recursive: true });
+        await (dependencies.copyDirectory ?? copyDirectory)(source, target);
+        break;
+      } catch (error) {
+        if (
+          !isTransientSkillCopyError(error) ||
+          attempt >= MAX_SKILL_COPY_RETRIES
+        ) {
+          throw error;
+        }
+
+        await (dependencies.sleep ?? sleep)(
+          SKILL_COPY_RETRY_DELAY_MS * 2 ** attempt,
+        );
+      }
+    }
+  }
+}
+
+export function isTransientSkillCopyError(error: unknown): boolean {
+  return (
+    typeof error === "object" &&
+    error !== null &&
+    "code" in error &&
+    ((error as NodeJS.ErrnoException).code === "EEXIST" ||
+      (error as NodeJS.ErrnoException).code === "ENOENT")
   );
+}
+
+async function copyDirectory(source: string, target: string): Promise<void> {
+  await cp(source, target, { recursive: true });
+}
+
+function sleep(delayMs: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, delayMs));
 }

--- a/src/agent/zai-transport.ts
+++ b/src/agent/zai-transport.ts
@@ -1,0 +1,315 @@
+import {
+  ZAI_DEFAULT_BASE_URL,
+  ZAI_RATE_LIMIT_BASE_DELAY_MS_ENV_KEY,
+  ZAI_RATE_LIMIT_MAX_DELAY_MS_ENV_KEY,
+  ZAI_RATE_LIMIT_MAX_RETRIES_ENV_KEY,
+} from "../constants.js";
+
+const DEFAULT_MAX_RETRIES = 3;
+const DEFAULT_BASE_DELAY_MS = 5_000;
+const DEFAULT_MAX_DELAY_MS = 300_000;
+
+export type ZaiTransportDependencies = {
+  baseUrl?: string;
+  env?: NodeJS.ProcessEnv;
+  fetch?: typeof fetch;
+  now?: () => number;
+  sleep?: (delayMs: number) => Promise<void>;
+};
+
+type ZaiRateLimitConfig = {
+  baseDelayMs: number;
+  maxDelayMs: number;
+  maxRetries: number;
+};
+
+/**
+ * Returns a fetch implementation scoped to a Z.AI ChatOpenAI client. It never
+ * mutates global fetch and bypasses both normalization and retries for requests
+ * outside the configured Z.AI API root.
+ */
+export function createZaiFetch(
+  dependencies: ZaiTransportDependencies = {},
+): typeof fetch {
+  const baseUrl = dependencies.baseUrl ?? ZAI_DEFAULT_BASE_URL;
+  const env = dependencies.env ?? process.env;
+  const fetchImplementation = dependencies.fetch ?? globalThis.fetch;
+  const now = dependencies.now ?? Date.now;
+  const sleep = dependencies.sleep ?? defaultSleep;
+
+  return async (input, init) => {
+    if (!isZaiRequest(input, baseUrl)) {
+      return fetchImplementation(input, init);
+    }
+
+    const normalizedRequest = await normalizeZaiRequest(input, init);
+    const config = resolveZaiRateLimitConfig(env);
+
+    for (let retryNumber = 0; ; retryNumber += 1) {
+      const retryInput =
+        normalizedRequest.input instanceof Request
+          ? normalizedRequest.input.clone()
+          : normalizedRequest.input;
+      const response = await fetchImplementation(
+        retryInput,
+        normalizedRequest.init,
+      );
+
+      if (response.status !== 429 || retryNumber >= config.maxRetries) {
+        return response;
+      }
+
+      await sleep(getZaiRetryDelayMs(response, retryNumber + 1, config, now));
+    }
+  };
+}
+
+/** Normalizes only file blocks contained in a JSON chat-completions body. */
+export function normalizeZaiRequestBody(body: string): string {
+  try {
+    const parsed: unknown = JSON.parse(body);
+
+    if (!isRecord(parsed)) {
+      return body;
+    }
+
+    const parsedMessages = parsed.messages;
+    if (!Array.isArray(parsedMessages)) {
+      return body;
+    }
+
+    let changed = false;
+    const messages = (parsedMessages as unknown[]).map((message) => {
+      if (!isRecord(message)) {
+        return message;
+      }
+
+      const messageContent = message.content;
+      if (!Array.isArray(messageContent)) {
+        return message;
+      }
+
+      let messageChanged = false;
+      const content = (messageContent as unknown[]).map((block) => {
+        const normalized = normalizeZaiContentBlock(block);
+        messageChanged ||= normalized !== block;
+        return normalized;
+      });
+
+      changed ||= messageChanged;
+      return messageChanged ? { ...message, content } : message;
+    });
+
+    return changed ? JSON.stringify({ ...parsed, messages }) : body;
+  } catch {
+    return body;
+  }
+}
+
+export function parseZaiRetryAfterMs(
+  headers: Headers,
+  now: () => number = Date.now,
+): number | null {
+  const retryAfter = headers.get("retry-after")?.trim();
+
+  if (!retryAfter) {
+    return null;
+  }
+
+  if (/^\d+(?:\.\d+)?$/u.test(retryAfter)) {
+    return Number(retryAfter) * 1_000;
+  }
+
+  const retryAt = Date.parse(retryAfter);
+  return Number.isNaN(retryAt) ? null : Math.max(0, retryAt - now());
+}
+
+export function resolveZaiRateLimitConfig(
+  env: NodeJS.ProcessEnv = process.env,
+): ZaiRateLimitConfig {
+  const baseDelayMs = readPositiveInteger(
+    ZAI_RATE_LIMIT_BASE_DELAY_MS_ENV_KEY,
+    env,
+    DEFAULT_BASE_DELAY_MS,
+  );
+  const maxDelayMs = readPositiveInteger(
+    ZAI_RATE_LIMIT_MAX_DELAY_MS_ENV_KEY,
+    env,
+    DEFAULT_MAX_DELAY_MS,
+  );
+
+  return {
+    baseDelayMs,
+    maxDelayMs,
+    maxRetries: readNonNegativeInteger(
+      ZAI_RATE_LIMIT_MAX_RETRIES_ENV_KEY,
+      env,
+      DEFAULT_MAX_RETRIES,
+    ),
+  };
+}
+
+function normalizeRequestInit(
+  init: RequestInit | undefined,
+): RequestInit | undefined {
+  if (typeof init?.body !== "string") {
+    return init;
+  }
+
+  const body = normalizeZaiRequestBody(init.body);
+  return body === init.body ? init : { ...init, body };
+}
+
+async function normalizeZaiRequest(
+  input: RequestInfo | URL,
+  init: RequestInit | undefined,
+): Promise<{ input: RequestInfo | URL; init: RequestInit | undefined }> {
+  const normalizedInit = normalizeRequestInit(init);
+
+  if (
+    !(input instanceof Request) ||
+    init?.body !== undefined ||
+    typeof input.body !== "object" ||
+    input.body === null
+  ) {
+    return { input, init: normalizedInit };
+  }
+
+  const body = await input.clone().text();
+  const normalizedBody = normalizeZaiRequestBody(body);
+
+  if (normalizedBody === body) {
+    return { input, init: normalizedInit };
+  }
+
+  return {
+    input: new Request(input, { body: normalizedBody }),
+    init: normalizedInit,
+  };
+}
+
+function normalizeZaiContentBlock(block: unknown): unknown {
+  if (!isRecord(block) || block.type !== "file") {
+    return block;
+  }
+
+  const text = normalizeZaiFileData(block.data);
+  return { type: "text", text };
+}
+
+function normalizeZaiFileData(data: unknown): string {
+  if (typeof data !== "string" || data.trim().length === 0) {
+    return "[file content omitted]";
+  }
+
+  const compact = data.trim();
+  if (!looksLikeBase64(compact)) {
+    return data;
+  }
+
+  try {
+    return new TextDecoder("utf-8", { fatal: true }).decode(
+      Buffer.from(compact, "base64"),
+    );
+  } catch {
+    // An alphanumeric word such as "text" is syntactically indistinguishable
+    // from unpadded base64. Preserve that readable input; delimiters/padding
+    // make an invalid payload unambiguously encoded binary.
+    return /[+/=]/u.test(compact) ? "[binary file content omitted]" : data;
+  }
+}
+
+function looksLikeBase64(value: string): boolean {
+  return value.length % 4 === 0 && /^[A-Za-z0-9+/=\r\n]+$/u.test(value);
+}
+
+function getZaiRetryDelayMs(
+  response: Response,
+  retryNumber: number,
+  config: ZaiRateLimitConfig,
+  now: () => number,
+): number {
+  const retryAfterMs = parseZaiRetryAfterMs(response.headers, now);
+
+  if (retryAfterMs !== null) {
+    return Math.min(retryAfterMs, config.maxDelayMs);
+  }
+
+  return Math.min(
+    config.baseDelayMs * 2 ** (retryNumber - 1),
+    config.maxDelayMs,
+  );
+}
+
+function isZaiRequest(input: RequestInfo | URL, baseUrl: string): boolean {
+  try {
+    const requestUrl = new URL(getRequestUrl(input));
+    const configuredBaseUrl = new URL(baseUrl);
+    const basePath = configuredBaseUrl.pathname.replace(/\/+$/u, "");
+
+    return (
+      requestUrl.origin === configuredBaseUrl.origin &&
+      (requestUrl.pathname === basePath ||
+        requestUrl.pathname.startsWith(`${basePath}/`))
+    );
+  } catch {
+    return false;
+  }
+}
+
+function getRequestUrl(input: RequestInfo | URL): string {
+  if (typeof input === "string") {
+    return input;
+  }
+
+  if (input instanceof URL) {
+    return input.href;
+  }
+
+  return input.url;
+}
+
+function readNonNegativeInteger(
+  key: string,
+  env: NodeJS.ProcessEnv,
+  fallback: number,
+): number {
+  const rawValue = env[key];
+
+  if (rawValue === undefined) {
+    return fallback;
+  }
+
+  if (!/^\d+$/u.test(rawValue)) {
+    throw new Error(`${key} must be a non-negative integer.`);
+  }
+
+  const value = Number(rawValue);
+  if (!Number.isSafeInteger(value)) {
+    throw new Error(`${key} must be a non-negative integer.`);
+  }
+
+  return value;
+}
+
+function readPositiveInteger(
+  key: string,
+  env: NodeJS.ProcessEnv,
+  fallback: number,
+): number {
+  const value = readNonNegativeInteger(key, env, fallback);
+
+  if (value === 0) {
+    throw new Error(`${key} must be a positive integer.`);
+  }
+
+  return value;
+}
+
+function defaultSleep(delayMs: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, delayMs));
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}

--- a/src/cli.tsx
+++ b/src/cli.tsx
@@ -55,6 +55,7 @@ import {
   saveOpenWikiOnboardingConfig,
 } from "./onboarding.js";
 import { openWikiLocalWikiDir } from "./openwiki-home.js";
+import { getOpenWikiErrorExitCode } from "./execution-lock.js";
 import {
   deleteConnectorSchedules,
   getSavedPowerScheduleStatus,
@@ -410,6 +411,8 @@ function App({ command }: AppProps) {
           return;
         }
 
+        process.exitCode = getOpenWikiErrorExitCode(error);
+
         const errorDiagnostics = getErrorDiagnostics(error);
         const message = getErrorMessage(error);
         const authFix = getAuthFix(error, message, sessionProvider);
@@ -426,7 +429,7 @@ function App({ command }: AppProps) {
           return;
         }
 
-        void getCredentialDiagnostics()
+        void getCredentialDiagnostics({ provider: sessionProvider })
           .catch(() => undefined)
           .then((credentialDiagnostics) => {
             if (!mountedRef.current || activeRunId.current !== runId) {
@@ -558,7 +561,7 @@ function App({ command }: AppProps) {
     });
 
     if (shouldShowCredentialDiagnostics()) {
-      void getCredentialDiagnostics()
+      void getCredentialDiagnostics({ provider: sessionProvider })
         .catch(() => undefined)
         .then((credentialDiagnostics) => {
           if (
@@ -660,6 +663,8 @@ function App({ command }: AppProps) {
           return;
         }
 
+        process.exitCode = getOpenWikiErrorExitCode(error);
+
         const errorDiagnostics = getErrorDiagnostics(error);
         const message = getErrorMessage(error);
         const authFix = getAuthFix(error, message, sessionProvider);
@@ -676,7 +681,7 @@ function App({ command }: AppProps) {
           return;
         }
 
-        void getCredentialDiagnostics()
+        void getCredentialDiagnostics({ provider: sessionProvider })
           .catch(() => undefined)
           .then((credentialDiagnostics) => {
             if (!mountedRef.current || activeRunId.current !== runId) {
@@ -4172,7 +4177,7 @@ async function runPrintCommand(
     process.stderr.write(`${message}\n`);
     writePrintAuthFix(error, message);
     writePrintErrorDiagnostics(error);
-    process.exitCode = 1;
+    process.exitCode = getOpenWikiErrorExitCode(error);
   }
 }
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -23,6 +23,13 @@ export const OPENAI_CHATGPT_PLAN_ENV_KEY = "OPENAI_CHATGPT_PLAN";
 export const ANTHROPIC_API_KEY_ENV_KEY = "ANTHROPIC_API_KEY";
 export const ANTHROPIC_BASE_URL_ENV_KEY = "ANTHROPIC_BASE_URL";
 export const OPENROUTER_API_KEY_ENV_KEY = "OPENROUTER_API_KEY";
+export const ZAI_API_KEY_ENV_KEY = "ZAI_API_KEY";
+export const ZAI_BASE_URL_ENV_KEY = "ZAI_BASE_URL";
+export const ZAI_RATE_LIMIT_MAX_RETRIES_ENV_KEY = "ZAI_RATE_LIMIT_MAX_RETRIES";
+export const ZAI_RATE_LIMIT_BASE_DELAY_MS_ENV_KEY =
+  "ZAI_RATE_LIMIT_BASE_DELAY_MS";
+export const ZAI_RATE_LIMIT_MAX_DELAY_MS_ENV_KEY =
+  "ZAI_RATE_LIMIT_MAX_DELAY_MS";
 export const OPENWIKI_OPENROUTER_PROVIDER_ONLY_ENV_KEY =
   "OPENWIKI_OPENROUTER_PROVIDER_ONLY";
 export const BEDROCK_AWS_ACCESS_KEY_ID_ENV_KEY = "BEDROCK_AWS_ACCESS_KEY_ID";
@@ -81,6 +88,7 @@ export const OPENWIKI_X_REFRESH_TOKEN_ENV_KEY = "OPENWIKI_X_REFRESH_TOKEN";
 export const OPENWIKI_TAVILY_API_KEY_ENV_KEY = "TAVILY_API_KEY";
 export const DEFAULT_PROVIDER = "openai";
 export const OPENROUTER_BASE_URL = "https://openrouter.ai/api/v1";
+export const ZAI_DEFAULT_BASE_URL = "https://api.z.ai/api/coding/paas/v4";
 
 export type OpenWikiProvider =
   | "anthropic"
@@ -94,7 +102,8 @@ export type OpenWikiProvider =
   | "openai"
   | "openai-chatgpt"
   | "openai-compatible"
-  | "openrouter";
+  | "openrouter"
+  | "zai";
 
 /**
  * How a provider authenticates. Providers default to `"api-key"` (a pasted
@@ -158,6 +167,8 @@ type ProviderConfig = {
    * with an alternative base URL (e.g. a self-hosted or proxied endpoint).
    */
   baseUrlEnvKey?: string;
+  /** Whether setup may optionally save a non-default base URL. */
+  optionalBaseUrl?: boolean;
   /**
    * When true, the provider has no default endpoint and requires a base URL to
    * be supplied via {@link ProviderConfig.baseUrlEnvKey}.
@@ -202,6 +213,7 @@ export const SELECTABLE_OPENWIKI_PROVIDERS = [
   "anthropic",
   "gemini",
   "gemini-enterprise",
+  "zai",
   "openrouter",
   "openai-compatible",
   "bedrock",
@@ -343,6 +355,14 @@ export const PROVIDER_CONFIGS: Record<OpenWikiProvider, ProviderConfig> = {
       { id: "openai/gpt-5.4-mini", label: "GPT 5.4 mini" },
       { id: "openai/gpt-5.5", label: "GPT 5.5" },
     ],
+  },
+  zai: {
+    apiKeyEnvKey: ZAI_API_KEY_ENV_KEY,
+    baseURL: ZAI_DEFAULT_BASE_URL,
+    baseUrlEnvKey: ZAI_BASE_URL_ENV_KEY,
+    label: "Z.AI",
+    modelOptions: [{ id: "glm-5.2", label: "GLM 5.2" }],
+    optionalBaseUrl: true,
   },
 };
 
@@ -540,6 +560,12 @@ export function providerRequiresBaseUrl(provider: OpenWikiProvider): boolean {
   return getProviderConfig(provider).requiresBaseUrl === true;
 }
 
+export function providerOffersOptionalBaseUrl(
+  provider: OpenWikiProvider,
+): boolean {
+  return getProviderConfig(provider).optionalBaseUrl === true;
+}
+
 export function getProviderSecretKeyEnvKey(
   provider: OpenWikiProvider,
 ): string | undefined {
@@ -722,28 +748,30 @@ export function resolveConfiguredProvider(
       ? "openai"
       : env[OPENAI_COMPATIBLE_API_KEY_ENV_KEY]
         ? "openai-compatible"
-        : env[OPENROUTER_API_KEY_ENV_KEY]
-          ? "openrouter"
-          : env[ANTHROPIC_API_KEY_ENV_KEY]
-            ? "anthropic"
-            : env[BASETEN_API_KEY_ENV_KEY]
-              ? "baseten"
-              : env[FIREWORKS_API_KEY_ENV_KEY]
-                ? "fireworks"
-                : env[NEBIUS_API_KEY_ENV_KEY]
-                  ? "nebius"
-                  : env[NVIDIA_API_KEY_ENV_KEY]
-                    ? "nvidia"
-                    : hasNonEmptyEnvValue(
-                          env,
-                          BEDROCK_AWS_ACCESS_KEY_ID_ENV_KEY,
-                        ) ||
-                        hasNonEmptyEnvValue(
-                          env,
-                          BEDROCK_AWS_SECRET_ACCESS_KEY_ENV_KEY,
-                        )
-                      ? "bedrock"
-                      : DEFAULT_PROVIDER)
+        : env[ZAI_API_KEY_ENV_KEY]
+          ? "zai"
+          : env[OPENROUTER_API_KEY_ENV_KEY]
+            ? "openrouter"
+            : env[ANTHROPIC_API_KEY_ENV_KEY]
+              ? "anthropic"
+              : env[BASETEN_API_KEY_ENV_KEY]
+                ? "baseten"
+                : env[FIREWORKS_API_KEY_ENV_KEY]
+                  ? "fireworks"
+                  : env[NEBIUS_API_KEY_ENV_KEY]
+                    ? "nebius"
+                    : env[NVIDIA_API_KEY_ENV_KEY]
+                      ? "nvidia"
+                      : hasNonEmptyEnvValue(
+                            env,
+                            BEDROCK_AWS_ACCESS_KEY_ID_ENV_KEY,
+                          ) ||
+                          hasNonEmptyEnvValue(
+                            env,
+                            BEDROCK_AWS_SECRET_ACCESS_KEY_ENV_KEY,
+                          )
+                        ? "bedrock"
+                        : DEFAULT_PROVIDER)
   );
 }
 

--- a/src/credentials.tsx
+++ b/src/credentials.tsx
@@ -28,6 +28,7 @@ import {
   getProviderRegionEnvKeys,
   getProviderSecretKeyEnvKey,
   providerRequiresApiKey,
+  providerOffersOptionalBaseUrl,
   isValidModelId,
   normalizeProvider,
   normalizeModelId,
@@ -589,7 +590,10 @@ export function orderedSetupSteps(
   ) {
     steps.push("gcp-location");
   }
-  if (providerRequiresBaseUrl(provider)) {
+  if (
+    providerRequiresBaseUrl(provider) ||
+    providerOffersOptionalBaseUrl(provider)
+  ) {
     steps.push("base-url");
   }
   if (providerRequiresRegion(provider)) {
@@ -2082,23 +2086,29 @@ export function InitSetup({
     if (step === "base-url") {
       const trimmedInput = input.trim();
 
-      if (trimmedInput.length === 0) {
+      if (
+        trimmedInput.length === 0 &&
+        !providerOffersOptionalBaseUrl(provider)
+      ) {
         setError(
           `${getProviderBaseUrlEnvKey(provider) ?? "Base URL"} is required.`,
         );
         return;
       }
 
-      const baseUrlWarnings = getProviderBaseUrlWarnings(
-        provider,
-        trimmedInput,
-      );
-      if (baseUrlWarnings.length > 0) {
-        setError(`Enter a valid base URL: ${baseUrlWarnings.join(", ")}.`);
-        return;
+      if (trimmedInput.length > 0) {
+        const baseUrlWarnings = getProviderBaseUrlWarnings(
+          provider,
+          trimmedInput,
+        );
+        if (baseUrlWarnings.length > 0) {
+          setError(`Enter a valid base URL: ${baseUrlWarnings.join(", ")}.`);
+          return;
+        }
       }
 
-      setBaseUrl(trimmedInput);
+      const nextBaseUrl = trimmedInput.length > 0 ? trimmedInput : null;
+      setBaseUrl(nextBaseUrl);
       setInput("");
       const nextStep =
         nextSetupStep("base-url", provider, selectedMode, allowModeSelection) ??
@@ -2121,7 +2131,7 @@ export function InitSetup({
 
       await completeSetup({
         nextApiKey: apiKey,
-        nextBaseUrl: trimmedInput,
+        nextBaseUrl,
         nextSecretKey: secretKey,
         nextRegion: region,
         nextGcpLocation: gcpLocation,
@@ -3296,7 +3306,8 @@ export function InitSetup({
               }
             />
           ) : null}
-          {providerRequiresBaseUrl(provider) ? (
+          {providerRequiresBaseUrl(provider) ||
+          providerOffersOptionalBaseUrl(provider) ? (
             <SetupStep
               label="Base URL"
               state={resolveStepStatus(
@@ -3306,7 +3317,11 @@ export function InitSetup({
               )}
               detail={
                 baseUrl ??
-                (isBaseUrlConfigured(provider) ? "configured" : "not set")
+                (isBaseUrlConfigured(provider)
+                  ? "configured"
+                  : providerOffersOptionalBaseUrl(provider)
+                    ? "default"
+                    : "not set")
               }
             />
           ) : null}
@@ -3679,8 +3694,9 @@ function Prompt({
           <Text color="yellow">{input}</Text>
         </Text>
         <Text color="gray">
-          For example an OpenAI-compatible gateway endpoint (such as a LiteLLM
-          gateway). Press Enter to save it.
+          {providerOffersOptionalBaseUrl(provider)
+            ? "Press Enter to use the default API root, or save a non-default root."
+            : "For example an OpenAI-compatible gateway endpoint (such as a LiteLLM gateway). Press Enter to save it."}
         </Text>
       </Box>
     );

--- a/src/env.ts
+++ b/src/env.ts
@@ -11,6 +11,8 @@ import {
   BEDROCK_AWS_SECRET_ACCESS_KEY_ENV_KEY,
   FIREWORKS_API_KEY_ENV_KEY,
   FIREWORKS_BASE_URL_ENV_KEY,
+  getProviderApiKeyEnvKey,
+  getProviderBaseUrlEnvKey,
   getProviderBaseUrlWarnings,
   GEMINI_API_KEY_ENV_KEY,
   GOOGLE_APPLICATION_CREDENTIALS_ENV_KEY,
@@ -56,6 +58,12 @@ import {
   OPENWIKI_PROVIDER_ENV_KEY,
   OPENWIKI_PROVIDER_RETRY_ATTEMPTS_ENV_KEY,
   resolveProviderRetryAttempts,
+  type OpenWikiProvider,
+  ZAI_API_KEY_ENV_KEY,
+  ZAI_BASE_URL_ENV_KEY,
+  ZAI_RATE_LIMIT_BASE_DELAY_MS_ENV_KEY,
+  ZAI_RATE_LIMIT_MAX_DELAY_MS_ENV_KEY,
+  ZAI_RATE_LIMIT_MAX_RETRIES_ENV_KEY,
 } from "./constants.js";
 import { isFileNotFoundError } from "./fs-errors.js";
 import { restrictDirToCurrentUser } from "./windows-acl.js";
@@ -111,6 +119,11 @@ export const MANAGED_ENV_KEYS = [
   GOOGLE_APPLICATION_CREDENTIALS_ENV_KEY,
   OPENROUTER_API_KEY_ENV_KEY,
   OPENWIKI_OPENROUTER_PROVIDER_ONLY_ENV_KEY,
+  ZAI_API_KEY_ENV_KEY,
+  ZAI_BASE_URL_ENV_KEY,
+  ZAI_RATE_LIMIT_MAX_RETRIES_ENV_KEY,
+  ZAI_RATE_LIMIT_BASE_DELAY_MS_ENV_KEY,
+  ZAI_RATE_LIMIT_MAX_DELAY_MS_ENV_KEY,
   BEDROCK_AWS_ACCESS_KEY_ID_ENV_KEY,
   BEDROCK_AWS_SECRET_ACCESS_KEY_ENV_KEY,
   BEDROCK_AWS_REGION_ENV_KEY,
@@ -260,13 +273,39 @@ export async function loadOpenWikiEnv(): Promise<EnvMap> {
   return env;
 }
 
-export async function getCredentialDiagnostics(): Promise<
-  CredentialDiagnostic[]
-> {
+export async function getCredentialDiagnostics(
+  options: { provider?: OpenWikiProvider } = {},
+): Promise<CredentialDiagnostic[]> {
   const fileEnv = await readOpenWikiEnv();
+  const keys = options.provider
+    ? getProviderDiagnosticEnvKeys(options.provider)
+    : CREDENTIAL_DIAGNOSTIC_ENV_KEYS;
 
-  return CREDENTIAL_DIAGNOSTIC_ENV_KEYS.map((key) =>
-    createCredentialDiagnostic(key, fileEnv),
+  return keys.map((key) => createCredentialDiagnostic(key, fileEnv));
+}
+
+function getProviderDiagnosticEnvKeys(
+  provider: OpenWikiProvider,
+): readonly string[] {
+  const providerKeys = new Set(
+    [
+      getProviderApiKeyEnvKey(provider),
+      getProviderBaseUrlEnvKey(provider),
+    ].filter((key): key is string => key !== undefined),
+  );
+
+  if (provider === "zai") {
+    providerKeys.add(ZAI_RATE_LIMIT_MAX_RETRIES_ENV_KEY);
+    providerKeys.add(ZAI_RATE_LIMIT_BASE_DELAY_MS_ENV_KEY);
+    providerKeys.add(ZAI_RATE_LIMIT_MAX_DELAY_MS_ENV_KEY);
+  }
+
+  return CREDENTIAL_DIAGNOSTIC_ENV_KEYS.filter(
+    (key) =>
+      key === OPENWIKI_PROVIDER_ENV_KEY ||
+      key === OPENWIKI_MODEL_ID_ENV_KEY ||
+      key === OPENWIKI_PROVIDER_RETRY_ATTEMPTS_ENV_KEY ||
+      providerKeys.has(key),
   );
 }
 
@@ -414,6 +453,10 @@ function getBaseUrlDiagnosticWarnings(
     return getProviderBaseUrlWarnings("openai-compatible", value);
   }
 
+  if (key === ZAI_BASE_URL_ENV_KEY) {
+    return getProviderBaseUrlWarnings("zai", value);
+  }
+
   return undefined;
 }
 
@@ -429,6 +472,10 @@ function isNonSecretDiagnosticKey(key: string): boolean {
     key === NVIDIA_BASE_URL_ENV_KEY ||
     key === OPENAI_BASE_URL_ENV_KEY ||
     key === OPENAI_COMPATIBLE_BASE_URL_ENV_KEY ||
+    key === ZAI_BASE_URL_ENV_KEY ||
+    key === ZAI_RATE_LIMIT_MAX_RETRIES_ENV_KEY ||
+    key === ZAI_RATE_LIMIT_BASE_DELAY_MS_ENV_KEY ||
+    key === ZAI_RATE_LIMIT_MAX_DELAY_MS_ENV_KEY ||
     key === BEDROCK_AWS_REGION_ENV_KEY ||
     key === GOOGLE_CLOUD_PROJECT_ENV_KEY ||
     key === GOOGLE_CLOUD_LOCATION_ENV_KEY ||

--- a/src/execution-lock.ts
+++ b/src/execution-lock.ts
@@ -1,0 +1,204 @@
+import { createHash } from "node:crypto";
+import {
+  lstat,
+  mkdir,
+  readlink,
+  realpath,
+  rm,
+  symlink,
+} from "node:fs/promises";
+import path from "node:path";
+import { openWikiLocksDir } from "./openwiki-home.js";
+import type { OpenWikiCommand, OpenWikiOutputMode } from "./agent/types.js";
+
+export const OPENWIKI_LOCK_EXIT_CODE = 73;
+const LOCK_WAIT_DELAY_MS = 50;
+
+export type ExecutionLockScope = {
+  command: OpenWikiCommand;
+  cwd: string;
+  outputMode: OpenWikiOutputMode;
+};
+
+export type ExecutionLockDependencies = {
+  isProcessAlive?: (pid: number) => boolean;
+  locksDir?: string;
+  processId?: number;
+  sleep?: (delayMs: number) => Promise<void>;
+};
+
+export class OpenWikiLockError extends Error {
+  readonly exitCode = OPENWIKI_LOCK_EXIT_CODE;
+
+  constructor(message: string) {
+    super(message);
+    this.name = "OpenWikiLockError";
+  }
+}
+
+/** Maps lock failures to the portable temporary-failure exit status. */
+export function getOpenWikiErrorExitCode(error: unknown): number {
+  return error instanceof OpenWikiLockError ? error.exitCode : 1;
+}
+
+/**
+ * Runs a task while holding its repository/personal lock and, for init runs,
+ * the additional shared-home setup lock. Separate code repositories therefore
+ * overlap, while a physical repository (including a directory symlink) does
+ * not.
+ */
+export async function withOpenWikiExecutionLock<T>(
+  scope: ExecutionLockScope,
+  run: () => Promise<T>,
+  dependencies: ExecutionLockDependencies = {},
+): Promise<T> {
+  const lockPaths = await resolveOpenWikiExecutionLockPaths(
+    scope,
+    dependencies,
+  );
+  const releases: Array<() => Promise<void>> = [];
+
+  try {
+    for (const lockPath of lockPaths) {
+      releases.push(await acquirePidSymlinkLock(lockPath, dependencies));
+    }
+
+    return await run();
+  } finally {
+    for (const release of releases.reverse()) {
+      await release();
+    }
+  }
+}
+
+export async function resolveOpenWikiExecutionLockPaths(
+  scope: ExecutionLockScope,
+  dependencies: ExecutionLockDependencies = {},
+): Promise<string[]> {
+  const locksDir = dependencies.locksDir ?? openWikiLocksDir;
+  const targetLock =
+    scope.outputMode === "local-wiki"
+      ? path.join(locksDir, "personal-wiki.lock")
+      : path.join(
+          locksDir,
+          `code-${createHash("sha256")
+            .update(await realpath(scope.cwd))
+            .digest("hex")}.lock`,
+        );
+
+  return scope.command === "init"
+    ? [path.join(locksDir, "home-setup.lock"), targetLock]
+    : [targetLock];
+}
+
+/** Reusable low-level lock used by bundled-skill synchronization as well. */
+export async function withPidSymlinkLock<T>(
+  lockPath: string,
+  run: () => Promise<T>,
+  dependencies: ExecutionLockDependencies = {},
+): Promise<T> {
+  const release = await acquirePidSymlinkLock(lockPath, dependencies);
+
+  try {
+    return await run();
+  } finally {
+    await release();
+  }
+}
+
+async function acquirePidSymlinkLock(
+  lockPath: string,
+  dependencies: ExecutionLockDependencies,
+): Promise<() => Promise<void>> {
+  const processId = dependencies.processId ?? process.pid;
+  const isProcessAlive = dependencies.isProcessAlive ?? defaultIsProcessAlive;
+  const sleep = dependencies.sleep ?? defaultSleep;
+
+  await mkdir(path.dirname(lockPath), { recursive: true, mode: 0o700 });
+
+  while (true) {
+    try {
+      await symlink(String(processId), lockPath);
+      return async () => {
+        const owner = await readlink(lockPath).catch(() => undefined);
+
+        if (owner === String(processId)) {
+          await rm(lockPath, { force: true });
+        }
+      };
+    } catch (error) {
+      if (!hasErrorCode(error, "EEXIST")) {
+        throw error;
+      }
+    }
+
+    const owner = await readPidSymlinkOwner(lockPath);
+    if (owner === null) {
+      continue;
+    }
+
+    if (!isProcessAlive(owner)) {
+      await rm(lockPath, { force: true });
+      continue;
+    }
+
+    await sleep(LOCK_WAIT_DELAY_MS);
+  }
+}
+
+async function readPidSymlinkOwner(lockPath: string): Promise<number | null> {
+  try {
+    const stats = await lstat(lockPath);
+
+    if (!stats.isSymbolicLink()) {
+      throw new OpenWikiLockError(
+        `OpenWiki lock path is not a PID symlink: ${lockPath}`,
+      );
+    }
+  } catch (error) {
+    if (hasErrorCode(error, "ENOENT")) {
+      return null;
+    }
+    throw error;
+  }
+
+  let owner: string;
+  try {
+    owner = await readlink(lockPath);
+  } catch (error) {
+    if (hasErrorCode(error, "ENOENT")) {
+      return null;
+    }
+    throw error;
+  }
+
+  if (!/^[1-9]\d*$/u.test(owner)) {
+    throw new OpenWikiLockError(
+      `OpenWiki PID lock has an invalid owner: ${lockPath}`,
+    );
+  }
+
+  return Number(owner);
+}
+
+function defaultIsProcessAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    return !hasErrorCode(error, "ESRCH");
+  }
+}
+
+function defaultSleep(delayMs: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, delayMs));
+}
+
+function hasErrorCode(error: unknown, code: string): boolean {
+  return (
+    typeof error === "object" &&
+    error !== null &&
+    "code" in error &&
+    (error as NodeJS.ErrnoException).code === code
+  );
+}

--- a/src/openwiki-home.ts
+++ b/src/openwiki-home.ts
@@ -4,6 +4,7 @@ import path from "node:path";
 import { restrictDirToCurrentUser } from "./windows-acl.js";
 
 export const openWikiHomeDir = path.join(os.homedir(), ".openwiki");
+export const openWikiLocksDir = path.join(openWikiHomeDir, "locks");
 export const openWikiConnectorsDir = path.join(openWikiHomeDir, "connectors");
 export const openWikiLocalWikiDir = path.join(openWikiHomeDir, "wiki");
 export const openWikiSkillsDir = path.join(openWikiHomeDir, "skills");
@@ -32,6 +33,7 @@ export async function ensureOpenWikiHome(): Promise<void> {
   await mkdir(openWikiHomeDir, { recursive: true, mode: 0o700 });
   await chmodIfExists(openWikiHomeDir, 0o700);
   await restrictDirToCurrentUser(openWikiHomeDir);
+  await mkdir(openWikiLocksDir, { recursive: true, mode: 0o700 });
   await mkdir(openWikiConnectorsDir, { recursive: true, mode: 0o700 });
   await mkdir(openWikiLocalWikiDir, { recursive: true, mode: 0o700 });
   await mkdir(openWikiSkillsDir, { recursive: true, mode: 0o700 });

--- a/test/agent-execution-lock.test.ts
+++ b/test/agent-execution-lock.test.ts
@@ -1,0 +1,21 @@
+import { expect, test } from "vitest";
+import { getOpenWikiExecutionLockScope } from "../src/agent/runtime-lock.ts";
+
+test("builds a repository lock scope before the native agent starts", () => {
+  expect(
+    getOpenWikiExecutionLockScope("init", "/workspace/repository", {
+      outputMode: "repository",
+    }),
+  ).toEqual({
+    command: "init",
+    cwd: "/workspace/repository",
+    outputMode: "repository",
+  });
+});
+
+test("uses the shared personal scope when no repository output mode is selected", () => {
+  expect(getOpenWikiExecutionLockScope("chat", "/ignored", {})).toMatchObject({
+    command: "chat",
+    outputMode: "local-wiki",
+  });
+});

--- a/test/constants.test.ts
+++ b/test/constants.test.ts
@@ -84,6 +84,7 @@ describe("normalizeProvider / isValidProvider", () => {
     expect(normalizeProvider("OPENROUTER")).toBe("openrouter");
     expect(normalizeProvider(" Nebius ")).toBe("nebius");
     expect(normalizeProvider(" Gemini-Enterprise ")).toBe("gemini-enterprise");
+    expect(normalizeProvider(" ZAI ")).toBe("zai");
   });
 
   test("returns null for unknown or nullish providers", () => {
@@ -99,6 +100,7 @@ describe("normalizeProvider / isValidProvider", () => {
     expect(isValidProvider("nvidia")).toBe(true);
     expect(isValidProvider("gemini")).toBe(true);
     expect(isValidProvider("gemini-enterprise")).toBe(true);
+    expect(isValidProvider("zai")).toBe(true);
     expect(isValidProvider("nope")).toBe(false);
   });
 });
@@ -117,6 +119,16 @@ describe("resolveConfiguredProvider", () => {
     expect(
       resolveConfiguredProvider({ OPENWIKI_PROVIDER: "gemini-enterprise" }),
     ).toBe("gemini-enterprise");
+  });
+
+  test("honors an explicit Z.AI provider independently of gateway credentials", () => {
+    expect(
+      resolveConfiguredProvider({
+        OPENAI_COMPATIBLE_API_KEY: "gateway-key",
+        OPENROUTER_API_KEY: "router-key",
+        OPENWIKI_PROVIDER: "zai",
+      }),
+    ).toBe("zai");
   });
 
   test("does NOT auto-select gemini from GEMINI_API_KEY alone", () => {
@@ -184,6 +196,9 @@ describe("resolveProviderBaseUrl", () => {
     expect(resolveProviderBaseUrl("nebius", {})).toBe(NEBIUS_BASE_URL);
     expect(resolveProviderBaseUrl("nvidia", {})).toBe(
       "https://integrate.api.nvidia.com/v1",
+    );
+    expect(resolveProviderBaseUrl("zai", {})).toBe(
+      "https://api.z.ai/api/coding/paas/v4",
     );
   });
 
@@ -425,6 +440,20 @@ describe("getMissingProviderEnvKey", () => {
     ).toBeNull();
   });
 
+  test("requires ZAI_API_KEY without falling back to gateway credentials", () => {
+    expect(
+      getMissingProviderEnvKey("zai", {
+        OPENAI_COMPATIBLE_API_KEY: "gateway-key",
+        OPENROUTER_API_KEY: "router-key",
+      }),
+    ).toBe("ZAI_API_KEY");
+    expect(
+      getMissingProviderEnvKey("zai", {
+        ZAI_API_KEY: "zai-key",
+      }),
+    ).toBeNull();
+  });
+
   test("reports the missing GCP project for gemini-enterprise", () => {
     expect(getMissingProviderEnvKey("gemini-enterprise", {})).toBe(
       "GOOGLE_CLOUD_PROJECT",
@@ -595,6 +624,7 @@ describe("getDefaultModelId", () => {
     );
     expect(getDefaultModelId("gemini")).toBe("gemini-3.6-flash");
     expect(getDefaultModelId("gemini-enterprise")).toBe("gemini-3.6-flash");
+    expect(getDefaultModelId("zai")).toBe("glm-5.2");
     expect(getDefaultModelId(DEFAULT_PROVIDER)).toBe(DEFAULT_MODEL_ID);
   });
 

--- a/test/credentials.test.ts
+++ b/test/credentials.test.ts
@@ -31,6 +31,8 @@ const ENV_KEYS = [
   "OPENROUTER_API_KEY",
   "OPENWIKI_MODEL_ID",
   "OPENWIKI_PROVIDER",
+  "ZAI_API_KEY",
+  "ZAI_BASE_URL",
 ] as const;
 
 const originalEnv = new Map<string, string | undefined>(
@@ -232,6 +234,17 @@ describe("orderedSetupSteps", () => {
     // api-key is present even when a key is already set, so navigation can
     // still reach and re-edit it.
     expect(orderedSetupSteps("openai", "code", false)).toContain("api-key");
+  });
+
+  test("Z.AI collects only its key, optional API root, and model", () => {
+    expect(orderedSetupSteps("zai", "code", false)).toEqual([
+      "provider",
+      "api-key",
+      "base-url",
+      "model",
+      "langsmith",
+      "code-repo-confirm",
+    ]);
   });
 });
 

--- a/test/env-behavior.test.ts
+++ b/test/env-behavior.test.ts
@@ -54,6 +54,8 @@ const KEYS_UNDER_TEST = [
   OPENROUTER_API_KEY_ENV_KEY,
   OPENWIKI_MODEL_ID_ENV_KEY,
   OPENWIKI_PROVIDER_ENV_KEY,
+  "ZAI_API_KEY",
+  "ZAI_BASE_URL",
   // Deprecated / recently un-deprecated OpenAI keys. Cleared in each hook so the
   // developer's ambient shell (which may export OPENAI_BASE_URL) cannot leak
   // into these tests, and a loaded value cannot leak back out to other tests.
@@ -327,6 +329,27 @@ describe("getSavedEnvValue", () => {
 });
 
 describe("getCredentialDiagnostics", () => {
+  test("shows only the selected Z.AI credential family and redacts its key", async () => {
+    await env.saveOpenWikiEnv({
+      [OPENROUTER_API_KEY_ENV_KEY]: "router-secret",
+      [OPENWIKI_PROVIDER_ENV_KEY]: "zai",
+      ZAI_API_KEY: "zai-secret",
+      ZAI_BASE_URL: "https://gateway.example/zai",
+    });
+
+    const diagnostics = await env.getCredentialDiagnostics({
+      provider: "zai" as never,
+    });
+    const keys = diagnostics.map((item) => item.key);
+    const zaiKey = diagnostics.find((item) => item.key === "ZAI_API_KEY");
+
+    expect(keys).toContain("ZAI_API_KEY");
+    expect(keys).toContain("ZAI_BASE_URL");
+    expect(keys).not.toContain(OPENROUTER_API_KEY_ENV_KEY);
+    expect(keys).not.toContain(OPENAI_COMPATIBLE_BASE_URL_ENV_KEY);
+    expect(zaiKey?.preview).not.toContain("zai-secret");
+  });
+
   test("includes the provider and each credential key in display order", async () => {
     const diagnostics = await env.getCredentialDiagnostics();
     const keys = diagnostics.map((entry) => entry.key);

--- a/test/execution-lock.test.ts
+++ b/test/execution-lock.test.ts
@@ -1,0 +1,318 @@
+import {
+  lstat,
+  mkdir,
+  mkdtemp,
+  rm,
+  symlink,
+  writeFile,
+} from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { describe, expect, test } from "vitest";
+import {
+  getOpenWikiErrorExitCode,
+  OpenWikiLockError,
+  resolveOpenWikiExecutionLockPaths,
+  withOpenWikiExecutionLock,
+  type ExecutionLockDependencies,
+  type ExecutionLockScope,
+} from "../src/execution-lock.ts";
+
+test("maps malformed lock failures to exit 73", () => {
+  expect(getOpenWikiErrorExitCode(new OpenWikiLockError("bad lock"))).toBe(73);
+  expect(getOpenWikiErrorExitCode(new Error("other error"))).toBe(1);
+});
+
+function repositoryScope(
+  cwd: string,
+  command: "chat" | "init" | "update" = "chat",
+): ExecutionLockScope {
+  return { command, cwd, outputMode: "repository" };
+}
+
+function personalScope(cwd: string): ExecutionLockScope {
+  return { command: "chat", cwd, outputMode: "local-wiki" };
+}
+
+function createDependencies(locksDir: string): ExecutionLockDependencies {
+  return {
+    locksDir,
+    sleep: (delayMs) =>
+      new Promise((resolve) => setTimeout(resolve, Math.min(delayMs, 1))),
+  };
+}
+
+async function waitFor(
+  assertion: () => void,
+  timeoutMs = 2_000,
+): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+
+  while (true) {
+    try {
+      assertion();
+      return;
+    } catch (error) {
+      if (Date.now() >= deadline) {
+        throw error;
+      }
+      await new Promise((resolve) => setTimeout(resolve, 5));
+    }
+  }
+}
+
+describe("withOpenWikiExecutionLock", () => {
+  test("allows separate repositories to enter together", async () => {
+    const root = await mkdtemp(path.join(os.tmpdir(), "openwiki-lock-"));
+    const locksDir = path.join(root, "locks");
+    const repoA = path.join(root, "repo-a");
+    const repoB = path.join(root, "repo-b");
+    const events: string[] = [];
+    let release: (() => void) | undefined;
+    const held = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+
+    try {
+      await Promise.all([mkdir(repoA), mkdir(repoB)]);
+      const dependencies = createDependencies(locksDir);
+      const first = withOpenWikiExecutionLock(
+        repositoryScope(repoA),
+        async () => {
+          events.push("a:start");
+          await held;
+          events.push("a:end");
+        },
+        dependencies,
+      );
+      const second = withOpenWikiExecutionLock(
+        repositoryScope(repoB),
+        async () => {
+          events.push("b:start");
+          await held;
+          events.push("b:end");
+        },
+        dependencies,
+      );
+
+      await waitFor(() => expect(events).toContain("a:start"));
+      await waitFor(() => expect(events).toContain("b:start"));
+      expect(events.slice(0, 2)).toEqual(
+        expect.arrayContaining(["a:start", "b:start"]),
+      );
+      release?.();
+      await Promise.all([first, second]);
+    } finally {
+      await rm(root, { force: true, recursive: true });
+    }
+  });
+
+  test("serializes a physical repository across symlinked paths", async () => {
+    const root = await mkdtemp(path.join(os.tmpdir(), "openwiki-lock-"));
+    const locksDir = path.join(root, "locks");
+    const repo = path.join(root, "repo");
+    const alias = path.join(root, "repo-alias");
+    const events: string[] = [];
+    let releaseFirst: (() => void) | undefined;
+    const firstHeld = new Promise<void>((resolve) => {
+      releaseFirst = resolve;
+    });
+
+    try {
+      await mkdir(repo);
+      await symlink(repo, alias, "dir");
+      const dependencies = createDependencies(locksDir);
+      const first = withOpenWikiExecutionLock(
+        repositoryScope(repo),
+        async () => {
+          events.push("first:start");
+          await firstHeld;
+          events.push("first:end");
+        },
+        dependencies,
+      );
+      await waitFor(() => expect(events).toEqual(["first:start"]));
+
+      const second = withOpenWikiExecutionLock(
+        repositoryScope(alias),
+        () => {
+          events.push("second:start");
+          events.push("second:end");
+          return Promise.resolve();
+        },
+        dependencies,
+      );
+      await new Promise((resolve) => setTimeout(resolve, 20));
+      expect(events).toEqual(["first:start"]);
+
+      releaseFirst?.();
+      await Promise.all([first, second]);
+      expect(events).toEqual([
+        "first:start",
+        "first:end",
+        "second:start",
+        "second:end",
+      ]);
+    } finally {
+      await rm(root, { force: true, recursive: true });
+    }
+  });
+
+  test("serializes personal runs while an unrelated repository can run", async () => {
+    const root = await mkdtemp(path.join(os.tmpdir(), "openwiki-lock-"));
+    const locksDir = path.join(root, "locks");
+    const repo = path.join(root, "repo");
+    const events: string[] = [];
+    let releasePersonal: (() => void) | undefined;
+    const personalHeld = new Promise<void>((resolve) => {
+      releasePersonal = resolve;
+    });
+
+    try {
+      await mkdir(repo);
+      const dependencies = createDependencies(locksDir);
+      const first = withOpenWikiExecutionLock(
+        personalScope(repo),
+        async () => {
+          events.push("personal:first:start");
+          await personalHeld;
+          events.push("personal:first:end");
+        },
+        dependencies,
+      );
+      await waitFor(() => expect(events).toEqual(["personal:first:start"]));
+
+      const second = withOpenWikiExecutionLock(
+        personalScope(repo),
+        () => {
+          events.push("personal:second:start");
+          return Promise.resolve();
+        },
+        dependencies,
+      );
+      const repository = withOpenWikiExecutionLock(
+        repositoryScope(repo),
+        () => {
+          events.push("repository:start");
+          return Promise.resolve();
+        },
+        dependencies,
+      );
+      await waitFor(() => expect(events).toContain("repository:start"));
+      expect(events).not.toContain("personal:second:start");
+
+      releasePersonal?.();
+      await Promise.all([first, second, repository]);
+      expect(events.indexOf("personal:second:start")).toBeGreaterThan(
+        events.indexOf("personal:first:end"),
+      );
+    } finally {
+      await rm(root, { force: true, recursive: true });
+    }
+  });
+
+  test("serializes init shared-home setup without blocking another normal repository", async () => {
+    const root = await mkdtemp(path.join(os.tmpdir(), "openwiki-lock-"));
+    const locksDir = path.join(root, "locks");
+    const repoA = path.join(root, "repo-a");
+    const repoB = path.join(root, "repo-b");
+    const repoC = path.join(root, "repo-c");
+    const events: string[] = [];
+    let releaseFirst: (() => void) | undefined;
+    const firstHeld = new Promise<void>((resolve) => {
+      releaseFirst = resolve;
+    });
+
+    try {
+      await Promise.all([mkdir(repoA), mkdir(repoB), mkdir(repoC)]);
+      const dependencies = createDependencies(locksDir);
+      const firstInit = withOpenWikiExecutionLock(
+        repositoryScope(repoA, "init"),
+        async () => {
+          events.push("init:first:start");
+          await firstHeld;
+          events.push("init:first:end");
+        },
+        dependencies,
+      );
+      await waitFor(() => expect(events).toEqual(["init:first:start"]));
+
+      const normal = withOpenWikiExecutionLock(
+        repositoryScope(repoB),
+        () => {
+          events.push("normal:start");
+          return Promise.resolve();
+        },
+        dependencies,
+      );
+      const secondInit = withOpenWikiExecutionLock(
+        repositoryScope(repoC, "init"),
+        () => {
+          events.push("init:second:start");
+          return Promise.resolve();
+        },
+        dependencies,
+      );
+      await waitFor(() => expect(events).toContain("normal:start"));
+      expect(events).not.toContain("init:second:start");
+
+      releaseFirst?.();
+      await Promise.all([firstInit, normal, secondInit]);
+      expect(events.indexOf("init:second:start")).toBeGreaterThan(
+        events.indexOf("init:first:end"),
+      );
+    } finally {
+      await rm(root, { force: true, recursive: true });
+    }
+  });
+
+  test("recovers a dead PID symlink and rejects malformed or regular-file locks", async () => {
+    const root = await mkdtemp(path.join(os.tmpdir(), "openwiki-lock-"));
+    const locksDir = path.join(root, "locks");
+    const repo = path.join(root, "repo");
+    const dependencies: ExecutionLockDependencies = {
+      ...createDependencies(locksDir),
+      isProcessAlive: () => false,
+    };
+
+    try {
+      await mkdir(repo);
+      const [lockPath] = await resolveOpenWikiExecutionLockPaths(
+        repositoryScope(repo),
+        dependencies,
+      );
+      await mkdir(path.dirname(lockPath), { recursive: true });
+      await symlink("99999999", lockPath);
+
+      await expect(
+        withOpenWikiExecutionLock(
+          repositoryScope(repo),
+          () => Promise.resolve(undefined),
+          dependencies,
+        ),
+      ).resolves.toBeUndefined();
+      await expect(lstat(lockPath)).rejects.toMatchObject({ code: "ENOENT" });
+
+      await writeFile(lockPath, "not a symlink");
+      await expect(
+        withOpenWikiExecutionLock(
+          repositoryScope(repo),
+          () => Promise.resolve(undefined),
+          dependencies,
+        ),
+      ).rejects.toMatchObject({ exitCode: 73 });
+
+      await rm(lockPath);
+      await symlink("not-a-pid", lockPath);
+      await expect(
+        withOpenWikiExecutionLock(
+          repositoryScope(repo),
+          () => Promise.resolve(undefined),
+          dependencies,
+        ),
+      ).rejects.toBeInstanceOf(OpenWikiLockError);
+    } finally {
+      await rm(root, { force: true, recursive: true });
+    }
+  });
+});

--- a/test/skills.test.ts
+++ b/test/skills.test.ts
@@ -9,7 +9,11 @@ import {
 import os from "node:os";
 import path from "node:path";
 import { describe, expect, test } from "vitest";
-import { replaceSkillDirectories } from "../src/agent/skills.ts";
+import { cp } from "node:fs/promises";
+import {
+  createBundledSkillsSynchronizer,
+  replaceSkillDirectories,
+} from "../src/agent/skills.ts";
 
 describe("replaceSkillDirectories", () => {
   test("overwrites bundled skills and preserves unrelated skills", async () => {
@@ -62,5 +66,144 @@ describe("replaceSkillDirectories", () => {
     // The exact degrade marker the post-run validator embeds, kept in sync so
     // the agent can find and repair a degraded fence.
     expect(skill).toContain("openwiki: mermaid parse failed");
+  });
+
+  test("retries a transient copy race and leaves the bundled skill complete", async () => {
+    const root = await mkdtemp(path.join(os.tmpdir(), "openwiki-skills-"));
+    const source = path.join(root, "source");
+    const target = path.join(root, "target");
+    const delays: number[] = [];
+    let shouldRace = true;
+
+    try {
+      await mkdir(path.join(source, "example"), { recursive: true });
+      await mkdir(target);
+      await writeFile(path.join(source, "example", "SKILL.md"), "latest");
+
+      await replaceSkillDirectories(source, target, {
+        copyDirectory: async (from, to) => {
+          if (shouldRace) {
+            shouldRace = false;
+            throw Object.assign(new Error("copy raced"), { code: "EEXIST" });
+          }
+          await cp(from, to, { recursive: true });
+        },
+        sleep: (delayMs) => {
+          delays.push(delayMs);
+          return Promise.resolve();
+        },
+      });
+
+      await expect(
+        readFile(path.join(target, "example", "SKILL.md"), "utf8"),
+      ).resolves.toBe("latest");
+      expect(delays).toEqual([25]);
+    } finally {
+      await rm(root, { force: true, recursive: true });
+    }
+  });
+
+  test("serializes concurrent bundled-skill syncs in one process", async () => {
+    const root = await mkdtemp(path.join(os.tmpdir(), "openwiki-skills-"));
+    const source = path.join(root, "source");
+    const target = path.join(root, "target");
+    const lockPath = path.join(root, "locks", "bundled-skills.lock");
+    const starts: number[] = [];
+    let releaseFirst: (() => void) | undefined;
+    const firstCopyHeld = new Promise<void>((resolve) => {
+      releaseFirst = resolve;
+    });
+
+    try {
+      await mkdir(path.join(source, "example"), { recursive: true });
+      await mkdir(target);
+      await writeFile(path.join(source, "example", "SKILL.md"), "latest");
+      const synchronize = createBundledSkillsSynchronizer(
+        source,
+        target,
+        lockPath,
+        {
+          copyDirectory: async (from, to) => {
+            starts.push(Date.now());
+            if (starts.length === 1) {
+              await firstCopyHeld;
+            }
+            await cp(from, to, { recursive: true });
+          },
+        },
+      );
+
+      const first = synchronize();
+      while (starts.length === 0) {
+        await new Promise((resolve) => setTimeout(resolve, 1));
+      }
+      const second = synchronize();
+      await new Promise((resolve) => setTimeout(resolve, 10));
+      expect(starts).toHaveLength(1);
+
+      releaseFirst?.();
+      await Promise.all([first, second]);
+      expect(starts).toHaveLength(2);
+      await expect(
+        readFile(path.join(target, "example", "SKILL.md"), "utf8"),
+      ).resolves.toBe("latest");
+    } finally {
+      await rm(root, { force: true, recursive: true });
+    }
+  });
+
+  test("serializes separate process synchronizers with the shared PID lock", async () => {
+    const root = await mkdtemp(path.join(os.tmpdir(), "openwiki-skills-"));
+    const source = path.join(root, "source");
+    const target = path.join(root, "target");
+    const lockPath = path.join(root, "locks", "bundled-skills.lock");
+    const starts: string[] = [];
+    let releaseFirst: (() => void) | undefined;
+    const firstCopyHeld = new Promise<void>((resolve) => {
+      releaseFirst = resolve;
+    });
+
+    try {
+      await mkdir(path.join(source, "example"), { recursive: true });
+      await mkdir(target);
+      await writeFile(path.join(source, "example", "SKILL.md"), "latest");
+      const first = createBundledSkillsSynchronizer(source, target, lockPath, {
+        copyDirectory: async (from, to) => {
+          starts.push("first");
+          await firstCopyHeld;
+          await cp(from, to, { recursive: true });
+        },
+        lock: {
+          isProcessAlive: (pid) => pid === 101,
+          processId: 101,
+          sleep: () => Promise.resolve(),
+        },
+      });
+      const second = createBundledSkillsSynchronizer(source, target, lockPath, {
+        copyDirectory: async (from, to) => {
+          starts.push("second");
+          await cp(from, to, { recursive: true });
+        },
+        lock: {
+          isProcessAlive: (pid) => pid === 101,
+          processId: 202,
+          sleep: () => new Promise((resolve) => setTimeout(resolve, 1)),
+        },
+      });
+
+      const firstRun = first();
+      while (!starts.includes("first")) {
+        await new Promise((resolve) => setTimeout(resolve, 1));
+      }
+      const secondRun = second();
+      await new Promise((resolve) => setTimeout(resolve, 10));
+      expect(starts).toEqual(["first"]);
+
+      releaseFirst?.();
+      await Promise.all([firstRun, secondRun]);
+      expect(starts).toEqual(["first", "second"]);
+    } finally {
+      await rm(root, { force: true, recursive: true });
+    }
   });
 });

--- a/test/startup.test.ts
+++ b/test/startup.test.ts
@@ -37,6 +37,7 @@ const MANAGED_ENV_KEYS = [
   BEDROCK_AWS_SECRET_ACCESS_KEY_ENV_KEY,
   OPENWIKI_PROVIDER_ENV_KEY,
   OPENROUTER_API_KEY_ENV_KEY,
+  "ZAI_API_KEY",
   OPENAI_CHATGPT_ACCESS_TOKEN_ENV_KEY,
   OPENAI_CHATGPT_REFRESH_TOKEN_ENV_KEY,
   OPENAI_CHATGPT_EXPIRES_AT_ENV_KEY,
@@ -138,6 +139,23 @@ afterEach(() => {
 });
 
 describe("resolveStartupCommand", () => {
+  test("fails before a provider request when explicit Z.AI credentials are absent", async () => {
+    process.env[OPENWIKI_PROVIDER_ENV_KEY] = "zai";
+    process.env[OPENROUTER_API_KEY_ENV_KEY] = "router-key";
+    delete process.env.ZAI_API_KEY;
+
+    const result = await resolveStartupCommand(
+      updatePrintCommand({ userMessage: "refresh API docs" }),
+      { isStdinTTY: false },
+    );
+
+    expect(result.kind).toBe("error");
+    if (result.kind === "error") {
+      expect(result.message).toContain("ZAI_API_KEY is required");
+      expect(result.message).not.toContain("OPENROUTER_API_KEY");
+    }
+  });
+
   test("fails fast for non-TTY interactive chat without a message", async () => {
     const result = await resolveStartupCommand(
       {

--- a/test/zai-provider.test.ts
+++ b/test/zai-provider.test.ts
@@ -1,0 +1,66 @@
+import { afterEach, describe, expect, test } from "vitest";
+import {
+  createModel,
+  shouldInstallOpenRouterDebugFetch,
+} from "../src/agent/index.ts";
+
+type OpenAiModel = {
+  clientConfig: {
+    apiKey?: string;
+    baseURL?: string;
+    fetch?: unknown;
+  };
+};
+
+const ENV_KEYS = [
+  "OPENAI_COMPATIBLE_API_KEY",
+  "OPENAI_COMPATIBLE_BASE_URL",
+  "OPENROUTER_API_KEY",
+  "ZAI_API_KEY",
+  "ZAI_BASE_URL",
+] as const;
+const originalEnv = new Map(ENV_KEYS.map((key) => [key, process.env[key]]));
+
+afterEach(() => {
+  for (const key of ENV_KEYS) {
+    const value = originalEnv.get(key);
+    if (value === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = value;
+    }
+  }
+});
+
+describe("Z.AI model creation", () => {
+  test("does not route Z.AI through the legacy global OpenRouter debug hook", () => {
+    expect(shouldInstallOpenRouterDebugFetch("zai")).toBe(false);
+    expect(shouldInstallOpenRouterDebugFetch("openrouter")).toBe(true);
+  });
+
+  test("uses ZAI credentials and a provider-local fetch adapter", () => {
+    process.env.ZAI_API_KEY = "zai-test-key";
+    process.env.ZAI_BASE_URL = "https://gateway.example/zai";
+    process.env.OPENROUTER_API_KEY = "router-test-key";
+    process.env.OPENAI_COMPATIBLE_API_KEY = "compatible-test-key";
+
+    const model = createModel("zai", "glm-5.2", 3) as OpenAiModel;
+
+    expect(model.clientConfig.apiKey).toBe("zai-test-key");
+    expect(model.clientConfig.baseURL).toBe("https://gateway.example/zai");
+    expect(typeof model.clientConfig.fetch).toBe("function");
+  });
+
+  test("does not install the Z.AI adapter for OpenAI-compatible clients", () => {
+    process.env.OPENAI_COMPATIBLE_API_KEY = "compatible-test-key";
+    process.env.OPENAI_COMPATIBLE_BASE_URL = "https://gateway.example/v1";
+
+    const model = createModel(
+      "openai-compatible",
+      "gateway-model",
+      3,
+    ) as OpenAiModel;
+
+    expect(model.clientConfig.fetch).toBeUndefined();
+  });
+});

--- a/test/zai-transport.test.ts
+++ b/test/zai-transport.test.ts
@@ -1,0 +1,213 @@
+import { describe, expect, test, vi } from "vitest";
+import {
+  createZaiFetch,
+  normalizeZaiRequestBody,
+  parseZaiRetryAfterMs,
+} from "../src/agent/zai-transport.ts";
+
+const ZAI_COMPLETIONS_URL =
+  "https://api.z.ai/api/coding/paas/v4/chat/completions";
+
+describe("normalizeZaiRequestBody", () => {
+  test("converts only Z.AI file blocks to readable text", () => {
+    const normalized = normalizeZaiRequestBody(
+      JSON.stringify({
+        messages: [
+          {
+            content: [
+              { type: "file", data: "aGVsbG8=" },
+              { type: "file", data: "ordinary text" },
+              { type: "file", data: "text" },
+              {
+                type: "file",
+                data: Buffer.from([0xff, 0xfe, 0xfd]).toString("base64"),
+              },
+              { type: "file", data: "" },
+              { type: "file" },
+              { type: "text", text: "leave this block unchanged" },
+            ],
+          },
+        ],
+      }),
+    );
+
+    expect(JSON.parse(normalized)).toEqual({
+      messages: [
+        {
+          content: [
+            { type: "text", text: "hello" },
+            { type: "text", text: "ordinary text" },
+            { type: "text", text: "text" },
+            { type: "text", text: "[binary file content omitted]" },
+            { type: "text", text: "[file content omitted]" },
+            { type: "text", text: "[file content omitted]" },
+            { type: "text", text: "leave this block unchanged" },
+          ],
+        },
+      ],
+    });
+  });
+
+  test("leaves malformed or unrelated JSON bodies byte-for-byte unchanged", () => {
+    const malformed = '{"messages":';
+    const unrelated = JSON.stringify({ request: { file: "not a message" } });
+
+    expect(normalizeZaiRequestBody(malformed)).toBe(malformed);
+    expect(normalizeZaiRequestBody(unrelated)).toBe(unrelated);
+  });
+});
+
+describe("createZaiFetch", () => {
+  test("normalizes only Z.AI requests and leaves another provider response untouched", async () => {
+    const calls: Array<{ input: RequestInfo | URL; init?: RequestInit }> = [];
+    const fetchImpl = vi.fn((input: RequestInfo | URL, init?: RequestInit) => {
+      calls.push({ input, init });
+      return Promise.resolve(new Response("busy", { status: 429 }));
+    });
+    const sleep = vi.fn(() => Promise.resolve());
+    const fetch = createZaiFetch({
+      env: { ZAI_RATE_LIMIT_MAX_RETRIES: "0" },
+      fetch: fetchImpl,
+      sleep,
+    });
+    const body = JSON.stringify({
+      messages: [{ content: [{ type: "file", data: "aGVsbG8=" }] }],
+    });
+
+    await fetch(ZAI_COMPLETIONS_URL, { body, method: "POST" });
+    await fetch("https://example.test/chat/completions", {
+      body,
+      method: "POST",
+    });
+
+    const firstRequestBody = calls[0]?.init?.body;
+    expect(typeof firstRequestBody).toBe("string");
+    if (typeof firstRequestBody !== "string") {
+      throw new Error("Expected the Z.AI request body to be JSON text.");
+    }
+    expect(firstRequestBody).toContain('"text":"hello"');
+    expect(calls[1]?.init?.body).toBe(body);
+    expect(sleep).not.toHaveBeenCalled();
+  });
+
+  test("normalizes a Z.AI Request body when fetch is called without init", async () => {
+    const fetchImpl = vi.fn(() =>
+      Promise.resolve(new Response("ok", { status: 200 })),
+    );
+    const fetch = createZaiFetch({ fetch: fetchImpl });
+    const request = new Request(ZAI_COMPLETIONS_URL, {
+      body: JSON.stringify({
+        messages: [{ content: [{ type: "file", data: "aGVsbG8=" }] }],
+      }),
+      method: "POST",
+    });
+
+    await fetch(request);
+
+    const forwarded = fetchImpl.mock.calls[0]?.[0];
+    expect(forwarded).toBeInstanceOf(Request);
+    await expect((forwarded as Request).text()).resolves.toContain(
+      '"text":"hello"',
+    );
+  });
+
+  test("uses Retry-After seconds or HTTP dates before exponential fallback", async () => {
+    expect(
+      parseZaiRetryAfterMs(new Headers({ "retry-after": "2" }), () => 0),
+    ).toBe(2_000);
+    expect(
+      parseZaiRetryAfterMs(
+        new Headers({ "retry-after": "Thu, 01 Jan 1970 00:00:03 GMT" }),
+        () => 1_000,
+      ),
+    ).toBe(2_000);
+
+    const sleep = vi.fn(() => Promise.resolve());
+    const responses = [
+      new Response("limited", { status: 429 }),
+      new Response("limited", { status: 429 }),
+      new Response("ok", { status: 200 }),
+    ];
+    const fetch = createZaiFetch({
+      env: {
+        ZAI_RATE_LIMIT_BASE_DELAY_MS: "10",
+        ZAI_RATE_LIMIT_MAX_DELAY_MS: "15",
+        ZAI_RATE_LIMIT_MAX_RETRIES: "2",
+      },
+      fetch: vi.fn(() => Promise.resolve(responses.shift() as Response)),
+      sleep,
+    });
+
+    await expect(fetch(ZAI_COMPLETIONS_URL)).resolves.toMatchObject({
+      status: 200,
+    });
+    expect(sleep.mock.calls.map(([delay]) => delay)).toEqual([10, 15]);
+  });
+
+  test("recreates a Request body for each Z.AI retry", async () => {
+    const requestBodies: string[] = [];
+    const responses = [
+      new Response("limited", { status: 429 }),
+      new Response("ok", { status: 200 }),
+    ];
+    const fetch = createZaiFetch({
+      env: { ZAI_RATE_LIMIT_MAX_RETRIES: "1" },
+      fetch: async (input) => {
+        if (input instanceof Request) {
+          requestBodies.push(await input.text());
+        }
+        return responses.shift() as Response;
+      },
+      sleep: () => Promise.resolve(),
+    });
+    const request = new Request(ZAI_COMPLETIONS_URL, {
+      body: JSON.stringify({
+        messages: [{ content: [{ type: "file", data: "aGVsbG8=" }] }],
+      }),
+      method: "POST",
+    });
+
+    await expect(fetch(request)).resolves.toMatchObject({ status: 200 });
+
+    expect(requestBodies).toEqual([
+      '{"messages":[{"content":[{"type":"text","text":"hello"}]}]}',
+      '{"messages":[{"content":[{"type":"text","text":"hello"}]}]}',
+    ]);
+  });
+
+  test("caps Retry-After, supports disabled retries, and returns the exhausted 429", async () => {
+    const cappedSleep = vi.fn(() => Promise.resolve());
+    const cappedFetch = createZaiFetch({
+      env: {
+        ZAI_RATE_LIMIT_MAX_DELAY_MS: "50",
+        ZAI_RATE_LIMIT_MAX_RETRIES: "1",
+      },
+      fetch: vi
+        .fn()
+        .mockResolvedValueOnce(
+          new Response("limited", {
+            headers: { "retry-after": "1000" },
+            status: 429,
+          }),
+        )
+        .mockResolvedValueOnce(new Response("ok", { status: 200 })),
+      sleep: cappedSleep,
+    });
+
+    await expect(cappedFetch(ZAI_COMPLETIONS_URL)).resolves.toMatchObject({
+      status: 200,
+    });
+    expect(cappedSleep.mock.calls.map(([delay]) => delay)).toEqual([50]);
+
+    const exhausted = new Response("still limited", { status: 429 });
+    const disabledFetch = vi.fn(() => Promise.resolve(exhausted));
+    const disabled = createZaiFetch({
+      env: { ZAI_RATE_LIMIT_MAX_RETRIES: "0" },
+      fetch: disabledFetch,
+      sleep: vi.fn(() => Promise.resolve()),
+    });
+
+    await expect(disabled(ZAI_COMPLETIONS_URL)).resolves.toBe(exhausted);
+    expect(disabledFetch).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
Closes #486

## Context

The current upstream `main` has no native Z.AI provider. This PR adds `zai` as a new, independent first-class provider.

It does **not** convert, rename, alias, or otherwise change the existing `openai-compatible` provider. `openai-compatible` remains the generic gateway integration; Z.AI has its own credentials, defaults, diagnostics, transport behavior, and model creation path.

## Changes

- Add `OPENWIKI_PROVIDER=zai`, `ZAI_API_KEY`, optional `ZAI_BASE_URL`, and the `glm-5.2` default model.
- Add Z.AI onboarding and secret-safe diagnostics that show only Z.AI-relevant settings.
- Use a provider-local Z.AI transport for file-block normalization and 429 retries.
- Keep Z.AI independent from OpenRouter and `openai-compatible`: no credential fallback or request routing through either provider.
- Move wrapper lifecycle safeguards for scoped execution locks and bundled-skill synchronization into OpenWiki.
- Document native Z.AI configuration in the README.

## Validation

- `pnpm typecheck`
- `pnpm format:check`
- `pnpm lint:check`
- `pnpm build`
- Full Vitest coverage was rerun in sharded batches. Under local macOS CPU contention, five existing Gemini/Mermaid tests exceeded their 5s default timeout; each passed when rerun in isolation or with a 30s runner timeout.
- Credential-redacted Z.AI JSON/SSE smoke requests and isolated CLI `code --init` smoke run.

No credentials, generated dependencies, wrapper/preload logic, `node_modules` changes, or global fetch hooks are included.