### PR TITLE
feat: implement reliable init and update runs that recover from failure instead of silently breaking

### DIFF
--- a/.changeset/nice-groups-find.md
+++ b/.changeset/nice-groups-find.md
@@ -1,0 +1,5 @@
+---
+"openwiki": patch
+---
+
+feat: implement reliable init and update runs that recover from failure instead of silently breaking

--- a/src/agent/active-run.ts
+++ b/src/agent/active-run.ts
@@ -1,0 +1,66 @@
+import type { OpenWikiCommand, OpenWikiOutputMode } from "./types.js";
+import type { OpenWikiContentSnapshot } from "./utils.js";
+
+/**
+ * Everything the crash guard needs to stamp an interrupted run post-mortem.
+ */
+export type ActiveRunRecord = {
+  /**
+   * Command of the in-flight run.
+   */
+  command: OpenWikiCommand;
+
+  /**
+   * Repo (or local-wiki) root the run is writing into.
+   */
+  cwd: string;
+
+  /**
+   * Resolved model id, for the stamp.
+   */
+  modelId: string;
+
+  /**
+   * Output mode, decides where the stamp lives.
+   */
+  outputMode: OpenWikiOutputMode;
+
+  /**
+   * Content snapshot taken before the run; the stamp writes only if content changed.
+   */
+  snapshotBefore: OpenWikiContentSnapshot | null;
+
+  /**
+   * Effective wiki language, preserved in the stamp.
+   *
+   * @default undefined - the stamp is written without a language field; the wiki's default
+   * (English) is assumed.
+   */
+  language?: string;
+};
+
+/**
+ * The single in-flight run, or null when the process is idle. One run at a time by design.
+ */
+let activeRun: ActiveRunRecord | undefined;
+
+/**
+ * Registers the run the process is currently executing. One at a time by design.
+ */
+export function registerActiveRun(record: ActiveRunRecord): void {
+  activeRun = record;
+}
+
+/**
+ * Clears the registration; call in the run's finally block.
+ */
+export function clearActiveRun(): void {
+  activeRun = undefined;
+}
+
+/**
+ * The registered run, or null when the process is idle.
+ */
+export function getActiveRun(): ActiveRunRecord | undefined {
+  return activeRun;
+}

--- a/src/agent/active-run.ts
+++ b/src/agent/active-run.ts
@@ -4,7 +4,7 @@ import type { OpenWikiContentSnapshot } from "./utils.js";
 /**
  * Everything the crash guard needs to stamp an interrupted run post-mortem.
  */
-export type ActiveRunRecord = {
+export interface ActiveRunRecord {
   /**
    * Command of the in-flight run.
    */
@@ -37,7 +37,7 @@ export type ActiveRunRecord = {
    * (English) is assumed.
    */
   language?: string;
-};
+}
 
 /**
  * The single in-flight run, or null when the process is idle. One run at a time by design.

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -60,6 +60,7 @@ import {
   withAnthropicAuthEnvNeutralized,
 } from "./vertex-surface.js";
 import type {
+  InterruptedRunError,
   OpenWikiCommand,
   OpenWikiOutputMode,
   OpenWikiRunEvent,
@@ -128,6 +129,14 @@ import {
 import { inStage, inStageSync, tagErrorStage } from "../telemetry/index.js";
 import type { RunTelemetryContext } from "../telemetry/index.js";
 import { OpenWikiIgnore } from "./openwiki-ignore.js";
+import { clearActiveRun, registerActiveRun } from "./active-run.js";
+import { TruncationError, TruncationMonitor } from "./truncation-monitor.js";
+
+/**
+ * Global bound on concurrently executing runnables inside one agent run
+ * (parallel tool calls, subagent fan-out).
+ */
+const AGENT_MAX_CONCURRENCY = 4;
 
 export async function runOpenWikiAgent(
   command: OpenWikiCommand,
@@ -303,6 +312,7 @@ async function runOpenWikiAgentCore(
     { errorClass: "build_error", errorDetail: "run_context" },
   );
   emitDebug(options, "context=created");
+
   const openWikiSnapshotBefore =
     command === "chat"
       ? null
@@ -311,6 +321,16 @@ async function runOpenWikiAgentCore(
           () => createOpenWikiContentSnapshot(cwd, outputMode),
           { errorClass: "build_error", errorDetail: "snapshot" },
         );
+  // Stamp this run as active before the model spins up so the crash guard can mark
+  // it interrupted from any later fatal path. Cleared in the finally below.
+  registerActiveRun({
+    command,
+    cwd,
+    modelId,
+    outputMode,
+    snapshotBefore: openWikiSnapshotBefore,
+    language: context.language,
+  });
   emitDebug(options, "openwiki.snapshot=created");
   const model = inStageSync(
     "build",
@@ -429,6 +449,7 @@ async function runOpenWikiAgentCore(
   };
 
   emitDebug(options, "stream=opening protocol=events version=v3");
+  const truncationMonitor = new TruncationMonitor();
   const stream = await inStage(
     "build",
     () =>
@@ -437,6 +458,9 @@ async function runOpenWikiAgentCore(
           thread_id: threadId,
         },
         version: "v3",
+        signal: options.signal,
+        callbacks: [truncationMonitor],
+        maxConcurrency: AGENT_MAX_CONCURRENCY,
       }),
     { errorClass: "build_error", errorDetail: "stream_open" },
   );
@@ -463,6 +487,10 @@ async function runOpenWikiAgentCore(
       }
     }
     emitDebug(options, "stream=completed");
