### PR TITLE
fix: allow comma in model id for gateway/proxy routing identifiers

### DIFF
--- a/.changeset/gentle-comets-allow.md
+++ b/.changeset/gentle-comets-allow.md
@@ -2,4 +2,4 @@
 "openwiki": patch
 ---
 
-Allow comma in model ID validation to support gateway/proxy routing identifiers (e.g. claude-code-router's provider,model-id format).
+fix: allow comma in model id for gateway/proxy routing identifiers

--- a/.changeset/gentle-comets-allow.md
+++ b/.changeset/gentle-comets-allow.md
@@ -1,0 +1,5 @@
+---
+"openwiki": patch
+---
+
+Allow comma in model ID validation to support gateway/proxy routing identifiers (e.g. claude-code-router's provider,model-id format).

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -920,7 +920,7 @@ export function isValidModelId(value: string): boolean {
     modelId.length <= 120 &&
     // Leading @ for Cloudflare Workers AI ids (@cf/...); interior @ for
     // Vertex AI @-versioned ids (e.g. claude-sonnet-4-5@20250929).
-    /^[@A-Za-z0-9][A-Za-z0-9._:/@+-]*$/u.test(modelId) &&
+    /^[@A-Za-z0-9][A-Za-z0-9._:/@+,-]*$/u.test(modelId) &&
     !modelId.includes("://")
   );
 }

--- a/test/constants.test.ts
+++ b/test/constants.test.ts
@@ -46,6 +46,13 @@ describe("isValidModelId", () => {
     expect(isValidModelId("nvidia/nemotron-3-super-120b-a12b")).toBe(true);
   });
 
+  test("accepts comma-bearing gateway/proxy routing ids", () => {
+    // Routing layers such as claude-code-router encode the target as
+    // `provider,model-id`; the comma is passed verbatim to the gateway, so it
+    // must survive validation rather than being treated as a delimiter here.
+    expect(isValidModelId("deepseek,deepseek-v4-pro")).toBe(true);
+  });
+
   test("accepts Cloudflare Workers AI model ids with leading '@'", () => {
     expect(isValidModelId("@cf/meta/llama-3-8b-instruct")).toBe(true);
     expect(isValidModelId("@cf/moonshotai/kimi-k2.7-code")).toBe(true);


### PR DESCRIPTION
## What and why

Several LLM API gateways and proxies use comma-separated identifiers to encode provider routing information. For example, `claude-code-router` uses a `provider,model-id` format (e.g. `deepseek,deepseek-v4-pro`), and other self-hosted routing solutions follow similar conventions.

The current `isValidModelId()` regex rejects commas, which means users of these gateways cannot pass their model ID via `--modelId` or the `OPENWIKI_MODEL_ID` env var — they get an "Invalid model ID" error and must manually patch the installed package.

A comma is not dangerous in a model identifier — it's a common separator used by routing layers. This PR adds it to the allowed character set, removing unnecessary friction without compromising safety.

## How tested

- `pnpm run format` — passes
- `pnpm run lint` — passes
- `pnpm test` — 784 of 785 tests pass (1 unrelated flaky mermaid timeout)
- `test/constants.test.ts` — all 69 tests pass
- Manually verified `isValidModelId("deepseek,deepseek-v4-pro")` returns `true`
- `://` rejection, empty string rejection, and >120-char rejection unchanged