### PR TITLE
feat: configure code-mode agent file policy

### DIFF
--- a/.changeset/tidy-wikis-rest.md
+++ b/.changeset/tidy-wikis-rest.md
@@ -1,0 +1,5 @@
+---
+"openwiki": minor
+---
+
+feat: add configurable `manage` and `preserve` policies for code-mode root agent files

--- a/README.md
+++ b/README.md
@@ -234,11 +234,21 @@ Locally the setup wizard saves this to `~/.openwiki/.env`. In CI, set it as a re
 
 Your wiki stays in the repository as plain Markdown you own, with OpenWiki-managed grounding and run metadata versioned alongside it.
 
-- **Agents read it as memory.** On each `code` run, OpenWiki maintains an `AGENTS.md` and `CLAUDE.md` at the repo root that point your coding agent at the wiki. It only rewrites its own `<!-- OPENWIKI:START -->…<!-- OPENWIKI:END -->` block and leaves the rest of each file untouched.
+- **Agents read it as memory.** On each `code` run, OpenWiki maintains an `AGENTS.md` and `CLAUDE.md` at the repo root that point your coding agent at the wiki. It only rewrites its own `<!-- OPENWIKI:START -->…<!-- OPENWIKI:END -->` block and leaves the rest of each file untouched. Repositories that own those files themselves can select the `preserve` policy below.
 - **Grounding stays with the wiki.** Versioned claim sidecars under `openwiki/.claims/` travel with the Markdown, so the evidence needed to maintain factual pages is inspectable and reviewable.
 - **You set the brief.** Repository-specific instructions live in `openwiki/INSTRUCTIONS.md`, a user-authored file OpenWiki reads for scope and priorities but never rewrites during normal runs.
 - **No-op runs do not churn docs.** A clean update skips model work and leaves wiki content untouched while refreshing `.last-update.json` to record that the check ran.
 - **Local, private config.** Provider choice, keys, and optional LangSmith tracing are saved to `~/.openwiki/.env` on your machine.
+
+Agent-file ownership is committed in `openwiki.config.yaml`. The default policy is `manage`; set `preserve` to leave existing root files byte-for-byte unchanged and keep missing files absent during init, update, chat, and scheduled runs:
+
+```yaml
+codeMode:
+  agentFiles:
+    policy: preserve
+```
+
+Use `--agent-files-policy <manage|preserve>` to override that policy for one code-mode run without rewriting the config. Resolution order is CLI override, committed config, then the `manage` default. The `agentFiles` mapping leaves room for future path configuration without changing the meaning of the policy setting. A newly generated workflow reads the committed config on later runs and omits `AGENTS.md` and `CLAUDE.md` from its pull request paths when the committed policy is `preserve`.
 
 ## Open Knowledge Format (OKF v0.2)
 
@@ -484,6 +494,7 @@ openwiki "generate docs"         # start with an initial request
 openwiki -p "what can you do?"   # one-shot, print, and exit
 openwiki --init                  # initialize code docs (personal: openwiki personal --init)
 openwiki --update                # update code docs (personal: openwiki personal --update)
