### PR TITLE
fix(agent): fail the run when output truncation drops a tool call (#458)

### DIFF
--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -382,6 +382,15 @@ async function runOpenWikiAgentCore(
 
   try {
     for await (const chunk of stream) {
+      // A truncated tool call is not a "no text" chunk to skip: the write the
+      // model asked for never happened, so the run must fail loudly rather than
+      // finish looking successful (#458). Throwing here lands in the catch
+      // below, which records the run as interrupted and cleans up.
+      const truncation = detectTruncatedOutput(chunk);
+      if (truncation) {
+        throw new Error(truncation);
+      }
+
       const event = parseStreamEvent(chunk);
 
       if (event) {
@@ -1054,6 +1063,74 @@ function createGeminiEnterpriseModel(
         ...retryOptions,
       });
   }
+}
+
+/**
+ * Detect a model output-token truncation that silently dropped work (#458).
+ *
+ * When a model hits its output limit while streaming a large tool call, the v3
+ * stream reports it two ways:
+ *
+ *   content-block-finish  content.type = "invalid_tool_call"
+ *   message-finish        reason       = "length"
+ *
+ * Both were classified as "no text to emit" and ignored. The incomplete tool
+ * call is never executed, so a requested `write_file` / `edit_file` simply does
+ * not happen — and the run could still finish reporting success, leaving the
+ * file change missing with nothing in the output saying why.
+ *
+ * Returns an actionable message when the chunk carries either signal, else null.
+ */
+export function detectTruncatedOutput(chunk: unknown): string | null {
+  if (!isProtocolStreamEvent(chunk) || chunk.method !== "messages") {
+    return null;
+  }
+
+  const payload = chunk.params.data;
+  if (!isRecord(payload)) {
+    return null;
+  }
+
+  const event = getStringRecordValue(payload, "event");
+
+  if (event === "content-block-finish") {
+    const content: unknown = payload.content;
+    const type = isRecord(content)
+      ? getStringRecordValue(content, "type")
+      : null;
+
+    if (type === "invalid_tool_call") {
+      const name = isRecord(content)
+        ? (getStringRecordValue(content, "name") ?? "a tool")
+        : "a tool";
+
+      return (
+        `The model ran out of output tokens while emitting a call to ${name}, ` +
+        `so the call was incomplete and was not executed. Any file write or ` +
+        `edit it requested did not happen. Retry with a smaller scope, or raise ` +
+        `the model's output token limit.`
+      );
+    }
+
+    return null;
+  }
+
+  if (event === "message-finish") {
+    const reason =
+      getStringRecordValue(payload, "reason") ??
+      getStringRecordValue(payload, "finish_reason");
+
+    if (reason === "length") {
+      return (
+        "The model stopped because it reached its output token limit, so the " +
+        "response is truncated and any tool call it was emitting was not " +
+        "executed. Retry with a smaller scope, or raise the model's output " +
+        "token limit."
+      );
+    }
+  }
+
+  return null;
 }
 
 export function parseStreamEvent(chunk: unknown): OpenWikiRunEvent | null {

--- a/test/truncated-output-detection.test.ts
+++ b/test/truncated-output-detection.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, test } from "vitest";
+
+import {
+  detectTruncatedOutput,
+  parseStreamEvent,
+} from "../src/agent/index.ts";
+
+// When a model hit its output limit mid tool call, the v3 stream said so twice —
+// content-block-finish with content.type "invalid_tool_call", and message-finish
+// with reason "length" — and both were classified as "no text to emit" and
+// dropped. The incomplete call never ran, so a requested write_file simply did
+// not happen while the run could still finish looking successful (issue #458).
+
+function chunk(data: unknown) {
+  return {
+    method: "messages",
+    params: { data, namespace: [] },
+    type: "event",
+  };
+}
+
+describe("detectTruncatedOutput", () => {
+  test("an invalid_tool_call block is reported with the tool name", () => {
+    const message = detectTruncatedOutput(
+      chunk({
+        content: { name: "write_file", type: "invalid_tool_call" },
+        event: "content-block-finish",
+      }),
+    );
+
+    expect(message).toBeTruthy();
+    expect(message).toContain("write_file");
+    expect(message).toContain("output tokens");
+    expect(message).toContain("was not executed");
+  });
+
+  test("an invalid_tool_call without a name still reports", () => {
+    const message = detectTruncatedOutput(
+      chunk({
+        content: { type: "invalid_tool_call" },
+        event: "content-block-finish",
+      }),
+    );
+
+    expect(message).toContain("a tool");
+  });
+
+  test("message-finish reason=length is reported", () => {
+    const message = detectTruncatedOutput(
+      chunk({ event: "message-finish", reason: "length" }),
+    );
+
+    expect(message).toContain("output token limit");
+    expect(message).toContain("truncated");
+  });
+
+  test("the finish_reason spelling is also honoured", () => {
+    const message = detectTruncatedOutput(
+      chunk({ event: "message-finish", finish_reason: "length" }),
+    );
+
+    expect(message).toContain("output token limit");
+  });
+
+  test("a normal stop is not a truncation", () => {
+    expect(
+      detectTruncatedOutput(chunk({ event: "message-finish", reason: "stop" })),
+    ).toBeNull();
+  });
+
+  test("a normal tool-use block is not a truncation", () => {
+    expect(
+      detectTruncatedOutput(
+        chunk({
+          content: { name: "write_file", type: "tool_use" },
+          event: "content-block-finish",
+        }),
+      ),
+    ).toBeNull();
+  });
+
+  test("ordinary text chunks are not truncations", () => {
+    expect(
+      detectTruncatedOutput(
+        chunk({ delta: { text: "hello", type: "text" }, event: "content-block-delta" }),
+      ),
+    ).toBeNull();
+  });
+
+  test("non-protocol chunks are ignored", () => {
+    expect(detectTruncatedOutput(null)).toBeNull();
+    expect(detectTruncatedOutput({ nope: true })).toBeNull();
+    expect(detectTruncatedOutput("string chunk")).toBeNull();
+  });
+
+  test("the tools channel is not inspected", () => {
+    expect(
+      detectTruncatedOutput({
+        method: "tools",
+        params: { data: { event: "message-finish", reason: "length" }, namespace: [] },
+        type: "event",
+      }),
+    ).toBeNull();
+  });
+
+  test("the same chunks still produce no user-visible text event", () => {
+    // Pins the old behaviour that made this invisible: parseStreamEvent returns
+    // null for both, which is why the run could finish reporting success.
+    expect(
+      parseStreamEvent(
+        chunk({
+          content: { name: "write_file", type: "invalid_tool_call" },
+          event: "content-block-finish",
+        }),
+      ),
+    ).toBeNull();
+    expect(
+      parseStreamEvent(chunk({ event: "message-finish", reason: "length" })),
+    ).toBeNull();
+  });
+});


### PR DESCRIPTION
Fixes #458.

When a model reaches its output-token limit while streaming a large tool call, the v3 stream reports it twice:

```
content-block-finish   content.type = "invalid_tool_call"
message-finish         reason       = "length"
```

Both were classified as "no text to emit" and dropped:

```ts
if (
  event === "message-start" ||
  event === "message-finish" ||
  event === "content-block-finish" ||
  event === "error"
) {
  return "";
}
```

The incomplete tool call is never executed, so a requested `write_file` / `edit_file` simply does not happen — and the outer run could still finish without an error, leaving the file change missing and nothing explaining why. That is the worst shape a failure can take: silent, and indistinguishable from success.

## The fix

`detectTruncatedOutput()` recognises both signals, and the stream loop throws an actionable message naming the tool that was cut off, suggesting a smaller scope or a higher output limit.

Throwing there lands in the **existing** catch, which already cleans up the temporary plan file and records the run as `"interrupted"` rather than a no-op — so the next update is not skipped against a partial wiki. That was already the right machinery; it just never got invoked for this case.

Both spellings of the finish field are honoured (`reason` and `finish_reason`); providers are not consistent about it.

## Deliberately narrow

Only those two signals throw. A normal stop, an ordinary `tool_use` block, text deltas, and the `tools` channel are all untouched — each with a test. A false positive here would abort healthy runs, which is worse than the bug being fixed.

## Tests

`test/truncated-output-detection.test.ts` — 10 cases, including one that pins the old invisibility: `parseStreamEvent` still returns `null` for both chunks, which is *why* the run could finish reporting success.

Full suite **779 passed**, typecheck and `lint:check` clean.

Related: #474 (configurable output token limit) would give users the lever this error message points at.

---
Reviewed and tested locally; drafted with AI assistance.