### PR TITLE
feat: add MiniMax as an inference provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,7 +219,7 @@ notes.
 
 ## Customizing
 
-OpenWiki supports OpenAI (with an API key or a ChatGPT login), OpenRouter, Gemini (AI Studio), Gemini Enterprise (Vertex AI), Nebius Token Factory, Fireworks, Baseten, NVIDIA NIM, an OpenAI-compatible provider, AWS Bedrock, Anthropic, and GitHub Copilot out of the box. The onboarding default is OpenAI with `gpt-5.6-terra`, and each inference provider also includes pre-defined model options plus support for custom model IDs.
+OpenWiki supports OpenAI (with an API key or a ChatGPT login), OpenRouter, Gemini (AI Studio), Gemini Enterprise (Vertex AI), Nebius Token Factory, Fireworks, Baseten, NVIDIA NIM, MiniMax, an OpenAI-compatible provider, AWS Bedrock, Anthropic, and GitHub Copilot out of the box. The onboarding default is OpenAI with `gpt-5.6-terra`, and each inference provider also includes pre-defined model options plus support for custom model IDs.
 
 ### GitHub Copilot
 
@@ -253,9 +253,12 @@ ANTHROPIC_BASE_URL=https://your-gateway.example.com/anthropic
 
 The `openai` provider likewise supports an alternative, OpenAI-compatible
 endpoint (for example a self-hosted or proxied gateway) via `OPENAI_BASE_URL`,
-set alongside `OPENAI_API_KEY`. Baseten, Fireworks, and NVIDIA NIM can be routed
-through alternate OpenAI-compatible gateways with `BASETEN_BASE_URL`,
-`FIREWORKS_BASE_URL`, and `NVIDIA_BASE_URL`, respectively. This is useful for
+set alongside `OPENAI_API_KEY`. Baseten, Fireworks, NVIDIA NIM, and MiniMax can
+be routed through alternate OpenAI-compatible gateways with `BASETEN_BASE_URL`,
+`FIREWORKS_BASE_URL`, `NVIDIA_BASE_URL`, and `MINIMAX_BASE_URL`, respectively.
+MiniMax defaults to its global endpoint (`https://api.minimax.io/v1`); set
+`MINIMAX_BASE_URL=https://api.minimaxi.com/v1` to use the other documented
+region. This is useful for
 OpenAI-compatible gateways that expose the Responses API, since the `openai`
 provider routes tool calls through the Responses API (`/v1/responses`) rather
 than chat completions:

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -7,6 +7,8 @@ export const COPILOT_API_KEY_ENV_KEY = "COPILOT_API_KEY";
 export const COPILOT_BASE_URL_ENV_KEY = "COPILOT_BASE_URL";
 export const FIREWORKS_API_KEY_ENV_KEY = "FIREWORKS_API_KEY";
 export const FIREWORKS_BASE_URL_ENV_KEY = "FIREWORKS_BASE_URL";
+export const MINIMAX_API_KEY_ENV_KEY = "MINIMAX_API_KEY";
+export const MINIMAX_BASE_URL_ENV_KEY = "MINIMAX_BASE_URL";
 export const NEBIUS_API_KEY_ENV_KEY = "NEBIUS_API_KEY";
 export const NVIDIA_API_KEY_ENV_KEY = "NVIDIA_API_KEY";
 export const NVIDIA_BASE_URL_ENV_KEY = "NVIDIA_BASE_URL";
@@ -92,6 +94,7 @@ export type OpenWikiProvider =
   | "fireworks"
   | "gemini"
   | "gemini-enterprise"
+  | "minimax"
   | "nebius"
   | "nvidia"
   | "openai"
@@ -227,6 +230,7 @@ export const SELECTABLE_OPENWIKI_PROVIDERS = [
   "bedrock",
   "fireworks",
   "baseten",
+  "minimax",
   "nebius",
   "nvidia",
 ] as const satisfies readonly SelectableOpenWikiProvider[];
@@ -290,6 +294,18 @@ export const PROVIDER_CONFIGS: Record<OpenWikiProvider, ProviderConfig> = {
         id: "accounts/fireworks/models/kimi-k2p7-code",
         label: "Kimi K2.7 Code",
       },
