### PR TITLE
fix(connectors): isolate per-connector and per-stream ingest failures (#412)

### DIFF
--- a/src/connectors/sources/x.ts
+++ b/src/connectors/sources/x.ts
@@ -115,52 +115,65 @@ async function ingest(
   const latestIds = { ...(state.latestIds ?? {}) };
   const startTime = getWindowStartTime(options.windowHours);
 
+  // Per-stream isolation (#412). A single stream failure - a 429 on mentions, a
+  // deleted list - used to throw out of ingest(), which orphaned the rawFiles
+  // already written and skipped writeConnectorState entirely, so latestIds never
+  // advanced and the next run re-fetched everything. Mirrors the per-item
+  // try/catch in hackernews.ts and git-repo.ts.
   for (const stream of streams) {
     if (stream === "list_posts") {
       for (const listId of listIds) {
         const key = `list_posts:${listId}`;
-        const pages = await fetchPaginatedX(
-          accessToken,
-          `/lists/${encodeURIComponent(listId)}/tweets`,
-          {
-            since_id: latestIds[key],
-            start_time: startTime,
-          },
-          config.maxPagesPerStream,
-        );
-        latestIds[key] = getNewestId(pages) ?? latestIds[key] ?? "";
-        rawFiles.push(
-          await writeRawJson("x", runId, `list-${listId}.json`, {
-            fetchedAt: new Date().toISOString(),
-            listId,
-            pages,
-            stream,
-            windowHours: normalizeWindowHours(options.windowHours),
-          }),
-        );
+        try {
+          const pages = await fetchPaginatedX(
+            accessToken,
+            `/lists/${encodeURIComponent(listId)}/tweets`,
+            {
+              since_id: latestIds[key],
+              start_time: startTime,
+            },
+            config.maxPagesPerStream,
+          );
+          latestIds[key] = getNewestId(pages) ?? latestIds[key] ?? "";
+          rawFiles.push(
+            await writeRawJson("x", runId, `list-${listId}.json`, {
+              fetchedAt: new Date().toISOString(),
+              listId,
+              pages,
+              stream,
+              windowHours: normalizeWindowHours(options.windowHours),
+            }),
+          );
+        } catch (error) {
+          warnings.push(`${key}: ${getErrorMessage(error)}`);
+        }
       }
       continue;
     }
 
     const key = stream;
-    const pages = await fetchPaginatedX(
-      accessToken,
-      getStreamPath(stream, userId),
-      stream === "bookmarks"
-        ? {}
-        : { since_id: latestIds[key], start_time: startTime },
-      config.maxPagesPerStream,
-    );
-    latestIds[key] = getNewestId(pages) ?? latestIds[key] ?? "";
-    rawFiles.push(
-      await writeRawJson("x", runId, `${stream}.json`, {
-        fetchedAt: new Date().toISOString(),
-        pages,
-        stream,
-        userId,
-        windowHours: normalizeWindowHours(options.windowHours),
-      }),
-    );
+    try {
+      const pages = await fetchPaginatedX(
+        accessToken,
+        getStreamPath(stream, userId),
+        stream === "bookmarks"
+          ? {}
+          : { since_id: latestIds[key], start_time: startTime },
+        config.maxPagesPerStream,
+      );
+      latestIds[key] = getNewestId(pages) ?? latestIds[key] ?? "";
+      rawFiles.push(
+        await writeRawJson("x", runId, `${stream}.json`, {
+          fetchedAt: new Date().toISOString(),
+          pages,
+          stream,
+          userId,
+          windowHours: normalizeWindowHours(options.windowHours),
+        }),
+      );
+    } catch (error) {
+      warnings.push(`${key}: ${getErrorMessage(error)}`);
+    }
   }
 
   const nextState = updateStateWithRun(
@@ -355,4 +368,8 @@ function getNestedString(value: unknown, path: string[]): string | null {
   }
 
   return typeof current === "string" ? current : null;
+}
+
+function getErrorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
 }

--- a/src/connectors/tools.ts
+++ b/src/connectors/tools.ts
@@ -18,7 +18,12 @@ import {
   discoverMcpConnectorTools,
   isMcpConnectorId,
 } from "./mcp-runtime.js";
-import type { ConnectorId, ConnectorIngestOptions } from "./types.js";
+import type {
+  ConnectorId,
+  ConnectorIngestOptions,
+  ConnectorIngestResult,
+  ConnectorRuntime,
+} from "./types.js";
 
 export function createOpenWikiConnectorTools(): StructuredToolInterface[] {
   return [
@@ -269,17 +274,41 @@ async function callMcpToolForConnector(
   return await callMcpConnectorTool(connectorId, toolName, args);
 }
 
-async function ingestAllConnectors() {
-  const registry = createConnectorRegistry();
-  const results = [];
+export async function ingestAllConnectors(
+  // Injectable so the isolation contract can be tested without real connectors.
+  registry: Record<string, ConnectorRuntime> = createConnectorRegistry(),
+) {
+  const results: ConnectorIngestResult[] = [];
 
+  // Per-connector isolation (#412). A single throw - an un-refreshable token,
+  // a 429 - used to propagate out of this loop, so `results` was never returned
+  // and every connector that had already succeeded was discarded. The result
+  // type already models failure via status: "error", so a failed connector
+  // reports itself instead of taking the run down.
   for (const connector of Object.values(registry)) {
-    results.push(await connector.ingest());
+    try {
+      results.push(await connector.ingest());
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      results.push({
+        connectorId: connector.id,
+        message: `Ingestion failed: ${message}`,
+        rawFiles: [],
+        runId: "",
+        statePath: getConnectorStatePathLabel(connector.id),
+        status: "error",
+        warnings: [message],
+      });
+    }
   }
 
   return {
     results,
   };
+}
+
+function getConnectorStatePathLabel(connectorId: ConnectorId): string {
+  return `~/.openwiki/connectors/${connectorId}/state.json`;
 }
 
 async function listRawItems(connectorId: ConnectorId) {

--- a/test/ingest-error-isolation.test.ts
+++ b/test/ingest-error-isolation.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, test } from "vitest";
+
+import { ingestAllConnectors } from "../src/connectors/tools.ts";
+import type {
+  ConnectorIngestResult,
+  ConnectorRuntime,
+} from "../src/connectors/types.ts";
+
+// ingestAllConnectors ran connectors in a bare sequential loop with no error
+// handling, so the first throw — an un-refreshable token, a 429 — propagated out
+// and `results` was never returned, discarding every connector that had already
+// succeeded (issue #412). The result type already models failure via
+// status:"error", so a failed connector should report itself instead.
+
+function ok(id: string): ConnectorIngestResult {
+  return {
+    connectorId: id as ConnectorIngestResult["connectorId"],
+    message: `${id} ok`,
+    rawFiles: [`${id}/raw.json`],
+    runId: "run-1",
+    statePath: `~/.openwiki/connectors/${id}/state.json`,
+    status: "success",
+    warnings: [],
+  };
+}
+
+function stub(id: string, behaviour: "ok" | "throw"): ConnectorRuntime {
+  return {
+    id,
+    ingest: () =>
+      behaviour === "throw"
+        ? Promise.reject(new Error(`${id} token could not be refreshed`))
+        : Promise.resolve(ok(id)),
+  } as unknown as ConnectorRuntime;
+}
+
+describe("ingestAllConnectors", () => {
+  test("a failure in the middle does not discard the connectors that succeeded", async () => {
+    const { results } = await ingestAllConnectors({
+      alpha: stub("alpha", "ok"),
+      beta: stub("beta", "throw"),
+      gamma: stub("gamma", "ok"),
+    });
+
+    expect(results).toHaveLength(3);
+    expect(results.map((result) => result.status)).toEqual([
+      "success",
+      "error",
+      "success",
+    ]);
+    // The successful connectors keep their raw files. Previously this whole
+    // array was lost to the throw.
+    expect(results[0].rawFiles).toEqual(["alpha/raw.json"]);
+    expect(results[2].rawFiles).toEqual(["gamma/raw.json"]);
+  });
+
+  test("a failure the FIRST connector hits still runs the rest", async () => {
+    const { results } = await ingestAllConnectors({
+      alpha: stub("alpha", "throw"),
+      beta: stub("beta", "ok"),
+    });
+
+    expect(results.map((result) => result.connectorId)).toEqual([
+      "alpha",
+      "beta",
+    ]);
+    expect(results[1].status).toBe("success");
+  });
+
+  test("the failure carries the cause, not just a status", async () => {
+    const { results } = await ingestAllConnectors({
+      alpha: stub("alpha", "throw"),
+    });
+
+    expect(results[0].status).toBe("error");
+    expect(results[0].message).toContain("Ingestion failed");
+    expect(results[0].message).toContain("token could not be refreshed");
+    expect(results[0].warnings[0]).toContain("token could not be refreshed");
+  });
+
+  test("every connector failing yields one error result each, not a throw", async () => {
+    const { results } = await ingestAllConnectors({
+      alpha: stub("alpha", "throw"),
+      beta: stub("beta", "throw"),
+    });
+
+    expect(results).toHaveLength(2);
+    expect(results.every((result) => result.status === "error")).toBe(true);
+  });
+
+  test("a non-Error rejection is still reported", async () => {
+    const results = (
+      await ingestAllConnectors({
+        alpha: {
+          id: "alpha",
+          // eslint-disable-next-line @typescript-eslint/prefer-promise-reject-errors
+          ingest: () => Promise.reject("rate limited"),
+        } as unknown as ConnectorRuntime,
+      })
+    ).results;
+
+    expect(results[0].status).toBe("error");
+    expect(results[0].message).toContain("rate limited");
+  });
+});


### PR DESCRIPTION
Fixes #412. Both halves.

## `ingestAllConnectors`

```ts
for (const connector of Object.values(registry)) {
  results.push(await connector.ingest());
}
```

A single throw — an un-refreshable token, a 429 — propagated out of the loop, so `results` was never returned and every connector that had already completed was discarded with it.

`ConnectorIngestResult` already models failure via `status: "error"`, so a failed connector now reports itself and the run continues. The registry is an optional parameter so the isolation contract is testable without real connectors.

## The X connector, one level down

`src/connectors/sources/x.ts` had the same shape inside `ingest`: the streams/lists loop had no per-iteration try/catch, unlike `hackernews.ts` and `git-repo.ts` which catch per item and push a warning.

Any single stream error threw out of `ingest()`, which meant:

- the `rawFiles` already written were orphaned on disk, and
- `writeConnectorState` never ran, so `latestIds` never advanced — the next run re-fetched everything it had just fetched

Each stream and each list is now caught individually and reported as a warning, matching the existing per-item pattern, so partial progress is kept and the cursor advances for the streams that did work.

## Tests

`test/ingest-error-isolation.test.ts` — 5 cases: a failure in the middle (successful connectors keep their `rawFiles`), a failure in the **first** position, the cause being carried rather than just a status, every connector failing, and a non-`Error` rejection.

Full suite **774 passed**, typecheck and `lint:check` clean.

---
Reviewed and tested locally; drafted with AI assistance.