### PR TITLE
fix: keep release workflow opt-in on forks

### DIFF
--- a/.changeset/quick-foxes-jump.md
+++ b/.changeset/quick-foxes-jump.md
@@ -1,0 +1,5 @@
+---
+"openwiki": patch
+---
+
+fix: keep release workflow opt-in on forks

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,9 @@ permissions:
 
 jobs:
   release:
+    # Upstream releases run by default. Forks must explicitly opt in because
+    # this job can create release PRs, push tags, and publish to npm.
+    if: github.repository == 'langchain-ai/openwiki' || vars.OPENWIKI_ENABLE_RELEASE == 'true'
     name: Release
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
Closes #532

## Summary

Keep the Release workflow enabled by default in `langchain-ai/openwiki`, while requiring an explicit opt-in for forks.

Fork release runs now:

- Run normally in `langchain-ai/openwiki`.
- Skip on forks by default.
- Run on forks when `OPENWIKI_ENABLE_RELEASE=true`.

## Why

The Release workflow can create a Changesets version PR, push tags, and publish to npm through trusted publishing.

A fork that only synchronizes `main` with upstream should not start that automation unexpectedly. In particular, forks commonly keep GitHub Actions from creating pull requests, which currently makes the workflow fail after it has already pushed a `changeset-release/main` branch.

Forks that intentionally maintain and publish their own package can still opt in with `OPENWIKI_ENABLE_RELEASE=true`, then configure the required Actions and npm trusted-publishing settings.

## Testing

- `actionlint .github/workflows/release.yml`
- `git diff --check`
- Live fork verification: [Release workflow skipped by default](https://github.com/jyje/openwiki/actions/runs/30555873532)
  - The workflow was triggered by a push to a fork-only test branch.
  - The `Release` job completed as `skipped` without running any steps.

I did not exercise the opt-in path because it can create a release PR or publish a package.

If a different fork opt-in mechanism is preferred, I am happy to adjust it.

It is a small safeguard, but I would be happy if it helps fork maintainers avoid unexpected release runs.
