### PR TITLE
fix(git-repo): report changes since the last run, not the dirty tree (#409)

### DIFF
--- a/src/connectors/sources/git-repo.ts
+++ b/src/connectors/sources/git-repo.ts
@@ -89,7 +89,11 @@ async function ingest(
 
     const repoPath = path.resolve(repo.path);
     try {
-      const manifest = await createRepoManifest(repo.id, repoPath);
+      const manifest = await createRepoManifest(
+        repo.id,
+        repoPath,
+        state.latestIds?.[repo.id],
+      );
       manifests.push(manifest);
     } catch (error) {
       warnings.push(`${repo.id}: ${getErrorMessage(error)}`);
@@ -131,6 +135,7 @@ async function ingest(
 async function createRepoManifest(
   id: string,
   repoPath: string,
+  previousHead?: string,
 ): Promise<GitRepoManifest> {
   const branch = await runGit(repoPath, ["rev-parse", "--abbrev-ref", "HEAD"]);
   const head = await runGit(repoPath, ["rev-parse", "HEAD"]);
@@ -145,11 +150,11 @@ async function createRepoManifest(
     .split(/\r?\n/u)
     .filter(Boolean);
   const status = await runGit(repoPath, ["status", "--short"]);
-  const changedFiles = (
-    await runGit(repoPath, ["diff", "--name-status", "HEAD"])
-  )
-    .split(/\r?\n/u)
-    .filter(Boolean);
+  const { changedFiles, resolvedPreviousHead } = await diffSinceLastRun(
+    repoPath,
+    head,
+    previousHead,
+  );
 
   return {
     branch,
@@ -157,9 +162,69 @@ async function createRepoManifest(
     head,
     id,
     path: repoPath,
+    previousHead: resolvedPreviousHead,
     recentCommits,
     status,
   };
+}
+
+/**
+ * Files that changed since the previous ingestion run.
+ *
+ * `git diff --name-status HEAD` reports only *uncommitted* working-tree
+ * changes, so the manifest used to describe the developer's dirty tree while
+ * the ingestion orchestrator presented it to the agent as the recent-changes
+ * window (#409). The connector already persists each repo's head in
+ * `state.latestIds`; this reads it back and diffs `previousHead..HEAD`.
+ *
+ * Falls back to the working-tree diff when there is no usable prior head — a
+ * first run has no baseline, and a head that no longer resolves (rebase, force
+ * push, gc) must not abort ingestion. Uncommitted work is still reported
+ * separately via `status`.
+ */
+export async function diffSinceLastRun(
+  repoPath: string,
+  head: string,
+  previousHead?: string,
+): Promise<{ changedFiles: string[]; resolvedPreviousHead?: string }> {
+  const splitNames = (out: string): string[] =>
+    out.split(/\r?\n/u).filter(Boolean);
+
+  if (!previousHead) {
+    return {
+      changedFiles: splitNames(
+        await runGit(repoPath, ["diff", "--name-status", "HEAD"]),
+      ),
+    };
+  }
+
+  if (previousHead === head) {
+    // Nothing landed since the last run. An empty window is the honest answer;
+    // a dirty tree is not a "change since last run".
+    return { changedFiles: [], resolvedPreviousHead: previousHead };
+  }
+
+  try {
+    return {
+      changedFiles: splitNames(
+        await runGit(repoPath, [
+          "diff",
+          "--name-status",
+          `${previousHead}..${head}`,
+        ]),
+      ),
+      resolvedPreviousHead: previousHead,
+    };
+  } catch {
+    // The recorded head is gone from this repo. Degrade to the working tree
+    // rather than failing the whole repo, and omit previousHead so the manifest
+    // does not claim a window it could not compute.
+    return {
+      changedFiles: splitNames(
+        await runGit(repoPath, ["diff", "--name-status", "HEAD"]),
+      ),
+    };
+  }
 }
 
 async function runGit(cwd: string, args: string[]): Promise<string> {

--- a/test/git-repo-diff-window.test.ts
+++ b/test/git-repo-diff-window.test.ts
@@ -1,0 +1,119 @@
+import { execFile } from "node:child_process";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { promisify } from "node:util";
+
+import { afterEach, beforeEach, describe, expect, test } from "vitest";
+
+import { diffSinceLastRun } from "../src/connectors/sources/git-repo.ts";
+
+// `git diff --name-status HEAD` reports only uncommitted working-tree changes,
+// so the manifest described the developer's dirty tree while ingestion presented
+// it to the agent as the "changes since last run" window (issue #409). These run
+// against a real repo — the whole bug was a wrong git invocation, so stubbing git
+// would test the wrong thing.
+
+const exec = promisify(execFile);
+
+let repo: string;
+
+async function git(...args: string[]): Promise<string> {
+  const { stdout } = await exec("git", args, { cwd: repo });
+  return stdout.trim();
+}
+
+async function commit(file: string, body: string): Promise<string> {
+  await writeFile(path.join(repo, file), body, "utf8");
+  await git("add", file);
+  await git("-c", "user.email=t@t", "-c", "user.name=t", "commit", "-m", file);
+  return git("rev-parse", "HEAD");
+}
+
+beforeEach(async () => {
+  repo = await mkdtemp(path.join(tmpdir(), "openwiki-gitrepo-"));
+  await git("init", "-q", "-b", "main");
+});
+
+afterEach(async () => {
+  await rm(repo, { force: true, recursive: true });
+});
+
+describe("diffSinceLastRun", () => {
+  test("reports commits landed since the recorded head, not the dirty tree", async () => {
+    const first = await commit("a.txt", "one");
+    await commit("b.txt", "two");
+    await commit("c.txt", "three");
+    const head = await git("rev-parse", "HEAD");
+
+    // An unrelated uncommitted edit that the old implementation would report.
+    await writeFile(path.join(repo, "a.txt"), "locally edited", "utf8");
+
+    const { changedFiles, resolvedPreviousHead } = await diffSinceLastRun(
+      repo,
+      head,
+      first,
+    );
+
+    expect(resolvedPreviousHead).toBe(first);
+    expect(changedFiles.join("\n")).toContain("b.txt");
+    expect(changedFiles.join("\n")).toContain("c.txt");
+    expect(changedFiles.join("\n")).not.toContain("a.txt");
+  });
+
+  test("an unchanged head means an empty window, not the dirty tree", async () => {
+    await commit("a.txt", "one");
+    const head = await git("rev-parse", "HEAD");
+    await writeFile(path.join(repo, "a.txt"), "dirty", "utf8");
+
+    const { changedFiles, resolvedPreviousHead } = await diffSinceLastRun(
+      repo,
+      head,
+      head,
+    );
+
+    expect(changedFiles).toEqual([]);
+    expect(resolvedPreviousHead).toBe(head);
+  });
+
+  test("first run with no recorded head falls back to the working tree", async () => {
+    await commit("a.txt", "one");
+    const head = await git("rev-parse", "HEAD");
+    await writeFile(path.join(repo, "a.txt"), "dirty", "utf8");
+
+    const { changedFiles, resolvedPreviousHead } = await diffSinceLastRun(
+      repo,
+      head,
+      undefined,
+    );
+
+    expect(resolvedPreviousHead).toBeUndefined();
+    expect(changedFiles.join("\n")).toContain("a.txt");
+  });
+
+  test("a recorded head that no longer resolves degrades instead of throwing", async () => {
+    await commit("a.txt", "one");
+    const head = await git("rev-parse", "HEAD");
+    await writeFile(path.join(repo, "a.txt"), "dirty", "utf8");
+
+    const { changedFiles, resolvedPreviousHead } = await diffSinceLastRun(
+      repo,
+      head,
+      "0".repeat(40), // rebased / force-pushed / gc'd away
+    );
+
+    // No previousHead claimed, because the window could not be computed.
+    expect(resolvedPreviousHead).toBeUndefined();
+    expect(changedFiles.join("\n")).toContain("a.txt");
+  });
+
+  test("a rename is reported with its status code", async () => {
+    const first = await commit("old.txt", "content");
+    await git("mv", "old.txt", "new.txt");
+    await git("-c", "user.email=t@t", "-c", "user.name=t", "commit", "-m", "mv");
+    const head = await git("rev-parse", "HEAD");
+
+    const { changedFiles } = await diffSinceLastRun(repo, head, first);
+    expect(changedFiles.join("\n")).toContain("new.txt");
+  });
+});


### PR DESCRIPTION
Fixes #409.

`createRepoManifest` never read the prior head back out of connector state, so `previousHead` was always `undefined` and `changedFiles` was always:

```ts
git diff --name-status HEAD
```

which reports only **uncommitted** working-tree changes. The connector already persists each repo's head in `state.latestIds`, and `src/ingestion.ts` presents `changedFiles` to the agent as the recent-changes window — so the agent was shown the developer's dirty tree and told it was the commits landed since last ingestion.

Threads `state.latestIds[repo.id]` into `createRepoManifest` and diffs `previousHead..HEAD`.

## The three cases a naive version gets wrong

Each has a test:

| case | behaviour |
|---|---|
| no recorded head | first run has no baseline — fall back to the working tree, the only sensible answer |
| head unchanged | nothing landed since the last run, so the window is **empty**. A dirty tree is not a change since last run, and it is already reported separately via `status` |
| head unresolvable | rebase / force push / gc removed the recorded commit. Degrade to the working tree rather than aborting the repo, and **omit `previousHead`** so the manifest does not claim a window it could not compute |

That last one matters: the connector catches per-repo and pushes a warning, so an unresolvable head would otherwise turn one stale state entry into a permanently skipped repo.

## Tests

`test/git-repo-diff-window.test.ts` — 5 cases against a **real temporary git repo**, not a stubbed `runGit`. The bug was a wrong git invocation, and a stub would have happily agreed with the wrong one. Covers commits-since-head with an unrelated dirty file present, unchanged head, first run, unresolvable head, and a rename.

Full suite **774 passed**, typecheck and `lint:check` clean.

---
Reviewed and tested locally; drafted with AI assistance.