### PR TITLE
chore: pin github actions to immutable commit SHAs

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Set up pnpm
         uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
@@ -22,7 +22,7 @@ jobs:
           run_install: false
 
       - name: Set up Node.js
-        uses: actions/setup-node@v7
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           node-version: "22"
           cache: pnpm
@@ -38,7 +38,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Set up pnpm
         uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
@@ -46,7 +46,7 @@ jobs:
           run_install: false
 
       - name: Set up Node.js
-        uses: actions/setup-node@v7
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           node-version: "22"
           cache: pnpm
@@ -70,7 +70,7 @@ jobs:
             node-version: "24"
     steps:
       - name: Check out repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Set up pnpm
         uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
@@ -78,7 +78,7 @@ jobs:
           run_install: false
 
       - name: Set up Node.js
-        uses: actions/setup-node@v7
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           node-version: ${{ matrix.node-version }}
           cache: pnpm
@@ -105,7 +105,7 @@ jobs:
         node-version: ["22", "24"]
     steps:
       - name: Check out repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Set up pnpm
         uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
@@ -113,7 +113,7 @@ jobs:
           run_install: false
 
       - name: Set up Node.js
-        uses: actions/setup-node@v7
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           node-version: ${{ matrix.node-version }}
           cache: pnpm
@@ -132,7 +132,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       # `pnpm audit` calls npm's retired quick-audit endpoint (HTTP 410), so we
       # scan the lockfile with Trivy instead. `severity: HIGH,CRITICAL` +
@@ -156,6 +156,6 @@ jobs:
       # `exit-code: 1` above, which runs regardless.
       - name: Upload Trivy results to GitHub Security
         if: always() && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false)
-        uses: github/codeql-action/upload-sarif@v4
+        uses: github/codeql-action/upload-sarif@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4
         with:
           sarif_file: trivy-results.sarif


### PR DESCRIPTION
## Summary

Follow-up to #468. Corridor flagged that the CI workflow references first-party GitHub Actions via **mutable major tags** instead of immutable commit SHAs. This PR pins them, closing a supply-chain gap across every job.

Before this change, `.github/workflows/checks.yml` used:

- `actions/checkout@v7`
- `actions/setup-node@v7`
- `github/codeql-action/upload-sarif@v4`

while `pnpm/action-setup` and `aquasecurity/trivy-action` were **already** SHA-pinned. The mutable tags were an inconsistency with the project's own convention: if an attacker gained write access to one of those action repos and retagged the major version to a malicious commit, the next CI run would execute it with access to repository secrets.

## Changes

Pin all three actions to their current commit SHAs across all jobs, with a `# vN` comment for readability:

| Action | Pinned SHA | Tag |
|---|---|---|
| `actions/checkout` | `3d3c42e5aac5ba805825da76410c181273ba90b1` | v7 |
| `actions/setup-node` | `820762786026740c76f36085b0efc47a31fe5020` | v7 |
| `github/codeql-action/upload-sarif` | `e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81` | v4 |

Now every `uses:` reference in the workflow is SHA-pinned.

## Scope

Kept intentionally separate from #468 (a test-portability fix) since this is a repo-wide CI hardening change touching all jobs. No test or source code is affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)