### PR TITLE
fix: fail translation runs on filesystem discovery errors

### DIFF
--- a/.changeset/strict-translation-discovery.md
+++ b/.changeset/strict-translation-discovery.md
@@ -1,0 +1,5 @@
+---
+"openwiki": patch
+---
+
+fix: surface translation filesystem discovery failures

--- a/src/agent/translation-middleware.ts
+++ b/src/agent/translation-middleware.ts
@@ -405,9 +405,22 @@ function extractText(content: MessageContent): string {
 async function collectMarkdownFiles(
   backend: BackendProtocolV2,
   directoryPath: string,
+  optionalRoot = directoryPath,
 ): Promise<string[]> {
   const result = await backend.ls(directoryPath);
-  if (result.error) return [];
+  if (result.error) {
+    // A repository-mode wiki root may not exist yet, which is a valid no-op.
+    // Every other listing failure means the file tree is incomplete and must
+    // abort the pass rather than silently claiming a language switch succeeded.
+    if (
+      directoryPath === optionalRoot &&
+      isMissingDirectoryError(result.error)
+    ) {
+      return [];
+    }
+
+    throw new Error(`Unable to list ${directoryPath}: ${result.error}`);
+  }
 
   const files: string[] = [];
   for (const entry of result.files ?? []) {
@@ -416,7 +429,9 @@ async function collectMarkdownFiles(
 
     const entryPath = path.posix.join(directoryPath, name);
     if (entry.is_dir) {
-      files.push(...(await collectMarkdownFiles(backend, entryPath)));
+      files.push(
+        ...(await collectMarkdownFiles(backend, entryPath, optionalRoot)),
+      );
       continue;
     }
     if (
@@ -427,6 +442,10 @@ async function collectMarkdownFiles(
     }
   }
   return files;
+}
+
+function isMissingDirectoryError(error: string): boolean {
+  return /(?:ENOENT|not found)/iu.test(error);
 }
 
 /**

--- a/test/translation-middleware.test.ts
+++ b/test/translation-middleware.test.ts
@@ -444,4 +444,52 @@ describe("createWikiTranslationMiddleware beforeAgent", () => {
     ).resolves.toBeUndefined();
     expect(calls).toHaveLength(0);
   });
+
+  test("fails a language switch when the wiki root cannot be listed", async () => {
+    const { backend } = await setup("repository");
+    const realLs = backend.ls.bind(backend);
+    vi.spyOn(backend, "ls").mockImplementation((directoryPath) =>
+      directoryPath === "/openwiki"
+        ? Promise.resolve({ error: "EACCES: permission denied" })
+        : realLs(directoryPath),
+    );
+    const { model, calls } = fakeModel((content) => `T\n${content}`);
+
+    await expect(
+      runBeforeAgent(
+        createWikiTranslationMiddleware(
+          backend,
+          "repository",
+          model,
+          switchTo("zh-CN"),
+        ),
+      ),
+    ).rejects.toThrow("Unable to list /openwiki: EACCES");
+    expect(calls).toHaveLength(0);
+  });
+
+  test("fails a language switch when a nested directory cannot be listed", async () => {
+    const { backend } = await setup("repository");
+    await backend.write("/openwiki/accessible.md", "# Accessible\n");
+    await backend.write("/openwiki/unreadable/page.md", "# Unreadable\n");
+    const realLs = backend.ls.bind(backend);
+    vi.spyOn(backend, "ls").mockImplementation((directoryPath) =>
+      directoryPath === "/openwiki/unreadable"
+        ? Promise.resolve({ error: "EIO: input/output error" })
+        : realLs(directoryPath),
+    );
+    const { model, calls } = fakeModel((content) => `T\n${content}`);
+
+    await expect(
+      runBeforeAgent(
+        createWikiTranslationMiddleware(
+          backend,
+          "repository",
+          model,
+          switchTo("zh-CN"),
+        ),
+      ),
+    ).rejects.toThrow("Unable to list /openwiki/unreadable: EIO");
+    expect(calls).toHaveLength(0);
+  });
 });


### PR DESCRIPTION
## Summary

Fixes #543.

Translation discovery previously converted every `backend.ls()` error into an empty directory. During a language switch this could translate visible pages, skip an unreadable subtree, and let the run persist the target language while leaving the wiki mixed.

## Changes

- Make recursive Markdown discovery throw an actionable error containing the affected virtual path and backend reason for permission, I/O, backend, and transient listing failures.
- Preserve the intentional repository-mode no-op when the top-level `/openwiki` root is genuinely absent (`ENOENT` or a not-found result); all nested missing directories remain failures because their contents are expected to exist after discovery.
- Because discovery runs before any page translation, a failed listing aborts the middleware before the outer update can claim the requested language completed.
- Add regression coverage for root permission failures, nested I/O failures, and the existing absent-root no-op behavior.
- Add a patch changeset.

## Why this fixes the data-integrity issue

An incomplete tree is no longer indistinguishable from an empty tree. Translation cannot silently finish with unknown pages, and the failed run does not reach language metadata persistence. A later retry will re-run discovery against the full tree rather than relying on per-page pending markers that could never be created for undiscovered files.

## Validation

- `pnpm run lint:check`
- `pnpm run typecheck`
- `pnpm exec prettier --check` (changed files)
- `pnpm test` — 67 files, 793 tests passed
