### PR TITLE
docs: document requesty via the openai-compatible provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -293,6 +293,20 @@ OPENAI_COMPATIBLE_BASE_URL=https://your-gateway.example.com/v1
 OPENWIKI_MODEL_ID=your-gateway-model-name
 ```
 
+Hosted OpenAI-compatible gateways work the same way. For example,
+[Requesty](https://requesty.ai) is a hosted gateway that fronts many upstream
+providers behind one OpenAI-compatible API at `https://router.requesty.ai/v1`,
+using `provider/model` model IDs (see the full list at
+`https://router.requesty.ai/v1/models`):
+
+```bash
+OPENWIKI_PROVIDER=openai-compatible
+OPENAI_COMPATIBLE_API_KEY=your-requesty-key
+OPENAI_COMPATIBLE_BASE_URL=https://router.requesty.ai/v1
+OPENWIKI_MODEL_ID=openai/gpt-5.5
+openwiki --init
+```
+
 Local LLM servers that expose OpenAI-compatible chat completions use the same
 provider. The model ID must match a model available from that local server:
 


### PR DESCRIPTION
## What

Adds a short Requesty example to the existing **OpenAI-compatible endpoints** section of the README, alongside the LiteLLM / Ollama / LM Studio / 9Router examples already there.

```bash
OPENWIKI_PROVIDER=openai-compatible
OPENAI_COMPATIBLE_API_KEY=your-requesty-key
OPENAI_COMPATIBLE_BASE_URL=https://router.requesty.ai/v1
OPENWIKI_MODEL_ID=openai/gpt-5.5
openwiki --init
```

## Why

A previous PR (#275) proposed adding Requesty as a dedicated first-class provider entry. It was closed with the note that the project recommends using the existing `openai-compatible` provider for any OpenAI-compatible gateway. This PR follows that guidance exactly: no new provider, no code changes — just a documentation example showing how to point the existing `openai-compatible` provider at Requesty's OpenAI-compatible endpoint (`https://router.requesty.ai/v1`), which uses `provider/model` model IDs.

## How I tested it

Docs-only change, so no unit tests were added. I verified the documented setup works end to end by making a live chat-completions call to `https://router.requesty.ai/v1` with `OPENAI_COMPATIBLE_BASE_URL`/key exactly as shown, using an OpenAI-compatible client — it returned a valid completion. `npx prettier --check README.md` passes.

## Disclosure

I work at Requesty. This is a documentation example for the already-recommended `openai-compatible` path; it adds no code and changes no behavior.
