### PR TITLE
feat: validate openai model availability

### DIFF
--- a/.changeset/smart-cats-validate.md
+++ b/.changeset/smart-cats-validate.md
@@ -2,4 +2,4 @@
 "openwiki": patch
 ---
 
-feat: validate selected OpenAI models against API-key availability before inference
+feat: validate selected openai models against api-key availability before inference

--- a/.changeset/smart-cats-validate.md
+++ b/.changeset/smart-cats-validate.md
@@ -1,0 +1,5 @@
+---
+"openwiki": patch
+---
+
+feat: validate selected OpenAI models against API-key availability before inference

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -41,6 +41,7 @@ import {
   resolveIndexLabels,
 } from "../okf/index-labels.js";
 import { OpenWikiLocalShellBackend } from "./docs-only-backend.js";
+import { getSelectedModelAvailability } from "../model-availability.js";
 import { createOpenWikiIndexMiddleware } from "./okf-middleware.js";
 import {
   createWikiTranslationMiddleware,
@@ -281,6 +282,25 @@ async function resolveRunConfig(
 
     const modelId = resolveModelId(options, provider);
     emitDebug(options, `model=${modelId}`);
+    const modelAvailability = await getSelectedModelAvailability({
+      provider,
+      modelId,
+      apiKey: getProviderApiKey(provider),
+      baseUrl: providerBaseUrl,
+    });
+    if (modelAvailability.status === "unavailable") {
+      throw new Error(
+        `${getProviderLabel(provider)} does not make model "${modelId}" available to the configured credentials. Set ${OPENWIKI_MODEL_ID_ENV_KEY} to an available model.`,
+      );
+    }
+    if (modelAvailability.status === "unknown") {
+      emitDebug(
+        options,
+        `model.availability=unknown${
+          modelAvailability.reason ? ` reason=${modelAvailability.reason}` : ""
+        }`,
+      );
+    }
     const providerRetryAttempts = resolveProviderRetryAttempts();
     emitDebug(options, `provider.retryAttempts=${providerRetryAttempts}`);
 

--- a/src/model-availability.ts
+++ b/src/model-availability.ts
@@ -5,12 +5,12 @@ export type ModelAvailability =
   | { status: "unavailable"; reason: string }
   | { status: "unknown"; reason?: string };
 
-type ModelAvailabilityCheck = {
+interface ModelAvailabilityCheck {
   apiKey?: string;
   baseUrl?: string;
   modelId: string;
   provider: OpenWikiProvider;
-};
+}
 
 type OpenAIModelListResponse = {
   data?: Array<{ id?: unknown }>;

--- a/src/model-availability.ts
+++ b/src/model-availability.ts
@@ -1,0 +1,85 @@
+import type { OpenWikiProvider } from "./config/constants.js";
+
+export type ModelAvailability =
+  | { status: "available" }
+  | { status: "unavailable"; reason: string }
+  | { status: "unknown"; reason?: string };
+
+type ModelAvailabilityCheck = {
+  apiKey?: string;
+  baseUrl?: string;
+  modelId: string;
+  provider: OpenWikiProvider;
+};
+
+type OpenAIModelListResponse = {
+  data?: Array<{ id?: unknown }>;
+};
+
+const OPENAI_API_BASE_URL = "https://api.openai.com/v1";
+
+/**
+ * Checks whether a selected model is exposed to the configured provider
+ * credential. `unknown` deliberately preserves the existing inference path:
+ * a catalogue lookup failure is not proof that a model cannot be invoked.
+ */
+export async function getSelectedModelAvailability(
+  check: ModelAvailabilityCheck,
+  fetchImpl: typeof fetch = globalThis.fetch,
+): Promise<ModelAvailability> {
+  if (check.provider !== "openai") {
+    return {
+      status: "unknown",
+      reason: "No availability adapter is configured.",
+    };
+  }
+
+  if (check.baseUrl !== undefined) {
+    return {
+      status: "unknown",
+      reason: "Custom OpenAI-compatible endpoints are not validated.",
+    };
+  }
+
+  if (!check.apiKey) {
+    return {
+      status: "unknown",
+      reason: "No API key is available for validation.",
+    };
+  }
+
+  try {
+    const response = await fetchImpl(`${OPENAI_API_BASE_URL}/models`, {
+      headers: { Authorization: `Bearer ${check.apiKey}` },
+    });
+
+    if (!response.ok) {
+      return {
+        status: "unknown",
+        reason: `Model availability lookup returned HTTP ${response.status}.`,
+      };
+    }
+
+    const body = (await response.json()) as OpenAIModelListResponse;
+    if (!Array.isArray(body.data)) {
+      return {
+        status: "unknown",
+        reason: "Model availability lookup returned an unexpected response.",
+      };
+    }
+
+    if (body.data.some((model) => model.id === check.modelId)) {
+      return { status: "available" };
+    }
+
+    return {
+      status: "unavailable",
+      reason: "The selected model is not available to this OpenAI API key.",
+    };
+  } catch {
+    return {
+      status: "unknown",
+      reason: "Model availability lookup could not be completed.",
+    };
+  }
+}

--- a/test/model-availability.test.ts
+++ b/test/model-availability.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, test } from "vitest";
+import { getSelectedModelAvailability } from "../src/model-availability.ts";
+
+const OPENAI_CHECK = {
+  apiKey: "test-api-key",
+  modelId: "gpt-test-model",
+  provider: "openai" as const,
+};
+
+describe("getSelectedModelAvailability", () => {
+  test("accepts a selected model returned by the OpenAI Models API", async () => {
+    const result = await getSelectedModelAvailability(OPENAI_CHECK, () =>
+      Promise.resolve(Response.json({ data: [{ id: "gpt-test-model" }] })),
+    );
+
+    expect(result).toEqual({ status: "available" });
+  });
+
+  test("rejects a selected model missing from the OpenAI Models API", async () => {
+    const result = await getSelectedModelAvailability(OPENAI_CHECK, () =>
+      Promise.resolve(Response.json({ data: [{ id: "another-model" }] })),
+    );
+
+    expect(result).toMatchObject({ status: "unavailable" });
+  });
+
+  test("does not block inference when the availability request fails", async () => {
+    const result = await getSelectedModelAvailability(OPENAI_CHECK, () =>
+      Promise.reject(new Error("offline")),
+    );
+
+    expect(result).toMatchObject({ status: "unknown" });
+  });
+
+  test("does not assume a custom endpoint has OpenAI Models API semantics", async () => {
+    const result = await getSelectedModelAvailability(
+      { ...OPENAI_CHECK, baseUrl: "https://gateway.example/v1" },
+      () => Promise.reject(new Error("fetch must not be called")),
+    );
+
+    expect(result).toMatchObject({ status: "unknown" });
+  });
+
+  test("does not validate providers without an availability adapter", async () => {
+    const result = await getSelectedModelAvailability({
+      ...OPENAI_CHECK,
+      provider: "anthropic",
+    });
+
+    expect(result).toMatchObject({ status: "unknown" });
+  });
+});


### PR DESCRIPTION
## Summary

- Validate the selected model against the direct OpenAI Models API before inference starts.
- Stop only when the selected model is authoritatively absent; preserve the existing inference path when the lookup fails or `OPENAI_BASE_URL` points to a custom endpoint.
- Add unit coverage for available, unavailable, lookup-failure, custom-endpoint, and unsupported-provider paths.

## Validation

- `pnpm test` — 58 files, 694 tests passed
- `pnpm typecheck`
- `pnpm lint:check`
- Live GitHub Actions verification: [OpenAI availability contract](https://github.com/jyje/openwiki/actions/runs/30277633642)
  - positive: `gpt-5.6-luna` is available
  - negative: a nonexistent model is unavailable
  - fallback: missing credentials and custom endpoints return `unknown` without blocking inference

The live workflow runs only on a fork-only verification branch. Its repository secret is not part of this PR, its workflow, or its logs.

## Related issue

This is the first provider-specific implementation for #490. Follow-up providers can reuse the same `available` / `unavailable` / `unknown` contract without making a catalogue lookup failure block inference.