+    ],
+  },
+  minimax: {
+    apiKeyEnvKey: MINIMAX_API_KEY_ENV_KEY,
+    // Defaults to the global endpoint; set MINIMAX_BASE_URL to target another
+    // documented region (for example https://api.minimaxi.com/v1).
+    baseURL: "https://api.minimax.io/v1",
+    baseUrlEnvKey: MINIMAX_BASE_URL_ENV_KEY,
+    label: "MiniMax",
+    modelOptions: [
+      { id: "MiniMax-M3", label: "M3" },
+      { id: "MiniMax-M2.7", label: "M2.7" },
     ],
   },
   nebius: {
@@ -810,16 +826,18 @@ export function resolveConfiguredProvider(
                   ? "nebius"
                   : env[NVIDIA_API_KEY_ENV_KEY]
                     ? "nvidia"
-                    : hasNonEmptyEnvValue(
-                          env,
-                          BEDROCK_AWS_ACCESS_KEY_ID_ENV_KEY,
-                        ) ||
-                        hasNonEmptyEnvValue(
-                          env,
-                          BEDROCK_AWS_SECRET_ACCESS_KEY_ENV_KEY,
-                        )
-                      ? "bedrock"
-                      : DEFAULT_PROVIDER)
+                    : env[MINIMAX_API_KEY_ENV_KEY]
+                      ? "minimax"
+                      : hasNonEmptyEnvValue(
+                            env,
+                            BEDROCK_AWS_ACCESS_KEY_ID_ENV_KEY,
+                          ) ||
+                          hasNonEmptyEnvValue(
+                            env,
+                            BEDROCK_AWS_SECRET_ACCESS_KEY_ENV_KEY,
+                          )
+                        ? "bedrock"
+                        : DEFAULT_PROVIDER)
   );
 }
 

