### PR TITLE
fix: skip telemetry for local OpenWiki runs

### DIFF
--- a/README.md
+++ b/README.md
@@ -502,8 +502,9 @@ If there's an inference provider or model you'd like to see added, please open a
 
 ## Telemetry
 
-OpenWiki collects anonymous, aggregate usage data so we can understand how the
-tool is used and improve it. Telemetry is on by default and easy to turn off.
+OpenWiki collects anonymous, aggregate usage data from the published CLI so we
+can understand how the tool is used and improve it. Telemetry is on by default
+for published builds and easy to turn off.
 
 **What is collected**, on a single `openwiki_run` event, keyed by a random
 install ID stored locally in `~/.openwiki/install-id`:
@@ -522,12 +523,14 @@ information. Geoip enrichment is disabled and your IP is never stored. Events
 are grouped by your random install ID so we can measure repeat usage, but that
 ID contains no personal data.
 
-**Scheduled/CI runs** are collected as anonymous reliability data (tagged so
-they can be told apart from human runs), under a shared CI identifier rather than
-a per-machine install ID, and never counted as distinct installs. To disable in
-CI, set `OPENWIKI_TELEMETRY_DISABLED=1` in your workflow environment.
+**Scheduled/CI runs** from published builds are collected as anonymous
+reliability data (tagged so they can be told apart from human runs), under a
+shared CI identifier rather than a per-machine install ID, and never counted as
+distinct installs. To disable in CI, set `OPENWIKI_TELEMETRY_DISABLED=1` in your
+workflow environment.
 
-To see exactly what a run would send, add `--telemetry-file=<path>` to any run.
+**Local development/source runs** are not sent. To see exactly what a published
+run would send, add `--telemetry-file=<path>` to any run.
 
 ### Opting out
 

