### PR TITLE
fix(cli): handle unhandled promise rejections with a clean error and non-zero exit

### DIFF
--- a/src/cli.tsx
+++ b/src/cli.tsx
@@ -41,6 +41,7 @@ import {
   isSecretLikeKey,
   sanitizeDiagnosticText,
 } from "./diagnostics.js";
+import { installUnhandledRejectionHandler } from "./unhandled-rejection.js";
 import { stripHtmlTags } from "./utils.js";
 import {
   type OpenWikiRunEvent,
@@ -91,6 +92,12 @@ import {
   FIRST_RUN_NOTICE_OPT_OUT,
   FIRST_RUN_NOTICE_VERIFY,
 } from "./telemetry/index.js";
+
+// Installed before any async work starts: a rejection that escapes every
+// awaited chain (e.g. a provider 429 inside a run nothing is awaiting) must
+// print a clean message and exit non-zero instead of aborting with a raw
+// Node stack trace.
+installUnhandledRejectionHandler();
 
 type RunState =
   | { status: "idle" }

--- a/src/unhandled-rejection.ts
+++ b/src/unhandled-rejection.ts
@@ -1,0 +1,30 @@
+import { getErrorMessage } from "./diagnostics.js";
+
+/**
+ * Last-resort handler for promise rejections that escape every awaited chain —
+ * for example a provider 429 raised inside an agent run that nothing is
+ * awaiting, or a promise floated inside a dependency. Without a listener Node
+ * aborts the process with a raw stack trace; this routes the failure through
+ * the same user-facing path as awaited errors (`getErrorMessage`, which
+ * redacts secrets and keeps the message actionable) and exits non-zero.
+ *
+ * Exported separately from the installer so tests can exercise the exact
+ * function the process invokes.
+ */
+export function handleUnhandledRejection(reason: unknown): void {
+  process.stderr.write(`${getErrorMessage(reason)}\n`);
+
+  // An escaped rejection leaves the process in an unknown state, so keep
+  // Node's crash semantics (its default is to abort) — just fail cleanly.
+  // Setting `process.exitCode` is not enough here: unlike the awaited error
+  // paths, there is no caller left to wind the process down.
+  process.exit(1);
+}
+
+/**
+ * Installs the top-level `unhandledRejection` net. The CLI entry calls this
+ * before any async work starts so every command is covered.
+ */
+export function installUnhandledRejectionHandler(): void {
+  process.on("unhandledRejection", handleUnhandledRejection);
+}

--- a/test/unhandled-rejection.test.ts
+++ b/test/unhandled-rejection.test.ts
@@ -1,0 +1,124 @@
+import { afterEach, describe, expect, test, vi } from "vitest";
+import {
+  handleUnhandledRejection,
+  installUnhandledRejectionHandler,
+} from "../src/unhandled-rejection.ts";
+
+/**
+ * A provider rate-limit rejection shaped like the one LangChain surfaces when
+ * the model provider returns 429 (see #494): an Error whose message carries
+ * the status line and troubleshooting URL, plus a numeric `status` field.
+ */
+function createRateLimitError(): Error & { status: number } {
+  return Object.assign(
+    new Error(
+      "429 The usage limit has been reached\n\nTroubleshooting URL: https://docs.langchain.com/oss/javascript/langchain/errors/MODEL_RATE_LIMIT/",
+    ),
+    { status: 429 },
+  );
+}
+
+function mockStderrAndExit() {
+  const stderrSpy = vi
+    .spyOn(process.stderr, "write")
+    .mockImplementation(() => true);
+  const exitSpy = vi
+    .spyOn(process, "exit")
+    .mockImplementation(() => undefined as never);
+
+  return {
+    written: (): string =>
+      stderrSpy.mock.calls.map((call) => String(call[0])).join(""),
+    exitSpy,
+  };
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("handleUnhandledRejection", () => {
+  test("prints the clean provider message and exits non-zero on a 429 rejection", () => {
+    const { written, exitSpy } = mockStderrAndExit();
+
+    handleUnhandledRejection(createRateLimitError());
+
+    const output = written();
+    expect(output).toContain("429 The usage limit has been reached");
+    expect(output).toContain("Troubleshooting URL:");
+    // A clean message, not the raw stack trace an unhandled rejection prints.
+    expect(output).not.toMatch(/^\s+at /mu);
+    expect(exitSpy).toHaveBeenCalledWith(1);
+  });
+
+  test("redacts secrets through the shared diagnostics path", () => {
+    const { written, exitSpy } = mockStderrAndExit();
+
+    handleUnhandledRejection(
+      new Error("429 rate limited for Bearer sk-live-secret-token"),
+    );
+
+    const output = written();
+    expect(output).not.toContain("sk-live-secret-token");
+    expect(output).toContain("Bearer [REDACTED]");
+    expect(exitSpy).toHaveBeenCalledWith(1);
+  });
+
+  test("falls back to a generic message for non-Error rejection reasons", () => {
+    const { written, exitSpy } = mockStderrAndExit();
+
+    handleUnhandledRejection("boom");
+
+    expect(written()).toContain("OpenWiki agent run failed.");
+    expect(exitSpy).toHaveBeenCalledWith(1);
+  });
+});
+
+describe("installUnhandledRejectionHandler", () => {
+  test("registers the handler on process", () => {
+    const before = process.rawListeners("unhandledRejection");
+
+    installUnhandledRejectionHandler();
+
+    try {
+      expect(process.rawListeners("unhandledRejection")).toContain(
+        handleUnhandledRejection,
+      );
+    } finally {
+      process.off("unhandledRejection", handleUnhandledRejection);
+    }
+
+    expect(process.rawListeners("unhandledRejection")).toEqual(before);
+  });
+
+  test("an escaped provider 429 is dispatched to the handler instead of crashing raw", () => {
+    const { written, exitSpy } = mockStderrAndExit();
+
+    // Vitest keeps its own unhandledRejection listeners to fail the run on
+    // stray rejections; detach them while simulating the escaped rejection so
+    // only the CLI's net observes it, then restore them.
+    const vitestListeners = process.rawListeners("unhandledRejection");
+    process.removeAllListeners("unhandledRejection");
+    installUnhandledRejectionHandler();
+
+    try {
+      process.emit(
+        "unhandledRejection",
+        createRateLimitError(),
+        Promise.resolve(),
+      );
+    } finally {
+      process.removeAllListeners("unhandledRejection");
+
+      for (const listener of vitestListeners) {
+        process.on(
+          "unhandledRejection",
+          listener as NodeJS.UnhandledRejectionListener,
+        );
+      }
+    }
+
+    expect(written()).toContain("429 The usage limit has been reached");
+    expect(exitSpy).toHaveBeenCalledWith(1);
+  });
+});


### PR DESCRIPTION
Fixes #494

## What

The CLI installs no `process.on("unhandledRejection")` handler, so a provider 429 rejecting in a promise nothing awaits (e.g. the orphaned second agent run from the #489 double-start) aborts with a raw Node stack trace instead of the clean error awaited failures get.

This adds a top-level handler installed at CLI entry before any async work: the rejection reason is routed through the existing `getErrorMessage()` path (secret redaction, provider special cases) to stderr, and the process exits 1. Command-agnostic per the root-cause follow-up in the issue: it covers `--init`, `--update`, and dependency-floated promises alike. The double-start itself stays tracked in #489.

## Tests

5 tests: the 429 shape from the issue produces the clean two-line message with no stack frames and exit 1; secrets are redacted; non-Error reasons handled; handler registration and dispatch of an emitted escaped rejection. Full suite: 773 passed. prettier, eslint, tsc clean.

Credit to @asgarov for the report and root-cause follow-up in #494.
