### PR TITLE
feat: validate custom NVIDIA NIM model availability

### DIFF
--- a/.changeset/nvidia-nim-availability-fail-open.md
+++ b/.changeset/nvidia-nim-availability-fail-open.md
@@ -1,0 +1,5 @@
+---
+"openwiki": patch
+---
+
+fix: keep NVIDIA NIM availability validation fail-open on inconclusive catalogue lookups

--- a/.changeset/nvidia-nim-availability.md
+++ b/.changeset/nvidia-nim-availability.md
@@ -1,0 +1,5 @@
+---
+"openwiki": patch
+---
+
+feat: validate selected models against custom NVIDIA NIM endpoints before inference

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -295,6 +295,10 @@ async function resolveRunConfig(
     onProviderResolved(provider);
 
     const providerBaseUrl = resolveProviderBaseUrl(provider);
+    const providerBaseUrlEnvKey = getProviderBaseUrlEnvKey(provider);
+    const providerBaseUrlIsCustom =
+      providerBaseUrlEnvKey !== undefined &&
+      Boolean(process.env[providerBaseUrlEnvKey]?.trim());
     emitDebug(options, `provider=${provider}`);
     if (providerBaseUrl) {
       emitDebug(
@@ -331,6 +335,7 @@ async function resolveRunConfig(
       modelId,
       apiKey: getProviderApiKey(provider),
       baseUrl: providerBaseUrl,
+      baseUrlIsCustom: providerBaseUrlIsCustom,
     });
     if (modelAvailability.status === "unavailable") {
       throw new Error(

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -111,6 +111,7 @@ import {
   OPENWIKI_PROVIDER_ENV_KEY,
   OPENWIKI_PROVIDER_RETRY_ATTEMPTS_ENV_KEY,
   OPENWIKI_STREAM_IDLE_TIMEOUT_ENV_KEY,
+  providerBaseUrlIsCustom,
   providerRequiresBaseUrl,
   providerRequiresRegion,
   providerRequiresSecretKey,
@@ -295,10 +296,7 @@ async function resolveRunConfig(
     onProviderResolved(provider);
 
     const providerBaseUrl = resolveProviderBaseUrl(provider);
-    const providerBaseUrlEnvKey = getProviderBaseUrlEnvKey(provider);
-    const providerBaseUrlIsCustom =
-      providerBaseUrlEnvKey !== undefined &&
-      Boolean(process.env[providerBaseUrlEnvKey]?.trim());
+    const baseUrlIsCustom = providerBaseUrlIsCustom(provider);
     emitDebug(options, `provider=${provider}`);
     if (providerBaseUrl) {
       emitDebug(
@@ -335,11 +333,11 @@ async function resolveRunConfig(
       modelId,
       apiKey: getProviderApiKey(provider),
       baseUrl: providerBaseUrl,
-      baseUrlIsCustom: providerBaseUrlIsCustom,
+      baseUrlIsCustom,
     });
     if (modelAvailability.status === "unavailable") {
       throw new Error(
-        `${getProviderLabel(provider)} does not make model "${modelId}" available to the configured credentials. Set ${OPENWIKI_MODEL_ID_ENV_KEY} to an available model.`,
+        `${getProviderLabel(provider)} does not make model "${modelId}" available. ${modelAvailability.reason} Set ${OPENWIKI_MODEL_ID_ENV_KEY} to an available model.`,
       );
     }
     if (modelAvailability.status === "unknown") {

--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -648,6 +648,38 @@ export function resolveProviderBaseUrl(
   return config.baseURL;
 }
 
+/**
+ * Reports whether the provider points at a user-supplied endpoint rather than
+ * its built-in default. Compares the resolved base URL against
+ * {@link ProviderConfig.baseURL} instead of testing whether the environment
+ * variable is set, so a user who pins the default value explicitly is not
+ * mistaken for a self-hosted deployment.
+ */
+export function providerBaseUrlIsCustom(
+  provider: OpenWikiProvider,
+  env: NodeJS.ProcessEnv = process.env,
+): boolean {
+  const resolved = resolveProviderBaseUrl(provider, env);
+
+  if (!resolved) {
+    return false;
+  }
+
+  const defaultBaseUrl = getProviderConfig(provider).baseURL;
+  if (!defaultBaseUrl) {
+    return true;
+  }
+
+  return (
+    normalizeBaseUrlForComparison(resolved) !==
+    normalizeBaseUrlForComparison(defaultBaseUrl)
+  );
+}
+
+function normalizeBaseUrlForComparison(value: string): string {
+  return value.trim().replace(/\/+$/u, "");
+}
+
 export function getProviderBaseUrlEnvKey(
   provider: OpenWikiProvider,
 ): string | undefined {

--- a/src/model-availability.ts
+++ b/src/model-availability.ts
@@ -20,6 +20,13 @@ type ModelListResponse = {
 const OPENAI_API_BASE_URL = "https://api.openai.com/v1";
 
 /**
+ * Wall-clock cap on the catalogue lookup. This runs before inference on an
+ * endpoint the user controls, so an unresponsive host must not stall the run:
+ * the abort surfaces as `unknown` and inference proceeds.
+ */
+const AVAILABILITY_LOOKUP_TIMEOUT_MS = 5_000;
+
+/**
  * Checks whether a selected model is exposed to the configured provider
  * credential. `unknown` deliberately preserves the existing inference path:
  * a catalogue lookup failure is not proof that a model cannot be invoked.
@@ -40,14 +47,16 @@ export async function getSelectedModelAvailability(
   }
 
   if (check.provider === "nvidia") {
-    if (!check.baseUrlIsCustom || !check.baseUrl) {
+    const baseUrl = check.baseUrl;
+
+    if (!check.baseUrlIsCustom || !baseUrl) {
       return {
         status: "unknown",
         reason: "The NVIDIA hosted endpoint is not validated.",
       };
     }
 
-    return checkNvidiaNimModelAvailability(check, fetchImpl);
+    return checkNvidiaNimModelAvailability(check, baseUrl, fetchImpl);
   }
 
   return {
@@ -71,12 +80,19 @@ async function checkOpenAIModelAvailability(
 
 async function checkNvidiaNimModelAvailability(
   check: ModelAvailabilityCheck,
+  baseUrl: string,
   fetchImpl: typeof fetch,
 ): Promise<ModelAvailability> {
-  const endpoint = new URL(
-    "models",
-    ensureTrailingSlash(check.baseUrl!),
-  ).toString();
+  let endpoint: string;
+
+  try {
+    endpoint = resolveModelListEndpoint(baseUrl);
+  } catch {
+    return {
+      status: "unknown",
+      reason: "The configured base URL could not be resolved to a catalogue.",
+    };
+  }
 
   return checkModelListAvailability({
     apiKey: check.apiKey,
@@ -110,6 +126,7 @@ async function checkModelListAvailability({
   try {
     const response = await fetchImpl(endpoint, {
       headers: { Authorization: `Bearer ${apiKey}` },
+      signal: AbortSignal.timeout(AVAILABILITY_LOOKUP_TIMEOUT_MS),
     });
 
     if (!response.ok) {
@@ -124,6 +141,15 @@ async function checkModelListAvailability({
       return {
         status: "unknown",
         reason: "Model availability lookup returned an unexpected response.",
+      };
+    }
+
+    if (body.data.length === 0) {
+      // A gateway that hides its catalogue from a key without list scope still
+      // serves inference, so an empty listing is no evidence of unavailability.
+      return {
+        status: "unknown",
+        reason: "Model availability lookup returned an empty catalogue.",
       };
     }
 
@@ -143,6 +169,16 @@ async function checkModelListAvailability({
   }
 }
 
-function ensureTrailingSlash(value: string): string {
-  return value.endsWith("/") ? value : `${value}/`;
+/**
+ * Appends `/models` to the API root's path. Building the URL from `pathname`
+ * rather than resolving a relative reference keeps a base URL that carries a
+ * query string or fragment from losing its last path segment.
+ */
+function resolveModelListEndpoint(baseUrl: string): string {
+  const url = new URL(baseUrl.trim());
+
+  url.pathname = `${url.pathname.replace(/\/+$/u, "")}/models`;
+  url.hash = "";
+
+  return url.toString();
 }

--- a/src/model-availability.ts
+++ b/src/model-availability.ts
@@ -8,11 +8,12 @@ export type ModelAvailability =
 interface ModelAvailabilityCheck {
   apiKey?: string;
   baseUrl?: string;
+  baseUrlIsCustom?: boolean;
   modelId: string;
   provider: OpenWikiProvider;
 }
 
-type OpenAIModelListResponse = {
+type ModelListResponse = {
   data?: Array<{ id?: unknown }>;
 };
 
@@ -27,21 +28,79 @@ export async function getSelectedModelAvailability(
   check: ModelAvailabilityCheck,
   fetchImpl: typeof fetch = globalThis.fetch,
 ): Promise<ModelAvailability> {
-  if (check.provider !== "openai") {
-    return {
-      status: "unknown",
-      reason: "No availability adapter is configured.",
-    };
+  if (check.provider === "openai") {
+    if (check.baseUrl !== undefined) {
+      return {
+        status: "unknown",
+        reason: "Custom OpenAI-compatible endpoints are not validated.",
+      };
+    }
+
+    return checkOpenAIModelAvailability(check, fetchImpl);
   }
 
-  if (check.baseUrl !== undefined) {
-    return {
-      status: "unknown",
-      reason: "Custom OpenAI-compatible endpoints are not validated.",
-    };
+  if (check.provider === "nvidia") {
+    if (!check.baseUrlIsCustom || !check.baseUrl) {
+      return {
+        status: "unknown",
+        reason: "The NVIDIA hosted endpoint is not validated.",
+      };
+    }
+
+    return checkNvidiaNimModelAvailability(check, fetchImpl);
   }
 
-  if (!check.apiKey) {
+  return {
+    status: "unknown",
+    reason: "No availability adapter is configured.",
+  };
+}
+
+async function checkOpenAIModelAvailability(
+  check: ModelAvailabilityCheck,
+  fetchImpl: typeof fetch,
+): Promise<ModelAvailability> {
+  return checkModelListAvailability({
+    apiKey: check.apiKey,
+    endpoint: `${OPENAI_API_BASE_URL}/models`,
+    fetchImpl,
+    modelId: check.modelId,
+    providerLabel: "OpenAI",
+  });
+}
+
+async function checkNvidiaNimModelAvailability(
+  check: ModelAvailabilityCheck,
+  fetchImpl: typeof fetch,
+): Promise<ModelAvailability> {
+  const endpoint = new URL(
+    "models",
+    ensureTrailingSlash(check.baseUrl!),
+  ).toString();
+
+  return checkModelListAvailability({
+    apiKey: check.apiKey,
+    endpoint,
+    fetchImpl,
+    modelId: check.modelId,
+    providerLabel: "NVIDIA NIM",
+  });
+}
+
+async function checkModelListAvailability({
+  apiKey,
+  endpoint,
+  fetchImpl,
+  modelId,
+  providerLabel,
+}: {
+  apiKey?: string;
+  endpoint: string;
+  fetchImpl: typeof fetch;
+  modelId: string;
+  providerLabel: string;
+}): Promise<ModelAvailability> {
+  if (!apiKey) {
     return {
       status: "unknown",
       reason: "No API key is available for validation.",
@@ -49,8 +108,8 @@ export async function getSelectedModelAvailability(
   }
 
   try {
-    const response = await fetchImpl(`${OPENAI_API_BASE_URL}/models`, {
-      headers: { Authorization: `Bearer ${check.apiKey}` },
+    const response = await fetchImpl(endpoint, {
+      headers: { Authorization: `Bearer ${apiKey}` },
     });
 
     if (!response.ok) {
@@ -60,7 +119,7 @@ export async function getSelectedModelAvailability(
       };
     }
 
-    const body = (await response.json()) as OpenAIModelListResponse;
+    const body = (await response.json()) as ModelListResponse;
     if (!Array.isArray(body.data)) {
       return {
         status: "unknown",
@@ -68,13 +127,13 @@ export async function getSelectedModelAvailability(
       };
     }
 
-    if (body.data.some((model) => model.id === check.modelId)) {
+    if (body.data.some((model) => model.id === modelId)) {
       return { status: "available" };
     }
 
     return {
       status: "unavailable",
-      reason: "The selected model is not available to this OpenAI API key.",
+      reason: `The selected model is not available through this ${providerLabel} endpoint.`,
     };
   } catch {
     return {
@@ -82,4 +141,8 @@ export async function getSelectedModelAvailability(
       reason: "Model availability lookup could not be completed.",
     };
   }
+}
+
+function ensureTrailingSlash(value: string): string {
+  return value.endsWith("/") ? value : `${value}/`;
 }

--- a/test/config/constants.test.ts
+++ b/test/config/constants.test.ts
@@ -25,6 +25,8 @@ import {
   NVIDIA_BASE_URL_ENV_KEY,
   normalizeModelId,
   normalizeProvider,
+  OPENAI_BASE_URL_ENV_KEY,
+  providerBaseUrlIsCustom,
   providerRequiresApiKey,
   providerRequiresRegion,
   providerRequiresSecretKey,
@@ -264,6 +266,50 @@ describe("resolveProviderBaseUrl", () => {
 
   test("returns undefined for a provider with no default and no override", () => {
     expect(resolveProviderBaseUrl("openai", {})).toBeUndefined();
+  });
+});
+
+describe("providerBaseUrlIsCustom", () => {
+  test("is false when the provider falls back to its built-in default", () => {
+    expect(providerBaseUrlIsCustom("nvidia", {})).toBe(false);
+    expect(providerBaseUrlIsCustom("openai", {})).toBe(false);
+  });
+
+  test("is false when the override restates the built-in default", () => {
+    // Copying the documented endpoint into the env var is not a self-hosted
+    // deployment, so it must not make the hosted catalogue authoritative.
+    expect(
+      providerBaseUrlIsCustom("nvidia", {
+        [NVIDIA_BASE_URL_ENV_KEY]: "https://integrate.api.nvidia.com/v1",
+      }),
+    ).toBe(false);
+    expect(
+      providerBaseUrlIsCustom("nvidia", {
+        [NVIDIA_BASE_URL_ENV_KEY]: " https://integrate.api.nvidia.com/v1/ ",
+      }),
+    ).toBe(false);
+  });
+
+  test("is true for an endpoint that differs from the built-in default", () => {
+    expect(
+      providerBaseUrlIsCustom("nvidia", {
+        [NVIDIA_BASE_URL_ENV_KEY]: "https://nim.internal/v1",
+      }),
+    ).toBe(true);
+  });
+
+  test("is true for a provider with no default once an override is set", () => {
+    expect(
+      providerBaseUrlIsCustom("openai", {
+        [OPENAI_BASE_URL_ENV_KEY]: "https://gateway.example/openai/v1",
+      }),
+    ).toBe(true);
+  });
+
+  test("ignores a whitespace-only override", () => {
+    expect(
+      providerBaseUrlIsCustom("nvidia", { [NVIDIA_BASE_URL_ENV_KEY]: "   " }),
+    ).toBe(false);
   });
 });
 

--- a/test/model-availability.test.ts
+++ b/test/model-availability.test.ts
@@ -112,4 +112,55 @@ describe("getSelectedModelAvailability", () => {
 
     expect(result).toMatchObject({ status: "unknown" });
   });
+
+  test("does not block when a custom NVIDIA NIM endpoint hides its catalogue", async () => {
+    const result = await getSelectedModelAvailability(NVIDIA_NIM_CHECK, () =>
+      Promise.resolve(Response.json({ object: "list", data: [] })),
+    );
+
+    expect(result).toMatchObject({ status: "unknown" });
+  });
+
+  test("keeps the API root path when the base URL carries a query string", async () => {
+    const result = await getSelectedModelAvailability(
+      { ...NVIDIA_NIM_CHECK, baseUrl: "https://nim.example/v1?api-version=1" },
+      (input) => {
+        expect(input).toBe("https://nim.example/v1/models?api-version=1");
+        return Promise.resolve(
+          Response.json({ data: [{ id: "nvidia/nemotron-test" }] }),
+        );
+      },
+    );
+
+    expect(result).toEqual({ status: "available" });
+  });
+
+  test("bounds a custom NVIDIA NIM lookup with an abort signal", async () => {
+    let signal: AbortSignal | undefined;
+
+    const result = await getSelectedModelAvailability(
+      NVIDIA_NIM_CHECK,
+      (_input, init) => {
+        signal = init?.signal ?? undefined;
+
+        return Promise.resolve(
+          Response.json({ data: [{ id: "nvidia/nemotron-test" }] }),
+        );
+      },
+    );
+
+    expect(result).toEqual({ status: "available" });
+    expect(signal).toBeInstanceOf(AbortSignal);
+    expect(signal?.aborted).toBe(false);
+  });
+
+  test("treats an aborted lookup as non-blocking", async () => {
+    const result = await getSelectedModelAvailability(NVIDIA_NIM_CHECK, () =>
+      Promise.reject(
+        new DOMException("The operation was aborted.", "TimeoutError"),
+      ),
+    );
+
+    expect(result).toMatchObject({ status: "unknown" });
+  });
 });

--- a/test/model-availability.test.ts
+++ b/test/model-availability.test.ts
@@ -7,6 +7,14 @@ const OPENAI_CHECK = {
   provider: "openai" as const,
 };
 
+const NVIDIA_NIM_CHECK = {
+  apiKey: "test-api-key",
+  baseUrl: "https://nim.example/v1",
+  baseUrlIsCustom: true,
+  modelId: "nvidia/nemotron-test",
+  provider: "nvidia" as const,
+};
+
 describe("getSelectedModelAvailability", () => {
   test("accepts a selected model returned by the OpenAI Models API", async () => {
     const result = await getSelectedModelAvailability(OPENAI_CHECK, () =>
@@ -46,6 +54,61 @@ describe("getSelectedModelAvailability", () => {
       ...OPENAI_CHECK,
       provider: "anthropic",
     });
+
+    expect(result).toMatchObject({ status: "unknown" });
+  });
+
+  test("accepts a model loaded by a custom NVIDIA NIM endpoint", async () => {
+    const result = await getSelectedModelAvailability(
+      NVIDIA_NIM_CHECK,
+      (input, init) => {
+        expect(input).toBe("https://nim.example/v1/models");
+        expect(new Headers(init?.headers).get("Authorization")).toBe(
+          "Bearer test-api-key",
+        );
+        return Promise.resolve(
+          Response.json({ data: [{ id: "nvidia/nemotron-test" }] }),
+        );
+      },
+    );
+
+    expect(result).toEqual({ status: "available" });
+  });
+
+  test("rejects a model absent from a custom NVIDIA NIM endpoint", async () => {
+    const result = await getSelectedModelAvailability(NVIDIA_NIM_CHECK, () =>
+      Promise.resolve(Response.json({ data: [{ id: "another-model" }] })),
+    );
+
+    expect(result).toMatchObject({ status: "unavailable" });
+  });
+
+  test("does not block custom NVIDIA NIM when no API key is available", async () => {
+    const result = await getSelectedModelAvailability(
+      { ...NVIDIA_NIM_CHECK, apiKey: undefined },
+      () => Promise.reject(new Error("fetch must not be called")),
+    );
+
+    expect(result).toMatchObject({ status: "unknown" });
+  });
+
+  test("does not block custom NVIDIA NIM when lookup fails", async () => {
+    const result = await getSelectedModelAvailability(NVIDIA_NIM_CHECK, () =>
+      Promise.reject(new Error("offline")),
+    );
+
+    expect(result).toMatchObject({ status: "unknown" });
+  });
+
+  test("does not assume the NVIDIA hosted endpoint exposes entitlement data", async () => {
+    const result = await getSelectedModelAvailability(
+      {
+        ...NVIDIA_NIM_CHECK,
+        baseUrl: "https://integrate.api.nvidia.com/v1",
+        baseUrlIsCustom: false,
+      },
+      () => Promise.reject(new Error("fetch must not be called")),
+    );
 
     expect(result).toMatchObject({ status: "unknown" });
   });


### PR DESCRIPTION
## Summary

- Validate selected models against a custom `NVIDIA_BASE_URL` NIM-compatible endpoint before inference starts.
- Treat a model missing from that endpoint's `/models` response as unavailable.
- Preserve inference when credentials are missing, the lookup fails, or the default NVIDIA hosted endpoint is used.

## Why

A custom NVIDIA NIM deployment exposes the models actually loaded by that endpoint. Checking its model catalogue before inference gives users an actionable error instead of waiting for the first inference request to fail.

The default NVIDIA hosted endpoint remains non-authoritative for this check, so its catalogue cannot block inference without stronger entitlement guarantees.

## Validation

- `pnpm run format:check`
- `pnpm run lint:check`
- `pnpm test`
  - 174 test files passed, 2 skipped
  - 2,330 tests passed, 3 skipped
- Fresh live GitHub Actions verification after conflict resolution: [NVIDIA availability contract](https://github.com/jyje/openwiki/actions/runs/31713023196)
  - verified PR head: `d94ed3cd78dcd74ac2d290b9db97a796917fcc2c`
  - 2 cases queried the live NVIDIA `/v1/models` endpoint
  - 3 cases deterministically verified non-blocking fallback behavior

### Live verification cases

| Case | Input | Network behavior | Expected output | Actual output |
| --- | --- | --- | --- | --- |
| Positive | model=`nvidia/nemotron-3-super-120b-a12b`, credential present, `baseUrlIsCustom=true` | Live `GET https://integrate.api.nvidia.com/v1/models` | `{ status: "available" }` | `available` |
| Negative | model=`openwiki-live-verification-nonexistent-model`, credential present, `baseUrlIsCustom=true` | Live `GET https://integrate.api.nvidia.com/v1/models` | `{ status: "unavailable" }` | `unavailable` |
| No credential | selected model, no API key, `baseUrlIsCustom=true` | No request | `{ status: "unknown" }` | `unknown` |
| Hosted default | selected model, placeholder key, `baseUrlIsCustom=false` | Fetch was configured to fail if called, proving no request was made | `{ status: "unknown" }` | `unknown` |
| Lookup failure | selected model, placeholder key, `baseUrlIsCustom=true` | Injected fetch rejects with `Error("offline")` | `{ status: "unknown" }` | `unknown` |

The positive and negative cases intentionally mark the reachable NVIDIA service as NIM-compatible to exercise the custom-endpoint adapter. Production use of the built-in hosted endpoint sets `baseUrlIsCustom=false`; the hosted-default case verifies that this path remains non-authoritative and does not issue a catalogue request.

Quoted directly from the successful Actions log:

```text
pr_head_sha=d94ed3cd78dcd74ac2d290b9db97a796917fcc2c
verification_sha=167804f283f08bddcb31c2a65f0f047233e75d5f
provider=nvidia
endpoint_mode=custom-nim-compatible
selected_model=nvidia/nemotron-3-super-120b-a12b
credential_present=true
case=positive provider=nvidia model=nvidia/nemotron-3-super-120b-a12b status=available
case=negative provider=nvidia model=openwiki-live-verification-nonexistent-model status=unavailable
case=no-credential provider=nvidia status=unknown
case=hosted-default provider=nvidia status=unknown
case=lookup-failure provider=nvidia status=unknown
Test Files 1 passed (1)
Tests 5 passed (5)
```

### Reviewer reproduction

From a checkout of this PR branch, install dependencies and run the focused offline suite:

```bash
pnpm install --frozen-lockfile
pnpm vitest run test/model-availability.test.ts --reporter=verbose
```

To exercise the behavior against a custom NVIDIA NIM deployment, configure the provider with the API root that exposes `/models`:

```bash
export OPENWIKI_PROVIDER=nvidia
export NVIDIA_API_KEY="<your-NIM-api-key>"
export NVIDIA_BASE_URL="https://<your-NIM-host>/v1"

# Pick an ID returned by the same endpoint.
export OPENWIKI_MODEL_ID="<served-model-id>"

curl -fsS "${NVIDIA_BASE_URL%/}/models" \
  -H "Authorization: Bearer ${NVIDIA_API_KEY}"

pnpm dev -- --debug -p "Reply with OK."
```

Expected positive behavior: the selected model appears in `data[].id`, availability resolves to `available`, and the run proceeds to inference.

To verify the early unavailable-model error:

```bash
OPENWIKI_MODEL_ID="openwiki-review-nonexistent-model" \
  pnpm dev -- --debug -p "This request should not reach inference."
```

Expected negative behavior: OpenWiki stops before inference and reports that NVIDIA NIM does not make the selected model available. If the catalogue request cannot be completed, validation returns `unknown` and preserves the existing inference path.

The temporary live-verification workflow and test file are not included in this PR branch.

## Related issue

This is the NVIDIA provider follow-up for #490 and reuses the shared availability contract introduced in #491.

Feedback is very welcome - please feel free to suggest changes or point out anything I may have missed.