### PR TITLE
fix: render array tool-call arguments as a value list

### DIFF
--- a/.changeset/listed-tool-array-args.md
+++ b/.changeset/listed-tool-array-args.md
@@ -1,0 +1,5 @@
+---
+"openwiki": patch
+---
+
+fix: display array tool-call arguments as a value list instead of `0=…, 1=…`

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -1669,14 +1669,16 @@ function formatToolCallName(name: string): string {
 function formatToolArgs(input: unknown): string {
   const value = parseStringifiedJson(input);
 
+  // Checked ahead of isRecord: arrays are `typeof "object"` and non-null, so
+  // the record branch would otherwise claim them and render `0=…, 1=…`.
+  if (Array.isArray(value)) {
+    return value.map(formatToolValue).join(", ");
+  }
+
   if (isRecord(value)) {
     return Object.entries(value)
       .map(([key, argValue]) => `${key}=${formatToolValue(argValue)}`)
       .join(", ");
-  }
-
-  if (Array.isArray(value)) {
-    return value.map(formatToolValue).join(", ");
   }
 
   if (value === undefined || value === null) {

--- a/test/tool-args-formatting.test.ts
+++ b/test/tool-args-formatting.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, test } from "vitest";
+import { parseStreamEvent } from "../src/agent/index.ts";
+
+// `formatToolArgs` is module-private, so these drive it the way the CLI does:
+// through the exported stream-event parser, whose "tools" branch builds the
+// displayed `call` string from the tool's input.
+function makeToolStartChunk(name: string, input: unknown): unknown {
+  return {
+    type: "event",
+    method: "tools",
+    params: {
+      data: { event: "on_tool_start", input, name },
+      namespace: [],
+    },
+  };
+}
+
+function callFor(name: string, input: unknown): string {
+  const event = parseStreamEvent(makeToolStartChunk(name, input));
+
+  expect(event?.type).toBe("tool_start");
+
+  return (event as { call: string }).call;
+}
+
+describe("tool_start argument formatting", () => {
+  test("renders a stringified array input as a value list", () => {
+    expect(callFor("search", '["a","b"]')).toBe('search("a", "b")');
+  });
+
+  test("renders a raw array input as a value list", () => {
+    expect(callFor("search", ["a", "b"])).toBe('search("a", "b")');
+  });
+
+  test("renders mixed array members without index keys", () => {
+    expect(callFor("search", [1, "two", true])).toBe('search(1, "two", true)');
+  });
+
+  test("still renders object inputs as key=value pairs", () => {
+    expect(callFor("read", { limit: 2, path: "docs/index.md" })).toBe(
+      'read(limit=2, path="docs/index.md")',
+    );
+  });
+
+  test("still renders a scalar input as a bare value", () => {
+    expect(callFor("echo", '"hello"')).toBe('echo("hello")');
+  });
+
+  test("still renders an empty argument list for a null input", () => {
+    expect(callFor("noop", null)).toBe("noop()");
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #567.

`formatToolArgs` in `src/agent/index.ts` has an explicit branch for array inputs, but it was unreachable. This file's `isRecord` does not exclude arrays, and an array is `typeof "object"` and non-null, so the record branch claimed arrays first and `Object.entries` rendered their numeric indices. A tool called with `["a","b"]` displayed as `search(0="a", 1="b")` instead of `search("a", "b")`.

Display-only — the tool still received its real input — but the rendered call was misleading, and the dead branch shows it was never the intended output.

## Changes

- Ordered the `Array.isArray` check ahead of the `isRecord` check inside `formatToolArgs`, which revives the branch that was already there, plus a comment recording why the order matters.

## Why not fix `isRecord` itself

Narrowing the shared `isRecord` to exclude arrays would be the broader change, and it is what `src/okf/frontmatter.ts` already does in its equivalent predicate — but `isRecord` has ~22 call sites in `src/agent/index.ts`, so that is a different, wider concern than this bug. Keeping the fix inside `formatToolArgs` leaves every other call site untouched, per the one-PR-one-change guidance in CONTRIBUTING. Happy to open that as a separate PR if you'd like it narrowed globally.

## How I tested it

Added `test/tool-args-formatting.test.ts`. `formatToolArgs` is module-private, so the tests drive it the way the CLI does — through the exported `parseStreamEvent`, whose `tools` branch builds the displayed `call` string:

- a stringified array input (`'["a","b"]'`) ⇒ `search("a", "b")`;
- a raw array input ⇒ same;
- mixed member types ⇒ `search(1, "two", true)`, no index keys;
- regression guards that object inputs still render `key=value`, a scalar still renders bare, and a null input still renders an empty argument list.

Confirmed these are real regression tests: with the source change reverted, the three array cases fail with exactly `search(0="a", 1="b")`; all six pass with it. There was no existing test coverage for `tool_start` argument rendering, hence the new file.

Validation:

- `pnpm run format`
- `pnpm run lint`
- `pnpm run typecheck`
- `pnpm test` — 873/875 pass. The two failures are `test/openwiki-ignore.test.ts > restricts shell execute while ignore rules are active` (shells out to `pwd`) and a 5s-timeout flake in `test/mermaid-validate.test.ts`. Both fail identically on an unmodified `main` on this machine, so they are environmental (Windows / slow mermaid render) and unrelated to this change.
