### PR TITLE
chore: improve health telemetry to better understand and diagnose init and update failures

### DIFF
--- a/.changeset/witty-brooms-buy.md
+++ b/.changeset/witty-brooms-buy.md
@@ -1,0 +1,5 @@
+---
+"openwiki": patch
+---
+
+chore: improve health telemetry to better understand and diagnose init and update failures

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -125,19 +125,15 @@ import {
   removeTemporaryPlanFile,
   shouldCheckUpdateNoop,
 } from "./utils.js";
-import {
-  describeErrorForTelemetry,
-  inStage,
-  inStageSync,
-  recordRunSafe,
-  tagErrorStage,
-} from "../telemetry/index.js";
+import { inStage, inStageSync, tagErrorStage } from "../telemetry/index.js";
+import type { RunTelemetryContext } from "../telemetry/index.js";
 import { OpenWikiIgnore } from "./openwiki-ignore.js";
 
 export async function runOpenWikiAgent(
   command: OpenWikiCommand,
   cwd = openWikiLocalWikiDir,
   options: OpenWikiRunOptions = {},
+  telemetryContext: RunTelemetryContext = {},
 ): Promise<OpenWikiRunResult> {
   const outputMode = options.outputMode ?? "local-wiki";
   const runtimeCwd = options.outputMode ? cwd : openWikiLocalWikiDir;
@@ -174,10 +170,10 @@ export async function runOpenWikiAgent(
       emitDebug(options, `update.noop gitHead=${noopStatus.gitHead}`);
       options.onEvent?.({ type: "text", text: message });
 
-      await recordRunSafe(command, options, {
-        provider: resolveConfiguredProvider(),
-        outcome: "noop",
-      });
+      // The single telemetry boundary (withRunTelemetry) owns the record; publish
+      // the short-circuit outcome and provider onto the shared context and return.
+      telemetryContext.provider = resolveConfiguredProvider();
+      telemetryContext.outcome = "noop";
 
       return {
         command,
@@ -193,17 +189,16 @@ export async function runOpenWikiAgent(
 
   const debugFetchCapture = installOpenRouterDebugFetch(options);
 
-  // Published to this scope the instant the provider is resolved, so a failure
-  // later in resolution still attributes the provider in the failure record. It
-  // stays undefined only if the very first resolution step throws.
-  let provider: OpenWikiProvider | undefined;
-
   try {
+    // Published onto the shared context the instant the provider is resolved, so a
+    // failure later in the run still attributes the provider. It stays undefined
+    // only if the very first resolution step throws. The single telemetry boundary
+    // (withRunTelemetry) reads this context to record the run.
     const config = await resolveRunConfig(options, (resolved) => {
-      provider = resolved;
+      telemetryContext.provider = resolved;
     });
 
-    const result = await runOpenWikiAgentCore(
+    return await runOpenWikiAgentCore(
       command,
       runtimeCwd,
       options,
@@ -212,24 +207,11 @@ export async function runOpenWikiAgent(
       config.providerRetryAttempts,
       openWikiIgnore,
     );
-
-    await recordRunSafe(command, options, {
-      provider: config.provider,
-      outcome: "success",
-    });
-
-    return result;
   } catch (error) {
+    // Enrich the error for the CLI's debug/auth UI, then rethrow. The telemetry
+    // record is owned by withRunTelemetry, which reads the stage/class tags this
+    // error already carries.
     attachOpenRouterDebugInfo(error, debugFetchCapture.getLastFailure());
-
-    await recordRunSafe(command, options, {
-      provider,
-      outcome: "failure",
-      // Class, stage, and status in one spread. Stage rides a non-enumerable tag
-      // (config here, or a later stage from runOpenWikiAgentCore); status is a
-      // bare int. No error text ever enters the payload.
-      ...describeErrorForTelemetry(error),
-    });
 
     throw error;
   } finally {
@@ -308,27 +290,36 @@ async function runOpenWikiAgentCore(
   openWikiIgnore: OpenWikiIgnore,
 ): Promise<OpenWikiRunResult> {
   const outputMode = options.outputMode ?? "local-wiki";
-  const context = await inStage("build", () =>
-    createRunContext(command, cwd, outputMode, options.language, openWikiIgnore),
+  const context = await inStage(
+    "build",
+    () =>
+      createRunContext(command, cwd, outputMode, options.language, openWikiIgnore),
+    { errorClass: "build_error", errorDetail: "run_context" },
   );
   emitDebug(options, "context=created");
   const openWikiSnapshotBefore =
     command === "chat"
       ? null
-      : await inStage("build", () =>
-          createOpenWikiContentSnapshot(cwd, outputMode),
+      : await inStage(
+          "build",
+          () => createOpenWikiContentSnapshot(cwd, outputMode),
+          { errorClass: "build_error", errorDetail: "snapshot" },
         );
   emitDebug(options, "openwiki.snapshot=created");
-  const model = inStageSync("build", () =>
-    createModel(provider, modelId, providerRetryAttempts),
+  const model = inStageSync(
+    "build",
+    () => createModel(provider, modelId, providerRetryAttempts),
+    { errorClass: "build_error", errorDetail: "model" },
   );
   emitDebug(options, `model.provider=${provider}`);
   emitDebug(options, "model=initialized");
   const threadId = options.threadId ?? createThreadId(cwd, createRunThreadId());
   emitDebug(options, `thread=${threadId}`);
   const checkpointTarget = resolveCheckpointTarget(command);
-  const checkpointer = await inStage("build", () =>
-    createCheckpointer(checkpointTarget),
+  const checkpointer = await inStage(
+    "build",
+    () => createCheckpointer(checkpointTarget),
+    { errorClass: "checkpointer_error", errorDetail: "create" },
   );
   emitDebug(
     options,
@@ -361,61 +352,64 @@ async function runOpenWikiAgentCore(
   // back to English for any language not in the static maps.
   const indexLabels = resolveIndexLabels(context.language);
   const conceptType = resolveConceptTypeLabel(context.language);
-  const agent = inStageSync("build", () =>
-    createDeepAgent({
-      model,
-      tools: createOpenWikiConnectorTools(),
-      checkpointer,
-      backend,
-      middleware:
-        command === "chat"
-          ? []
-          : [
-              ...(translation
-                ? [
-                    createWikiTranslationMiddleware(
-                      wikiBackend,
-                      outputMode,
-                      model,
-                      translation,
-                      (message) => {
-                        options.onEvent?.({ type: "text", text: message });
-                        // Also emit to stderr so the warning survives the TUI
-                        // re-render and --print's discard of streamed text.
-                        process.stderr.write(`${message}\n`);
-                      },
-                      // The pass announces itself with one line in place of the
-                      // suppressed per-token translation output. It is routine
-                      // progress, so unlike a warning it is not mirrored to stderr.
-                      // The trailing blank line keeps it a distinct Markdown block:
-                      // the TUI coalesces consecutive text events into one
-                      // block-lexed log item, so without it the status would run
-                      // straight into the agent's first streamed line.
-                      (message) => {
-                        options.onEvent?.({
-                          type: "text",
-                          text: `${message}\n\n`,
-                        });
-                      },
-                    ),
-                  ]
-                : []),
-              createOpenWikiIndexMiddleware(
-                wikiBackend,
-                outputMode,
-                indexLabels,
-                conceptType,
-              ),
-            ],
-      skills: ["/skills/"],
-      permissions: AGENT_FILESYSTEM_PERMISSIONS,
-      systemPrompt: createSystemPrompt(
-        command,
-        outputMode,
-        context.language,
-        openWikiIgnore,
-      ),
-    }),
+  const agent = inStageSync(
+    "build",
+    () =>
+      createDeepAgent({
+        model,
+        tools: createOpenWikiConnectorTools(),
+        checkpointer,
+        backend,
+        middleware:
+          command === "chat"
+            ? []
+            : [
+                ...(translation
+                  ? [
+                      createWikiTranslationMiddleware(
+                        wikiBackend,
+                        outputMode,
+                        model,
+                        translation,
+                        (message) => {
+                          options.onEvent?.({ type: "text", text: message });
+                          // Also emit to stderr so the warning survives the TUI
+                          // re-render and --print's discard of streamed text.
+                          process.stderr.write(`${message}\n`);
+                        },
+                        // The pass announces itself with one line in place of the
+                        // suppressed per-token translation output. It is routine
+                        // progress, so unlike a warning it is not mirrored to stderr.
+                        // The trailing blank line keeps it a distinct Markdown block:
+                        // the TUI coalesces consecutive text events into one
+                        // block-lexed log item, so without it the status would run
+                        // straight into the agent's first streamed line.
+                        (message) => {
+                          options.onEvent?.({
+                            type: "text",
+                            text: `${message}\n\n`,
+                          });
+                        },
+                      ),
+                    ]
+                  : []),
+                createOpenWikiIndexMiddleware(
+                  wikiBackend,
+                  outputMode,
+                  indexLabels,
+                  conceptType,
+                ),
+              ],
+        skills: ["/skills/"],
+        permissions: AGENT_FILESYSTEM_PERMISSIONS,
+        systemPrompt: createSystemPrompt(
+          command,
+          outputMode,
+          context.language,
+          openWikiIgnore,
+        ),
+      }),
+    { errorClass: "build_error", errorDetail: "agent" },
   );
   emitDebug(options, "agent=created");
 
@@ -429,13 +423,16 @@ async function runOpenWikiAgentCore(
   };
 
   emitDebug(options, "stream=opening protocol=events version=v3");
-  const stream = await inStage("build", () =>
-    agent.streamEvents(input, {
-      configurable: {
-        thread_id: threadId,
-      },
-      version: "v3",
-    }),
+  const stream = await inStage(
+    "build",
+    () =>
+      agent.streamEvents(input, {
+        configurable: {
+          thread_id: threadId,
+        },
+        version: "v3",
+      }),
+    { errorClass: "build_error", errorDetail: "stream_open" },
   );
   emitDebug(options, "stream=started protocol=events version=v3");
 
@@ -502,10 +499,21 @@ async function runOpenWikiAgentCore(
     );
   }
 
+  if (checkpointTarget.persistent) {
+    // Locking down the checkpoint file is a checkpointer concern; a filesystem
+    // failure here owns to us, not the user, so it carries its own class rather
+    // than the stage-only tag the metadata write below relies on.
+    await inStage(
+      "finalize",
+      () => chmodIfExists(checkpointTarget.connString, 0o600),
+      { errorClass: "checkpointer_error", errorDetail: "chmod" },
+    );
+  }
+
+  // Stage-only tag: a write failure here classifies from the raw error (a
+  // filesystem code becomes filesystem_error), and deriveOwner's finalize
+  // exception routes that to openwiki since the run reached our own persistence.
   const metadataWritten = await inStage("finalize", async () => {
-    if (checkpointTarget.persistent) {
-      await chmodIfExists(checkpointTarget.connString, 0o600);
-    }
     await cleanupTemporaryPlanFile(command, cwd, outputMode, options);
     return persistRunMetadataIfChanged(
       command,

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -125,7 +125,13 @@ import {
   removeTemporaryPlanFile,
   shouldCheckUpdateNoop,
 } from "./utils.js";
-import { classifyError, recordRunSafe } from "../telemetry/index.js";
+import {
+  describeErrorForTelemetry,
+  inStage,
+  inStageSync,
+  recordRunSafe,
+  tagErrorStage,
+} from "../telemetry/index.js";
 import { OpenWikiIgnore } from "./openwiki-ignore.js";
 
 export async function runOpenWikiAgent(
@@ -187,14 +193,69 @@ export async function runOpenWikiAgent(
 
   const debugFetchCapture = installOpenRouterDebugFetch(options);
 
-  // Resolved inside the try so a failure during resolution (missing key,
-  // invalid model, missing base URL) is still recorded. They may be undefined
-  // in the catch if resolution threw before assigning them.
+  // Published to this scope the instant the provider is resolved, so a failure
+  // later in resolution still attributes the provider in the failure record. It
+  // stays undefined only if the very first resolution step throws.
   let provider: OpenWikiProvider | undefined;
-  let modelId: string | undefined;
 
   try {
-    provider = resolveConfiguredProvider();
+    const config = await resolveRunConfig(options, (resolved) => {
+      provider = resolved;
+    });
+
+    const result = await runOpenWikiAgentCore(
+      command,
+      runtimeCwd,
+      options,
+      config.provider,
+      config.modelId,
+      config.providerRetryAttempts,
+      openWikiIgnore,
+    );
+
+    await recordRunSafe(command, options, {
+      provider: config.provider,
+      outcome: "success",
+    });
+
+    return result;
+  } catch (error) {
+    attachOpenRouterDebugInfo(error, debugFetchCapture.getLastFailure());
+
+    await recordRunSafe(command, options, {
+      provider,
+      outcome: "failure",
+      // Class, stage, and status in one spread. Stage rides a non-enumerable tag
+      // (config here, or a later stage from runOpenWikiAgentCore); status is a
+      // bare int. No error text ever enters the payload.
+      ...describeErrorForTelemetry(error),
+    });
+
+    throw error;
+  } finally {
+    debugFetchCapture.restore();
+  }
+}
+
+/**
+ * Resolves everything the run needs before the agent is built: provider,
+ * credentials, model id, and retry count. Any throw here is tagged `config` so
+ * the failure telemetry locates it to the resolution stage. `onProviderResolved`
+ * fires the moment the provider is known, letting the caller attribute a failure
+ * that happens later in resolution to the right provider.
+ */
+async function resolveRunConfig(
+  options: OpenWikiRunOptions,
+  onProviderResolved: (provider: OpenWikiProvider) => void,
+): Promise<{
+  provider: OpenWikiProvider;
+  modelId: string;
+  providerRetryAttempts: number;
+}> {
+  try {
+    const provider = resolveConfiguredProvider();
+    onProviderResolved(provider);
+
     const providerBaseUrl = resolveProviderBaseUrl(provider);
     emitDebug(options, `provider=${provider}`);
     if (providerBaseUrl) {
@@ -225,39 +286,15 @@ export async function runOpenWikiAgent(
       emitDebug(options, "chatgpt.token=fresh");
     }
 
-    modelId = resolveModelId(options, provider);
+    const modelId = resolveModelId(options, provider);
     emitDebug(options, `model=${modelId}`);
     const providerRetryAttempts = resolveProviderRetryAttempts();
     emitDebug(options, `provider.retryAttempts=${providerRetryAttempts}`);
 
-    const result = await runOpenWikiAgentCore(
-      command,
-      runtimeCwd,
-      options,
-      provider,
-      modelId,
-      providerRetryAttempts,
-      openWikiIgnore,
-    );
-
-    await recordRunSafe(command, options, {
-      provider,
-      outcome: "success",
-    });
-
-    return result;
+    return { provider, modelId, providerRetryAttempts };
   } catch (error) {
-    attachOpenRouterDebugInfo(error, debugFetchCapture.getLastFailure());
-
-    await recordRunSafe(command, options, {
-      provider,
-      outcome: "failure",
-      errorClass: classifyError(error),
-    });
-
+    tagErrorStage(error, "config");
     throw error;
-  } finally {
-    debugFetchCapture.restore();
   }
 }
 
@@ -271,26 +308,28 @@ async function runOpenWikiAgentCore(
   openWikiIgnore: OpenWikiIgnore,
 ): Promise<OpenWikiRunResult> {
   const outputMode = options.outputMode ?? "local-wiki";
-  const context = await createRunContext(
-    command,
-    cwd,
-    outputMode,
-    options.language,
-    openWikiIgnore,
+  const context = await inStage("build", () =>
+    createRunContext(command, cwd, outputMode, options.language, openWikiIgnore),
   );
   emitDebug(options, "context=created");
   const openWikiSnapshotBefore =
     command === "chat"
       ? null
-      : await createOpenWikiContentSnapshot(cwd, outputMode);
+      : await inStage("build", () =>
+          createOpenWikiContentSnapshot(cwd, outputMode),
+        );
   emitDebug(options, "openwiki.snapshot=created");
-  const model = createModel(provider, modelId, providerRetryAttempts);
+  const model = inStageSync("build", () =>
+    createModel(provider, modelId, providerRetryAttempts),
+  );
   emitDebug(options, `model.provider=${provider}`);
   emitDebug(options, "model=initialized");
   const threadId = options.threadId ?? createThreadId(cwd, createRunThreadId());
   emitDebug(options, `thread=${threadId}`);
   const checkpointTarget = resolveCheckpointTarget(command);
-  const checkpointer = await createCheckpointer(checkpointTarget);
+  const checkpointer = await inStage("build", () =>
+    createCheckpointer(checkpointTarget),
+  );
   emitDebug(
     options,
     checkpointTarget.persistent
@@ -322,60 +361,62 @@ async function runOpenWikiAgentCore(
   // back to English for any language not in the static maps.
   const indexLabels = resolveIndexLabels(context.language);
   const conceptType = resolveConceptTypeLabel(context.language);
-  const agent = createDeepAgent({
-    model,
-    tools: createOpenWikiConnectorTools(),
-    checkpointer,
-    backend,
-    middleware:
-      command === "chat"
-        ? []
-        : [
-            ...(translation
-              ? [
-                  createWikiTranslationMiddleware(
-                    wikiBackend,
-                    outputMode,
-                    model,
-                    translation,
-                    (message) => {
-                      options.onEvent?.({ type: "text", text: message });
-                      // Also emit to stderr so the warning survives the TUI
-                      // re-render and --print's discard of streamed text.
-                      process.stderr.write(`${message}\n`);
-                    },
-                    // The pass announces itself with one line in place of the
-                    // suppressed per-token translation output. It is routine
-                    // progress, so unlike a warning it is not mirrored to stderr.
-                    // The trailing blank line keeps it a distinct Markdown block:
-                    // the TUI coalesces consecutive text events into one
-                    // block-lexed log item, so without it the status would run
-                    // straight into the agent's first streamed line.
-                    (message) => {
-                      options.onEvent?.({
-                        type: "text",
-                        text: `${message}\n\n`,
-                      });
-                    },
-                  ),
-                ]
-              : []),
-            createOpenWikiIndexMiddleware(
-              wikiBackend,
-              outputMode,
-              indexLabels,
-              conceptType,
-            ),
-          ],
-    skills: ["/skills/"],
-    permissions: AGENT_FILESYSTEM_PERMISSIONS,
-    systemPrompt: createSystemPrompt(
-      command,
-      outputMode,
-      context.language,
-      openWikiIgnore,
-    ),
-  });
+  const agent = inStageSync("build", () =>
+    createDeepAgent({
+      model,
+      tools: createOpenWikiConnectorTools(),
+      checkpointer,
+      backend,
+      middleware:
+        command === "chat"
+          ? []
+          : [
+              ...(translation
+                ? [
+                    createWikiTranslationMiddleware(
+                      wikiBackend,
+                      outputMode,
+                      model,
+                      translation,
+                      (message) => {
+                        options.onEvent?.({ type: "text", text: message });
+                        // Also emit to stderr so the warning survives the TUI
+                        // re-render and --print's discard of streamed text.
+                        process.stderr.write(`${message}\n`);
+                      },
+                      // The pass announces itself with one line in place of the
+                      // suppressed per-token translation output. It is routine
+                      // progress, so unlike a warning it is not mirrored to stderr.
+                      // The trailing blank line keeps it a distinct Markdown block:
+                      // the TUI coalesces consecutive text events into one
+                      // block-lexed log item, so without it the status would run
+                      // straight into the agent's first streamed line.
+                      (message) => {
+                        options.onEvent?.({
+                          type: "text",
+                          text: `${message}\n\n`,
+                        });
+                      },
+                    ),
+                  ]
+                : []),
+              createOpenWikiIndexMiddleware(
+                wikiBackend,
+                outputMode,
+                indexLabels,
+                conceptType,
+              ),
+            ],
+      skills: ["/skills/"],
+      permissions: AGENT_FILESYSTEM_PERMISSIONS,
+      systemPrompt: createSystemPrompt(
+        command,
+        outputMode,
+        context.language,
+        openWikiIgnore,
+      ),
+    }),
+  );
   emitDebug(options, "agent=created");
 
   const input = {
@@ -388,12 +429,14 @@ async function runOpenWikiAgentCore(
   };
 
   emitDebug(options, "stream=opening protocol=events version=v3");
-  const stream = await agent.streamEvents(input, {
-    configurable: {
-      thread_id: threadId,
-    },
-    version: "v3",
-  });
+  const stream = await inStage("build", () =>
+    agent.streamEvents(input, {
+      configurable: {
+        thread_id: threadId,
+      },
+      version: "v3",
+    }),
+  );
   emitDebug(options, "stream=started protocol=events version=v3");
 
   let unhandledChunkCount = 0;
@@ -418,6 +461,8 @@ async function runOpenWikiAgentCore(
     }
     emitDebug(options, "stream=completed");
   } catch (error) {
+    tagErrorStage(error, "run");
+
     await cleanupTemporaryPlanFile(command, cwd, outputMode, options).catch(
       () => {
         emitDebug(options, "plan.cleanup=failed");
@@ -457,21 +502,21 @@ async function runOpenWikiAgentCore(
     );
   }
 
-  if (checkpointTarget.persistent) {
-    await chmodIfExists(checkpointTarget.connString, 0o600);
-  }
-
-  await cleanupTemporaryPlanFile(command, cwd, outputMode, options);
-
-  const metadataWritten = await persistRunMetadataIfChanged(
-    command,
-    cwd,
-    modelId,
-    outputMode,
-    openWikiSnapshotBefore,
-    "complete",
-    context.language,
-  );
+  const metadataWritten = await inStage("finalize", async () => {
+    if (checkpointTarget.persistent) {
+      await chmodIfExists(checkpointTarget.connString, 0o600);
+    }
+    await cleanupTemporaryPlanFile(command, cwd, outputMode, options);
+    return persistRunMetadataIfChanged(
+      command,
+      cwd,
+      modelId,
+      outputMode,
+      openWikiSnapshotBefore,
+      "complete",
+      context.language,
+    );
+  });
 
   if (metadataWritten) {
     emitDebug(options, "metadata=written");

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -293,7 +293,13 @@ async function runOpenWikiAgentCore(
   const context = await inStage(
     "build",
     () =>
-      createRunContext(command, cwd, outputMode, options.language, openWikiIgnore),
+      createRunContext(
+        command,
+        cwd,
+        outputMode,
+        options.language,
+        openWikiIgnore,
+      ),
     { errorClass: "build_error", errorDetail: "run_context" },
   );
   emitDebug(options, "context=created");

--- a/src/agent/okf-middleware.ts
+++ b/src/agent/okf-middleware.ts
@@ -14,6 +14,7 @@ import {
   type IndexLabels,
 } from "../okf/index-labels.js";
 import { MUTATION_PATH_METADATA_KEY } from "./docs-only-backend.js";
+import { inStage } from "../telemetry/index.js";
 import type { OpenWikiOutputMode } from "./types.js";
 
 const OKF_RESERVED_FILES = new Set(["index.md", "log.md"]);
@@ -33,8 +34,29 @@ export function createOpenWikiIndexMiddleware(
   return createMiddleware({
     name: "OpenWikiIndexMiddleware",
     beforeAgent: async () => {
-      await migrateWikiToOkf(backend, outputMode, conceptType);
+      // Owned OKF pass: a throw here is our conformance code failing, not the
+      // model. Tag class+detail at the origin so it does not fall to the run
+      // stage's raw classifier (which would read agent_error).
+      await inStage(
+        "build",
+        () => migrateWikiToOkf(backend, outputMode, conceptType),
+        { errorClass: "okf_error", errorDetail: "migrate" },
+      );
     },
+    // Telemetry guard: this wrap only *decorates a successful* tool result with a
+    // front-matter warning; it deliberately does not catch tool throws. LangChain's
+    // tool node swallows a thrown tool error into a ToolMessage fed back to the
+    // model so the agent can recover, so tool/connector throws never reach the run
+    // failure path. Consequences to keep in mind before changing this:
+    //   - `connector_error` has no fatal propagating path at all (the connector
+    //     pull in runCodeModeConnectors is fail-open by design), so it is a
+    //     documented telemetry blind spot, not a bucket some run produces.
+    //   - `tool_error` is reachable only when a tool-named error escapes to the
+    //     failure path; classifyError matches it by `error.name`, not here.
+    //   - Tool-input parse errors are swallowed by LangChain upstream and never
+    //     become `tool_error`.
+    // Do not turn this into a catch that rethrows: that would make every recoverable
+    // tool error fatal and record otherwise-successful runs as failures.
     wrapToolCall: async (request, handler) =>
       addFrontmatterWarning(
         await handler(request),
@@ -43,8 +65,16 @@ export function createOpenWikiIndexMiddleware(
         request.toolCall.name,
       ),
     afterAgent: async () => {
-      await validateWikiMermaid(backend, outputMode);
-      await synchronizeWikiIndexes(backend, outputMode, labels, conceptType);
+      await inStage(
+        "finalize",
+        () => validateWikiMermaid(backend, outputMode),
+        { errorClass: "okf_error", errorDetail: "mermaid" },
+      );
+      await inStage(
+        "finalize",
+        () => synchronizeWikiIndexes(backend, outputMode, labels, conceptType),
+        { errorClass: "okf_error", errorDetail: "index_sync" },
+      );
     },
   });
 }

--- a/src/cli.tsx
+++ b/src/cli.tsx
@@ -86,12 +86,18 @@ import {
   OPENWIKI_VERSION,
   type OpenWikiProvider,
 } from "./constants.js";
-import type { OpenWikiCommand, OpenWikiOutputMode } from "./agent/types.js";
+import type {
+  OpenWikiCommand,
+  OpenWikiOutputMode,
+  OpenWikiRunOptions,
+} from "./agent/types.js";
 import {
   firstRunNoticePending,
   FIRST_RUN_NOTICE_BODY,
   FIRST_RUN_NOTICE_OPT_OUT,
   FIRST_RUN_NOTICE_VERIFY,
+  withRunTelemetry,
+  type RunTelemetryContext,
 } from "./telemetry/index.js";
 
 type RunState =
@@ -581,34 +587,52 @@ function App({ command }: AppProps) {
         });
     }
 
-    const setupPromise =
-      runMode === "code"
-        ? ensureCodeModeRepoSetup(runtimeCwd, {
+    const handleRunEvent = (event: OpenWikiRunEvent): void => {
+      if (!mountedRef.current || activeRunId.current !== runId) {
+        return;
+      }
+
+      activeRunLog.current = appendRunLogEvent(
+        activeRunLog.current,
+        event,
+        nextLogId,
+      );
+      setRunState((currentState) =>
+        currentState.status === "running"
+          ? {
+              ...currentState,
+              log: activeRunLog.current,
+            }
+          : currentState,
+      );
+    };
+
+    const runOptions: OpenWikiRunOptions = {
+      debug: isDebugMode(),
+      isFollowup: activeMessageIsFollowup,
+      language: command.language,
+      modelId: sessionModelId,
+      outputMode: runtimeOutputMode,
+      threadId: sessionThreadId.current,
+      telemetryFile: command.telemetryFile ?? undefined,
+      onEvent: handleRunEvent,
+    };
+
+    // withRunTelemetry is the single boundary that records this run. It wraps repo
+    // setup and the connector pull too (not just the agent), so a throw in either
+    // pre-agent step is recorded rather than reaching only the UI catch below.
+    const telemetryContext: RunTelemetryContext = {};
+
+    withRunTelemetry(
+      resolvedCommand,
+      runOptions,
+      telemetryContext,
+      async () => {
+        if (runMode === "code") {
+          await ensureCodeModeRepoSetup(runtimeCwd, {
             createWorkflow: resolvedCommand === "init",
-          })
-        : Promise.resolve();
-
-    setupPromise
-      .then(async () => {
-        const handleRunEvent = (event: OpenWikiRunEvent): void => {
-          if (!mountedRef.current || activeRunId.current !== runId) {
-            return;
-          }
-
-          activeRunLog.current = appendRunLogEvent(
-            activeRunLog.current,
-            event,
-            nextLogId,
-          );
-          setRunState((currentState) =>
-            currentState.status === "running"
-              ? {
-                  ...currentState,
-                  log: activeRunLog.current,
-                }
-              : currentState,
-          );
-        };
+          });
+        }
 
         // Code-mode connectors pull their evidence and augment the agent message
         // before the run, matching the --print path exactly. They emit progress
@@ -622,18 +646,14 @@ function App({ command }: AppProps) {
               )
             : activeUserMessage;
 
-        return runOpenWikiAgent(resolvedCommand, runtimeCwd, {
-          debug: isDebugMode(),
-          isFollowup: activeMessageIsFollowup,
-          language: command.language,
-          modelId: sessionModelId,
-          outputMode: runtimeOutputMode,
-          threadId: sessionThreadId.current,
-          userMessage,
-          telemetryFile: command.telemetryFile ?? undefined,
-          onEvent: handleRunEvent,
-        });
-      })
+        return runOpenWikiAgent(
+          resolvedCommand,
+          runtimeCwd,
+          { ...runOptions, userMessage },
+          telemetryContext,
+        );
+      },
+    )
       .then((result) => {
         if (!mountedRef.current || activeRunId.current !== runId) {
           return;
@@ -4156,40 +4176,59 @@ async function runPrintCommand(
     const runtimeCwd = getRunModeCwd(command.mode);
     const runtimeOutputMode = getRunModeOutputMode(command.mode);
 
-    if (command.mode === "code") {
-      await ensureCodeModeRepoSetup(runtimeCwd, {
-        createWorkflow: command.command === "init",
-      });
-    }
-
-    // Code-mode connectors (e.g. langsmith) pull their evidence and augment the
-    // agent message before the run, so --print behaves exactly like interactive.
     const handlePrintEvent = (event: OpenWikiRunEvent): void => {
       if (event.type === "text" && event.source !== "subgraph") {
         output.push(event.text);
       }
     };
 
-    const userMessage =
-      command.mode === "code" && command.command !== "chat"
-        ? await runCodeModeConnectors(
-            runtimeCwd,
-            command.userMessage ?? undefined,
-            handlePrintEvent,
-          )
-        : command.userMessage;
-
-    await runOpenWikiAgent(command.command, runtimeCwd, {
+    const runOptions: OpenWikiRunOptions = {
       debug: isDebugMode(),
       isFollowup: command.command === "chat",
       language: command.language,
       modelId: command.modelId,
       outputMode: runtimeOutputMode,
       threadId: createOpenWikiThreadId(runtimeCwd),
-      userMessage,
       telemetryFile: command.telemetryFile ?? undefined,
       onEvent: handlePrintEvent,
-    });
+    };
+
+    // withRunTelemetry is the single boundary that records this run, wrapping repo
+    // setup and the connector pull as well as the agent so a throw in either
+    // pre-agent step is recorded rather than only surfaced on stderr below.
+    const telemetryContext: RunTelemetryContext = {};
+
+    await withRunTelemetry(
+      command.command,
+      runOptions,
+      telemetryContext,
+      async () => {
+        if (command.mode === "code") {
+          await ensureCodeModeRepoSetup(runtimeCwd, {
+            createWorkflow: command.command === "init",
+          });
+        }
+
+        // Code-mode connectors (e.g. langsmith) pull their evidence and augment
+        // the agent message before the run, so --print behaves exactly like
+        // interactive.
+        const userMessage =
+          command.mode === "code" && command.command !== "chat"
+            ? await runCodeModeConnectors(
+                runtimeCwd,
+                command.userMessage ?? undefined,
+                handlePrintEvent,
+              )
+            : command.userMessage;
+
+        await runOpenWikiAgent(
+          command.command,
+          runtimeCwd,
+          { ...runOptions, userMessage },
+          telemetryContext,
+        );
+      },
+    );
 
     const text = output.join("").trim();
 

--- a/src/ingestion.ts
+++ b/src/ingestion.ts
@@ -24,6 +24,10 @@ import type {
   OpenWikiRunOptions,
   OpenWikiRunResult,
 } from "./agent/types.js";
+import {
+  withRunTelemetry,
+  type RunTelemetryContext,
+} from "./telemetry/index.js";
 
 const INGESTION_WINDOW_HOURS = 24;
 
@@ -166,7 +170,7 @@ async function runSourceIngestion({
 
     emitDeterministicPullSummary(emit, deterministicPull);
 
-    const agentResult = await runOpenWikiAgent("update", cwd, {
+    const runOptions: OpenWikiRunOptions = {
       isFollowup: false,
       modelId,
       onEvent: emit,
@@ -179,7 +183,17 @@ async function runSourceIngestion({
         rawFiles,
         sourceConfig,
       }),
-    });
+    };
+
+    // withRunTelemetry is the single boundary that records this per-source update
+    // run, matching the CLI paths so ingestion runs land in telemetry too.
+    const telemetryContext: RunTelemetryContext = {};
+    const agentResult = await withRunTelemetry(
+      "update",
+      runOptions,
+      telemetryContext,
+      () => runOpenWikiAgent("update", cwd, runOptions, telemetryContext),
+    );
 
     return {
       agentResult,

--- a/src/telemetry/config.ts
+++ b/src/telemetry/config.ts
@@ -6,7 +6,7 @@ import { openWikiHomeDir } from "../openwiki-home.js";
  * Publishable PostHog project key. Safe to ship (client/ingestion key).
  */
 export const DEFAULT_POSTHOG_KEY =
-  "phc_Cki9DqcLbYkGudQaiaTSAfQZxXvjL6EyoaQjEJGJrwPF";
+  "phc_CYLu3ZMxPwqWFrCfUQi48i54btUbAjPLtk5yEuETg7oH";
 export const DEFAULT_POSTHOG_HOST = "https://us.i.posthog.com";
 
 /**

--- a/src/telemetry/config.ts
+++ b/src/telemetry/config.ts
@@ -6,7 +6,7 @@ import { openWikiHomeDir } from "../openwiki-home.js";
  * Publishable PostHog project key. Safe to ship (client/ingestion key).
  */
 export const DEFAULT_POSTHOG_KEY =
-  "phc_CYLu3ZMxPwqWFrCfUQi48i54btUbAjPLtk5yEuETg7oH";
+  "phc_Cki9DqcLbYkGudQaiaTSAfQZxXvjL6EyoaQjEJGJrwPF";
 export const DEFAULT_POSTHOG_HOST = "https://us.i.posthog.com";
 
 /**

--- a/src/telemetry/errors.ts
+++ b/src/telemetry/errors.ts
@@ -1,35 +1,81 @@
-import type { TelemetryErrorClass, TelemetryErrorStage } from "./types.js";
+import { deriveOwner, normalizeErrorDetail } from "./taxonomy.js";
+import type {
+  TelemetryErrorClass,
+  TelemetryErrorOwner,
+  TelemetryErrorStage,
+} from "./types.js";
 
 /**
- * Provider-native error codes we recognize, mapped to a class. Read internally
- * only to disambiguate otherwise-identical statuses (a context-limit 400 vs any
- * other 400); the code string itself is never emitted (Open 4a). Anything not on
- * this list is ignored, so the envelope stays closed.
+ * A failure family paired with its detail, the two-level result of classifying a
+ * raw error. `errorDetail` is the specific failure within the family, or undefined
+ * when the family has no detail split or none could be read from the raw error.
  */
-const PROVIDER_ERROR_CODES: Readonly<Record<string, TelemetryErrorClass>> = {
-  context_length_exceeded: "provider_context_limit",
-  string_above_max_length: "provider_context_limit",
-  rate_limit_exceeded: "provider_rate_limit",
-  insufficient_quota: "provider_quota_exceeded",
-  billing_hard_limit_reached: "provider_quota_exceeded",
-  invalid_api_key: "provider_auth",
-  authentication_error: "provider_auth",
-  permission_error: "provider_auth",
-  overloaded_error: "provider_overloaded",
-  content_policy_violation: "provider_content_filter",
-  content_filter: "provider_content_filter",
+export interface ErrorClassification {
+  /**
+   * The closed-set failure family.
+   */
+  errorClass: TelemetryErrorClass;
+
+  /**
+   * The specific failure within the family, or undefined.
+   *
+   * @default undefined - the family has no detail split, or none was resolvable
+   * from the raw error alone.
+   */
+  errorDetail?: string;
+}
+
+/**
+ * Provider-native error codes we recognize, mapped to a class and detail. Read
+ * internally only to disambiguate otherwise-identical statuses (a context-limit 400
+ * vs any other 400); the code string itself is never emitted. Anything not on this
+ * list is ignored, so the envelope stays closed.
+ */
+const PROVIDER_ERROR_CODES: Readonly<Record<string, ErrorClassification>> = {
+  context_length_exceeded: { errorClass: "context_limit_error" },
+  string_above_max_length: { errorClass: "context_limit_error" },
+  rate_limit_exceeded: {
+    errorClass: "provider_error",
+    errorDetail: "rate_limit",
+  },
+  insufficient_quota: {
+    errorClass: "provider_error",
+    errorDetail: "quota_exceeded",
+  },
+  billing_hard_limit_reached: {
+    errorClass: "provider_error",
+    errorDetail: "quota_exceeded",
+  },
+  invalid_api_key: { errorClass: "provider_error", errorDetail: "auth" },
+  authentication_error: { errorClass: "provider_error", errorDetail: "auth" },
+  permission_error: { errorClass: "provider_error", errorDetail: "auth" },
+  overloaded_error: { errorClass: "provider_error", errorDetail: "overloaded" },
+  content_policy_violation: {
+    errorClass: "provider_error",
+    errorDetail: "content_filter",
+  },
+  content_filter: {
+    errorClass: "provider_error",
+    errorDetail: "content_filter",
+  },
 };
 
 /**
- * Maps an unknown error to a closed {@link TelemetryErrorClass}. Priority runs
- * most-specific to least: abort, recognized provider code, HTTP status, tool
- * shape, message regexes, filesystem code, then the single `agent_error`
- * catch-all. Never leaks the message: it is read to test regexes in-process, but
- * only an enum member is ever returned.
+ * Maps an unknown error to a closed {@link ErrorClassification} from the raw error
+ * alone (status, provider code, message, filesystem code). Priority runs
+ * most-specific to least: abort, recognized provider code, HTTP status, tool shape,
+ * message regexes, filesystem code, then the single `agent_error` catch-all.
+ *
+ * This reads only the raw signal; the owned families whose class comes from where
+ * the error was thrown (`build_error`, `connector_error`, `okf_error`,
+ * `checkpointer_error`, plus tagged `config_error`/`tool_error` details) are
+ * resolved from the origin tag by {@link describeErrorForTelemetry}, which prefers
+ * the tag over this. Never leaks the message: it is read to test regexes in-process,
+ * but only an enum member is ever returned.
  */
-export function classifyError(error: unknown): TelemetryErrorClass {
+export function classifyError(error: unknown): ErrorClassification {
   if (error instanceof Error && error.name === "AbortError") {
-    return "aborted";
+    return { errorClass: "aborted" };
   }
 
   const providerCode = extractProviderErrorCode(error);
@@ -39,63 +85,84 @@ export function classifyError(error: unknown): TelemetryErrorClass {
 
   const status = extractStatus(error);
   if (status === 401 || status === 403) {
-    return "provider_auth";
+    return { errorClass: "provider_error", errorDetail: "auth" };
   }
   if (status === 429) {
-    return "provider_rate_limit";
+    return { errorClass: "provider_error", errorDetail: "rate_limit" };
   }
   if (status === 529 || status === 503) {
-    return "provider_overloaded";
+    return { errorClass: "provider_error", errorDetail: "overloaded" };
   }
   if (status !== undefined && status >= 500 && status < 600) {
-    return "provider_server_error";
+    return { errorClass: "provider_error", errorDetail: "server_error" };
   }
 
   if (error instanceof Error && /tool/iu.test(error.name)) {
-    return "tool_error";
+    // The tool name is a raw string; the emitted tool-name detail rides the origin
+    // tag (validated against the tool registry), not this raw-error path.
+    return { errorClass: "tool_error" };
   }
 
   const message = error instanceof Error ? error.message.toLowerCase() : "";
   if (/is required to run openwiki/u.test(message)) {
-    return /base url/u.test(message) ? "missing_config" : "missing_credentials";
+    return {
+      errorClass: "config_error",
+      errorDetail: /base url/u.test(message)
+        ? "missing_base_url"
+        : "missing_credentials",
+    };
   }
   if (/invalid model id/u.test(message)) {
-    return "invalid_model";
+    return { errorClass: "config_error", errorDetail: "invalid_model" };
   }
   if (
     /context length|maximum context|too many tokens|context window/u.test(
       message,
     )
   ) {
-    return "provider_context_limit";
+    return { errorClass: "context_limit_error" };
   }
   if (/quota|insufficient_quota|billing/u.test(message)) {
-    return "provider_quota_exceeded";
+    return { errorClass: "provider_error", errorDetail: "quota_exceeded" };
   }
   if (/timeout|timed out|etimedout/u.test(message)) {
-    return "provider_timeout";
+    return { errorClass: "provider_error", errorDetail: "timeout" };
   }
-  if (
-    /econnrefused|enotfound|network|fetch failed|econnreset|eai_again/u.test(
-      message,
-    )
-  ) {
-    return "network";
+  if (/enotfound|eai_again/u.test(message)) {
+    return { errorClass: "network_error", errorDetail: "dns" };
+  }
+  if (/econnrefused/u.test(message)) {
+    return { errorClass: "network_error", errorDetail: "refused" };
+  }
+  if (/econnreset/u.test(message)) {
+    return { errorClass: "network_error", errorDetail: "reset" };
+  }
+  if (/network|fetch failed/u.test(message)) {
+    return { errorClass: "network_error", errorDetail: "unreachable" };
   }
   if (/content policy|content filter|content_filter|refus/u.test(message)) {
-    return "provider_content_filter";
+    return { errorClass: "provider_error", errorDetail: "content_filter" };
   }
-  if (/could not parse|invalid json|schema/u.test(message)) {
-    return "output_invalid";
+  if (/could not parse|invalid json/u.test(message)) {
+    return { errorClass: "output_error", errorDetail: "json_parse" };
+  }
+  if (/schema/u.test(message)) {
+    return { errorClass: "output_error", errorDetail: "schema" };
   }
 
   const code =
     error instanceof Error ? (error as NodeJS.ErrnoException).code : undefined;
-  if (code === "ENOENT" || code === "EACCES" || code === "EPERM") {
-    return "filesystem";
+  if (code === "ENOENT") {
+    return { errorClass: "filesystem_error", errorDetail: "not_found" };
+  }
+  if (code === "EACCES" || code === "EPERM") {
+    return { errorClass: "filesystem_error", errorDetail: "permission" };
+  }
+  if (code === "ENOSPC") {
+    return { errorClass: "filesystem_error", errorDetail: "no_space" };
   }
 
-  return "agent_error";
+  return { errorClass: "agent_error" };
 }
 
 /**
@@ -142,31 +209,79 @@ function extractProviderErrorCode(error: unknown): string | undefined {
 }
 
 /**
- * Non-enumerable symbol tag carrying the pipeline stage a failure occurred in.
- * Non-enumerable so it never serializes into a telemetry payload or a JSON dump.
+ * The origin tag stamped onto an error as it unwinds: always the pipeline `stage`,
+ * and for owned families the `errorClass` and `errorDetail` decided at the throw
+ * site (where the class is known from context, not from a message string). Carried
+ * on a non-enumerable symbol so it never serializes into a telemetry payload or a
+ * JSON dump.
  */
-const ERROR_STAGE = Symbol.for("openwiki.telemetry.errorStage");
+interface ErrorOriginTag {
+  /**
+   * The pipeline stage the failure occurred in.
+   */
+  stage: TelemetryErrorStage;
+
+  /**
+   * The failure family, when the throw site owns the classification. Absent for a
+   * plain stage bracket, which leaves the class to the raw-error classifier.
+   *
+   * @default undefined - stage-only tag; the class comes from `classifyError`.
+   */
+  errorClass?: TelemetryErrorClass;
+
+  /**
+   * The detail decided at the throw site, paired with `errorClass`.
+   *
+   * @default undefined - no origin-supplied detail.
+   */
+  errorDetail?: string;
+}
 
 /**
- * Stamps `stage` onto `error` if it does not already carry one (first tag wins,
- * so the innermost/earliest stage is preserved as the error unwinds). No-op for
- * non-objects.
+ * The class an owned-family throw site declares about itself, passed to
+ * {@link inStage} / {@link inStageSync} so the tag carries class and detail, not
+ * just stage.
  */
-export function tagErrorStage(
-  error: unknown,
-  stage: TelemetryErrorStage,
-): void {
+export interface ErrorOrigin {
+  /**
+   * The failure family this throw site produces.
+   */
+  errorClass: TelemetryErrorClass;
+
+  /**
+   * The specific detail within the family (e.g. the pass name, or a registry id).
+   *
+   * @default undefined - the family has no detail split.
+   */
+  errorDetail?: string;
+}
+
+/**
+ * Non-enumerable symbol carrying the {@link ErrorOriginTag}. Non-enumerable so it
+ * never serializes into a telemetry payload or a JSON dump.
+ */
+const ERROR_ORIGIN = Symbol.for("openwiki.telemetry.errorOrigin");
+
+/**
+ * Stamps an origin tag onto `error` if it does not already carry one (first tag
+ * wins, so the innermost/earliest origin is preserved as the error unwinds). No-op
+ * for non-objects.
+ *
+ * @param error - The thrown value to tag.
+ * @param tag - The stage, and optionally the owned-family class and detail.
+ */
+function tagErrorOrigin(error: unknown, tag: ErrorOriginTag): void {
   if (typeof error !== "object" || error === null) {
     return;
   }
 
   const target = error as Record<symbol, unknown>;
-  if (target[ERROR_STAGE] !== undefined) {
+  if (target[ERROR_ORIGIN] !== undefined) {
     return;
   }
 
-  Object.defineProperty(error, ERROR_STAGE, {
-    value: stage,
+  Object.defineProperty(error, ERROR_ORIGIN, {
+    value: tag,
     enumerable: false,
     configurable: true,
     writable: false,
@@ -174,17 +289,13 @@ export function tagErrorStage(
 }
 
 /**
- * Reads the stage tag off an error, or undefined if it was never tagged. An
- * untagged failure emits no stage (the sender omits the field) rather than a
- * named "unknown" bucket.
+ * Reads the origin tag off an error, or undefined if it was never tagged.
  */
-export function readErrorStage(
-  error: unknown,
-): TelemetryErrorStage | undefined {
+function readErrorOrigin(error: unknown): ErrorOriginTag | undefined {
   if (typeof error === "object" && error !== null) {
-    const tag = (error as Record<symbol, unknown>)[ERROR_STAGE];
-    if (typeof tag === "string") {
-      return tag as TelemetryErrorStage;
+    const tag = (error as Record<symbol, unknown>)[ERROR_ORIGIN];
+    if (typeof tag === "object" && tag !== null && "stage" in tag) {
+      return tag as ErrorOriginTag;
     }
   }
 
@@ -192,17 +303,37 @@ export function readErrorStage(
 }
 
 /**
- * Runs `fn`, tagging any thrown error with `stage` before it propagates. The one
- * call the run pipeline uses to bracket a stage.
+ * Stamps just the pipeline `stage` onto `error` (first tag wins). The one call a
+ * plain stage bracket uses; the class is left to the raw-error classifier.
+ */
+export function tagErrorStage(
+  error: unknown,
+  stage: TelemetryErrorStage,
+): void {
+  tagErrorOrigin(error, { stage });
+}
+
+/**
+ * Runs `fn`, tagging any thrown error with `stage` (and, when `origin` is given,
+ * the owned-family class and detail) before it propagates. The one call the run
+ * pipeline uses to bracket a stage. Pass `origin` at an owned-family throw site so
+ * the failure carries its class and detail from where it was thrown, not from a
+ * message string.
+ *
+ * @param stage - The pipeline stage to tag on a throw.
+ * @param fn - The work to run.
+ * @param origin - The owned-family class and detail, when the throw site owns the
+ *   classification.
  */
 export async function inStage<T>(
   stage: TelemetryErrorStage,
   fn: () => Promise<T>,
+  origin?: ErrorOrigin,
 ): Promise<T> {
   try {
     return await fn();
   } catch (error) {
-    tagErrorStage(error, stage);
+    tagErrorOrigin(error, { stage, ...origin });
     throw error;
   }
 }
@@ -211,27 +342,77 @@ export async function inStage<T>(
  * Synchronous {@link inStage}, for the synchronous build steps (`createModel`,
  * `createDeepAgent`) that can throw before any promise is created.
  */
-export function inStageSync<T>(stage: TelemetryErrorStage, fn: () => T): T {
+export function inStageSync<T>(
+  stage: TelemetryErrorStage,
+  fn: () => T,
+  origin?: ErrorOrigin,
+): T {
   try {
     return fn();
   } catch (error) {
-    tagErrorStage(error, stage);
+    tagErrorOrigin(error, { stage, ...origin });
     throw error;
   }
 }
 
 /**
- * The single call the failure path uses: class, stage, and status in one object,
- * ready to spread into the run facts.
+ * The full telemetry description of a failure, ready to spread into the run facts.
  */
-export function describeErrorForTelemetry(error: unknown): {
+export interface ErrorTelemetry {
+  /**
+   * The closed-set failure family.
+   */
   errorClass: TelemetryErrorClass;
+
+  /**
+   * The specific failure within the family, normalized against its allowlist, or
+   * undefined.
+   */
+  errorDetail: string | undefined;
+
+  /**
+   * The pipeline stage the failure was tagged at, or undefined when uninstrumented.
+   */
   errorStage: TelemetryErrorStage | undefined;
+
+  /**
+   * Who owns the fix, derived from (class, detail, stage).
+   */
+  errorOwner: TelemetryErrorOwner;
+
+  /**
+   * The provider's numeric status, or undefined. A bare integer.
+   */
   httpStatus: number | undefined;
-} {
+}
+
+/**
+ * The single call the failure path uses: class, detail, owner, stage, and status in
+ * one object, ready to spread into the run facts. The class and detail come from the
+ * origin tag when the throw site owned the classification (build/connector/okf/
+ * checkpointer, or a tagged config/tool detail), otherwise from {@link classifyError}
+ * reading the raw error. The detail is normalized against its family's allowlist, so
+ * an off-list value is dropped rather than emitted. Never leaks the message.
+ */
+export function describeErrorForTelemetry(error: unknown): ErrorTelemetry {
+  const origin = readErrorOrigin(error);
+  const classified = classifyError(error);
+
+  // An origin tag that names a class owns both class and detail; a stage-only tag
+  // leaves both to the raw-error classifier.
+  const errorClass = origin?.errorClass ?? classified.errorClass;
+  const rawDetail = origin?.errorClass
+    ? origin.errorDetail
+    : classified.errorDetail;
+
+  const errorDetail = normalizeErrorDetail(errorClass, rawDetail);
+  const errorStage = origin?.stage;
+
   return {
-    errorClass: classifyError(error),
-    errorStage: readErrorStage(error),
+    errorClass,
+    errorDetail,
+    errorStage,
+    errorOwner: deriveOwner(errorClass, errorDetail, errorStage),
     httpStatus: extractStatus(error),
   };
 }

--- a/src/telemetry/errors.ts
+++ b/src/telemetry/errors.ts
@@ -1,12 +1,40 @@
-import type { TelemetryErrorClass } from "./types.js";
+import type { TelemetryErrorClass, TelemetryErrorStage } from "./types.js";
 
 /**
- * Maps an unknown error to a closed TelemetryErrorClass. Importantly, this never
- * leaks the message which could contain sensitive information.
+ * Provider-native error codes we recognize, mapped to a class. Read internally
+ * only to disambiguate otherwise-identical statuses (a context-limit 400 vs any
+ * other 400); the code string itself is never emitted (Open 4a). Anything not on
+ * this list is ignored, so the envelope stays closed.
+ */
+const PROVIDER_ERROR_CODES: Readonly<Record<string, TelemetryErrorClass>> = {
+  context_length_exceeded: "provider_context_limit",
+  string_above_max_length: "provider_context_limit",
+  rate_limit_exceeded: "provider_rate_limit",
+  insufficient_quota: "provider_quota_exceeded",
+  billing_hard_limit_reached: "provider_quota_exceeded",
+  invalid_api_key: "provider_auth",
+  authentication_error: "provider_auth",
+  permission_error: "provider_auth",
+  overloaded_error: "provider_overloaded",
+  content_policy_violation: "provider_content_filter",
+  content_filter: "provider_content_filter",
+};
+
+/**
+ * Maps an unknown error to a closed {@link TelemetryErrorClass}. Priority runs
+ * most-specific to least: abort, recognized provider code, HTTP status, tool
+ * shape, message regexes, filesystem code, then the single `agent_error`
+ * catch-all. Never leaks the message: it is read to test regexes in-process, but
+ * only an enum member is ever returned.
  */
 export function classifyError(error: unknown): TelemetryErrorClass {
   if (error instanceof Error && error.name === "AbortError") {
     return "aborted";
+  }
+
+  const providerCode = extractProviderErrorCode(error);
+  if (providerCode && providerCode in PROVIDER_ERROR_CODES) {
+    return PROVIDER_ERROR_CODES[providerCode];
   }
 
   const status = extractStatus(error);
@@ -16,19 +44,49 @@ export function classifyError(error: unknown): TelemetryErrorClass {
   if (status === 429) {
     return "provider_rate_limit";
   }
+  if (status === 529 || status === 503) {
+    return "provider_overloaded";
+  }
+  if (status !== undefined && status >= 500 && status < 600) {
+    return "provider_server_error";
+  }
+
+  if (error instanceof Error && /tool/iu.test(error.name)) {
+    return "tool_error";
+  }
 
   const message = error instanceof Error ? error.message.toLowerCase() : "";
-  if (/is required to run openwiki/.test(message)) {
-    return /base url/.test(message) ? "missing_config" : "missing_credentials";
+  if (/is required to run openwiki/u.test(message)) {
+    return /base url/u.test(message) ? "missing_config" : "missing_credentials";
   }
-  if (/invalid model id/.test(message)) {
+  if (/invalid model id/u.test(message)) {
     return "invalid_model";
   }
-  if (/timeout|timed out|etimedout/.test(message)) {
+  if (
+    /context length|maximum context|too many tokens|context window/u.test(
+      message,
+    )
+  ) {
+    return "provider_context_limit";
+  }
+  if (/quota|insufficient_quota|billing/u.test(message)) {
+    return "provider_quota_exceeded";
+  }
+  if (/timeout|timed out|etimedout/u.test(message)) {
     return "provider_timeout";
   }
-  if (/econnrefused|enotfound|network|fetch failed/.test(message)) {
+  if (
+    /econnrefused|enotfound|network|fetch failed|econnreset|eai_again/u.test(
+      message,
+    )
+  ) {
     return "network";
+  }
+  if (/content policy|content filter|content_filter|refus/u.test(message)) {
+    return "provider_content_filter";
+  }
+  if (/could not parse|invalid json|schema/u.test(message)) {
+    return "output_invalid";
   }
 
   const code =
@@ -41,15 +99,139 @@ export function classifyError(error: unknown): TelemetryErrorClass {
 }
 
 /**
- * Best-effort extraction of an HTTP-ish status from provider SDK errors.
+ * Best-effort extraction of an HTTP-ish status from a provider SDK error. Reads
+ * the common shapes, including the nested `response.status` some clients use.
  */
-function extractStatus(error: unknown): number | undefined {
+export function extractStatus(error: unknown): number | undefined {
   if (typeof error !== "object" || error === null) {
     return undefined;
   }
 
-  const candidate = error as { status?: unknown; statusCode?: unknown };
-  const raw = candidate.status ?? candidate.statusCode;
+  const candidate = error as {
+    status?: unknown;
+    statusCode?: unknown;
+    response?: { status?: unknown } | null;
+  };
+  const raw =
+    candidate.status ?? candidate.statusCode ?? candidate.response?.status;
 
   return typeof raw === "number" ? raw : undefined;
+}
+
+/**
+ * Reads the provider's own error code from the common SDK shapes, lowercased. Used
+ * only to pick a class; the return value is never emitted.
+ */
+function extractProviderErrorCode(error: unknown): string | undefined {
+  if (typeof error !== "object" || error === null) {
+    return undefined;
+  }
+
+  const candidate = error as {
+    code?: unknown;
+    type?: unknown;
+    error?: { code?: unknown; type?: unknown } | null;
+  };
+  const raw =
+    candidate.code ??
+    candidate.type ??
+    candidate.error?.code ??
+    candidate.error?.type;
+
+  return typeof raw === "string" ? raw.trim().toLowerCase() : undefined;
+}
+
+/**
+ * Non-enumerable symbol tag carrying the pipeline stage a failure occurred in.
+ * Non-enumerable so it never serializes into a telemetry payload or a JSON dump.
+ */
+const ERROR_STAGE = Symbol.for("openwiki.telemetry.errorStage");
+
+/**
+ * Stamps `stage` onto `error` if it does not already carry one (first tag wins,
+ * so the innermost/earliest stage is preserved as the error unwinds). No-op for
+ * non-objects.
+ */
+export function tagErrorStage(
+  error: unknown,
+  stage: TelemetryErrorStage,
+): void {
+  if (typeof error !== "object" || error === null) {
+    return;
+  }
+
+  const target = error as Record<symbol, unknown>;
+  if (target[ERROR_STAGE] !== undefined) {
+    return;
+  }
+
+  Object.defineProperty(error, ERROR_STAGE, {
+    value: stage,
+    enumerable: false,
+    configurable: true,
+    writable: false,
+  });
+}
+
+/**
+ * Reads the stage tag off an error, or undefined if it was never tagged. An
+ * untagged failure emits no stage (the sender omits the field) rather than a
+ * named "unknown" bucket.
+ */
+export function readErrorStage(
+  error: unknown,
+): TelemetryErrorStage | undefined {
+  if (typeof error === "object" && error !== null) {
+    const tag = (error as Record<symbol, unknown>)[ERROR_STAGE];
+    if (typeof tag === "string") {
+      return tag as TelemetryErrorStage;
+    }
+  }
+
+  return undefined;
+}
+
+/**
+ * Runs `fn`, tagging any thrown error with `stage` before it propagates. The one
+ * call the run pipeline uses to bracket a stage.
+ */
+export async function inStage<T>(
+  stage: TelemetryErrorStage,
+  fn: () => Promise<T>,
+): Promise<T> {
+  try {
+    return await fn();
+  } catch (error) {
+    tagErrorStage(error, stage);
+    throw error;
+  }
+}
+
+/**
+ * Synchronous {@link inStage}, for the synchronous build steps (`createModel`,
+ * `createDeepAgent`) that can throw before any promise is created.
+ */
+export function inStageSync<T>(stage: TelemetryErrorStage, fn: () => T): T {
+  try {
+    return fn();
+  } catch (error) {
+    tagErrorStage(error, stage);
+    throw error;
+  }
+}
+
+/**
+ * The single call the failure path uses: class, stage, and status in one object,
+ * ready to spread into the run facts.
+ */
+export function describeErrorForTelemetry(error: unknown): {
+  errorClass: TelemetryErrorClass;
+  errorStage: TelemetryErrorStage | undefined;
+  httpStatus: number | undefined;
+} {
+  return {
+    errorClass: classifyError(error),
+    errorStage: readErrorStage(error),
+    httpStatus: extractStatus(error),
+  };
 }

--- a/src/telemetry/index.ts
+++ b/src/telemetry/index.ts
@@ -1,6 +1,8 @@
 export { buildRunEvent, recordRun } from "./senders.js";
 export type { RunEventContext } from "./senders.js";
 export { recordRunSafe } from "./record-run-safe.js";
+export { withRunTelemetry } from "./with-run-telemetry.js";
+export type { RunTelemetryContext } from "./with-run-telemetry.js";
 export { firstRunNoticePending } from "./install-id.js";
 export {
   FIRST_RUN_NOTICE_BODY,
@@ -14,10 +16,17 @@ export {
   inStageSync,
   tagErrorStage,
 } from "./errors.js";
+export type {
+  ErrorClassification,
+  ErrorOrigin,
+  ErrorTelemetry,
+} from "./errors.js";
+export { deriveOwner, normalizeErrorDetail } from "./taxonomy.js";
 export { isCiEnvironment, isTelemetryDisabled } from "./gates.js";
 export type {
   RunTelemetry,
   TelemetryErrorClass,
+  TelemetryErrorOwner,
   TelemetryErrorStage,
   TelemetryMode,
 } from "./types.js";

--- a/src/telemetry/index.ts
+++ b/src/telemetry/index.ts
@@ -7,10 +7,17 @@ export {
   FIRST_RUN_NOTICE_OPT_OUT,
   FIRST_RUN_NOTICE_VERIFY,
 } from "./config.js";
-export { classifyError } from "./errors.js";
+export {
+  classifyError,
+  describeErrorForTelemetry,
+  inStage,
+  inStageSync,
+  tagErrorStage,
+} from "./errors.js";
 export { isCiEnvironment, isTelemetryDisabled } from "./gates.js";
 export type {
   RunTelemetry,
   TelemetryErrorClass,
+  TelemetryErrorStage,
   TelemetryMode,
 } from "./types.js";

--- a/src/telemetry/record-run-safe.ts
+++ b/src/telemetry/record-run-safe.ts
@@ -7,7 +7,7 @@ import { getConfiguredConnectorIds } from "../connectors/registry.js";
 import type { OpenWikiProvider } from "../constants.js";
 
 import { recordRun } from "./senders.js";
-import type { TelemetryErrorClass } from "./types.js";
+import type { TelemetryErrorClass, TelemetryErrorStage } from "./types.js";
 
 /**
  * Translates a finished agent run into the single telemetry event and records
@@ -24,9 +24,10 @@ import type { TelemetryErrorClass } from "./types.js";
  *
  * @param command - Which run lifecycle finished. Only init/update are recorded.
  * @param options - The run options; read for `outputMode` and `telemetryFile`.
- * @param facts - What the run produced: its `outcome`, an optional `errorClass`
- *   (present on failure), and the resolved `provider` (which may be undefined
- *   when resolution failed before the provider was known).
+ * @param facts - What the run produced: its `outcome`, the failure diagnostics
+ *   (`errorClass`, plus an optional `errorStage` and `httpStatus`, all present
+ *   only on failure), and the resolved `provider` (which may be undefined when
+ *   resolution failed before the provider was known).
  */
 export async function recordRunSafe(
   command: OpenWikiCommand,
@@ -35,6 +36,8 @@ export async function recordRunSafe(
     provider?: OpenWikiProvider;
     outcome: "success" | "failure" | "noop";
     errorClass?: TelemetryErrorClass;
+    errorStage?: TelemetryErrorStage;
+    httpStatus?: number;
   },
 ): Promise<void> {
   // Chat is deliberately not recorded: it is interactive and would emit one
@@ -49,6 +52,8 @@ export async function recordRunSafe(
     command,
     outcome: facts.outcome,
     errorClass: facts.errorClass,
+    errorStage: facts.errorStage,
+    httpStatus: facts.httpStatus,
     // Setup choices are captured on init only (the configuration moment); on
     // updates these are omitted entirely.
     ...(command === "init"

--- a/src/telemetry/record-run-safe.ts
+++ b/src/telemetry/record-run-safe.ts
@@ -7,7 +7,11 @@ import { getConfiguredConnectorIds } from "../connectors/registry.js";
 import type { OpenWikiProvider } from "../constants.js";
 
 import { recordRun } from "./senders.js";
-import type { TelemetryErrorClass, TelemetryErrorStage } from "./types.js";
+import type {
+  TelemetryErrorClass,
+  TelemetryErrorOwner,
+  TelemetryErrorStage,
+} from "./types.js";
 
 /**
  * Translates a finished agent run into the single telemetry event and records
@@ -25,9 +29,9 @@ import type { TelemetryErrorClass, TelemetryErrorStage } from "./types.js";
  * @param command - Which run lifecycle finished. Only init/update are recorded.
  * @param options - The run options; read for `outputMode` and `telemetryFile`.
  * @param facts - What the run produced: its `outcome`, the failure diagnostics
- *   (`errorClass`, plus an optional `errorStage` and `httpStatus`, all present
- *   only on failure), and the resolved `provider` (which may be undefined when
- *   resolution failed before the provider was known).
+ *   (`errorClass`, plus an optional `errorDetail`, `errorOwner`, `errorStage`, and
+ *   `httpStatus`, all present only on failure), and the resolved `provider` (which
+ *   may be undefined when resolution failed before the provider was known).
  */
 export async function recordRunSafe(
   command: OpenWikiCommand,
@@ -36,6 +40,8 @@ export async function recordRunSafe(
     provider?: OpenWikiProvider;
     outcome: "success" | "failure" | "noop";
     errorClass?: TelemetryErrorClass;
+    errorDetail?: string;
+    errorOwner?: TelemetryErrorOwner;
     errorStage?: TelemetryErrorStage;
     httpStatus?: number;
   },
@@ -52,6 +58,8 @@ export async function recordRunSafe(
     command,
     outcome: facts.outcome,
     errorClass: facts.errorClass,
+    errorDetail: facts.errorDetail,
+    errorOwner: facts.errorOwner,
     errorStage: facts.errorStage,
     httpStatus: facts.httpStatus,
     // Setup choices are captured on init only (the configuration moment); on

--- a/src/telemetry/senders.ts
+++ b/src/telemetry/senders.ts
@@ -72,6 +72,12 @@ export function buildRunEvent(
       command: details.command,
       outcome: details.outcome,
       ...(details.errorClass ? { error_class: details.errorClass } : {}),
+      // The specific failure within the family and who owns the fix. Detail is an
+      // allowlisted word (dropped upstream if off-list); owner is derived from
+      // (class, detail, stage) so the dashboard can roll up by who must act,
+      // including the cross-owner exceptions PostHog cannot derive. Failure-only.
+      ...(details.errorDetail ? { error_detail: details.errorDetail } : {}),
+      ...(details.errorOwner ? { error_owner: details.errorOwner } : {}),
       // Where in the pipeline the failure was tagged, and the provider's numeric
       // status if one was present. Both failure-only and omitted when absent, so
       // the null bucket reads as "not instrumented / no status" rather than a

--- a/src/telemetry/senders.ts
+++ b/src/telemetry/senders.ts
@@ -1,5 +1,7 @@
+import { readFileSync } from "node:fs";
 import { mkdir, writeFile } from "node:fs/promises";
 import path from "node:path";
+import { fileURLToPath } from "node:url";
 
 import { capture } from "./client.js";
 import { DEFAULT_POSTHOG_HOST, TELEMETRY_RUN_EVENT } from "./config.js";
@@ -38,6 +40,17 @@ export interface RunEventContext {
    * sentinel. The builder does not resolve this; the caller decides.
    */
   distinctId: string;
+
+  /**
+   * OpenWiki version from the bundled `package.json` (e.g. "0.2.3"). Stamped on
+   * every event so adoption and per-version breakage are readable, and so the
+   * dashboard can scope metrics to a known version. Resolved by the caller from
+   * disk; the builder stays pure.
+   *
+   * @default undefined - the bundled package.json could not be read or had no
+   * version; the field is omitted rather than sent empty.
+   */
+  appVersion?: string;
 }
 
 /**
@@ -59,12 +72,24 @@ export function buildRunEvent(
       command: details.command,
       outcome: details.outcome,
       ...(details.errorClass ? { error_class: details.errorClass } : {}),
+      // Where in the pipeline the failure was tagged, and the provider's numeric
+      // status if one was present. Both failure-only and omitted when absent, so
+      // the null bucket reads as "not instrumented / no status" rather than a
+      // named value. No provider strings ride with the status.
+      ...(details.errorStage ? { error_stage: details.errorStage } : {}),
+      ...(details.httpStatus !== undefined
+        ? { http_status: details.httpStatus }
+        : {}),
       ...(details.mode ? { mode: details.mode } : {}),
       ...(details.provider ? { provider: details.provider } : {}),
       ...connectorProperties(details.configuredConnectors ?? []),
       // True for the published build, false for dev/source/seed runs; lets real
       // usage be separated from local testing and pre-launch seed data.
       production: context.production,
+      // Distribution provenance: the OpenWiki version from the bundled
+      // package.json, stamped on every event so adoption and per-version
+      // breakage are readable. Omitted when the caller could not resolve it.
+      ...(context.appVersion ? { app_version: context.appVersion } : {}),
       // Splits any metric human vs CI; also drives identity via the caller.
       ci: context.ci,
       // Never build a PostHog person: every run is anonymous. Unique-install
@@ -101,6 +126,7 @@ export async function recordRun(details: RunTelemetry): Promise<void> {
       ci,
       production: isProductionBuild(),
       distinctId,
+      appVersion: packageProvenance().appVersion,
     });
     const sent = await capture(event);
 
@@ -114,6 +140,79 @@ export async function recordRun(details: RunTelemetry): Promise<void> {
   } catch {
     // Intentionally ignored: telemetry must never break a run.
   }
+}
+
+/**
+ * Non-identifying distribution provenance read once from the bundled
+ * `package.json`: the OpenWiki version. Static build metadata, so it is resolved
+ * lazily and cached for the process lifetime.
+ */
+interface PackageProvenance {
+  /**
+   * `version` from the bundled package.json, or undefined when it could not be
+   * read.
+   */
+  appVersion?: string;
+}
+
+/**
+ * Cached result of {@link packageProvenance}. `undefined` means "not resolved
+ * yet"; once resolved it is an object (possibly empty on failure) and never
+ * re-read.
+ */
+let cachedProvenance: PackageProvenance | undefined;
+
+/**
+ * Reads the bundled `package.json` for its `version`, walking up from this
+ * module's own location to the nearest package.json that declares a `name` (the
+ * name gates out unrelated package.json files without itself being emitted). The
+ * version is static, non-identifying build metadata; no user repository content
+ * is ever touched. Fully failure-safe: any error (missing file, bad JSON, no
+ * name) yields an empty object, so provenance is simply omitted from the event
+ * rather than breaking the run. Cached for the process lifetime.
+ */
+function packageProvenance(): PackageProvenance {
+  if (cachedProvenance !== undefined) {
+    return cachedProvenance;
+  }
+
+  cachedProvenance = {};
+  try {
+    let dir = path.dirname(fileURLToPath(import.meta.url));
+    // Walk up a bounded number of levels: dist/ layouts and src/ layouts differ,
+    // so the nearest named package.json may be a few directories up. Bounded so a
+    // stray package.json high in the tree cannot send us walking to the root.
+    for (let depth = 0; depth < 6; depth++) {
+      const candidate = path.join(dir, "package.json");
+      try {
+        const parsed: unknown = JSON.parse(readFileSync(candidate, "utf8"));
+        if (
+          typeof parsed === "object" &&
+          parsed !== null &&
+          typeof (parsed as { name?: unknown }).name === "string"
+        ) {
+          const pkg = parsed as { version?: unknown };
+          cachedProvenance = {
+            appVersion:
+              typeof pkg.version === "string" ? pkg.version : undefined,
+          };
+          break;
+        }
+      } catch {
+        // No readable/valid package.json at this level; keep walking up.
+      }
+
+      const parent = path.dirname(dir);
+      if (parent === dir) {
+        break;
+      }
+      dir = parent;
+    }
+  } catch {
+    // Intentionally ignored: provenance is best-effort, never fatal.
+  }
+
+  return cachedProvenance;
 }
 
 /**

--- a/src/telemetry/taxonomy.ts
+++ b/src/telemetry/taxonomy.ts
@@ -1,0 +1,159 @@
+import type {
+  TelemetryErrorClass,
+  TelemetryErrorOwner,
+  TelemetryErrorStage,
+} from "./types.js";
+
+/**
+ * The hardcoded `errorDetail` allowlist for each closed family: the exact set of
+ * detail values that family may emit. This is the anonymity spine for the detail
+ * property. Any observed detail not present for its family is dropped to undefined
+ * (see {@link normalizeErrorDetail}), so only these hand-named words ever leave the
+ * process. Families with no detail split map to an empty list.
+ *
+ * Two families are deliberately absent (`connector_error`, `tool_error`): their
+ * detail is a registry id, not a fixed word, and is validated at its tag site
+ * against the connector/tool registry instead (see {@link OPEN_DETAIL_CLASSES}).
+ */
+const FIXED_ERROR_DETAILS: Readonly<
+  Record<
+    Exclude<TelemetryErrorClass, "connector_error" | "tool_error">,
+    readonly string[]
+  >
+> = {
+  config_error: [
+    "missing_credentials",
+    "missing_base_url",
+    "missing_secret_key",
+    "missing_region",
+    "invalid_model",
+  ],
+  filesystem_error: ["not_found", "permission", "no_space"],
+  provider_error: [
+    "auth",
+    "rate_limit",
+    "overloaded",
+    "server_error",
+    "timeout",
+    "quota_exceeded",
+    "content_filter",
+  ],
+  network_error: ["dns", "refused", "reset", "unreachable"],
+  build_error: ["run_context", "snapshot", "model", "agent", "stream_open"],
+  okf_error: ["migrate", "index_sync", "mermaid"],
+  checkpointer_error: ["create", "persist", "chmod"],
+  output_error: ["json_parse", "schema"],
+  // No detail split: the family is the whole signal.
+  context_limit_error: [],
+  agent_error: [],
+  aborted: [],
+};
+
+/**
+ * Families whose detail is a registry id (the connector id or the tool name) rather
+ * than a fixed word. Their detail is validated at the tag site against the known
+ * connector/tool set, which is the same closed set already emitted as `connector_*`
+ * booleans, so it is trusted here without a static allowlist.
+ */
+const OPEN_DETAIL_CLASSES: ReadonlySet<TelemetryErrorClass> = new Set([
+  "connector_error",
+  "tool_error",
+]);
+
+/**
+ * Provider-error details that are really the user's key or account, not a transient
+ * provider fault, so they route to `environment` instead of `provider`.
+ */
+const PROVIDER_ENVIRONMENT_DETAILS: ReadonlySet<string> = new Set([
+  "auth",
+  "quota_exceeded",
+]);
+
+/**
+ * Network-error details that are the user's machine or network, not the path to the
+ * provider, so they route to `environment` instead of `provider`.
+ */
+const NETWORK_ENVIRONMENT_DETAILS: ReadonlySet<string> = new Set([
+  "dns",
+  "refused",
+]);
+
+/**
+ * Validates an observed `detail` against its family's allowlist, returning it only
+ * when legal and undefined otherwise. This is the runtime guarantee behind the
+ * detail property's anonymity: a fixed-family detail must be on the family's
+ * hardcoded list; an open-family detail (connector/tool id) is trusted as a
+ * non-empty string because its tag site already validated it against the registry;
+ * a no-detail family always yields undefined.
+ *
+ * @param errorClass - The failure family the detail belongs to.
+ * @param detail - The observed detail, or undefined when none was resolved.
+ * @returns The detail if it is legal for the family, otherwise undefined.
+ */
+export function normalizeErrorDetail(
+  errorClass: TelemetryErrorClass,
+  detail: string | undefined,
+): string | undefined {
+  if (detail === undefined || detail === "") {
+    return undefined;
+  }
+
+  if (OPEN_DETAIL_CLASSES.has(errorClass)) {
+    return detail;
+  }
+
+  const allowed =
+    FIXED_ERROR_DETAILS[errorClass as keyof typeof FIXED_ERROR_DETAILS];
+  return allowed.includes(detail) ? detail : undefined;
+}
+
+/**
+ * Derives who owns the fix for a failure from its class, detail, and stage. The
+ * single source of owner truth; no other site should branch on (class, detail) to
+ * decide an owner. Encodes the three cross-owner exceptions where a family sits
+ * under one owner but a couple of its details are really someone else's problem:
+ *
+ * - `provider_error` is the provider's, except `auth`/`quota_exceeded` (the user's
+ *   key or account) which are `environment`.
+ * - `network_error` is the provider path's, except `dns`/`refused` (the user's
+ *   machine or network) which are `environment`.
+ * - `filesystem_error` is the user's, except at `finalize` (our own wiki write
+ *   path) which is `openwiki`.
+ *
+ * @param errorClass - The failure family.
+ * @param detail - The normalized detail, or undefined.
+ * @param stage - The pipeline stage the failure was tagged at, or undefined.
+ * @returns The owner responsible for acting on the failure.
+ */
+export function deriveOwner(
+  errorClass: TelemetryErrorClass,
+  detail: string | undefined,
+  stage: TelemetryErrorStage | undefined,
+): TelemetryErrorOwner {
+  switch (errorClass) {
+    case "config_error":
+      return "environment";
+    case "filesystem_error":
+      return stage === "finalize" ? "openwiki" : "environment";
+    case "provider_error":
+      return detail !== undefined && PROVIDER_ENVIRONMENT_DETAILS.has(detail)
+        ? "environment"
+        : "provider";
+    case "network_error":
+      return detail !== undefined && NETWORK_ENVIRONMENT_DETAILS.has(detail)
+        ? "environment"
+        : "provider";
+    case "context_limit_error":
+    case "build_error":
+    case "connector_error":
+    case "okf_error":
+    case "checkpointer_error":
+    case "tool_error":
+    case "output_error":
+      return "openwiki";
+    case "agent_error":
+      return "unowned";
+    case "aborted":
+      return "control";
+  }
+}

--- a/src/telemetry/types.ts
+++ b/src/telemetry/types.ts
@@ -1,28 +1,44 @@
 /**
- * Closed set of failure categories. Raw error strings are never sent; only these
- * enum values leave the process. `provider_*` marks an error the model provider's
- * API returned; bare names are our-side or environment failures. `agent_error` is
- * the single catch-all for any failure that matched no rule (including a thrown
- * non-`Error`).
+ * Closed set of failure families, the big bucket a failure falls in. Raw error
+ * strings are never sent; only these enum values leave the process. Each family
+ * pairs with an `errorDetail` (the specific failure inside it) and derives an
+ * `errorOwner` (whose problem it is). `agent_error` is the residual for any
+ * failure that matched no rule (including a thrown non-`Error`); it is the quality
+ * meter and should trend toward zero.
+ *
+ * The full taxonomy (families, per-family detail allowlists, and owner rules) lives
+ * in `taxonomy.ts`.
  */
 export type TelemetryErrorClass =
-  | "missing_credentials"
-  | "missing_config"
-  | "invalid_model"
-  | "provider_auth"
-  | "provider_rate_limit"
-  | "provider_timeout"
-  | "provider_overloaded"
-  | "provider_server_error"
-  | "provider_context_limit"
-  | "provider_quota_exceeded"
-  | "provider_content_filter"
-  | "network"
-  | "output_invalid"
-  | "agent_error"
+  | "config_error"
+  | "filesystem_error"
+  | "provider_error"
+  | "network_error"
+  | "context_limit_error"
+  | "build_error"
+  | "connector_error"
+  | "okf_error"
+  | "checkpointer_error"
   | "tool_error"
-  | "filesystem"
+  | "output_error"
+  | "agent_error"
   | "aborted";
+
+/**
+ * Who owns the fix for a failure, derived from its class, detail, and stage (see
+ * `deriveOwner` in `taxonomy.ts`). This is emitted so the health dashboard can roll
+ * failures up by who has to act, including the cross-owner exceptions (a
+ * `provider_error` with detail `auth` is really the user's key, so it owns to
+ * `environment`) that PostHog cannot derive on its own.
+ *
+ * - `environment`: the user's setup, credentials, or machine.
+ * - `provider`: the provider API failed transiently; retry/backoff.
+ * - `openwiki`: we own the fix, whether a bug or work like chunking.
+ * - `unowned`: the agent/model core failed in a way we have not named yet.
+ * - `control`: the run was cancelled; excluded from failure-rate math.
+ */
+export type TelemetryErrorOwner =
+  "environment" | "provider" | "openwiki" | "unowned" | "control";
 
 /**
  * Ordered pipeline stage a failure was tagged at: config -> build -> run ->
@@ -60,9 +76,29 @@ export interface RunTelemetry {
   outcome: "success" | "failure" | "noop";
 
   /**
-   * Closed-set failure category. Present only when `outcome` is "failure".
+   * Closed-set failure family. Present only when `outcome` is "failure".
    */
   errorClass?: TelemetryErrorClass;
+
+  /**
+   * The specific failure within `errorClass`, from that family's hardcoded
+   * allowlist (see `taxonomy.ts`), e.g. `auth` inside `provider_error`. One shared
+   * property across all families. Anything off the family's allowlist is dropped to
+   * undefined rather than sent raw, so the anonymity envelope stays closed.
+   *
+   * @default undefined - the family has no detail split, or the observed detail was
+   * not on the family's allowlist; the field is omitted rather than sent raw.
+   */
+  errorDetail?: string;
+
+  /**
+   * Who owns the fix, derived from (class, detail, stage) at record time. Emitted
+   * (not left for PostHog to derive) because the owner rules include cross-owner
+   * exceptions PostHog cannot express. Present only when `outcome` is "failure".
+   *
+   * @default undefined - no failure to attribute (the run did not fail).
+   */
+  errorOwner?: TelemetryErrorOwner;
 
   /**
    * Pipeline stage the failure was tagged at. Present only when `outcome` is

--- a/src/telemetry/types.ts
+++ b/src/telemetry/types.ts
@@ -1,5 +1,9 @@
 /**
- * Closed set of failure categories. Raw error strings are never sent.
+ * Closed set of failure categories. Raw error strings are never sent; only these
+ * enum values leave the process. `provider_*` marks an error the model provider's
+ * API returned; bare names are our-side or environment failures. `agent_error` is
+ * the single catch-all for any failure that matched no rule (including a thrown
+ * non-`Error`).
  */
 export type TelemetryErrorClass =
   | "missing_credentials"
@@ -8,12 +12,25 @@ export type TelemetryErrorClass =
   | "provider_auth"
   | "provider_rate_limit"
   | "provider_timeout"
+  | "provider_overloaded"
+  | "provider_server_error"
+  | "provider_context_limit"
+  | "provider_quota_exceeded"
+  | "provider_content_filter"
   | "network"
+  | "output_invalid"
   | "agent_error"
   | "tool_error"
   | "filesystem"
-  | "aborted"
-  | "unknown";
+  | "aborted";
+
+/**
+ * Ordered pipeline stage a failure was tagged at: config -> build -> run ->
+ * finalize. Lets a failure be read as "where in the run did it break", so a class
+ * can be located to a phase. An untagged failure carries no stage (the field is
+ * omitted), which reads as "not instrumented here" rather than a named bucket.
+ */
+export type TelemetryErrorStage = "config" | "build" | "run" | "finalize";
 
 /**
  * Which brain a run targeted.
@@ -46,6 +63,23 @@ export interface RunTelemetry {
    * Closed-set failure category. Present only when `outcome` is "failure".
    */
   errorClass?: TelemetryErrorClass;
+
+  /**
+   * Pipeline stage the failure was tagged at. Present only when `outcome` is
+   * "failure", and only when the throwing path was instrumented.
+   *
+   * @default undefined - the error carried no stage tag; the throw site is not
+   * instrumented, so no stage is emitted.
+   */
+  errorStage?: TelemetryErrorStage;
+
+  /**
+   * HTTP-ish status read off the provider error, when one was present. A bare
+   * integer; no provider strings ride with it. Present only on failure.
+   *
+   * @default undefined - the error exposed no numeric status.
+   */
+  httpStatus?: number;
 
   /**
    * Which brain was set up (code = repository, personal = local wiki). Init

--- a/src/telemetry/with-run-telemetry.ts
+++ b/src/telemetry/with-run-telemetry.ts
@@ -1,0 +1,85 @@
+import type { OpenWikiCommand, OpenWikiRunOptions } from "../agent/types.js";
+import type { OpenWikiProvider } from "../constants.js";
+
+import { describeErrorForTelemetry } from "./errors.js";
+import { recordRunSafe } from "./record-run-safe.js";
+
+/**
+ * Mutable run facts that resolve as a run proceeds, enriched in place by
+ * `runOpenWikiAgent` and read by {@link withRunTelemetry} once the run settles.
+ *
+ * This is what lets the single telemetry boundary sit *outside* the agent, wrapping
+ * the pre-agent repo setup and connector pulls that today reach no telemetry, while
+ * still attributing the provider and a `noop` short-circuit that are only knowable
+ * *inside* the agent. The caller creates one, hands it to both the wrapper and the
+ * agent, and the agent writes to it as those facts become known.
+ */
+export interface RunTelemetryContext {
+  /**
+   * The resolved LLM provider, published the instant provider resolution succeeds so
+   * that a failure later in the run still attributes the right provider.
+   *
+   * @default undefined - resolution never reached the provider (e.g. a pre-agent
+   * setup or connector throw, or the very first resolution step threw); the run is
+   * recorded with provider "unknown".
+   */
+  provider?: OpenWikiProvider;
+
+  /**
+   * The non-failure outcome the run reached, set by the agent. The wrapper defaults a
+   * clean return to "success" and any throw to "failure", so only a `noop`
+   * short-circuit needs to be published here.
+   *
+   * @default undefined - the run returned without short-circuiting; recorded as
+   * "success".
+   */
+  outcome?: "success" | "noop";
+}
+
+/**
+ * The single telemetry boundary for one run: the sole place an `openwiki_run` event
+ * is recorded.
+ *
+ * It wraps the whole setup -> connectors -> agent sequence a caller performs, so a
+ * failure anywhere in that sequence (repo setup, connector pull, agent prologue, or
+ * the agent itself) is recorded exactly once, closing the pre-agent coverage holes
+ * where a throw previously reached no telemetry. On a clean return it records the
+ * outcome the agent published on `ctx` (defaulting to "success"); on a throw it
+ * records "failure" with the anonymous diagnostics from
+ * {@link describeErrorForTelemetry}, then rethrows so the CLI still owns the failure
+ * UX. It never throws from telemetry: `recordRunSafe` swallows its own errors.
+ *
+ * @param command - Which run lifecycle this is. Only init/update are recorded; chat
+ *   is dropped downstream by `recordRunSafe`.
+ * @param options - The run options; `recordRunSafe` reads `outputMode` and
+ *   `telemetryFile` from them.
+ * @param ctx - The mutable context the wrapped `run` enriches (provider, outcome).
+ * @param run - The run to perform and record: setup, connectors, and the agent.
+ */
+export async function withRunTelemetry<T>(
+  command: OpenWikiCommand,
+  options: OpenWikiRunOptions,
+  ctx: RunTelemetryContext,
+  run: () => Promise<T>,
+): Promise<T> {
+  try {
+    const result = await run();
+
+    await recordRunSafe(command, options, {
+      provider: ctx.provider,
+      outcome: ctx.outcome ?? "success",
+    });
+
+    return result;
+  } catch (error) {
+    await recordRunSafe(command, options, {
+      provider: ctx.provider,
+      outcome: "failure",
+      // Class, detail, owner, stage, and status in one spread. Everything rides
+      // closed-set enums or bare integers; no error text enters the payload.
+      ...describeErrorForTelemetry(error),
+    });
+
+    throw error;
+  }
+}

--- a/test/telemetry.test.ts
+++ b/test/telemetry.test.ts
@@ -24,7 +24,12 @@ vi.mock("posthog-node", () => ({ PostHog: posthog.PostHog }));
 import { getConfiguredConnectorIds } from "../src/connectors/registry.ts";
 import { capture as captureEvent } from "../src/telemetry/client.ts";
 import { DEFAULT_POSTHOG_KEY } from "../src/telemetry/config.ts";
-import { classifyError } from "../src/telemetry/errors.ts";
+import {
+  classifyError,
+  describeErrorForTelemetry,
+  readErrorStage,
+  tagErrorStage,
+} from "../src/telemetry/errors.ts";
 import {
   ciSentinelId,
   isCiEnvironment,
@@ -118,6 +123,78 @@ describe("classifyError", () => {
 
     expect(result).toBe("agent_error");
     expect(result).not.toContain("secret");
+  });
+});
+
+describe("classifyError - provider granularity", () => {
+  test("a recognized provider code wins over the status", () => {
+    expect(
+      classifyError({ status: 400, code: "context_length_exceeded" }),
+    ).toBe("provider_context_limit");
+  });
+
+  test("maps the new statuses", () => {
+    expect(classifyError({ status: 529 })).toBe("provider_overloaded");
+    expect(classifyError({ status: 503 })).toBe("provider_overloaded");
+    expect(classifyError({ status: 500 })).toBe("provider_server_error");
+  });
+
+  test("reads a nested response.status", () => {
+    expect(classifyError({ response: { status: 503 } })).toBe(
+      "provider_overloaded",
+    );
+  });
+
+  test("classifies context limit and content filter by message", () => {
+    expect(
+      classifyError(new Error("maximum context length is 200000 tokens")),
+    ).toBe("provider_context_limit");
+    expect(classifyError(new Error("Blocked by content policy"))).toBe(
+      "provider_content_filter",
+    );
+  });
+
+  test("folds any unclassified throw into agent_error", () => {
+    expect(classifyError(new Error("something weird"))).toBe("agent_error");
+    expect(classifyError("boom")).toBe("agent_error");
+    expect(classifyError(undefined)).toBe("agent_error");
+  });
+});
+
+describe("error stage tags", () => {
+  test("first tag wins and never serializes", () => {
+    const error = new Error("x");
+    tagErrorStage(error, "build");
+    tagErrorStage(error, "run");
+
+    expect(readErrorStage(error)).toBe("build");
+    expect(Object.keys(error)).not.toContain(
+      "Symbol(openwiki.telemetry.errorStage)",
+    );
+    expect(JSON.stringify(error)).not.toMatch(/build/u);
+  });
+
+  test("an untagged error reports no stage", () => {
+    expect(readErrorStage(new Error("x"))).toBeUndefined();
+  });
+
+  test("describeErrorForTelemetry assembles class, stage, and status", () => {
+    const error = Object.assign(new Error("nope"), { status: 503 });
+    tagErrorStage(error, "run");
+
+    expect(describeErrorForTelemetry(error)).toEqual({
+      errorClass: "provider_overloaded",
+      errorStage: "run",
+      httpStatus: 503,
+    });
+  });
+
+  test("describeErrorForTelemetry leaves stage and status undefined when absent", () => {
+    expect(describeErrorForTelemetry(new Error("boom"))).toEqual({
+      errorClass: "agent_error",
+      errorStage: undefined,
+      httpStatus: undefined,
+    });
   });
 });
 

--- a/test/telemetry.test.ts
+++ b/test/telemetry.test.ts
@@ -36,7 +36,8 @@ import {
   isTelemetryDisabled,
   noticeSuppressed,
 } from "../src/telemetry/gates.ts";
-import { recordRun } from "../src/telemetry/senders.ts";
+import { buildRunEvent, recordRun } from "../src/telemetry/senders.ts";
+import type { RunEventContext } from "../src/telemetry/senders.ts";
 import type { RunTelemetry } from "../src/telemetry/types.ts";
 
 const ENV_KEYS = [
@@ -403,5 +404,85 @@ describe("recordRun connector properties", () => {
       false,
     );
     expect(props).toMatchObject({ command: "update", outcome: "success" });
+  });
+});
+
+describe("buildRunEvent diagnostics", () => {
+  const baseContext: RunEventContext = {
+    ci: false,
+    production: true,
+    distinctId: "install-abc",
+  };
+
+  test("failure diagnostics ride the payload", () => {
+    // A failure with a tagged stage and a provider status must surface both,
+    // alongside the class, as flat anonymous properties.
+    const event = buildRunEvent(
+      {
+        command: "init",
+        outcome: "failure",
+        errorClass: "provider_overloaded",
+        errorStage: "run",
+        httpStatus: 529,
+      },
+      baseContext,
+    );
+
+    expect(event.properties).toMatchObject({
+      error_class: "provider_overloaded",
+      error_stage: "run",
+      http_status: 529,
+    });
+  });
+
+  test("success omits stage and status", () => {
+    // No failure means no diagnostics: the fields must be absent, not null/0,
+    // so the PostHog null bucket stays meaningful.
+    const event = buildRunEvent(
+      { command: "init", outcome: "success" },
+      baseContext,
+    );
+
+    expect(event.properties).not.toHaveProperty("error_class");
+    expect(event.properties).not.toHaveProperty("error_stage");
+    expect(event.properties).not.toHaveProperty("http_status");
+  });
+
+  test("http_status of 0 would still ride, but omission is by undefined only", () => {
+    // Guard the `!== undefined` check: a (hypothetical) zero status is a real
+    // value and must not be dropped by a falsy test.
+    const event = buildRunEvent(
+      {
+        command: "init",
+        outcome: "failure",
+        errorClass: "agent_error",
+        httpStatus: 0,
+      },
+      baseContext,
+    );
+
+    expect(event.properties.http_status).toBe(0);
+  });
+
+  test("app_version is stamped when the context supplies it", () => {
+    // app_version is a peer of production/ci and rides every event (init or
+    // update) when the caller resolved it.
+    const event = buildRunEvent(
+      { command: "update", outcome: "success" },
+      { ...baseContext, appVersion: "9.9.9" },
+    );
+
+    expect(event.properties).toMatchObject({ app_version: "9.9.9" });
+  });
+
+  test("app_version is omitted when the context could not resolve it", () => {
+    // A failed package.json read leaves appVersion undefined; the field must
+    // simply not appear rather than send an empty string.
+    const event = buildRunEvent(
+      { command: "init", outcome: "success" },
+      baseContext,
+    );
+
+    expect(event.properties).not.toHaveProperty("app_version");
   });
 });

--- a/test/telemetry.test.ts
+++ b/test/telemetry.test.ts
@@ -21,15 +21,21 @@ const posthog = vi.hoisted(() => {
 });
 vi.mock("posthog-node", () => ({ PostHog: posthog.PostHog }));
 
+import { PROVIDER_CONFIGS } from "../src/constants.ts";
 import { getConfiguredConnectorIds } from "../src/connectors/registry.ts";
 import { capture as captureEvent } from "../src/telemetry/client.ts";
 import { DEFAULT_POSTHOG_KEY } from "../src/telemetry/config.ts";
 import {
   classifyError,
   describeErrorForTelemetry,
-  readErrorStage,
+  inStage,
+  inStageSync,
   tagErrorStage,
 } from "../src/telemetry/errors.ts";
+import {
+  deriveOwner,
+  normalizeErrorDetail,
+} from "../src/telemetry/taxonomy.ts";
 import {
   ciSentinelId,
   isCiEnvironment,
@@ -38,7 +44,12 @@ import {
 } from "../src/telemetry/gates.ts";
 import { buildRunEvent, recordRun } from "../src/telemetry/senders.ts";
 import type { RunEventContext } from "../src/telemetry/senders.ts";
-import type { RunTelemetry } from "../src/telemetry/types.ts";
+import type {
+  RunTelemetry,
+  TelemetryErrorClass,
+  TelemetryErrorStage,
+  TelemetryEvent,
+} from "../src/telemetry/types.ts";
 
 const ENV_KEYS = [
   "OPENWIKI_TELEMETRY_DISABLED",
@@ -91,39 +102,58 @@ async function readTee(file: string): Promise<Record<string, unknown>> {
 }
 
 describe("classifyError", () => {
-  test("maps known shapes to the right enum", () => {
+  test("maps known shapes to family and detail", () => {
     const abort = new Error("aborted");
     abort.name = "AbortError";
 
-    expect(classifyError(abort)).toBe("aborted");
-    expect(classifyError({ status: 401 })).toBe("provider_auth");
-    expect(classifyError({ status: 403 })).toBe("provider_auth");
-    expect(classifyError({ statusCode: 429 })).toBe("provider_rate_limit");
+    expect(classifyError(abort)).toEqual({ errorClass: "aborted" });
+    expect(classifyError({ status: 401 })).toEqual({
+      errorClass: "provider_error",
+      errorDetail: "auth",
+    });
+    expect(classifyError({ status: 403 })).toEqual({
+      errorClass: "provider_error",
+      errorDetail: "auth",
+    });
+    expect(classifyError({ statusCode: 429 })).toEqual({
+      errorClass: "provider_error",
+      errorDetail: "rate_limit",
+    });
     expect(
       classifyError(new Error("OPENAI_API_KEY is required to run OpenWiki.")),
-    ).toBe("missing_credentials");
+    ).toEqual({
+      errorClass: "config_error",
+      errorDetail: "missing_credentials",
+    });
     expect(
       classifyError(new Error("A base URL is required to run OpenWiki.")),
-    ).toBe("missing_config");
-    expect(classifyError(new Error("Invalid model ID: nope"))).toBe(
-      "invalid_model",
-    );
-    expect(classifyError(new Error("Request timed out"))).toBe(
-      "provider_timeout",
-    );
-    expect(classifyError(new Error("fetch failed"))).toBe("network");
+    ).toEqual({ errorClass: "config_error", errorDetail: "missing_base_url" });
+    expect(classifyError(new Error("Invalid model ID: nope"))).toEqual({
+      errorClass: "config_error",
+      errorDetail: "invalid_model",
+    });
+    expect(classifyError(new Error("Request timed out"))).toEqual({
+      errorClass: "provider_error",
+      errorDetail: "timeout",
+    });
+    expect(classifyError(new Error("fetch failed"))).toEqual({
+      errorClass: "network_error",
+      errorDetail: "unreachable",
+    });
     expect(
       classifyError(Object.assign(new Error("x"), { code: "ENOENT" })),
-    ).toBe("filesystem");
-    expect(classifyError(new Error("something weird"))).toBe("agent_error");
+    ).toEqual({ errorClass: "filesystem_error", errorDetail: "not_found" });
+    expect(classifyError(new Error("something weird"))).toEqual({
+      errorClass: "agent_error",
+    });
   });
 
   test("never returns the raw message", () => {
     const secret = "token=/Users/me/.openwiki/secret-value";
     const result = classifyError(new Error(secret));
 
-    expect(result).toBe("agent_error");
-    expect(result).not.toContain("secret");
+    expect(result).toEqual({ errorClass: "agent_error" });
+    expect(JSON.stringify(result)).not.toContain("secret");
   });
 });
 
@@ -131,72 +161,255 @@ describe("classifyError - provider granularity", () => {
   test("a recognized provider code wins over the status", () => {
     expect(
       classifyError({ status: 400, code: "context_length_exceeded" }),
-    ).toBe("provider_context_limit");
+    ).toEqual({ errorClass: "context_limit_error" });
   });
 
-  test("maps the new statuses", () => {
-    expect(classifyError({ status: 529 })).toBe("provider_overloaded");
-    expect(classifyError({ status: 503 })).toBe("provider_overloaded");
-    expect(classifyError({ status: 500 })).toBe("provider_server_error");
+  test("maps the new statuses to provider_error details", () => {
+    expect(classifyError({ status: 529 })).toEqual({
+      errorClass: "provider_error",
+      errorDetail: "overloaded",
+    });
+    expect(classifyError({ status: 503 })).toEqual({
+      errorClass: "provider_error",
+      errorDetail: "overloaded",
+    });
+    expect(classifyError({ status: 500 })).toEqual({
+      errorClass: "provider_error",
+      errorDetail: "server_error",
+    });
   });
 
   test("reads a nested response.status", () => {
-    expect(classifyError({ response: { status: 503 } })).toBe(
-      "provider_overloaded",
-    );
+    expect(classifyError({ response: { status: 503 } })).toEqual({
+      errorClass: "provider_error",
+      errorDetail: "overloaded",
+    });
   });
 
   test("classifies context limit and content filter by message", () => {
     expect(
       classifyError(new Error("maximum context length is 200000 tokens")),
-    ).toBe("provider_context_limit");
-    expect(classifyError(new Error("Blocked by content policy"))).toBe(
-      "provider_content_filter",
-    );
+    ).toEqual({ errorClass: "context_limit_error" });
+    expect(classifyError(new Error("Blocked by content policy"))).toEqual({
+      errorClass: "provider_error",
+      errorDetail: "content_filter",
+    });
+  });
+
+  test("splits network detail by the underlying code", () => {
+    expect(
+      classifyError(new Error("getaddrinfo ENOTFOUND api.provider.com")),
+    ).toEqual({ errorClass: "network_error", errorDetail: "dns" });
+    expect(
+      classifyError(new Error("connect ECONNREFUSED 127.0.0.1:443")),
+    ).toEqual({ errorClass: "network_error", errorDetail: "refused" });
   });
 
   test("folds any unclassified throw into agent_error", () => {
-    expect(classifyError(new Error("something weird"))).toBe("agent_error");
-    expect(classifyError("boom")).toBe("agent_error");
-    expect(classifyError(undefined)).toBe("agent_error");
+    expect(classifyError(new Error("something weird"))).toEqual({
+      errorClass: "agent_error",
+    });
+    expect(classifyError("boom")).toEqual({ errorClass: "agent_error" });
+    expect(classifyError(undefined)).toEqual({ errorClass: "agent_error" });
   });
 });
 
-describe("error stage tags", () => {
-  test("first tag wins and never serializes", () => {
+describe("taxonomy", () => {
+  test("deriveOwner encodes the default owners", () => {
+    expect(deriveOwner("config_error", "missing_credentials", "config")).toBe(
+      "environment",
+    );
+    expect(deriveOwner("context_limit_error", undefined, "run")).toBe(
+      "openwiki",
+    );
+    expect(deriveOwner("build_error", "snapshot", "build")).toBe("openwiki");
+    expect(deriveOwner("provider_error", "rate_limit", "run")).toBe("provider");
+    expect(deriveOwner("network_error", "reset", "run")).toBe("provider");
+    expect(deriveOwner("agent_error", undefined, undefined)).toBe("unowned");
+    expect(deriveOwner("aborted", undefined, undefined)).toBe("control");
+  });
+
+  test("deriveOwner encodes the cross-owner exceptions", () => {
+    expect(deriveOwner("provider_error", "auth", "run")).toBe("environment");
+    expect(deriveOwner("provider_error", "quota_exceeded", "run")).toBe(
+      "environment",
+    );
+    expect(deriveOwner("network_error", "dns", "run")).toBe("environment");
+    expect(deriveOwner("network_error", "refused", "run")).toBe("environment");
+    expect(deriveOwner("filesystem_error", "permission", "finalize")).toBe(
+      "openwiki",
+    );
+    expect(deriveOwner("filesystem_error", "permission", "build")).toBe(
+      "environment",
+    );
+  });
+
+  test("normalizeErrorDetail drops anything off the family allowlist", () => {
+    expect(normalizeErrorDetail("provider_error", "auth")).toBe("auth");
+    expect(
+      normalizeErrorDetail("provider_error", "not_a_detail"),
+    ).toBeUndefined();
+    // A family with no detail split never emits one.
+    expect(
+      normalizeErrorDetail("context_limit_error", "anything"),
+    ).toBeUndefined();
+    // Open families trust a registry id (validated at the tag site).
+    expect(normalizeErrorDetail("connector_error", "langsmith")).toBe(
+      "langsmith",
+    );
+    expect(normalizeErrorDetail("tool_error", "read_file")).toBe("read_file");
+  });
+});
+
+describe("error origin tags", () => {
+  test("first stage tag wins and never serializes", () => {
     const error = new Error("x");
     tagErrorStage(error, "build");
     tagErrorStage(error, "run");
 
-    expect(readErrorStage(error)).toBe("build");
-    expect(Object.keys(error)).not.toContain(
-      "Symbol(openwiki.telemetry.errorStage)",
-    );
+    expect(describeErrorForTelemetry(error).errorStage).toBe("build");
     expect(JSON.stringify(error)).not.toMatch(/build/u);
   });
 
   test("an untagged error reports no stage", () => {
-    expect(readErrorStage(new Error("x"))).toBeUndefined();
+    expect(
+      describeErrorForTelemetry(new Error("x")).errorStage,
+    ).toBeUndefined();
   });
 
-  test("describeErrorForTelemetry assembles class, stage, and status", () => {
+  test("an origin tag supplies the owned family class and detail", async () => {
+    const captured = await inStage(
+      "run",
+      () => {
+        throw new Error("index write failed");
+      },
+      { errorClass: "okf_error", errorDetail: "index_sync" },
+    ).catch((error: unknown) => error);
+
+    expect(describeErrorForTelemetry(captured)).toMatchObject({
+      errorClass: "okf_error",
+      errorDetail: "index_sync",
+      errorStage: "run",
+      errorOwner: "openwiki",
+    });
+  });
+
+  test("an off-allowlist origin detail is dropped, not emitted", async () => {
+    const captured = await inStage(
+      "build",
+      () => {
+        throw new Error("x");
+      },
+      { errorClass: "build_error", errorDetail: "totally_made_up" },
+    ).catch((error: unknown) => error);
+
+    const described = describeErrorForTelemetry(captured);
+    expect(described.errorClass).toBe("build_error");
+    expect(described.errorDetail).toBeUndefined();
+  });
+
+  test("assembles class, detail, owner, stage, and status", () => {
     const error = Object.assign(new Error("nope"), { status: 503 });
     tagErrorStage(error, "run");
 
     expect(describeErrorForTelemetry(error)).toEqual({
-      errorClass: "provider_overloaded",
+      errorClass: "provider_error",
+      errorDetail: "overloaded",
       errorStage: "run",
+      errorOwner: "provider",
       httpStatus: 503,
     });
   });
 
-  test("describeErrorForTelemetry leaves stage and status undefined when absent", () => {
+  test("owner exception: a provider auth failure owns to environment", () => {
+    const error = Object.assign(new Error("unauthorized"), { status: 401 });
+
+    expect(describeErrorForTelemetry(error)).toMatchObject({
+      errorClass: "provider_error",
+      errorDetail: "auth",
+      errorOwner: "environment",
+    });
+  });
+
+  test("leaves detail, stage, and status undefined when absent", () => {
     expect(describeErrorForTelemetry(new Error("boom"))).toEqual({
       errorClass: "agent_error",
+      errorDetail: undefined,
       errorStage: undefined,
+      errorOwner: "unowned",
       httpStatus: undefined,
     });
   });
+});
+
+describe("owned-family origins tagged at their throw sites", () => {
+  // Each row is an origin actually stamped in the run pipeline (build steps in
+  // runOpenWikiAgentCore, the checkpointer create/chmod sites, and the OKF
+  // middleware passes). The test guards the seam between the throw site and the
+  // taxonomy: a detail typo, or one missing from its family's allowlist, would be
+  // silently dropped by normalizeErrorDetail, so asserting the detail survives is
+  // what catches a divergence between where we tag and what taxonomy.ts permits.
+  const origins: Array<{
+    errorClass: TelemetryErrorClass;
+    errorDetail: string;
+    errorStage: TelemetryErrorStage;
+  }> = [
+    {
+      errorClass: "build_error",
+      errorDetail: "run_context",
+      errorStage: "build",
+    },
+    { errorClass: "build_error", errorDetail: "snapshot", errorStage: "build" },
+    { errorClass: "build_error", errorDetail: "model", errorStage: "build" },
+    { errorClass: "build_error", errorDetail: "agent", errorStage: "build" },
+    {
+      errorClass: "build_error",
+      errorDetail: "stream_open",
+      errorStage: "build",
+    },
+    {
+      errorClass: "checkpointer_error",
+      errorDetail: "create",
+      errorStage: "build",
+    },
+    {
+      errorClass: "checkpointer_error",
+      errorDetail: "chmod",
+      errorStage: "finalize",
+    },
+    { errorClass: "okf_error", errorDetail: "migrate", errorStage: "build" },
+    { errorClass: "okf_error", errorDetail: "mermaid", errorStage: "finalize" },
+    {
+      errorClass: "okf_error",
+      errorDetail: "index_sync",
+      errorStage: "finalize",
+    },
+  ];
+
+  test.each(origins)(
+    "$errorClass/$errorDetail at $errorStage keeps its detail and owns to openwiki",
+    ({ errorClass, errorDetail, errorStage }) => {
+      let captured: unknown;
+      try {
+        inStageSync(
+          errorStage,
+          () => {
+            throw new Error("boom");
+          },
+          { errorClass, errorDetail },
+        );
+      } catch (error) {
+        captured = error;
+      }
+
+      expect(describeErrorForTelemetry(captured)).toMatchObject({
+        errorClass,
+        errorDetail,
+        errorStage,
+        errorOwner: "openwiki",
+      });
+    },
+  );
 });
 
 describe("gates", () => {
@@ -415,13 +628,15 @@ describe("buildRunEvent diagnostics", () => {
   };
 
   test("failure diagnostics ride the payload", () => {
-    // A failure with a tagged stage and a provider status must surface both,
-    // alongside the class, as flat anonymous properties.
+    // A failure with a tagged stage, a detail, an owner, and a provider status
+    // must surface all of them, alongside the class, as flat anonymous properties.
     const event = buildRunEvent(
       {
         command: "init",
         outcome: "failure",
-        errorClass: "provider_overloaded",
+        errorClass: "provider_error",
+        errorDetail: "overloaded",
+        errorOwner: "provider",
         errorStage: "run",
         httpStatus: 529,
       },
@@ -429,13 +644,15 @@ describe("buildRunEvent diagnostics", () => {
     );
 
     expect(event.properties).toMatchObject({
-      error_class: "provider_overloaded",
+      error_class: "provider_error",
+      error_detail: "overloaded",
+      error_owner: "provider",
       error_stage: "run",
       http_status: 529,
     });
   });
 
-  test("success omits stage and status", () => {
+  test("success omits every failure diagnostic", () => {
     // No failure means no diagnostics: the fields must be absent, not null/0,
     // so the PostHog null bucket stays meaningful.
     const event = buildRunEvent(
@@ -444,6 +661,8 @@ describe("buildRunEvent diagnostics", () => {
     );
 
     expect(event.properties).not.toHaveProperty("error_class");
+    expect(event.properties).not.toHaveProperty("error_detail");
+    expect(event.properties).not.toHaveProperty("error_owner");
     expect(event.properties).not.toHaveProperty("error_stage");
     expect(event.properties).not.toHaveProperty("http_status");
   });
@@ -484,5 +703,293 @@ describe("buildRunEvent diagnostics", () => {
     );
 
     expect(event.properties).not.toHaveProperty("app_version");
+  });
+});
+
+describe("anonymity envelope: one representative failure per reachable family", () => {
+  // The closed value sets a property may carry. These are an independent
+  // restatement of the taxonomy (types.ts unions, taxonomy.ts allowlists): the
+  // point of an anonymity guard is that widening what leaves the process must be
+  // consciously mirrored here, so a raw string sneaking into any property fails
+  // its key's check and an entirely new key trips the `default` throw below.
+  const ENUM_ALLOWLISTS: Readonly<Record<string, ReadonlySet<string>>> = {
+    command: new Set(["init", "update"]),
+    outcome: new Set(["success", "failure", "noop"]),
+    error_class: new Set([
+      "config_error",
+      "filesystem_error",
+      "provider_error",
+      "network_error",
+      "context_limit_error",
+      "build_error",
+      "connector_error",
+      "okf_error",
+      "checkpointer_error",
+      "tool_error",
+      "output_error",
+      "agent_error",
+      "aborted",
+    ]),
+    error_owner: new Set([
+      "environment",
+      "provider",
+      "openwiki",
+      "unowned",
+      "control",
+    ]),
+    error_stage: new Set(["config", "build", "run", "finalize"]),
+    mode: new Set(["code", "personal"]),
+  };
+
+  // The union of every fixed family's detail allowlist (taxonomy.ts
+  // FIXED_ERROR_DETAILS). A deliberate second copy: normalizeErrorDetail is the
+  // runtime gate, and this is the test-side contract it must not outgrow.
+  const DETAIL_ALLOWLIST: ReadonlySet<string> = new Set([
+    "missing_credentials",
+    "missing_base_url",
+    "missing_secret_key",
+    "missing_region",
+    "invalid_model",
+    "not_found",
+    "permission",
+    "no_space",
+    "auth",
+    "rate_limit",
+    "overloaded",
+    "server_error",
+    "timeout",
+    "quota_exceeded",
+    "content_filter",
+    "dns",
+    "refused",
+    "reset",
+    "unreachable",
+    "run_context",
+    "snapshot",
+    "model",
+    "agent",
+    "stream_open",
+    "migrate",
+    "index_sync",
+    "mermaid",
+    "create",
+    "persist",
+    "chmod",
+    "json_parse",
+    "schema",
+  ]);
+
+  // Provider is the one free-ish string that rides an init event; it must be a
+  // known registry key or the "unknown" fallback recordRunSafe substitutes when
+  // resolution failed before the provider was known.
+  const PROVIDER_ALLOWLIST: ReadonlySet<string> = new Set([
+    ...Object.keys(PROVIDER_CONFIGS),
+    "unknown",
+  ]);
+
+  const sweepContext: RunEventContext = {
+    ci: false,
+    production: true,
+    // An anonymous install UUID, exactly the shape recordRun attributes to.
+    distinctId: "0f9a2c1e-4b3d-4e5f-8a1b-2c3d4e5f6a7b",
+    appVersion: "0.2.3",
+  };
+
+  /**
+   * Asserts the entire event is inside the anonymity envelope: an anonymous
+   * identity, the one known event name, and every property either a closed enum,
+   * a bare integer, a boolean, or an allowlisted word. The `default` branch turns
+   * any unrecognized key into a failure, so this doubles as the "keys are a subset
+   * of the allowed set" guarantee.
+   */
+  function assertAnonymousEnvelope(event: TelemetryEvent): void {
+    // Never a name, email, or path: only an install UUID or a CI sentinel slug.
+    expect(event.distinctId).toMatch(/^[0-9a-f-]{36}$|^ci-[a-z0-9-]+$/u);
+    expect(event.event).toBe("openwiki_run");
+
+    for (const [key, value] of Object.entries(event.properties)) {
+      // Connector adoption booleans: the id is registry-derived (the same closed
+      // set as the configured-connector list), and the value is literally `true`.
+      if (key.startsWith("connector_")) {
+        expect(value).toBe(true);
+        continue;
+      }
+
+      switch (key) {
+        case "command":
+        case "outcome":
+        case "error_class":
+        case "error_owner":
+        case "error_stage":
+        case "mode":
+          expect(ENUM_ALLOWLISTS[key].has(value as string)).toBe(true);
+          break;
+        case "error_detail":
+          expect(DETAIL_ALLOWLIST.has(value as string)).toBe(true);
+          break;
+        case "provider":
+          expect(PROVIDER_ALLOWLIST.has(value as string)).toBe(true);
+          break;
+        case "http_status":
+          // A bare integer; no provider strings ride with it.
+          expect(Number.isInteger(value)).toBe(true);
+          break;
+        case "app_version":
+          expect(value).toMatch(/^\d+\.\d+\.\d+/u);
+          break;
+        case "production":
+        case "ci":
+        case "$process_person_profile":
+          expect(typeof value).toBe("boolean");
+          break;
+        default:
+          throw new Error(`unexpected telemetry property "${key}"`);
+      }
+    }
+  }
+
+  /**
+   * Runs a synchronous throw through {@link inStageSync} so the error carries the
+   * origin tag an owned-family throw site would stamp, then returns it — the same
+   * path production takes before the failure reaches describeErrorForTelemetry.
+   */
+  function tagged(
+    stage: TelemetryErrorStage,
+    origin: { errorClass: TelemetryErrorClass; errorDetail: string },
+  ): unknown {
+    try {
+      inStageSync(
+        stage,
+        () => {
+          throw new Error("boom");
+        },
+        origin,
+      );
+    } catch (error) {
+      return error;
+    }
+    throw new Error("expected the staged fn to throw");
+  }
+
+  // One representative failure per family that a run can actually produce, built
+  // the way production builds it: a raw error the classifier reads, or a throw
+  // carrying the origin tag its owned-family site stamps. `connector_error` and
+  // `tool_error` are intentionally absent — they have no fatal propagating path
+  // (connector pulls are fail-open; tool throws are swallowed into ToolMessages),
+  // so a "representative failure" for them cannot exist to sweep.
+  const FAILURE_FIXTURES: ReadonlyArray<{
+    family: TelemetryErrorClass;
+    label: string;
+    makeError: () => unknown;
+  }> = [
+    {
+      family: "config_error",
+      label: "a missing-credentials config error",
+      makeError: () => new Error("OPENAI_API_KEY is required to run OpenWiki."),
+    },
+    {
+      family: "filesystem_error",
+      label: "a filesystem ENOENT",
+      makeError: () =>
+        Object.assign(new Error("open failed"), { code: "ENOENT" }),
+    },
+    {
+      family: "provider_error",
+      label: "a 401 provider auth failure",
+      makeError: () => ({ status: 401 }),
+    },
+    {
+      family: "network_error",
+      label: "a DNS lookup failure",
+      makeError: () => new Error("getaddrinfo ENOTFOUND api.provider.com"),
+    },
+    {
+      family: "context_limit_error",
+      label: "a context-length provider code",
+      makeError: () => ({ status: 400, code: "context_length_exceeded" }),
+    },
+    {
+      family: "build_error",
+      label: "a tagged model-build failure",
+      makeError: () =>
+        tagged("build", { errorClass: "build_error", errorDetail: "model" }),
+    },
+    {
+      family: "checkpointer_error",
+      label: "a tagged checkpointer create failure",
+      makeError: () =>
+        tagged("build", {
+          errorClass: "checkpointer_error",
+          errorDetail: "create",
+        }),
+    },
+    {
+      family: "okf_error",
+      label: "a tagged OKF index-sync failure",
+      makeError: () =>
+        tagged("finalize", {
+          errorClass: "okf_error",
+          errorDetail: "index_sync",
+        }),
+    },
+    {
+      family: "output_error",
+      label: "a JSON parse failure",
+      makeError: () => new Error("could not parse JSON output"),
+    },
+    {
+      family: "agent_error",
+      label: "an unclassified throw",
+      makeError: () => new Error("something weird happened"),
+    },
+    {
+      family: "aborted",
+      label: "a user abort",
+      makeError: () =>
+        Object.assign(new Error("aborted"), { name: "AbortError" }),
+    },
+  ];
+
+  test.each(FAILURE_FIXTURES)(
+    "$family ($label) resolves its class and stays inside the envelope",
+    ({ family, makeError }) => {
+      const described = describeErrorForTelemetry(makeError());
+      const event = buildRunEvent(
+        {
+          command: "init",
+          outcome: "failure",
+          mode: "personal",
+          provider: "anthropic",
+          configuredConnectors: ["web-search"],
+          errorClass: described.errorClass,
+          errorDetail: described.errorDetail,
+          errorOwner: described.errorOwner,
+          errorStage: described.errorStage,
+          httpStatus: described.httpStatus,
+        },
+        sweepContext,
+      );
+
+      // The classifier/tag wiring resolved the family we forced end-to-end...
+      expect(event.properties.error_class).toBe(family);
+      // ...and the whole assembled payload is anonymous.
+      assertAnonymousEnvelope(event);
+    },
+  );
+
+  test("a successful init stays inside the envelope", () => {
+    const event = buildRunEvent(
+      runDetails({ outcome: "success" }),
+      sweepContext,
+    );
+    assertAnonymousEnvelope(event);
+  });
+
+  test("a noop update stays inside the envelope", () => {
+    const event = buildRunEvent(
+      { command: "update", outcome: "noop" },
+      sweepContext,
+    );
+    assertAnonymousEnvelope(event);
   });
 });


### PR DESCRIPTION
## Summary

Failures used to collapse into a generic `agent_error` bucket so we couldn't tell why a run broke. This gives each failure event three coordinates instead of one label:
- what broke by widening the error classes
- where it broke by adding a config/build/run/finalize stage tag
- the provider's `http_status`.

This also stamps `app_version` on every event to help us understand version adoption and whether or not a specific version may be responsible for a breaking change.

Same privacy story as before: only enums and bare integers leave the process, no raw strings or provider error codes. Everything is anonymous.

## Tests

Added coverage for the new classifier paths, stage tagging, and the assembled event payload.