--- a/src/telemetry/senders.ts
+++ b/src/telemetry/senders.ts
@@ -96,10 +96,27 @@ export async function recordRun(details: RunTelemetry): Promise<void> {
 
   try {
     const ci = isCiEnvironment();
+    const production = isProductionBuild();
+    if (!production) {
+      const event = buildRunEvent(details, {
+        ci,
+        production,
+        distinctId: "local-dev",
+      });
+      await writeTelemetryFile(details.telemetryFile, {
+        disabled: false,
+        ci,
+        localDev: true,
+        sent: false,
+        event,
+      });
+      return;
+    }
+
     const distinctId = ci ? ciSentinelId() : (await getOrCreateInstallId()).id;
     const event = buildRunEvent(details, {
       ci,
-      production: isProductionBuild(),
+      production,
       distinctId,
     });
     const sent = await capture(event);

--- a/test/telemetry.test.ts
+++ b/test/telemetry.test.ts
@@ -31,7 +31,7 @@ import {
   isTelemetryDisabled,
   noticeSuppressed,
 } from "../src/telemetry/gates.ts";
-import { recordRun } from "../src/telemetry/senders.ts";
+import { buildRunEvent, recordRun } from "../src/telemetry/senders.ts";
 import type { RunTelemetry } from "../src/telemetry/types.ts";
 
 const ENV_KEYS = [
@@ -209,30 +209,36 @@ describe("senders.recordRun", () => {
     await rm(file, { force: true });
   });
 
-  test("human run uses the install id, ci=false, profile off", async () => {
+  test("source run sends nothing and tees a local-dev marker", async () => {
     const file = path.join(tmpdir(), "ow-tel-normal.json");
 
     await recordRun(runDetails({ telemetryFile: file }));
 
     const tee = (await readTee(file)) as {
       ci: boolean;
+      localDev: boolean;
       sent: boolean;
       event: {
         distinctId: string;
-        properties: { ci: boolean; $process_person_profile: boolean };
+        properties: {
+          ci: boolean;
+          production: boolean;
+          $process_person_profile: boolean;
+        };
       };
     };
     expect(tee.ci).toBe(false);
-    expect(tee.sent).toBe(true);
-    expect(tee.event.distinctId).toMatch(/^[0-9a-f-]{36}$/i);
+    expect(tee.localDev).toBe(true);
+    expect(tee.sent).toBe(false);
+    expect(tee.event.distinctId).toBe("local-dev");
     expect(tee.event.properties.ci).toBe(false);
-    // Every run is anonymous: no person profile is ever created.
+    expect(tee.event.properties.production).toBe(false);
     expect(tee.event.properties.$process_person_profile).toBe(false);
-    expect(posthog.captureImmediate).toHaveBeenCalledOnce();
+    expect(posthog.captureImmediate).not.toHaveBeenCalled();
     await rm(file, { force: true });
   });
 
-  test("CI run uses the sentinel id, ci=true, profile off", async () => {
+  test("source CI run also sends nothing", async () => {
     process.env.OPENWIKI_SCHEDULED = "1";
     const file = path.join(tmpdir(), "ow-tel-ci.json");
 
@@ -240,16 +246,20 @@ describe("senders.recordRun", () => {
 
     const tee = (await readTee(file)) as {
       ci: boolean;
+      localDev: boolean;
+      sent: boolean;
       event: {
         distinctId: string;
         properties: { ci: boolean; $process_person_profile: boolean };
       };
     };
     expect(tee.ci).toBe(true);
-    expect(tee.event.distinctId).toBe("ci-unknown");
+    expect(tee.localDev).toBe(true);
+    expect(tee.sent).toBe(false);
+    expect(tee.event.distinctId).toBe("local-dev");
     expect(tee.event.properties.ci).toBe(true);
-    // CI stays anonymous (no person profile).
     expect(tee.event.properties.$process_person_profile).toBe(false);
+    expect(posthog.captureImmediate).not.toHaveBeenCalled();
     await rm(file, { force: true });
   });
 
@@ -274,20 +284,23 @@ describe("getConfiguredConnectorIds", () => {
   });
 });
 
-describe("recordRun connector properties", () => {
-  function runEvent(): { event: string; properties: Record<string, unknown> } {
-    return posthog.captureImmediate.mock.calls[0]?.[0] as {
-      event: string;
-      properties: Record<string, unknown>;
-    };
+describe("buildRunEvent connector properties", () => {
+  function runEvent(details: RunTelemetry): {
+    event: string;
+    properties: Record<string, unknown>;
+  } {
+    return buildRunEvent(details, {
+      ci: false,
+      production: true,
+      distinctId: "id-1",
+    });
   }
 
-  test("configured connectors become boolean connector_<id> properties", async () => {
-    await recordRun(
+  test("configured connectors become boolean connector_<id> properties", () => {
+    const arg = runEvent(
       runDetails({ configuredConnectors: ["web-search", "notion"] }),
     );
 
-    const arg = runEvent();
     expect(arg.event).toBe("openwiki_run");
     // Hyphens are normalized to underscores; only configured ones appear.
     expect(arg.properties).toMatchObject({
@@ -297,29 +310,32 @@ describe("recordRun connector properties", () => {
     expect(arg.properties).not.toHaveProperty("connector_slack");
   });
 
-  test("no connector_ properties when nothing is configured", async () => {
-    await recordRun(runDetails({ configuredConnectors: [] }));
+  test("no connector_ properties when nothing is configured", () => {
+    const props = runEvent(runDetails({ configuredConnectors: [] })).properties;
 
-    const props = runEvent().properties;
     expect(Object.keys(props).some((key) => key.startsWith("connector_"))).toBe(
       false,
     );
   });
 
-  test("stamps production=false when running from source (dev/test)", async () => {
-    // Tests import from src/, so isProductionBuild() (dist/ check) is false;
-    // the published build runs from dist/ and would send production=true.
-    await recordRun(runDetails());
+  test("stamps production from the supplied context", () => {
+    const event = buildRunEvent(runDetails(), {
+      ci: false,
+      production: false,
+      distinctId: "id-1",
+    });
 
-    expect(runEvent().properties.production).toBe(false);
+    expect(event.properties.production).toBe(false);
   });
 
-  test("update runs omit the init-only setup fields", async () => {
+  test("update runs omit the init-only setup fields", () => {
     // The agent only sets mode/provider/connectors on init; an update payload
     // built without them must not carry mode/provider/connector_ properties.
-    await recordRun({ command: "update", outcome: "success" });
+    const props = runEvent({
+      command: "update",
+      outcome: "success",
+    }).properties;
 
-    const props = runEvent().properties;
     expect(props).not.toHaveProperty("mode");
     expect(props).not.toHaveProperty("provider");
     expect(Object.keys(props).some((key) => key.startsWith("connector_"))).toBe(


### PR DESCRIPTION
## Description
OpenWiki source/dev runs were only tagged as non-production, but still attempted to send PostHog telemetry. This skips sending outside the compiled published build while preserving `--telemetry-file` output for inspection.

## Test Plan
- [x] `pnpm exec vitest run --no-color test/telemetry.test.ts`
- [x] `pnpm run typecheck`
- [x] `pnpm exec eslint src/telemetry/senders.ts test/telemetry.test.ts`

Made by [Open SWE](https://openswe.vercel.app/agents/5562ff24-a3e9-8baf-2e83-314bef5fed9d)