--- a/src/credentials.tsx
+++ b/src/credentials.tsx
@@ -5424,6 +5424,7 @@ function getProviderArticle(provider: OpenWikiProvider): "a" | "an" {
     provider === "fireworks" ||
     provider === "gemini" ||
     provider === "gemini-enterprise" ||
+    provider === "minimax" ||
     provider === "nebius"
     ? "a"
     : "an";

--- a/src/env.ts
+++ b/src/env.ts
@@ -19,6 +19,8 @@ import {
   GOOGLE_CLOUD_LOCATION_ENV_KEY,
   GOOGLE_CLOUD_PROJECT_ENV_KEY,
   isValidModelId,
+  MINIMAX_API_KEY_ENV_KEY,
+  MINIMAX_BASE_URL_ENV_KEY,
   NEBIUS_API_KEY_ENV_KEY,
   normalizeProvider,
   NVIDIA_API_KEY_ENV_KEY,
@@ -94,6 +96,8 @@ export const MANAGED_ENV_KEYS = [
   COPILOT_BASE_URL_ENV_KEY,
   FIREWORKS_API_KEY_ENV_KEY,
   FIREWORKS_BASE_URL_ENV_KEY,
+  MINIMAX_API_KEY_ENV_KEY,
+  MINIMAX_BASE_URL_ENV_KEY,
   NEBIUS_API_KEY_ENV_KEY,
   NVIDIA_API_KEY_ENV_KEY,
   NVIDIA_BASE_URL_ENV_KEY,
@@ -406,6 +410,10 @@ function getBaseUrlDiagnosticWarnings(
     return getProviderBaseUrlWarnings("fireworks", value);
   }
 
+  if (key === MINIMAX_BASE_URL_ENV_KEY) {
+    return getProviderBaseUrlWarnings("minimax", value);
+  }
+
   if (key === NVIDIA_BASE_URL_ENV_KEY) {
     return getProviderBaseUrlWarnings("nvidia", value);
   }
@@ -431,6 +439,7 @@ function isNonSecretDiagnosticKey(key: string): boolean {
     key === BASETEN_BASE_URL_ENV_KEY ||
     key === COPILOT_BASE_URL_ENV_KEY ||
     key === FIREWORKS_BASE_URL_ENV_KEY ||
+    key === MINIMAX_BASE_URL_ENV_KEY ||
     key === NVIDIA_BASE_URL_ENV_KEY ||
     key === OPENAI_BASE_URL_ENV_KEY ||
     key === OPENAI_COMPATIBLE_BASE_URL_ENV_KEY ||

--- a/test/constants.test.ts
+++ b/test/constants.test.ts
@@ -34,6 +34,13 @@ import {
   resolveProviderLocation,
   resolveProviderRegion,
   resolveProviderRetryAttempts,
+  MINIMAX_API_KEY_ENV_KEY,
+  MINIMAX_BASE_URL_ENV_KEY,
+  PROVIDER_CONFIGS,
+  SELECTABLE_OPENWIKI_PROVIDERS,
+  getProviderBaseUrlEnvKey,
+  getProviderLabel,
+  providerRequiresBaseUrl,
 } from "../src/constants.ts";
 
 describe("isValidModelId", () => {
@@ -686,5 +693,60 @@ describe("isModelIdForOtherProvider", () => {
     expect(isModelIdForOtherProvider("  claude-opus-4-8  ", "openai")).toBe(
       true,
     );
+  });
+});
+
+describe("MiniMax provider", () => {
+  test("exposes MiniMax API key and base URL env key constants", () => {
+    expect(MINIMAX_API_KEY_ENV_KEY).toBe("MINIMAX_API_KEY");
+    expect(MINIMAX_BASE_URL_ENV_KEY).toBe("MINIMAX_BASE_URL");
+  });
+
+  test("is a valid, selectable provider", () => {
+    expect(isValidProvider("minimax")).toBe(true);
+    expect(SELECTABLE_OPENWIKI_PROVIDERS).toContain("minimax");
+  });
+
+  test("has a complete provider config pinned to the global endpoint", () => {
+    const config = PROVIDER_CONFIGS.minimax;
+
+    expect(config.apiKeyEnvKey).toBe(MINIMAX_API_KEY_ENV_KEY);
+    expect(config.label).toBe("MiniMax");
+    expect(config.baseURL).toBe("https://api.minimax.io/v1");
+    expect(config.baseUrlEnvKey).toBe(MINIMAX_BASE_URL_ENV_KEY);
+    expect(config.requiresBaseUrl).not.toBe(true);
+  });
+
+  test("ships documented model presets in a stable order", () => {
+    expect(getProviderModelOptions("minimax")).toEqual([
+      { id: "MiniMax-M3", label: "M3" },
+      { id: "MiniMax-M2.7", label: "M2.7" },
+    ]);
+  });
+
+  test("defaults to the flagship model", () => {
+    expect(getDefaultModelId("minimax")).toBe("MiniMax-M3");
+  });
+
+  test("accessors resolve through the shared provider config", () => {
+    expect(getProviderApiKeyEnvKey("minimax")).toBe(MINIMAX_API_KEY_ENV_KEY);
+    expect(getProviderLabel("minimax")).toBe("MiniMax");
+    expect(getProviderBaseUrlEnvKey("minimax")).toBe(MINIMAX_BASE_URL_ENV_KEY);
+    expect(providerRequiresBaseUrl("minimax")).toBe(false);
+  });
+
+  test("defaults to the global base URL and honors a regional override", () => {
+    expect(resolveProviderBaseUrl("minimax", {})).toBe(
+      "https://api.minimax.io/v1",
+    );
+    expect(
+      resolveProviderBaseUrl("minimax", {
+        [MINIMAX_BASE_URL_ENV_KEY]: "https://api.minimaxi.com/v1",
+      }),
+    ).toBe("https://api.minimaxi.com/v1");
+  });
+
+  test("falls back to minimax when only a MiniMax key is present", () => {
+    expect(resolveConfiguredProvider({ MINIMAX_API_KEY: "x" })).toBe("minimax");
   });
 });


### PR DESCRIPTION
Reason: OpenWiki's inference provider registry had no first-class MiniMax provider, so its models were only reachable through the generic OpenAI-compatible endpoint.

## What changed

Adds MiniMax as a first-class, selectable inference provider, following the
existing OpenAI-compatible API-key provider pattern (Baseten, Fireworks, NVIDIA
NIM).

- `src/constants.ts`
  - New `MINIMAX_API_KEY` / `MINIMAX_BASE_URL` env-key constants.
  - `minimax` added to the `OpenWikiProvider` type and the
    `SELECTABLE_OPENWIKI_PROVIDERS` onboarding list.
  - New `PROVIDER_CONFIGS.minimax` entry pinned to the global endpoint
    (`https://api.minimax.io/v1`) with a `MINIMAX_BASE_URL` override, plus the
    `MiniMax-M3` and `MiniMax-M2.7` model presets.
  - `resolveConfiguredProvider` now selects `minimax` when only `MINIMAX_API_KEY`
    is present.
- `src/env.ts` — `MINIMAX_API_KEY` / `MINIMAX_BASE_URL` registered as managed
  env keys, and `MINIMAX_BASE_URL` wired into the base-URL diagnostic warnings
  and treated as a non-secret diagnostic key.
- `src/credentials.tsx` — onboarding article for `minimax` ("a MiniMax").
- `README.md` — provider list and the alternative-base-URL section document
  MiniMax, including how to point `MINIMAX_BASE_URL` at the other documented
  regional endpoint.
- `test/constants.test.ts` — new coverage for the provider config, model
  presets, default model, base-URL resolution/override, and credential
  auto-selection.

The provider resolves through the existing default `ChatOpenAI` construction
path, so no dispatch change in `createModel` is required.

## Checks

- `pnpm run typecheck`
- `pnpm exec vitest run test/constants.test.ts test/create-model.test.ts test/env.test.ts` (105 passed)
- `pnpm exec prettier --check` and `pnpm exec eslint` on the changed files

Native install lifecycle scripts (`better-sqlite3`) were skipped because the
build toolchain is unavailable in this environment; this is unrelated to the
change and does not affect the checks above.