+openwiki code --update --agent-files-policy preserve # preserve root agent files for one run
 openwiki visualize               # interactive graph + live reader
 openwiki visualize openwiki --export docs/openwiki-visualizer  # static graph + reader
 openwiki auth <provider>         # authenticate a connector (slack, gmail, x, notion)

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -200,6 +200,7 @@ export async function runOpenWikiAgent(
         "run",
         () =>
           runNativeRepositoryGeneration({
+            agentFilesPolicy: options.agentFilesPolicy,
             root: runtimeCwd,
             mode: command,
             language: options.language,

--- a/src/agent/repository-runner.ts
+++ b/src/agent/repository-runner.ts
@@ -22,6 +22,7 @@ import {
   type RepositoryPageSnapshot,
 } from "../generation/repository-run.js";
 import type { RepositoryRunMode } from "../generation/run-state.js";
+import type { CodeModeAgentFilesPolicy } from "../config/code-mode.js";
 import { OPENWIKI_PRODUCER_ACTOR } from "../version.js";
 import {
   AGENT_FILESYSTEM_PERMISSIONS,
@@ -137,6 +138,9 @@ function createSubmissionRejection(
  * Inputs for one native repository-generation command.
  */
 export interface NativeRepositoryGenerationOptions {
+  /** One-run override for repository agent-file handling. */
+  agentFilesPolicy?: CodeModeAgentFilesPolicy | null;
+
   /**
    * Absolute Git repository root owned by the run.
    */
@@ -263,6 +267,7 @@ async function beginNativeRepositoryRun(
   options: NativeRepositoryGenerationOptions,
 ): Promise<BeginRepositoryRunResult> {
   return beginRepositoryRun({
+    agentFilesPolicy: options.agentFilesPolicy,
     root: options.root,
     mode: options.mode,
     language: options.language ?? undefined,

--- a/src/agent/types.ts
+++ b/src/agent/types.ts
@@ -1,3 +1,5 @@
+import type { CodeModeAgentFilesPolicy } from "../config/code-mode.js";
+
 export type OpenWikiCommand = "chat" | "init" | "update";
 export type OpenWikiOutputMode = "local-wiki" | "repository";
 
@@ -76,6 +78,7 @@ export type OpenWikiRunEvent =
     };
 
 export type OpenWikiRunOptions = {
+  agentFilesPolicy?: CodeModeAgentFilesPolicy | null;
   debug?: boolean;
   isFollowup?: boolean;
   language?: string | null;

--- a/src/cli/app/app.tsx
+++ b/src/cli/app/app.tsx
@@ -64,6 +64,7 @@ import { requestProcessInterrupt } from "../process-interrupt.js";
 import { appendRunLogEvent } from "../run-log/reducer.js";
 import type { RunLogItem } from "../run-log/types.js";
 import {
+  getCodeModeRepoSetupOptions,
   getRunModeCwd,
   getRunModeOutputMode,
   shouldAutoExitStartupRun,
@@ -556,6 +557,7 @@ export function App({ command }: AppProps) {
     };
 
     const runOptions: OpenWikiRunOptions = {
+      agentFilesPolicy: command.agentFilesPolicy,
       debug: isDebugMode(),
       isFollowup: activeMessageIsFollowup,
       language: command.language,
@@ -577,9 +579,13 @@ export function App({ command }: AppProps) {
       telemetryContext,
       async () => {
         if (runMode === "code") {
-          await ensureCodeModeRepoSetup(runtimeCwd, {
-            createWorkflow: resolvedCommand === "init",
-          });
+          await ensureCodeModeRepoSetup(
+            runtimeCwd,
+            getCodeModeRepoSetupOptions({
+              ...command,
+              command: resolvedCommand,
+            }),
+          );
         }
 
         await scheduler.yield();

--- a/src/cli/commands.ts
+++ b/src/cli/commands.ts
@@ -1,5 +1,9 @@
 import { isValidModelId, normalizeModelId } from "../config/constants.js";
 import { openWikiLocalWikiDisplayPath } from "../config/openwiki-home.js";
+import {
+  isCodeModeAgentFilesPolicy,
+  type CodeModeAgentFilesPolicy,
+} from "../config/code-mode.js";
 import type { OpenWikiCommand } from "../agent/types.js";
 import { resolveLanguage } from "../platform/language.js";
 import { isAuthProviderId } from "../auth/providers.js";
@@ -149,6 +153,7 @@ export type CliCommand =
       command: OpenWikiCommand;
       dryRun: boolean;
       language: string | null;
+      agentFilesPolicy: CodeModeAgentFilesPolicy | null;
       mode: OpenWikiRunMode;
       modeSource: OpenWikiRunModeSource;
       modelId: string | null;
@@ -737,6 +742,7 @@ function parseRunCommand(
   initialMode: OpenWikiRunMode,
   initialModeSource: OpenWikiRunModeSource,
 ): CliCommand {
+  let agentFilesPolicy: CodeModeAgentFilesPolicy | null = null;
   let dryRun = false;
   let language: string | null = null;
   let mode = initialMode;
@@ -770,6 +776,43 @@ function parseRunCommand(
 
     if (arg === "--print" || arg === "-p") {
       print = true;
+      continue;
+    }
+
+    if (arg === "--agent-files-policy") {
+      const nextArg = argv[index + 1];
+
+      if (!nextArg || nextArg.startsWith("-")) {
+        return {
+          kind: "error",
+          exitCode: 1,
+          message: "--agent-files-policy requires manage or preserve.",
+        };
+      }
+      if (!isCodeModeAgentFilesPolicy(nextArg)) {
+        return {
+          kind: "error",
+          exitCode: 1,
+          message: `Invalid --agent-files-policy value: ${nextArg}. Expected manage or preserve.`,
+        };
+      }
+
+      agentFilesPolicy = nextArg;
+      index += 1;
+      continue;
+    }
+
+    if (arg.startsWith("--agent-files-policy=")) {
+      const [, value = ""] = arg.split("=", 2);
+      if (!isCodeModeAgentFilesPolicy(value)) {
+        return {
+          kind: "error",
+          exitCode: 1,
+          message: `Invalid --agent-files-policy value: ${value}. Expected manage or preserve.`,
+        };
+      }
+
+      agentFilesPolicy = value;
       continue;
     }
 
@@ -981,6 +1024,14 @@ function parseRunCommand(
     mode = "code";
   }
 
+  if (agentFilesPolicy !== null && mode !== "code") {
+    return {
+      kind: "error",
+      exitCode: 1,
+      message: "--agent-files-policy is only available in code mode.",
+    };
+  }
+
   if (print && !shouldStart) {
     return {
       kind: "error",
@@ -992,6 +1043,7 @@ function parseRunCommand(
   return {
     kind: "run",
     exitCode: 0,
+    agentFilesPolicy,
     command,
     dryRun,
     language:
@@ -1092,6 +1144,7 @@ export const helpContent: HelpContent = {
   usage: [
     "openwiki [--init|--update] [message]",
     "openwiki code [--init|--update] [message]",
+    "openwiki code --agent-files-policy <manage|preserve> [--init|--update] [message]",
     "openwiki personal [--init|--update] [message]",
     "openwiki --mode <personal|code> [--init|--update] [message]",
     "openwiki [--language <locale>] [--init|--update] [message]",
@@ -1217,6 +1270,11 @@ export const helpContent: HelpContent = {
       description: "Run once and print the final assistant output.",
     },
     {
+      label: "--agent-files-policy <manage|preserve>",
+      description:
+        "Override root agent-file handling for this code-mode run (default: config, then manage).",
+    },
+    {
       label: "--debug",
       description:
         "Show full credential and error diagnostics when a run fails.",
@@ -1262,6 +1320,7 @@ export const helpContent: HelpContent = {
     "openwiki personal --init",
     "openwiki code --init",
     "openwiki --update",
+    "openwiki code --update --agent-files-policy preserve",
     "openwiki --update --mode personal",
     'openwiki "What can you do?"',
     'openwiki -p "Summarize what OpenWiki can do"',

--- a/src/cli/run-mode.ts
+++ b/src/cli/run-mode.ts
@@ -1,5 +1,6 @@
 import type { OpenWikiOutputMode } from "../agent/types.js";
 import { openWikiLocalWikiDir } from "../config/openwiki-home.js";
+import type { CodeModeRepoSetupOptions } from "../ingestion/code-mode.js";
 import type { CliCommand, OpenWikiRunMode } from "./commands.js";
 
 /**
@@ -52,6 +53,16 @@ export function getRunModeOutputMode(
   mode: OpenWikiRunMode,
 ): OpenWikiOutputMode {
   return mode === "code" ? "repository" : "local-wiki";
+}
+
+/** Maps a parsed code-mode command to repository setup behavior. */
+export function getCodeModeRepoSetupOptions(
+  command: Extract<CliCommand, { kind: "run" }>,
+): CodeModeRepoSetupOptions {
+  return {
+    agentFilesPolicy: command.agentFilesPolicy,
+    createWorkflow: command.command === "init",
+  };
 }
 
 /**

--- a/src/cli/runners.ts
+++ b/src/cli/runners.ts
@@ -36,7 +36,11 @@ import type { CliCommand } from "./commands.js";
 import { isDebugMode } from "./debug.js";
 import { getAuthFix, getAuthFixSteps } from "./diagnostics/auth-fix.js";
 import { getErrorDiagnostics } from "./diagnostics/error-diagnostics.js";
-import { getRunModeCwd, getRunModeOutputMode } from "./run-mode.js";
+import {
+  getCodeModeRepoSetupOptions,
+  getRunModeCwd,
+  getRunModeOutputMode,
+} from "./run-mode.js";
 import { formatRepositoryPrintProgress } from "./run-log/progress.js";
 import {
   formatPowerScheduleStatus,
@@ -276,6 +280,7 @@ export async function runPrintCommand(
     };
 
     const runOptions: OpenWikiRunOptions = {
+      agentFilesPolicy: command.agentFilesPolicy,
       debug: isDebugMode(),
       isFollowup: command.command === "chat",
       language: command.language,
@@ -297,9 +302,10 @@ export async function runPrintCommand(
       telemetryContext,
       async () => {
         if (command.mode === "code") {
-          await ensureCodeModeRepoSetup(runtimeCwd, {
-            createWorkflow: command.command === "init",
-          });
+          await ensureCodeModeRepoSetup(
+            runtimeCwd,
+            getCodeModeRepoSetupOptions(command),
+          );
         }
 
         // Code-mode connectors (e.g. langsmith) pull their evidence and augment

--- a/src/config/code-mode.ts
+++ b/src/config/code-mode.ts
@@ -1,0 +1,124 @@
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import { parse } from "yaml";
+import { isFileNotFoundError } from "../platform/fs-errors.js";
+
+export const CODE_MODE_CONFIG_FILENAME = "openwiki.config.yaml";
+export const DEFAULT_CODE_MODE_AGENT_FILES_POLICY = "manage";
+
+export type CodeModeAgentFilesPolicy = "manage" | "preserve";
+export type CodeModeAgentFilesPolicySource = "cli" | "config" | "default";
+
+export interface ResolvedCodeModeAgentFilesPolicy {
+  /** Policy applied to the current run. */
+  policy: CodeModeAgentFilesPolicy;
+  /** Where the current run's policy came from. */
+  source: CodeModeAgentFilesPolicySource;
+  /** Committed policy used by later runs, or null when the default applies. */
+  configuredPolicy: CodeModeAgentFilesPolicy | null;
+}
+
+export function isCodeModeAgentFilesPolicy(
+  value: string,
+): value is CodeModeAgentFilesPolicy {
+  return value === "manage" || value === "preserve";
+}
+
+/**
+ * Resolve the current code-mode agent-file policy without mutating repository
+ * configuration. CLI overrides win over committed config, which wins over the
+ * backward-compatible `manage` default.
+ */
+export async function resolveCodeModeAgentFilesPolicy(
+  cwd: string,
+  cliOverride: CodeModeAgentFilesPolicy | null = null,
+): Promise<ResolvedCodeModeAgentFilesPolicy> {
+  const configuredPolicy = await readConfiguredAgentFilesPolicy(cwd);
+
+  if (cliOverride !== null) {
+    return { configuredPolicy, policy: cliOverride, source: "cli" };
+  }
+
+  if (configuredPolicy !== null) {
+    return {
+      configuredPolicy,
+      policy: configuredPolicy,
+      source: "config",
+    };
+  }
+
+  return {
+    configuredPolicy: null,
+    policy: DEFAULT_CODE_MODE_AGENT_FILES_POLICY,
+    source: "default",
+  };
+}
+
+async function readConfiguredAgentFilesPolicy(
+  cwd: string,
+): Promise<CodeModeAgentFilesPolicy | null> {
+  let text: string;
+
+  try {
+    text = await readFile(path.join(cwd, CODE_MODE_CONFIG_FILENAME), "utf8");
+  } catch (error) {
+    if (isFileNotFoundError(error)) {
+      return null;
+    }
+    throw error;
+  }
+
+  let config: unknown;
+  try {
+    config = parse(text) as unknown;
+  } catch (error) {
+    throw invalidConfig(errorMessage(error));
+  }
+
+  if (config === null || config === undefined) {
+    return null;
+  }
+  if (!isRecord(config)) {
+    throw invalidConfig("the document root must be a mapping.");
+  }
+
+  const codeMode = config.codeMode;
+  if (codeMode === undefined) {
+    return null;
+  }
+  if (!isRecord(codeMode)) {
+    throw invalidConfig("codeMode must be a mapping.");
+  }
+
+  const agentFiles = codeMode.agentFiles;
+  if (agentFiles === undefined) {
+    return null;
+  }
+  if (!isRecord(agentFiles)) {
+    throw invalidConfig("codeMode.agentFiles must be a mapping.");
+  }
+
+  const policy = agentFiles.policy;
+  if (policy === undefined) {
+    return null;
+  }
+  if (typeof policy !== "string" || !isCodeModeAgentFilesPolicy(policy)) {
+    throw invalidConfig(
+      "codeMode.agentFiles.policy must be manage or preserve.",
+    );
+  }
+
+  return policy;
+}
+
+function invalidConfig(message: string): Error {
+  return new Error(`Invalid ${CODE_MODE_CONFIG_FILENAME}: ${message}`);
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/src/generation/repository-run.ts
+++ b/src/generation/repository-run.ts
@@ -3,6 +3,7 @@ import { OpenWikiLocalShellBackend } from "../agent/docs-only-backend.js";
 import { OpenWikiIgnore } from "../agent/openwiki-ignore.js";
 import type { RunContext } from "../agent/types.js";
 import type { UpdateNoopStatus } from "../agent/utils.js";
+import type { CodeModeAgentFilesPolicy } from "../config/code-mode.js";
 import {
   createOpenWikiContentSnapshot,
   createRepositorySourceSnapshot,
@@ -73,6 +74,9 @@ import {
  * Inputs required to start or resume one repository-generation run.
  */
 export interface BeginRepositoryRunInput {
+  /** One-run override for repository agent-file handling. */
+  agentFilesPolicy?: CodeModeAgentFilesPolicy | null;
+
   /**
    * Absolute Git repository root for the run.
    */
@@ -332,6 +336,7 @@ export async function beginRepositoryRun(
     resolvedRequest.kind === "resolved" ? resolvedRequest.language : undefined;
 
   await ensureCodeModeRepoSetup(input.root, {
+    agentFilesPolicy: input.agentFilesPolicy,
     createWorkflow: input.mode === "init",
   });
 

--- a/src/ingestion/code-mode.ts
+++ b/src/ingestion/code-mode.ts
@@ -12,6 +12,11 @@ import {
 import { isFileNotFoundError } from "../platform/fs-errors.js";
 import { createConnectorRegistry } from "../connectors/registry.js";
 import { UPDATE_METADATA_PATH } from "../config/constants.js";
+import {
+  DEFAULT_CODE_MODE_AGENT_FILES_POLICY,
+  resolveCodeModeAgentFilesPolicy,
+  type CodeModeAgentFilesPolicy,
+} from "../config/code-mode.js";
 import { createConnectorSynthesisGuidance } from "./ingestion.js";
 import type { OpenWikiRunEvent } from "../agent/types.js";
 
@@ -40,25 +45,37 @@ export interface CodeModeRepoSetupOptions {
    * resolved for this run.
    */
   env?: NodeJS.ProcessEnv;
+  /** One-run override for the committed code-mode agent-file policy. */
+  agentFilesPolicy?: CodeModeAgentFilesPolicy | null;
 }
 
 /**
- * Ensure the repo is set up for code mode: refresh the managed agent-instruction
- * snippets, and, when `options.createWorkflow` is set, create the scheduled-update
- * workflow if it does not already exist.
+ * Ensure the repo is set up for code mode: optionally refresh the managed
+ * agent-instruction snippets and, when `options.createWorkflow` is set, create
+ * the scheduled-update workflow if it does not already exist.
  */
 export async function ensureCodeModeRepoSetup(
   cwd: string,
   options: CodeModeRepoSetupOptions = {},
 ): Promise<void> {
+  const agentFiles = await resolveCodeModeAgentFilesPolicy(
+    cwd,
+    options.agentFilesPolicy,
+  );
+  const scheduledAgentFilesPolicy =
+    agentFiles.configuredPolicy ?? DEFAULT_CODE_MODE_AGENT_FILES_POLICY;
+
   if (options.createWorkflow) {
     await ensureCodeModeWorkflow(
       cwd,
       options.cronExpression ?? DEFAULT_CODE_MODE_CRON,
       options.env ?? process.env,
+      scheduledAgentFilesPolicy,
     );
   }
-  await writeCodeModeAgentSnippets(cwd);
+  if (agentFiles.policy === "manage") {
+    await writeCodeModeAgentSnippets(cwd);
+  }
 }
 
 /**
@@ -70,6 +87,7 @@ async function ensureCodeModeWorkflow(
   cwd: string,
   cronExpression: string,
   env: NodeJS.ProcessEnv,
+  agentFilesPolicy: CodeModeAgentFilesPolicy,
 ): Promise<void> {
   const workflowPath = path.join(
     cwd,
@@ -90,7 +108,7 @@ async function ensureCodeModeWorkflow(
   await mkdir(path.dirname(workflowPath), { recursive: true });
   await writeFile(
     workflowPath,
-    createCodeModeWorkflow(cronExpression, env),
+    createCodeModeWorkflow(cronExpression, env, agentFilesPolicy),
     "utf8",
   );
 }
@@ -323,7 +341,13 @@ function createWorkflowProviderEnv(env: NodeJS.ProcessEnv): string {
 function createCodeModeWorkflow(
   cronExpression: string,
   env: NodeJS.ProcessEnv,
+  agentFilesPolicy: CodeModeAgentFilesPolicy,
 ): string {
+  const agentFilePaths =
+    agentFilesPolicy === "manage"
+      ? "            AGENTS.md\n            CLAUDE.md\n"
+      : "";
+
   return `name: OpenWiki Update
 
 on:
@@ -381,9 +405,7 @@ jobs:
         with:
           add-paths: |
             openwiki
-            AGENTS.md
-            CLAUDE.md
-            .github/workflows/openwiki-update.yml
+${agentFilePaths}            .github/workflows/openwiki-update.yml
           branch: openwiki/update
           commit-message: "docs: update OpenWiki"
           title: "docs: update OpenWiki"

--- a/test/agent/repository-runner.test.ts
+++ b/test/agent/repository-runner.test.ts
@@ -63,6 +63,7 @@ type HarnessPlanInput = {
 
 const harness = vi.hoisted(() => ({
   agentOptions: [] as CapturedAgentOptions[],
+  beginInputs: [] as unknown[],
   beginCalls: 0,
   changedPaths: ["README.md"],
   currentRun: undefined as HarnessRun | undefined,
@@ -271,7 +272,8 @@ vi.mock("../../src/generation/repository-run.js", () => ({
     job.status = "skipped";
     return Promise.resolve();
   },
-  beginRepositoryRun() {
+  beginRepositoryRun(input: unknown) {
+    harness.beginInputs.push(input);
     harness.beginCalls += 1;
     if (harness.noop) {
       return Promise.resolve({
@@ -457,9 +459,12 @@ import type { OpenWikiRunEvent } from "../../src/agent/types.ts";
  *
  * @returns Complete ordered event stream emitted by the runner.
  */
-async function runHarness(): Promise<OpenWikiRunEvent[]> {
+async function runHarness(
+  agentFilesPolicy: "manage" | "preserve" | null = null,
+): Promise<OpenWikiRunEvent[]> {
   const events: OpenWikiRunEvent[] = [];
   await runNativeRepositoryGeneration({
+    agentFilesPolicy,
     root: "/repo",
     mode: "update",
     modelId: "test-model",
@@ -472,6 +477,7 @@ async function runHarness(): Promise<OpenWikiRunEvent[]> {
 
 beforeEach(() => {
   harness.agentOptions = [];
+  harness.beginInputs = [];
   harness.beginCalls = 0;
   harness.changedPaths = ["README.md"];
   harness.currentRun = undefined;
@@ -496,6 +502,14 @@ beforeEach(() => {
 });
 
 describe("runNativeRepositoryGeneration", () => {
+  test("forwards the agent-file policy into the durable run", async () => {
+    await runHarness("preserve");
+
+    expect(harness.beginInputs[0]).toEqual(
+      expect.objectContaining({ agentFilesPolicy: "preserve" }),
+    );
+  });
+
   test("uses exact shell-free tool surfaces and a fresh worker per page", async () => {
     const events = await runHarness();
 

--- a/test/agent/run-openwiki-agent-routing.test.ts
+++ b/test/agent/run-openwiki-agent-routing.test.ts
@@ -95,6 +95,7 @@ describe("runOpenWikiAgent repository routing", () => {
 
     for (const command of ["init", "update"] as const) {
       const result = await runOpenWikiAgent(command, root, {
+        agentFilesPolicy: "preserve",
         outputMode: "repository",
         userMessage: "Honor the repository-specific documentation scope.",
       });
@@ -108,13 +109,18 @@ describe("runOpenWikiAgent repository routing", () => {
       expect.objectContaining({
         root,
         mode: "init",
+        agentFilesPolicy: "preserve",
         force: true,
         planningContext: "Honor the repository-specific documentation scope.",
       }),
     );
     expect(harness.runNativeRepositoryGeneration).toHaveBeenNthCalledWith(
       2,
-      expect.objectContaining({ root, mode: "update" }),
+      expect.objectContaining({
+        agentFilesPolicy: "preserve",
+        root,
+        mode: "update",
+      }),
     );
     expect(harness.createDeepAgent).not.toHaveBeenCalled();
   });

--- a/test/cli/commands.test.ts
+++ b/test/cli/commands.test.ts
@@ -70,6 +70,10 @@ describe("parseCommand — help", () => {
   test("help documents the output language option", () => {
     expect(getHelpText()).toContain("-l, --language <locale>");
   });
+
+  test("help documents the root agent-file opt-out", () => {
+    expect(getHelpText()).toContain("--agent-files-policy <manage|preserve>");
+  });
 });
 
 describe("parseCommand — chat default", () => {
@@ -85,6 +89,7 @@ describe("parseCommand — chat default", () => {
       userMessage: null,
       print: false,
       dryRun: false,
+      agentFilesPolicy: null,
       modelId: null,
     });
   });
@@ -293,6 +298,67 @@ describe("parseCommand — init/update", () => {
 
   test("repeating the same command flag is allowed", () => {
     expect(parseCommand(["personal", "--init", "--init"]).kind).toBe("run");
+  });
+
+  for (const [name, argv, command] of [
+    ["chat", ["code", "--agent-files-policy", "preserve"], "chat"],
+    ["init", ["code", "--init", "--agent-files-policy", "preserve"], "init"],
+    [
+      "update",
+      ["code", "--update", "--agent-files-policy", "preserve"],
+      "update",
+    ],
+  ] as const) {
+    test(`--agent-files-policy applies to the ${name} command`, () => {
+      expect(parseCommand([...argv])).toMatchObject({
+        agentFilesPolicy: "preserve",
+        command,
+        kind: "run",
+        mode: "code",
+      });
+    });
+  }
+
+  test("--agent-files-policy accepts the equals form and explicit manage policy", () => {
+    expect(
+      parseCommand(["--update", "--agent-files-policy=manage"]),
+    ).toMatchObject({
+      agentFilesPolicy: "manage",
+      command: "update",
+      kind: "run",
+      mode: "code",
+    });
+  });
+
+  test("--agent-files-policy requires a policy", () => {
+    expect(parseCommand(["--update", "--agent-files-policy"])).toMatchObject({
+      kind: "error",
+      message: "--agent-files-policy requires manage or preserve.",
+    });
+  });
+
+  test("--agent-files-policy rejects an unknown policy", () => {
+    expect(
+      parseCommand(["--update", "--agent-files-policy", "ignore"]),
+    ).toMatchObject({
+      kind: "error",
+      message:
+        "Invalid --agent-files-policy value: ignore. Expected manage or preserve.",
+    });
+  });
+
+  test("--agent-files-policy is rejected in personal mode", () => {
+    expect(
+      parseCommand([
+        "personal",
+        "--update",
+        "--agent-files-policy",
+        "preserve",
+      ]),
+    ).toMatchObject({
+      kind: "error",
+      message: "--agent-files-policy is only available in code mode.",
+    });
   });
 });
 

--- a/test/cli/run-mode.test.ts
+++ b/test/cli/run-mode.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, test } from "vitest";
 import {
   argvRequestsPrint,
+  getCodeModeRepoSetupOptions,
   getRunModeCwd,
   getRunModeOutputMode,
   shouldAutoExitStartupRun,
@@ -17,6 +18,7 @@ function runCommand(
 ): CliCommand {
   return {
     kind: "run",
+    agentFilesPolicy: null,
     command: "init",
     dryRun: false,
     exitCode: 0,
@@ -124,6 +126,28 @@ describe("getRunModeOutputMode", () => {
     expect(getRunModeOutputMode("code")).toBe("repository");
     expect(getRunModeOutputMode("local-wiki")).toBe("local-wiki");
   });
+});
+
+describe("getCodeModeRepoSetupOptions", () => {
+  for (const [command, createWorkflow] of [
+    ["chat", false],
+    ["init", true],
+    ["update", false],
+  ] as const) {
+    test(`forwards agent-file policy for ${command}`, () => {
+      expect(
+        getCodeModeRepoSetupOptions(
+          runCommand({ agentFilesPolicy: "preserve", command }) as Extract<
+            CliCommand,
+            { kind: "run" }
+          >,
+        ),
+      ).toEqual({
+        agentFilesPolicy: "preserve",
+        createWorkflow,
+      });
+    });
+  }
 });
 
 describe("shouldAutoExitStartupRun", () => {

--- a/test/cli/runners.test.ts
+++ b/test/cli/runners.test.ts
@@ -556,6 +556,7 @@ describe("runPrintCommand", () => {
 
     await runPrintCommand(
       makeCommand("run", {
+        agentFilesPolicy: null,
         command: "update",
         dryRun: false,
         language: null,
@@ -579,6 +580,7 @@ describe("runPrintCommand", () => {
 
     await runPrintCommand(
       makeCommand("run", {
+        agentFilesPolicy: "preserve",
         command: "init",
         dryRun: false,
         language: null,
@@ -593,11 +595,13 @@ describe("runPrintCommand", () => {
     );
 
     expect(ensureCodeModeRepoSetup).toHaveBeenCalledWith(expect.any(String), {
+      agentFilesPolicy: "preserve",
       createWorkflow: true,
     });
     expect(runCodeModeConnectors).toHaveBeenCalled();
     // The augmented message from the connector pull reaches the agent run.
     const agentArgs = vi.mocked(runOpenWikiAgent).mock.calls[0];
+    expect(agentArgs[2].agentFilesPolicy).toBe("preserve");
     expect(agentArgs[2].userMessage).toBe("augmented");
     expect(process.exitCode).toBe(0);
   });
@@ -612,6 +616,7 @@ describe("runPrintCommand", () => {
 
     await runPrintCommand(
       makeCommand("run", {
+        agentFilesPolicy: null,
         command: "update",
         dryRun: false,
         language: null,

--- a/test/config/code-mode.test.ts
+++ b/test/config/code-mode.test.ts
@@ -1,0 +1,141 @@
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, test } from "vitest";
+import {
+  CODE_MODE_CONFIG_FILENAME,
+  resolveCodeModeAgentFilesPolicy,
+} from "../../src/config/code-mode.ts";
+import { ensureCodeModeRepoSetup } from "../../src/ingestion/code-mode.ts";
+
+const tempRepos: string[] = [];
+
+async function createTempRepo(): Promise<string> {
+  const repo = await mkdtemp(path.join(tmpdir(), "openwiki-code-config-"));
+  tempRepos.push(repo);
+  return repo;
+}
+
+async function writeConfig(repo: string, contents: string): Promise<void> {
+  await writeFile(path.join(repo, CODE_MODE_CONFIG_FILENAME), contents, "utf8");
+}
+
+async function readIfPresent(filePath: string): Promise<string | null> {
+  try {
+    return await readFile(filePath, "utf8");
+  } catch {
+    return null;
+  }
+}
+
+afterEach(async () => {
+  await Promise.all(
+    tempRepos
+      .splice(0)
+      .map((repo) => rm(repo, { force: true, recursive: true })),
+  );
+});
+
+describe("resolveCodeModeAgentFilesPolicy", () => {
+  test("defaults to manage when no config or CLI override exists", async () => {
+    const repo = await createTempRepo();
+
+    await expect(resolveCodeModeAgentFilesPolicy(repo)).resolves.toEqual({
+      configuredPolicy: null,
+      policy: "manage",
+      source: "default",
+    });
+  });
+
+  for (const policy of ["manage", "preserve"] as const) {
+    test(`reads ${policy} from committed config`, async () => {
+      const repo = await createTempRepo();
+      await writeConfig(
+        repo,
+        `codeMode:\n  agentFiles:\n    policy: ${policy}\n`,
+      );
+
+      await expect(resolveCodeModeAgentFilesPolicy(repo)).resolves.toEqual({
+        configuredPolicy: policy,
+        policy,
+        source: "config",
+      });
+    });
+  }
+
+  for (const [configuredPolicy, cliPolicy] of [
+    ["manage", "preserve"],
+    ["preserve", "manage"],
+  ] as const) {
+    test(`CLI ${cliPolicy} overrides config ${configuredPolicy}`, async () => {
+      const repo = await createTempRepo();
+      await writeConfig(
+        repo,
+        `codeMode:\n  agentFiles:\n    policy: ${configuredPolicy}\n`,
+      );
+
+      await expect(
+        resolveCodeModeAgentFilesPolicy(repo, cliPolicy),
+      ).resolves.toEqual({
+        configuredPolicy,
+        policy: cliPolicy,
+        source: "cli",
+      });
+    });
+  }
+
+  test("a CLI override neither rewrites nor creates config", async () => {
+    const configuredRepo = await createTempRepo();
+    const original =
+      "# Repository policy\ncodeMode:\n  agentFiles:\n    policy: manage\n";
+    await writeConfig(configuredRepo, original);
+
+    await ensureCodeModeRepoSetup(configuredRepo, {
+      agentFilesPolicy: "preserve",
+    });
+
+    expect(
+      await readFile(
+        path.join(configuredRepo, CODE_MODE_CONFIG_FILENAME),
+        "utf8",
+      ),
+    ).toBe(original);
+
+    const unconfiguredRepo = await createTempRepo();
+    await ensureCodeModeRepoSetup(unconfiguredRepo, {
+      agentFilesPolicy: "preserve",
+    });
+    expect(
+      await readIfPresent(
+        path.join(unconfiguredRepo, CODE_MODE_CONFIG_FILENAME),
+      ),
+    ).toBeNull();
+  });
+
+  test("rejects an unknown configured policy", async () => {
+    const repo = await createTempRepo();
+    await writeConfig(repo, "codeMode:\n  agentFiles:\n    policy: ignore\n");
+
+    await expect(resolveCodeModeAgentFilesPolicy(repo)).rejects.toThrow(
+      "Invalid openwiki.config.yaml: codeMode.agentFiles.policy must be manage or preserve.",
+    );
+  });
+
+  test("rejects a scalar agentFiles value", async () => {
+    const repo = await createTempRepo();
+    await writeConfig(repo, "codeMode:\n  agentFiles: preserve\n");
+
+    await expect(resolveCodeModeAgentFilesPolicy(repo)).rejects.toThrow(
+      "Invalid openwiki.config.yaml: codeMode.agentFiles must be a mapping.",
+    );
+  });
+
+  test("rejects malformed YAML before applying a CLI override", async () => {
+    const repo = await createTempRepo();
+    await writeConfig(repo, "codeMode: [\n");
+
+    await expect(
+      resolveCodeModeAgentFilesPolicy(repo, "preserve"),
+    ).rejects.toThrow("Invalid openwiki.config.yaml:");
+  });
+});

--- a/test/generation/repository-run.test.ts
+++ b/test/generation/repository-run.test.ts
@@ -513,6 +513,28 @@ afterEach(async () => {
 });
 
 describe("beginRepositoryRun", () => {
+  test("keeps a one-run preserve policy during durable setup", async () => {
+    const root = await createRepository();
+    const agentsPath = path.join(root, "AGENTS.md");
+    const claudePath = path.join(root, "CLAUDE.md");
+    const existingAgents = "# Repository-owned agent instructions\n";
+    await writeFile(agentsPath, existingAgents, "utf8");
+    await rm(claudePath, { force: true });
+
+    await beginRepositoryRun({
+      agentFilesPolicy: "preserve",
+      root,
+      mode: "update",
+      actor: ACTOR,
+      now: () => new Date(STARTED_AT),
+    });
+
+    await expect(readFile(agentsPath, "utf8")).resolves.toBe(existingAgents);
+    await expect(readFile(claudePath, "utf8")).rejects.toMatchObject({
+      code: "ENOENT",
+    });
+  });
+
   test("rolls back fresh init and removes new run state after metadata failure", async () => {
     const root = await createRepository(["old.md"]);
     const oldContent = await readFile(

--- a/test/ingestion/code-mode.test.ts
+++ b/test/ingestion/code-mode.test.ts
@@ -8,6 +8,7 @@ import {
   runCodeModeConnectors,
 } from "../../src/ingestion/code-mode.ts";
 import type { OpenWikiRunEvent } from "../../src/agent/types.ts";
+import { CODE_MODE_CONFIG_FILENAME } from "../../src/config/code-mode.ts";
 
 const SNIPPET_START = "<!-- OPENWIKI:START -->";
 const SNIPPET_END = "<!-- OPENWIKI:END -->";
@@ -108,6 +109,17 @@ function expectFailurePreservingWorkflow(workflow: string): void {
       .filter((command): command is string => command !== undefined)
       .join("\n"),
   ).not.toContain("openwiki/update");
+}
+
+async function writeAgentFilesPolicy(
+  repo: string,
+  policy: "manage" | "preserve",
+): Promise<void> {
+  await writeFile(
+    path.join(repo, CODE_MODE_CONFIG_FILENAME),
+    `codeMode:\n  agentFiles:\n    policy: ${policy}\n`,
+    "utf8",
+  );
 }
 
 afterEach(async () => {
@@ -263,6 +275,66 @@ ${SNIPPET_END}
       expect(await readIfPresent(path.join(repo, "CLAUDE.md"))).toBeNull();
     });
   }
+
+  test("preserve config leaves existing agent files byte-for-byte and wiki content untouched", async () => {
+    const repo = await createTempRepo();
+    const agentsPath = path.join(repo, "AGENTS.md");
+    const claudePath = path.join(repo, "CLAUDE.md");
+    const wikiPath = path.join(repo, "openwiki", "index.md");
+    const existingAgents = "# Existing AGENTS\n\nKeep this byte-for-byte.\n";
+    const existingClaude = "# Existing CLAUDE\r\n\r\nKeep this too.\r\n";
+    const existingWiki = "# Existing wiki\n";
+    await writeAgentFilesPolicy(repo, "preserve");
+    await mkdir(path.dirname(wikiPath), { recursive: true });
+    await Promise.all([
+      writeFile(agentsPath, existingAgents, "utf8"),
+      writeFile(claudePath, existingClaude, "utf8"),
+      writeFile(wikiPath, existingWiki, "utf8"),
+    ]);
+
+    await ensureCodeModeRepoSetup(repo);
+
+    expect(await readIfPresent(agentsPath)).toBe(existingAgents);
+    expect(await readIfPresent(claudePath)).toBe(existingClaude);
+    expect(await readIfPresent(wikiPath)).toBe(existingWiki);
+  });
+
+  test("preserve config leaves missing agent files missing", async () => {
+    const repo = await createTempRepo();
+    await writeAgentFilesPolicy(repo, "preserve");
+
+    await ensureCodeModeRepoSetup(repo);
+
+    expect(await readIfPresent(path.join(repo, "AGENTS.md"))).toBeNull();
+    expect(await readIfPresent(path.join(repo, "CLAUDE.md"))).toBeNull();
+  });
+
+  test("CLI preserve overrides a committed manage policy", async () => {
+    const repo = await createTempRepo();
+    const agentsPath = path.join(repo, "AGENTS.md");
+    const existing = "# Keep me\n";
+    await writeAgentFilesPolicy(repo, "manage");
+    await writeFile(agentsPath, existing, "utf8");
+
+    await ensureCodeModeRepoSetup(repo, { agentFilesPolicy: "preserve" });
+
+    expect(await readIfPresent(agentsPath)).toBe(existing);
+    expect(await readIfPresent(path.join(repo, "CLAUDE.md"))).toBeNull();
+  });
+
+  test("CLI manage overrides a committed preserve policy", async () => {
+    const repo = await createTempRepo();
+    await writeAgentFilesPolicy(repo, "preserve");
+
+    await ensureCodeModeRepoSetup(repo, { agentFilesPolicy: "manage" });
+
+    expect(await readIfPresent(path.join(repo, "AGENTS.md"))).toContain(
+      SNIPPET_START,
+    );
+    expect(await readIfPresent(path.join(repo, "CLAUDE.md"))).toContain(
+      SNIPPET_START,
+    );
+  });
 });
 
 describe("ensureCodeModeRepoSetup workflow", () => {
@@ -325,6 +397,53 @@ describe("ensureCodeModeRepoSetup workflow", () => {
     );
     expect(dogfoodSteps.indexOf(restore)).toBeLessThan(
       dogfoodSteps.indexOf(cleanup),
+    );
+  });
+
+  test("generated workflow reads committed preserve config on later runs", async () => {
+    const repo = await createTempRepo();
+    await writeAgentFilesPolicy(repo, "preserve");
+
+    await ensureCodeModeRepoSetup(repo, {
+      createWorkflow: true,
+    });
+
+    const workflow = await readIfPresent(
+      path.join(repo, ".github", "workflows", "openwiki-update.yml"),
+    );
+    expect(workflow).toContain("run: openwiki code --update --print");
+    expect(workflow).not.toContain("--agent-files-policy");
+    expect(workflow).not.toContain("            AGENTS.md");
+    expect(workflow).not.toContain("            CLAUDE.md");
+    expect(await readIfPresent(path.join(repo, "AGENTS.md"))).toBeNull();
+    expect(await readIfPresent(path.join(repo, "CLAUDE.md"))).toBeNull();
+
+    // A later scheduled invocation has no CLI override and resolves the same
+    // committed policy instead of recreating either root file.
+    await ensureCodeModeRepoSetup(repo);
+    expect(await readIfPresent(path.join(repo, "AGENTS.md"))).toBeNull();
+    expect(await readIfPresent(path.join(repo, "CLAUDE.md"))).toBeNull();
+  });
+
+  test("a one-run CLI override does not become scheduled policy", async () => {
+    const repo = await createTempRepo();
+
+    await ensureCodeModeRepoSetup(repo, {
+      agentFilesPolicy: "preserve",
+      createWorkflow: true,
+    });
+
+    const workflow = await readIfPresent(
+      path.join(repo, ".github", "workflows", "openwiki-update.yml"),
+    );
+    expect(workflow).not.toContain("--agent-files-policy");
+    expect(workflow).toContain("            AGENTS.md");
+    expect(workflow).toContain("            CLAUDE.md");
+    expect(await readIfPresent(path.join(repo, "AGENTS.md"))).toBeNull();
+
+    await ensureCodeModeRepoSetup(repo);
+    expect(await readIfPresent(path.join(repo, "AGENTS.md"))).toContain(
+      SNIPPET_START,
     );
   });
 


### PR DESCRIPTION
## Summary

- add a committed `openwiki.config.yaml` setting at `codeMode.agentFiles.policy` with `manage` and `preserve` values
- keep `manage` as the backward-compatible default and resolve policy in the order CLI > config > default
- add `--agent-files-policy <manage|preserve>` as a one-run code-mode override
- make `preserve` leave existing root `AGENTS.md` and `CLAUDE.md` byte-for-byte unchanged and keep missing files absent
- make newly generated scheduled workflows read the committed config, omitting agent files from `add-paths` when the committed policy is `preserve`
- cover precedence, init/update/chat paths, workflow behavior, invalid config, CLI parsing, and help output
- document the configuration and include a minor changeset

## Configuration

```yaml
codeMode:
  agentFiles:
    policy: preserve
```

The `agentFiles` mapping keeps policy separate from possible future path configuration. A CLI override applies only to the current run and never rewrites or creates the config file.

## Why

Some repositories already have an intentional agent-instruction layout. For example, a repository may keep shared guidance in `/AGENTS.md` and use `/.claude/CLAUDE.md` only as a pointer to it, with no root `/CLAUDE.md` by design.

Code mode currently creates or updates both root files on every run. The `preserve` policy lets these repositories update `openwiki/**` without mutating their existing instruction layout, while retaining the current behavior by default.

Fixes #556.

## Validation

- `pnpm run format`
- `pnpm run lint`
- `pnpm run lint:check`
- `pnpm run typecheck`
- `pnpm run build`
- `pnpm run format:check`
- targeted policy/command tests: 5 files, 165 tests passed
- full coverage run: 2,041 of 2,065 tests passed locally on Windows
  - all 24 failures are in unrelated Windows/environment-sensitive cases (POSIX path and shell assumptions, symlink/permission-mode limitations, user-home state leakage, and Mermaid/jsdom timeouts)
- `changeset status`