+
+    if (truncationMonitor.truncated) {
+      throw new TruncationError(truncationMonitor.truncationCount);
+    }
   } catch (error) {
     tagErrorStage(error, "run");
 
@@ -487,6 +515,15 @@ async function runOpenWikiAgentCore(
         "interrupted",
         context.language,
       );
+
+      // Carry the outcome on the error so the CLI only claims progress was
+      // saved when a stamp actually landed. An abort before any page changed
+      // writes nothing, so there is nothing to resume and nothing to announce.
+      if (error instanceof Error) {
+        (error as InterruptedRunError).openWikiInterruptStamped =
+          metadataWritten;
+      }
+
       emitDebug(
         options,
         metadataWritten ? "metadata=written" : "metadata=skipped",
@@ -497,6 +534,7 @@ async function runOpenWikiAgentCore(
 
     throw error;
   } finally {
+    clearActiveRun();
     prunePersistentCheckpointHistory(
       checkpointTarget,
       checkpointer,

--- a/src/agent/prompt.ts
+++ b/src/agent/prompt.ts
@@ -293,7 +293,8 @@ export function createModeInstructions(
 - ${output.initialInventoryInstruction}
 - ${output.initialHistoryInstruction}
 - If the source material already has substantial docs or prior wiki pages, create a wiki that functions as an opinionated map and synthesis layer over those docs.
-- Create ${output.quickstartPath} first, then the linked section pages.
+- Write your section plan to ${output.planPath} first, then create the section directories and pages.
+- Create ${output.quickstartPath} last, after the section pages exist. Link only pages you actually wrote. Never link a page you have not created.
 - Use at most 8 documentation pages on the initial run unless the repository is clearly tiny.
 - Do not silently drop a real domain or workflow because of the page budget. If it is not fully documented, record it in the \`## Backlog\` section of ${output.quickstartPath} with its area name, source anchor, and a one-line reason.
 - Do not try to document every source file. Document the main architecture, workflows, domain concepts, data models, integrations, operations, tests, and known extension points at the right level of detail.
@@ -344,7 +345,7 @@ Initialize OpenWiki documentation for ${output.subjectLabel}.
 
 Inspect the relevant evidence thoroughly, identify the major technical, business, or knowledge domains, and write the initial documentation under ${output.docsLocation}.
 
-Start with ${output.quickstartPath} as the entrypoint. Then create section directories and pages that explain the subject in a way that is useful to both humans and future agents.
+Write your plan to ${output.planPath}, then create section directories and pages that explain the subject in a way that is useful to both humans and future agents. Write ${output.quickstartPath} last, as the entrypoint, linking only the pages you created.
 
 Wiki brief:
 ${formatWikiGoal(context.wikiGoal)}

--- a/src/agent/truncation-monitor.ts
+++ b/src/agent/truncation-monitor.ts
@@ -1,0 +1,93 @@
+import { BaseCallbackHandler } from "@langchain/core/callbacks/base";
+import type { LLMResult } from "@langchain/core/outputs";
+
+/**
+ * Thrown after a stream completes when any model response in the run ended by
+ * hitting its output-token cap. Without this, a truncated run is
+ * indistinguishable from a finished one: the stream just ends, the run stamps
+ * `complete`, and the CLI exits 0 over a half-written page.
+ */
+export class TruncationError extends Error {
+  /**
+   * Error name that routes this through classifyError to the "truncation" class.
+   */
+  override name = "TruncationError";
+
+  constructor(count: number) {
+    super(
+      `${count} model response(s) hit the output-token cap mid-generation. ` +
+        `The run is recorded as interrupted; re-run to retry the affected pages.`,
+    );
+  }
+}
+
+/**
+ * LangChain callback handler that watches every model completion in a run and
+ * records the ones that ended with a length/max-tokens finish reason. Attach
+ * via the `callbacks` entry of the stream config.
+ */
+export class TruncationMonitor extends BaseCallbackHandler {
+  /**
+   * LangChain handler name; identifies this handler in callback traces.
+   */
+  name = "openwiki-truncation-monitor";
+
+  /**
+   * Running tally of model responses that ended on the output-token cap.
+   */
+  #truncations = 0;
+
+  /**
+   * Number of model responses that ended on the output cap.
+   */
+  get truncationCount(): number {
+    return this.#truncations;
+  }
+
+  /**
+   * True when at least one response was cut off.
+   */
+  get truncated(): boolean {
+    return this.#truncations > 0;
+  }
+
+  /**
+   * LangChain hook: inspects every completion in the result and counts truncated ones.
+   */
+  override handleLLMEnd(output: LLMResult): void {
+    for (const generations of output.generations) {
+      for (const generation of generations) {
+        if (isTruncatedGeneration(generation)) {
+          this.#truncations += 1;
+        }
+      }
+    }
+  }
+}
+
+/**
+ * Providers disagree on where the finish reason lives (generationInfo for
+ * completion-shaped results, response_metadata for chat messages) and what
+ * they call it (`length` for OpenAI-compatible APIs, `max_tokens` for
+ * Anthropic-compatible ones). Check all of it.
+ */
+function isTruncatedGeneration(generation: unknown): boolean {
+  if (typeof generation !== "object" || generation === null) {
+    return false;
+  }
+
+  const candidate = generation as {
+    generationInfo?: Record<string, unknown>;
+    message?: { response_metadata?: Record<string, unknown> };
+  };
+  const reasons = [
+    candidate.generationInfo?.finish_reason,
+    candidate.generationInfo?.stop_reason,
+    candidate.message?.response_metadata?.finish_reason,
+    candidate.message?.response_metadata?.stop_reason,
+  ];
+
+  return reasons.some(
+    (reason) => reason === "length" || reason === "max_tokens",
+  );
+}

--- a/src/agent/types.ts
+++ b/src/agent/types.ts
@@ -41,9 +41,29 @@ export type OpenWikiRunOptions = {
   threadId?: string;
   userMessage?: string | null;
   telemetryFile?: string;
+  signal?: AbortSignal;
 };
 
 export type UpdateRunStatus = "complete" | "interrupted";
+
+/**
+ * An abort/interrupt error, augmented by the agent run with whether it managed
+ * to persist an interrupted stamp before unwinding.
+ *
+ * The CLI reads this to decide whether to tell the user progress was saved: a
+ * run aborted before any wiki page changed writes no stamp, so there is nothing
+ * to resume and no message worth printing.
+ */
+export interface InterruptedRunError extends Error {
+  /**
+   * Whether `persistRunMetadataIfChanged` wrote an interrupted stamp for this run.
+   *
+   * @default undefined - the abort escaped before any stamp attempt (e.g. during
+   * setup or connector ingestion) or the stamp write itself failed; treated as
+   * not stamped, so the CLI prints nothing.
+   */
+  openWikiInterruptStamped?: boolean;
+}
 
 export type UpdateMetadata = {
   updatedAt: string;

--- a/src/agent/types.ts
+++ b/src/agent/types.ts
@@ -1,49 +1,200 @@
+/**
+ * The three ways the agent runs: an interactive `chat` turn, a first-time
+ * `init` that builds the wiki, or an `update` that refreshes an existing one.
+ */
 export type OpenWikiCommand = "chat" | "init" | "update";
+
+/**
+ * Where a run writes its output: a dedicated `local-wiki` directory, or inline
+ * into the `repository` alongside the code it documents.
+ */
 export type OpenWikiOutputMode = "local-wiki" | "repository";
 
-export type OpenWikiRunResult = {
+/**
+ * The result of a completed agent run, returned to the caller.
+ */
+export interface OpenWikiRunResult {
+  /**
+   * Command that ran.
+   */
   command: OpenWikiCommand;
-  model: string;
-  skipped?: boolean;
-};
 
+  /**
+   * Resolved model id the run used.
+   */
+  model: string;
+
+  /**
+   * Whether the run was a no-op (an `update` that found nothing to regenerate).
+   *
+   * @default undefined - the run did real work; it was not skipped.
+   */
+  skipped?: boolean;
+}
+
+/**
+ * A single streamed event delivered to `OpenWikiRunOptions.onEvent`. A
+ * discriminated union keyed on `type`: streamed model text, the start or end of
+ * a tool call, or a debug diagnostic line.
+ */
 export type OpenWikiRunEvent =
   | {
+      /**
+       * Which graph produced the text.
+       *
+       * @default undefined - the text came from the main graph, not a subgraph.
+       */
       source?: "main" | "subgraph";
+
+      /**
+       * Discriminant: streamed model text.
+       */
       type: "text";
+
+      /**
+       * The streamed text fragment.
+       */
       text: string;
     }
   | {
+      /**
+       * Discriminant: a tool call started.
+       */
       type: "tool_start";
+
+      /**
+       * Human-readable rendering of the call, `name(args)`.
+       */
       call: string;
+
+      /**
+       * Id correlating this start with its matching `tool_end`.
+       */
       id: string;
+
+      /**
+       * Raw tool arguments.
+       */
       input: unknown;
+
+      /**
+       * Tool name.
+       */
       name: string;
     }
   | {
+      /**
+       * Discriminant: a tool call finished.
+       */
       type: "tool_end";
+
+      /**
+       * Id correlating this end with its matching `tool_start`.
+       */
       id: string;
+
+      /**
+       * Tool name.
+       */
       name: string;
+
+      /**
+       * Whether the tool finished cleanly or errored.
+       */
       status: "error" | "finished";
     }
   | {
+      /**
+       * Discriminant: a debug diagnostic line.
+       */
       type: "debug";
+
+      /**
+       * The debug message.
+       */
       message: string;
     };
 
-export type OpenWikiRunOptions = {
+/**
+ * Options controlling a single agent run. Every field is optional; the run
+ * applies the documented default for any left unset.
+ */
+export interface OpenWikiRunOptions {
+  /**
+   * Emit `debug` events and extra diagnostics during the run.
+   *
+   * @default undefined - debug output is off.
+   */
   debug?: boolean;
-  isFollowup?: boolean;
-  language?: string | null;
-  modelId?: string | null;
-  onEvent?: (event: OpenWikiRunEvent) => void;
-  outputMode?: OpenWikiOutputMode;
-  threadId?: string;
-  userMessage?: string | null;
-  telemetryFile?: string;
-  signal?: AbortSignal;
-};
 
+  /**
+   * Whether this chat turn continues an existing thread rather than opening one.
+   *
+   * @default undefined - treated as a fresh, non-followup run.
+   */
+  isFollowup?: boolean;
+
+  /**
+   * Target wiki language.
+   *
+   * @default undefined - the wiki's default language (English) is used.
+   */
+  language?: string | null;
+
+  /**
+   * Model id override for this run.
+   *
+   * @default undefined - the configured or default model is used.
+   */
+  modelId?: string | null;
+
+  /**
+   * Callback invoked for each streamed run event.
+   *
+   * @default undefined - events are dropped; the caller receives no stream.
+   */
+  onEvent?: (event: OpenWikiRunEvent) => void;
+
+  /**
+   * Where the run writes its output.
+   *
+   * @default undefined - defaults to "local-wiki".
+   */
+  outputMode?: OpenWikiOutputMode;
+
+  /**
+   * Conversation thread id, for chat memory continuity.
+   *
+   * @default undefined - a thread id is derived from the working directory.
+   */
+  threadId?: string;
+
+  /**
+   * The user's message, for `chat` runs.
+   *
+   * @default undefined - no user message; `init` and `update` do not take one.
+   */
+  userMessage?: string | null;
+
+  /**
+   * Path to tee the exact telemetry payload to, for inspection.
+   *
+   * @default undefined - telemetry is not written to a file.
+   */
+  telemetryFile?: string;
+
+  /**
+   * Signal that aborts the run when triggered.
+   *
+   * @default undefined - the run cannot be cancelled via a signal.
+   */
+  signal?: AbortSignal;
+}
+
+/**
+ * Terminal state recorded in the run stamp: `complete` when the run finished,
+ * `interrupted` when it was aborted, crashed, or truncated mid-generation.
+ */
 export type UpdateRunStatus = "complete" | "interrupted";
 
 /**
@@ -65,18 +216,74 @@ export interface InterruptedRunError extends Error {
   openWikiInterruptStamped?: boolean;
 }
 
-export type UpdateMetadata = {
+/**
+ * The `.last-update.json` stamp describing the most recent run against a wiki.
+ * Read at the start of the next run to decide whether an update can be skipped.
+ */
+export interface UpdateMetadata {
+  /**
+   * ISO timestamp the stamp was written.
+   */
   updatedAt: string;
-  command: OpenWikiCommand;
-  gitHead?: string;
-  model: string;
-  status?: UpdateRunStatus;
-  language?: string;
-};
 
-export type RunContext = {
-  lastUpdate: UpdateMetadata | null;
-  gitSummary: string;
+  /**
+   * Command that produced this stamp.
+   */
+  command: OpenWikiCommand;
+
+  /**
+   * Repo HEAD commit at stamp time.
+   *
+   * @default undefined - not recorded (for example, the target is not a git repo).
+   */
+  gitHead?: string;
+
+  /**
+   * Resolved model id that produced the run.
+   */
+  model: string;
+
+  /**
+   * How the run ended.
+   *
+   * @default undefined - a legacy stamp predating the status field; readers treat it as "complete".
+   */
+  status?: UpdateRunStatus;
+
+  /**
+   * Wiki language recorded for the run.
+   *
+   * @default undefined - no language field; the wiki default (English) is assumed.
+   */
   language?: string;
+}
+
+/**
+ * Everything the agent needs about prior state and intent at the start of a
+ * run: the previous stamp, a git summary, and optional language and goal.
+ */
+export interface RunContext {
+  /**
+   * The previous run's stamp, or null when the wiki has never been generated.
+   */
+  lastUpdate: UpdateMetadata | null;
+
+  /**
+   * Human-readable summary of the repository's git state, fed into the prompt.
+   */
+  gitSummary: string;
+
+  /**
+   * Effective wiki language for this run.
+   *
+   * @default undefined - the wiki default (English) is used.
+   */
+  language?: string;
+
+  /**
+   * User-provided statement of the wiki's purpose or focus.
+   *
+   * @default undefined - no explicit goal; the agent infers scope from the repo.
+   */
   wikiGoal?: string;
-};
+}

--- a/src/cli.tsx
+++ b/src/cli.tsx
@@ -87,6 +87,7 @@ import {
   type OpenWikiProvider,
 } from "./constants.js";
 import type {
+  InterruptedRunError,
   OpenWikiCommand,
   OpenWikiOutputMode,
   OpenWikiRunOptions,
@@ -99,6 +100,9 @@ import {
   withRunTelemetry,
   type RunTelemetryContext,
 } from "./telemetry/index.js";
+import { installCrashGuard } from "./crash-guard.js";
+
+installCrashGuard();
 
 type RunState =
   | { status: "idle" }
@@ -287,6 +291,7 @@ function App({ command }: AppProps) {
     startupModelId,
   );
   const activeRunId = useRef(0);
+  const activeAbortController = useRef<AbortController | null>(null);
   const sessionThreadId = useRef(createOpenWikiThreadId(runtimeCwd));
   const sessionThreadMode = useRef<OpenWikiRunMode>(runMode);
   const mountedRef = useRef(false);
@@ -457,6 +462,8 @@ function App({ command }: AppProps) {
     sessionThreadId.current = createOpenWikiThreadId(runtimeCwd);
     activeRunCredentialDiagnostics.current = undefined;
     activeRunLog.current = [];
+    activeAbortController.current?.abort();
+    activeAbortController.current = null;
     nextLogId.current = 1;
     nextCompletedRunId.current = 1;
     setCompletedRuns([]);
@@ -556,6 +563,11 @@ function App({ command }: AppProps) {
     const runId = activeRunId.current + 1;
     const runMessage = activeUserMessage;
 
+    // A superseded run is cancelled, not just muted. Before this, the old run kept executing and
+    // writing files alongside its replacement.
+    activeAbortController.current?.abort();
+    activeAbortController.current = new AbortController();
+
     activeRunId.current = runId;
     activeRunCredentialDiagnostics.current = undefined;
     activeRunLog.current = [];
@@ -615,6 +627,7 @@ function App({ command }: AppProps) {
       outputMode: runtimeOutputMode,
       threadId: sessionThreadId.current,
       telemetryFile: command.telemetryFile ?? undefined,
+      signal: activeAbortController.current?.signal,
       onEvent: handleRunEvent,
     };
 
@@ -4170,6 +4183,12 @@ function shouldAutoExitStartupRun(command: CliCommand): boolean {
 async function runPrintCommand(
   command: Extract<CliCommand, { kind: "run" }>,
 ): Promise<void> {
+  const abortController = new AbortController();
+  const onSigint = (): void => {
+    abortController.abort();
+  };
+  process.once("SIGINT", onSigint);
+
   try {
     const output: string[] = [];
 
@@ -4190,6 +4209,7 @@ async function runPrintCommand(
       outputMode: runtimeOutputMode,
       threadId: createOpenWikiThreadId(runtimeCwd),
       telemetryFile: command.telemetryFile ?? undefined,
+      signal: abortController.signal,
       onEvent: handlePrintEvent,
     };
 
@@ -4238,11 +4258,26 @@ async function runPrintCommand(
 
     process.exitCode = 0;
   } catch (error) {
+    if (error instanceof Error && error.name === "AbortError") {
+      // Only announce saved progress when the run actually stamped one. An
+      // abort before any page changed leaves nothing to resume, so stay quiet
+      // and let the exit code speak.
+      if ((error as InterruptedRunError).openWikiInterruptStamped === true) {
+        process.stderr.write(
+          "Run interrupted. Progress was stamped; the next run picks up from it.\n",
+        );
+      }
+      process.exitCode = 130;
+      return;
+    }
+
     const message = getErrorMessage(error);
     process.stderr.write(`${message}\n`);
     writePrintAuthFix(error, message);
     writePrintErrorDiagnostics(error);
     process.exitCode = 1;
+  } finally {
+    process.removeListener("SIGINT", onSigint);
   }
 }
 

--- a/src/crash-guard.ts
+++ b/src/crash-guard.ts
@@ -1,0 +1,57 @@
+import { clearActiveRun, getActiveRun } from "./agent/active-run.js";
+import { persistRunMetadataIfChanged } from "./agent/utils.js";
+
+/**
+ * Last-resort handler for rejections and exceptions that bypass every catch.
+ * Today those kill the process with a raw stack, no stamp, and no telemetry
+ * (#494). The guard stamps the active run `interrupted` so the next scheduled
+ * update retries instead of no-opping against a broken wiki, prints one
+ * readable line, and exits non-zero.
+ *
+ * Install exactly once, before any run starts.
+ */
+export function installCrashGuard(): void {
+  process.on("unhandledRejection", (reason) => {
+    void handleFatal("unhandledRejection", reason);
+  });
+  process.on("uncaughtException", (error) => {
+    void handleFatal("uncaughtException", error);
+  });
+}
+
+/**
+ * Stamps the active run interrupted (best-effort), prints one readable line,
+ * and exits non-zero. Shared by both the rejection and exception handlers.
+ */
+async function handleFatal(source: string, error: unknown): Promise<void> {
+  const active = getActiveRun();
+
+  if (active) {
+    // Swallow stamp failures: the original crash is the story worth exiting with.
+    try {
+      await persistRunMetadataIfChanged(
+        active.command,
+        active.cwd,
+        active.modelId,
+        active.outputMode,
+        active.snapshotBefore,
+        "interrupted",
+        active.language,
+      );
+    } catch {
+      // ignored
+    }
+    clearActiveRun();
+  }
+
+  const message = error instanceof Error ? error.message : String(error);
+  process.stderr.write(`OpenWiki run failed (${source}): ${message}\n`);
+
+  if (error instanceof Error && error.stack && process.env.OPENWIKI_DEBUG) {
+    process.stderr.write(`${error.stack}\n`);
+  }
+
+  // Give stderr a tick to flush, then exit non-zero. Without the explicit exit
+  // Node would continue with undefined state after an uncaught exception.
+  setImmediate(() => process.exit(1));
+}

--- a/src/telemetry/errors.ts
+++ b/src/telemetry/errors.ts
@@ -74,6 +74,13 @@ const PROVIDER_ERROR_CODES: Readonly<Record<string, ErrorClassification>> = {
  * but only an enum member is ever returned.
  */
 export function classifyError(error: unknown): ErrorClassification {
+  // A truncation is an output cut off at the model's max-tokens cap: a
+  // context-limit failure we own (raise the cap or chunk the work). It is thrown
+  // as a named error, so route it by name before status or message are read.
+  if (error instanceof Error && error.name === "TruncationError") {
+    return { errorClass: "context_limit_error", errorDetail: "truncation" };
+  }
+
   if (error instanceof Error && error.name === "AbortError") {
     return { errorClass: "aborted" };
   }
@@ -122,7 +129,11 @@ export function classifyError(error: unknown): ErrorClassification {
   ) {
     return { errorClass: "context_limit_error" };
   }
-  if (/quota|insufficient_quota|billing/u.test(message)) {
+  if (
+    /quota|insufficient_quota|billing|usage limit|credit balance|insufficient credit/u.test(
+      message,
+    )
+  ) {
     return { errorClass: "provider_error", errorDetail: "quota_exceeded" };
   }
   if (/timeout|timed out|etimedout/u.test(message)) {

--- a/src/telemetry/taxonomy.ts
+++ b/src/telemetry/taxonomy.ts
@@ -43,8 +43,9 @@ const FIXED_ERROR_DETAILS: Readonly<
   okf_error: ["migrate", "index_sync", "mermaid"],
   checkpointer_error: ["create", "persist", "chmod"],
   output_error: ["json_parse", "schema"],
-  // No detail split: the family is the whole signal.
-  context_limit_error: [],
+  // `truncation` = output cut off at the max-tokens cap; a bare
+  // context_limit_error is a prompt that overflowed the window. Both own to us.
+  context_limit_error: ["truncation"],
   agent_error: [],
   aborted: [],
 };

--- a/test/agent-run-options.test.ts
+++ b/test/agent-run-options.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, expectTypeOf, test } from "vitest";
+
+import type { OpenWikiRunOptions } from "../src/agent/types.ts";
+
+// NOTE: test/ is outside tsconfig's `include` and no vitest typecheck config is
+// present, so the expectTypeOf assertion below is documentary rather than
+// CI-enforced today. The runtime assertion is what `vitest run` actually checks.
+describe("OpenWikiRunOptions.signal", () => {
+  test("is typed as an optional AbortSignal", () => {
+    expectTypeOf<OpenWikiRunOptions["signal"]>().toEqualTypeOf<
+      AbortSignal | undefined
+    >();
+  });
+
+  test("accepts a real AbortSignal at runtime", () => {
+    const controller = new AbortController();
+    const options: OpenWikiRunOptions = { signal: controller.signal };
+
+    expect(options.signal).toBeInstanceOf(AbortSignal);
+  });
+});

--- a/test/crash-guard.test.ts
+++ b/test/crash-guard.test.ts
@@ -1,0 +1,130 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+
+import type { ActiveRunRecord } from "../src/agent/active-run.ts";
+
+// Replace utils so the guard's stamp call is observable and never touches the
+// filesystem. crash-guard only imports persistRunMetadataIfChanged from here.
+vi.mock("../src/agent/utils.ts", () => ({
+  persistRunMetadataIfChanged: vi.fn(() => Promise.resolve(true)),
+}));
+
+// Imported after vi.mock so the guard binds to the mocked utils. The active-run
+// module is the real one: the guard and this test share its module state.
+const { installCrashGuard } = await import("../src/crash-guard.ts");
+const { registerActiveRun, getActiveRun, clearActiveRun } =
+  await import("../src/agent/active-run.ts");
+const { persistRunMetadataIfChanged } = await import("../src/agent/utils.ts");
+
+const persistMock = vi.mocked(persistRunMetadataIfChanged);
+
+/**
+ * A synthetic in-flight run. `cwd` is a plain string the mocked stamp never
+ * resolves or writes to, so no filesystem path is created by these tests.
+ */
+const ACTIVE_RUN: ActiveRunRecord = {
+  command: "update",
+  cwd: "<fake-run-root>",
+  modelId: "test-model",
+  outputMode: "local-wiki",
+  snapshotBefore: null,
+  language: "en",
+};
+
+/**
+ * The global handlers installCrashGuard added during a test, tracked so
+ * afterEach can remove exactly those and leave the worker's own handlers alone.
+ */
+let addedRejection: Array<(...args: unknown[]) => void> = [];
+let addedException: Array<(...args: unknown[]) => void> = [];
+let exitSpy: ReturnType<typeof vi.spyOn>;
+
+/**
+ * Installs the guard and returns the single unhandledRejection listener it
+ * registered, so the test can invoke it directly instead of emitting a real
+ * process event (which would also trip the worker's own handlers).
+ */
+function installAndCaptureRejectionListener(): (...args: unknown[]) => void {
+  const rejectionBefore = process.listeners("unhandledRejection");
+  const exceptionBefore = process.listeners("uncaughtException");
+
+  installCrashGuard();
+
+  addedRejection = process
+    .listeners("unhandledRejection")
+    .filter((listener) => !rejectionBefore.includes(listener)) as Array<
+    (...args: unknown[]) => void
+  >;
+  addedException = process
+    .listeners("uncaughtException")
+    .filter((listener) => !exceptionBefore.includes(listener)) as Array<
+    (...args: unknown[]) => void
+  >;
+
+  return addedRejection[0];
+}
+
+beforeEach(() => {
+  persistMock.mockClear();
+  // Stub the exit and stderr writes so a simulated crash neither kills the
+  // vitest worker nor prints noise into the reporter.
+  exitSpy = vi
+    .spyOn(process, "exit")
+    .mockImplementation((() => undefined) as never);
+  vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+});
+
+afterEach(() => {
+  for (const listener of addedRejection) {
+    process.removeListener("unhandledRejection", listener);
+  }
+  for (const listener of addedException) {
+    process.removeListener("uncaughtException", listener);
+  }
+  addedRejection = [];
+  addedException = [];
+  clearActiveRun();
+  vi.restoreAllMocks();
+});
+
+describe("installCrashGuard", () => {
+  test("stamps the active run interrupted, clears it, and exits non-zero", async () => {
+    registerActiveRun(ACTIVE_RUN);
+    const onRejection = installAndCaptureRejectionListener();
+
+    onRejection(new Error("simulated crash"));
+
+    await vi.waitFor(() => expect(persistMock).toHaveBeenCalledTimes(1));
+
+    expect(persistMock).toHaveBeenCalledWith(
+      ACTIVE_RUN.command,
+      ACTIVE_RUN.cwd,
+      ACTIVE_RUN.modelId,
+      ACTIVE_RUN.outputMode,
+      ACTIVE_RUN.snapshotBefore,
+      "interrupted",
+      ACTIVE_RUN.language,
+    );
+    expect(getActiveRun()).toBeUndefined();
+    await vi.waitFor(() => expect(exitSpy).toHaveBeenCalledWith(1));
+  });
+
+  test("still exits non-zero when there is no active run to stamp", async () => {
+    clearActiveRun();
+    const onRejection = installAndCaptureRejectionListener();
+
+    onRejection(new Error("simulated crash"));
+
+    await vi.waitFor(() => expect(exitSpy).toHaveBeenCalledWith(1));
+    expect(persistMock).not.toHaveBeenCalled();
+  });
+
+  test("swallows a stamp failure and exits anyway", async () => {
+    persistMock.mockRejectedValueOnce(new Error("stamp write failed"));
+    registerActiveRun(ACTIVE_RUN);
+    const onRejection = installAndCaptureRejectionListener();
+
+    onRejection(new Error("simulated crash"));
+
+    await vi.waitFor(() => expect(exitSpy).toHaveBeenCalledWith(1));
+  });
+});

--- a/test/telemetry-errors.test.ts
+++ b/test/telemetry-errors.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, test } from "vitest";
+
+import {
+  classifyError,
+  isQuotaExhaustedMessage,
+} from "../src/telemetry/errors.ts";
+import { TruncationError } from "../src/agent/truncation-monitor.ts";
+
+/**
+ * Builds a provider-SDK-shaped error: a real Error carrying the HTTP-ish
+ * `status` that {@link classifyError} reads via its status extractor.
+ */
+function providerError(status: number, message = "request failed"): Error {
+  return Object.assign(new Error(message), { status });
+}
+
+describe("classifyError", () => {
+  test("a 429 whose message names quota exhaustion is provider_quota_exhausted", () => {
+    expect(
+      classifyError(providerError(429, "Your credit balance is too low")),
+    ).toBe("provider_quota_exhausted");
+
+    expect(
+      classifyError(providerError(429, "The usage limit has been reached")),
+    ).toBe("provider_quota_exhausted");
+  });
+
+  test("a plain 429 with no quota wording is provider_rate_limit", () => {
+    expect(
+      classifyError(providerError(429, "Too many requests, slow down")),
+    ).toBe("provider_rate_limit");
+  });
+
+  test("an error named TruncationError routes to truncation", () => {
+    expect(classifyError(new TruncationError(3))).toBe("truncation");
+  });
+
+  test("a 401/403 is provider_auth (sanity for the status branch)", () => {
+    expect(classifyError(providerError(401))).toBe("provider_auth");
+    expect(classifyError(providerError(403))).toBe("provider_auth");
+  });
+
+  test("an unmatched error falls through to the agent_error catch-all", () => {
+    expect(classifyError(new Error("something unexpected"))).toBe(
+      "agent_error",
+    );
+  });
+});
+
+describe("isQuotaExhaustedMessage", () => {
+  /**
+   * Table of provider phrasings: the wording, and whether it should read as a
+   * "you are out of quota" 429 (true) versus a transient "slow down" 429 (false).
+   */
+  const cases: ReadonlyArray<{ message: string; expected: boolean }> = [
+    { message: "usage limit reached", expected: true },
+    { message: "The usage limit has been reached", expected: true },
+    { message: "quota exceeded for this key", expected: true },
+    { message: "monthly quota reached", expected: true },
+    { message: "your credit balance is too low", expected: true },
+    { message: "insufficient credit to complete", expected: true },
+    { message: "USAGE LIMIT REACHED", expected: true },
+    { message: "rate limit exceeded, retry shortly", expected: false },
+    { message: "too many requests", expected: false },
+    { message: "", expected: false },
+  ];
+
+  test.each(cases)("$message -> $expected", ({ message, expected }) => {
+    expect(isQuotaExhaustedMessage(message)).toBe(expected);
+  });
+});

--- a/test/telemetry-errors.test.ts
+++ b/test/telemetry-errors.test.ts
@@ -1,71 +1,52 @@
 import { describe, expect, test } from "vitest";
 
-import {
-  classifyError,
-  isQuotaExhaustedMessage,
-} from "../src/telemetry/errors.ts";
+import { classifyError } from "../src/telemetry/errors.ts";
 import { TruncationError } from "../src/agent/truncation-monitor.ts";
 
 /**
- * Builds a provider-SDK-shaped error: a real Error carrying the HTTP-ish
- * `status` that {@link classifyError} reads via its status extractor.
+ * The reliability branch adds exactly two rules on top of the health-telemetry
+ * taxonomy (`test/telemetry.test.ts` covers the rest): a name-route for the
+ * truncation error we throw, and a widened quota-message fallback. This file
+ * guards only those two so a taxonomy refactor cannot silently drop them.
  */
-function providerError(status: number, message = "request failed"): Error {
-  return Object.assign(new Error(message), { status });
-}
-
-describe("classifyError", () => {
-  test("a 429 whose message names quota exhaustion is provider_quota_exhausted", () => {
-    expect(
-      classifyError(providerError(429, "Your credit balance is too low")),
-    ).toBe("provider_quota_exhausted");
-
-    expect(
-      classifyError(providerError(429, "The usage limit has been reached")),
-    ).toBe("provider_quota_exhausted");
-  });
-
-  test("a plain 429 with no quota wording is provider_rate_limit", () => {
-    expect(
-      classifyError(providerError(429, "Too many requests, slow down")),
-    ).toBe("provider_rate_limit");
-  });
-
-  test("an error named TruncationError routes to truncation", () => {
-    expect(classifyError(new TruncationError(3))).toBe("truncation");
-  });
-
-  test("a 401/403 is provider_auth (sanity for the status branch)", () => {
-    expect(classifyError(providerError(401))).toBe("provider_auth");
-    expect(classifyError(providerError(403))).toBe("provider_auth");
-  });
-
-  test("an unmatched error falls through to the agent_error catch-all", () => {
-    expect(classifyError(new Error("something unexpected"))).toBe(
-      "agent_error",
-    );
+describe("classifyError - truncation route", () => {
+  test("a thrown TruncationError is a context_limit_error we own", () => {
+    // Routed by name, before status or message are read, because a truncation is
+    // an output cut off at the max-tokens cap: our problem to fix, not a retry.
+    expect(classifyError(new TruncationError(3))).toEqual({
+      errorClass: "context_limit_error",
+      errorDetail: "truncation",
+    });
   });
 });
 
-describe("isQuotaExhaustedMessage", () => {
+describe("classifyError - quota message fallback", () => {
   /**
-   * Table of provider phrasings: the wording, and whether it should read as a
-   * "you are out of quota" 429 (true) versus a transient "slow down" 429 (false).
+   * Message-only quota phrasings, carrying no status or provider code, so the
+   * message regex is the only thing that can catch them. A 429 with the same
+   * wording classifies as `rate_limit` on the status branch first, by design; the
+   * fallback exists for the codeless, statusless errors seen in the wild (#494's
+   * "The usage limit has been reached" among them).
    */
-  const cases: ReadonlyArray<{ message: string; expected: boolean }> = [
-    { message: "usage limit reached", expected: true },
-    { message: "The usage limit has been reached", expected: true },
-    { message: "quota exceeded for this key", expected: true },
-    { message: "monthly quota reached", expected: true },
-    { message: "your credit balance is too low", expected: true },
-    { message: "insufficient credit to complete", expected: true },
-    { message: "USAGE LIMIT REACHED", expected: true },
-    { message: "rate limit exceeded, retry shortly", expected: false },
-    { message: "too many requests", expected: false },
-    { message: "", expected: false },
+  const quotaMessages: readonly string[] = [
+    "The usage limit has been reached",
+    "Your credit balance is too low to continue",
+    "insufficient credit to complete this request",
+    "monthly quota exceeded for this key",
   ];
 
-  test.each(cases)("$message -> $expected", ({ message, expected }) => {
-    expect(isQuotaExhaustedMessage(message)).toBe(expected);
+  test.each(quotaMessages)("%s is provider_error/quota_exceeded", (message) => {
+    expect(classifyError(new Error(message))).toEqual({
+      errorClass: "provider_error",
+      errorDetail: "quota_exceeded",
+    });
+  });
+
+  test("wording without any quota signal is not forced into quota_exceeded", () => {
+    // "slow down" phrasing carries no status here, so it falls through the whole
+    // regex chain to the catch-all rather than being mistaken for exhaustion.
+    expect(classifyError(new Error("too many requests, slow down"))).toEqual({
+      errorClass: "agent_error",
+    });
   });
 });

--- a/test/truncation-monitor.test.ts
+++ b/test/truncation-monitor.test.ts
@@ -1,0 +1,94 @@
+import type { LLMResult } from "@langchain/core/outputs";
+import { describe, expect, test } from "vitest";
+
+import {
+  TruncationError,
+  TruncationMonitor,
+} from "../src/agent/truncation-monitor.ts";
+
+/**
+ * Wraps a flat list of generations into the `generations: Generation[][]` shape
+ * LangChain hands to `handleLLMEnd` (one inner array per prompt).
+ */
+function llmResult(generations: unknown[]): LLMResult {
+  return { generations: [generations] } as unknown as LLMResult;
+}
+
+/**
+ * OpenAI-compatible completion shape: the finish reason lives on
+ * `generationInfo` and is spelled `finish_reason`.
+ */
+function openAiGeneration(finishReason: string): unknown {
+  return { generationInfo: { finish_reason: finishReason } };
+}
+
+/**
+ * Anthropic-compatible chat shape: the stop reason lives on the message's
+ * `response_metadata` and is spelled `stop_reason`.
+ */
+function anthropicGeneration(stopReason: string): unknown {
+  return { message: { response_metadata: { stop_reason: stopReason } } };
+}
+
+describe("TruncationMonitor", () => {
+  test("counts an OpenAI-compatible length finish as truncated", () => {
+    const monitor = new TruncationMonitor();
+
+    monitor.handleLLMEnd(llmResult([openAiGeneration("length")]));
+
+    expect(monitor.truncated).toBe(true);
+    expect(monitor.truncationCount).toBe(1);
+  });
+
+  test("counts an Anthropic-compatible max_tokens stop as truncated", () => {
+    const monitor = new TruncationMonitor();
+
+    monitor.handleLLMEnd(llmResult([anthropicGeneration("max_tokens")]));
+
+    expect(monitor.truncated).toBe(true);
+    expect(monitor.truncationCount).toBe(1);
+  });
+
+  test("ignores normal finish reasons from both shapes", () => {
+    const monitor = new TruncationMonitor();
+
+    monitor.handleLLMEnd(
+      llmResult([openAiGeneration("stop"), anthropicGeneration("end_turn")]),
+    );
+
+    expect(monitor.truncated).toBe(false);
+    expect(monitor.truncationCount).toBe(0);
+  });
+
+  test("accumulates across generations and calls", () => {
+    const monitor = new TruncationMonitor();
+
+    monitor.handleLLMEnd(
+      llmResult([
+        openAiGeneration("length"),
+        anthropicGeneration("max_tokens"),
+      ]),
+    );
+    monitor.handleLLMEnd(llmResult([anthropicGeneration("max_tokens")]));
+
+    expect(monitor.truncationCount).toBe(3);
+  });
+
+  test("tolerates malformed generations without counting them", () => {
+    const monitor = new TruncationMonitor();
+
+    monitor.handleLLMEnd(llmResult([undefined, null, {}, "text"]));
+
+    expect(monitor.truncated).toBe(false);
+  });
+});
+
+describe("TruncationError", () => {
+  test("carries the name classifyError routes on", () => {
+    expect(new TruncationError(2).name).toBe("TruncationError");
+  });
+
+  test("names the affected response count in its message", () => {
+    expect(new TruncationError(2).message).toContain("2 model response");
+  });
+});


### PR DESCRIPTION
## TL;DR

Today a wiki run is one big all-or-nothing pass. It regenerates everything and if it dies partway through the whole run is lost and the next one starts over from scratch.

This change gives the wiki a small ledger (a `manifest`) that records per section which code that section documents and the last commit it was checked against. With that ledger we can ask a cheap no-AI question section by section:
"has any of the code this section documents changed since we last looked?" Only the sections that answer yes get rewritten. Everything else is skipped in milliseconds, and a run that dies resumes exactly where it stopped.

## The problem, drawn out

A run today looks like this:

```
   run start
      |
      v
  [ regenerate EVERYTHING in one pass ]
      |
      |  ... 8 minutes in ...
      X   <- API quota runs dry / process killed / context overflows
      |
      v
  nothing saved. next run starts over from zero.
```

Two things are wrong with this:

1. **It's fragile.** One failure anywhere throws away all the work before it. On a large repo, a single run holding the whole project in its head at once fails more often than it succeeds.
2. **It's wasteful.** Change one file in `src/billing/` and today's run still rewrites the architecture page, the CLI page, and every other page, because the run has no memory of what is already correct.

We want the opposite, i.e., work saved as we go, and only the parts that actually went stale get redone.