### PR TITLE
fix: warn and back up before replacing custom content in agent files

### DIFF
--- a/.changeset/witty-planes-grin.md
+++ b/.changeset/witty-planes-grin.md
@@ -1,0 +1,7 @@
+---
+"openwiki": patch
+---
+
+fix: warn and back up before replacing custom content in AGENTS.md and CLAUDE.md
+
+OpenWiki now detects when a repo's `AGENTS.md` or `CLAUDE.md` has custom content inside its managed `<!-- OPENWIKI:START -->…<!-- OPENWIKI:END -->` block. Before refreshing, it saves the file to `<file>.openwiki.bak` and prints a warning naming the file and the backup path. Canonical blocks are left untouched (no rewrite, no backup), and malformed markers still abort without changing either file. The scheduled-update workflow now includes the backups in its pull request so CI users can recover replaced content.

--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ Locally the setup wizard saves this to `~/.openwiki/.env`. In CI, set it as a re
 
 Everything OpenWiki writes is plain Markdown you own and version alongside your code.
 
-- **Agents read it as memory.** On each `code` run, OpenWiki maintains an `AGENTS.md` and `CLAUDE.md` at the repo root that point your coding agent at the wiki. It only rewrites its own `<!-- OPENWIKI:START -->…<!-- OPENWIKI:END -->` block and leaves the rest of each file untouched.
+- **Agents read it as memory.** On each `code` run, OpenWiki maintains an `AGENTS.md` and `CLAUDE.md` at the repo root that point your coding agent at the wiki. It only rewrites its own `<!-- OPENWIKI:START -->…<!-- OPENWIKI:END -->` block and leaves the rest of each file untouched. If it finds custom content inside that block, it saves the file to `<file>.openwiki.bak` and prints a warning naming the file and the backup path before refreshing — recover by copying the backup back over the file, and stop future replacements by moving your content outside the markers. Backups are never deleted automatically; remove them after review.
 - **You set the brief.** Repository-specific instructions live in `openwiki/INSTRUCTIONS.md`, a user-authored file OpenWiki reads for scope and priorities but never rewrites during normal runs.
 - **No-op runs are free.** After a run, OpenWiki snapshots the `openwiki/` directory and only records new metadata when something actually changed, so scheduled workflows never churn.
 - **Local, private config.** Provider choice, keys, and optional LangSmith tracing are saved to `~/.openwiki/.env` on your machine.

--- a/src/cli.tsx
+++ b/src/cli.tsx
@@ -631,6 +631,16 @@ function App({ command }: AppProps) {
         if (runMode === "code") {
           await ensureCodeModeRepoSetup(runtimeCwd, {
             createWorkflow: resolvedCommand === "init",
+            // Mirror warnings to stderr so they survive a TUI re-render and an
+            // error-terminated run, which discards the run log.
+            onWarning: (message) => {
+              handleRunEvent({
+                source: "main",
+                text: message,
+                type: "text",
+              });
+              process.stderr.write(`${message}\n`);
+            },
           });
         }
 
@@ -4206,6 +4216,9 @@ async function runPrintCommand(
         if (command.mode === "code") {
           await ensureCodeModeRepoSetup(runtimeCwd, {
             createWorkflow: command.command === "init",
+            // Explicit stderr wiring pins the warning channel against future
+            // default changes; stderr keeps piped stdout clean.
+            onWarning: (message) => process.stderr.write(`${message}\n`),
           });
         }
 

--- a/src/cli.tsx
+++ b/src/cli.tsx
@@ -11,7 +11,11 @@ import {
 import { startNgrokTunnel } from "./auth/ngrok.js";
 import { runVisualizeServer } from "./visualize/server.js";
 import { formatAuthProviderList, runOAuthAuth } from "./auth/oauth.js";
-import { ensureCodeModeRepoSetup, runCodeModeConnectors } from "./code-mode.js";
+import {
+  createMirroredWarningSink,
+  ensureCodeModeRepoSetup,
+  runCodeModeConnectors,
+} from "./code-mode.js";
 import {
   commandEmitsTelemetry,
   helpContent,
@@ -633,14 +637,13 @@ function App({ command }: AppProps) {
             createWorkflow: resolvedCommand === "init",
             // Mirror warnings to stderr so they survive a TUI re-render and an
             // error-terminated run, which discards the run log.
-            onWarning: (message) => {
+            onWarning: createMirroredWarningSink((message) => {
               handleRunEvent({
                 source: "main",
                 text: message,
                 type: "text",
               });
-              process.stderr.write(`${message}\n`);
-            },
+            }),
           });
         }
 

--- a/src/code-mode.ts
+++ b/src/code-mode.ts
@@ -2,7 +2,7 @@ import { mkdir, readFile, rename, rm, writeFile } from "node:fs/promises";
 import { randomUUID } from "node:crypto";
 import path from "node:path";
 import { OPENWIKI_VERSION } from "./constants.js";
-import { isFileNotFoundError } from "./fs-errors.js";
+import { isFileNotFoundError, pathExists } from "./fs-errors.js";
 import { createConnectorRegistry } from "./connectors/registry.js";
 import { UPDATE_METADATA_PATH } from "./constants.js";
 import { createConnectorSynthesisGuidance } from "./ingestion.js";
@@ -177,17 +177,16 @@ async function readLastUpdatedAt(
 }
 
 /**
- * One agent file's prepared outcome. `backupContent` and `warning` are present
- * only when the managed block holds non-canonical content that is about to be
- * replaced. `nextContent` equals `originalContent` when the file should not be
- * rewritten at all (canonical block, or marker-less append already staged).
+ * One agent file's prepared outcome. `backup` is present only when the managed
+ * block holds non-canonical content that is about to be replaced. `nextContent`
+ * equals `originalContent` when the file should not be rewritten at all
+ * (canonical block, or marker-less append already staged).
  */
 interface PreparedAgentFile {
   agentsPath: string;
   originalContent: string;
   nextContent: string;
-  backupContent?: string;
-  warning?: string;
+  backup?: { content: string; warning: string };
 }
 
 async function writeCodeModeAgentSnippets(
@@ -195,6 +194,7 @@ async function writeCodeModeAgentSnippets(
   onWarning?: (message: string) => void,
 ): Promise<void> {
   const snippet = createCodeModeAgentsSnippet();
+  const normalizedSnippet = normalizeLineEndings(snippet);
   const warn = createWarningSink(onWarning);
 
   // Phase 1 — validate and prepare both files in memory. A malformed-marker
@@ -202,21 +202,32 @@ async function writeCodeModeAgentSnippets(
   // leaves a backup for either file.
   const prepared = await Promise.all(
     CODE_MODE_AGENT_FILES.map((fileName) =>
-      prepareCodeModeAgentSnippet(path.join(cwd, fileName), snippet),
+      prepareCodeModeAgentSnippet(
+        path.join(cwd, fileName),
+        snippet,
+        normalizedSnippet,
+      ),
     ),
   );
 
-  // Phase 2 — write backups and emit warnings, in agent-file order, before any
-  // replacement is written. Backups are sourced from the already-read content,
-  // so an editor touching the file in between cannot make the backup diverge.
-  for (const file of prepared) {
-    if (file.backupContent === undefined) {
-      continue;
-    }
-    await writeBackupAtomically(file.agentsPath, file.backupContent);
-    if (file.warning !== undefined) {
-      warn(file.warning);
-    }
+  // Phase 2 — write backups for files whose non-canonical block is about to be
+  // replaced, sourced from the already-read content so an editor touching the
+  // file in between cannot make the backup diverge. Backups run in parallel
+  // (independent files); warnings emit afterward in agent-file order.
+  const toBackUp = prepared.filter(
+    (
+      file,
+    ): file is PreparedAgentFile & {
+      backup: NonNullable<PreparedAgentFile["backup"]>;
+    } => file.backup !== undefined,
+  );
+  await Promise.all(
+    toBackUp.map((file) =>
+      writeBackupAtomically(file.agentsPath, file.backup.content),
+    ),
+  );
+  for (const file of toBackUp) {
+    warn(file.backup.warning);
   }
 
   // Phase 3 — write only files whose content actually changed. Canonical
@@ -257,18 +268,6 @@ function normalizeLineEndings(content: string): string {
   return content.replace(/\r\n?/g, "\n");
 }
 
-async function pathExists(filePath: string): Promise<boolean> {
-  try {
-    await readFile(filePath);
-    return true;
-  } catch (error) {
-    if (!isFileNotFoundError(error)) {
-      return true;
-    }
-    return false;
-  }
-}
-
 /**
  * Write the backup copy atomically (temp file plus rename, mirroring the
  * credential-file pattern) so a crash mid-write cannot leave a torn backup.
@@ -291,6 +290,7 @@ async function writeBackupAtomically(
 async function prepareCodeModeAgentSnippet(
   agentsPath: string,
   snippet: string,
+  normalizedSnippet: string,
 ): Promise<PreparedAgentFile> {
   let currentContent = "";
 
@@ -333,7 +333,7 @@ async function prepareCodeModeAgentSnippet(
 
   // Canonical block: leave the file untouched. Skip-write preserves mtime and
   // line endings and avoids a rewrite on every chat run.
-  if (normalizeLineEndings(region) === normalizeLineEndings(snippet)) {
+  if (normalizeLineEndings(region) === normalizedSnippet) {
     return {
       agentsPath,
       originalContent: currentContent,
@@ -342,15 +342,17 @@ async function prepareCodeModeAgentSnippet(
   }
 
   // Non-canonical block: user content sits inside the managed region. Back it
-  // up before the refresh replaces it, and say so out loud.
+  // up before the refresh replaces it, and warn naming the file and backup.
   const backupPath = `${agentsPath}${OPENWIKI_AGENTS_BACKUP_SUFFIX}`;
   const overwritingExisting = await pathExists(backupPath);
   return {
     agentsPath,
     originalContent: currentContent,
     nextContent: `${currentContent.slice(0, startIndex)}${snippet}${currentContent.slice(endIndex + OPENWIKI_AGENTS_SNIPPET_END.length)}`,
-    backupContent: currentContent,
-    warning: `OpenWiki: found content between the managed markers of ${path.basename(agentsPath)} that differs from the generated snippet; backup saved to ${backupPath}${overwritingExisting ? " (previous backup replaced)" : ""}. Move custom content outside the markers to keep it.`,
+    backup: {
+      content: currentContent,
+      warning: `OpenWiki: found content between the managed markers of ${path.basename(agentsPath)} that differs from the generated snippet; backup saved to ${backupPath}${overwritingExisting ? " (previous backup replaced)" : ""}. Move custom content outside the markers to keep it.`,
+    },
   };
 }
 

--- a/src/code-mode.ts
+++ b/src/code-mode.ts
@@ -1,4 +1,5 @@
-import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { mkdir, readFile, rename, rm, writeFile } from "node:fs/promises";
+import { randomUUID } from "node:crypto";
 import path from "node:path";
 import { OPENWIKI_VERSION } from "./constants.js";
 import { isFileNotFoundError } from "./fs-errors.js";
@@ -9,6 +10,7 @@ import type { OpenWikiRunEvent } from "./agent/types.js";
 
 const OPENWIKI_AGENTS_SNIPPET_START = "<!-- OPENWIKI:START -->";
 const OPENWIKI_AGENTS_SNIPPET_END = "<!-- OPENWIKI:END -->";
+const OPENWIKI_AGENTS_BACKUP_SUFFIX = ".openwiki.bak";
 const DEFAULT_CODE_MODE_CRON = "0 8 * * *";
 
 // Root agent-instruction files OpenWiki keeps pointed at the generated wiki.
@@ -26,6 +28,12 @@ export interface CodeModeRepoSetupOptions {
   createWorkflow?: boolean;
   /** Cron expression for a freshly created workflow. Defaults to {@link DEFAULT_CODE_MODE_CRON}. */
   cronExpression?: string;
+  /**
+   * Sink for warnings about non-canonical content inside the managed
+   * agent-instruction blocks. When absent, warnings go to stderr. A throwing
+   * sink falls back to stderr and never breaks the run.
+   */
+  onWarning?: (message: string) => void;
 }
 
 /**
@@ -43,7 +51,7 @@ export async function ensureCodeModeRepoSetup(
       options.cronExpression ?? DEFAULT_CODE_MODE_CRON,
     );
   }
-  await writeCodeModeAgentSnippets(cwd);
+  await writeCodeModeAgentSnippets(cwd, options.onWarning);
 }
 
 /**
@@ -168,27 +176,122 @@ async function readLastUpdatedAt(
   }
 }
 
-async function writeCodeModeAgentSnippets(cwd: string): Promise<void> {
+/**
+ * One agent file's prepared outcome. `backupContent` and `warning` are present
+ * only when the managed block holds non-canonical content that is about to be
+ * replaced. `nextContent` equals `originalContent` when the file should not be
+ * rewritten at all (canonical block, or marker-less append already staged).
+ */
+interface PreparedAgentFile {
+  agentsPath: string;
+  originalContent: string;
+  nextContent: string;
+  backupContent?: string;
+  warning?: string;
+}
+
+async function writeCodeModeAgentSnippets(
+  cwd: string,
+  onWarning?: (message: string) => void,
+): Promise<void> {
   const snippet = createCodeModeAgentsSnippet();
-  // Prepare and validate both files before writing either one. If one file has
-  // malformed markers, setup fails without partially refreshing its sibling.
-  const updates = await Promise.all(
+  const warn = createWarningSink(onWarning);
+
+  // Phase 1 — validate and prepare both files in memory. A malformed-marker
+  // throw here aborts before any backup or write, so an aborted run never
+  // leaves a backup for either file.
+  const prepared = await Promise.all(
     CODE_MODE_AGENT_FILES.map((fileName) =>
       prepareCodeModeAgentSnippet(path.join(cwd, fileName), snippet),
     ),
   );
 
+  // Phase 2 — write backups and emit warnings, in agent-file order, before any
+  // replacement is written. Backups are sourced from the already-read content,
+  // so an editor touching the file in between cannot make the backup diverge.
+  for (const file of prepared) {
+    if (file.backupContent === undefined) {
+      continue;
+    }
+    await writeBackupAtomically(file.agentsPath, file.backupContent);
+    if (file.warning !== undefined) {
+      warn(file.warning);
+    }
+  }
+
+  // Phase 3 — write only files whose content actually changed. Canonical
+  // files are skipped entirely, so mtime and line endings stay untouched.
   await Promise.all(
-    updates.map(({ agentsPath, nextContent }) =>
-      writeFile(agentsPath, nextContent, "utf8"),
-    ),
+    prepared
+      .filter((file) => file.nextContent !== file.originalContent)
+      .map(({ agentsPath, nextContent }) =>
+        writeFile(agentsPath, nextContent, "utf8"),
+      ),
   );
+}
+
+/**
+ * A warning sink that never breaks the run: a throwing custom sink falls back
+ * to stderr, and the default sink writes straight to stderr.
+ */
+function createWarningSink(
+  onWarning: ((message: string) => void) | undefined,
+): (message: string) => void {
+  if (onWarning === undefined) {
+    return (message) => process.stderr.write(`${message}\n`);
+  }
+  return (message) => {
+    try {
+      onWarning(message);
+    } catch {
+      process.stderr.write(`${message}\n`);
+    }
+  };
+}
+
+/**
+ * Normalize CRLF and lone-CR line endings to LF so Windows-edited and old-Mac
+ * files compare equal to the LF canonical snippet.
+ */
+function normalizeLineEndings(content: string): string {
+  return content.replace(/\r\n?/g, "\n");
+}
+
+async function pathExists(filePath: string): Promise<boolean> {
+  try {
+    await readFile(filePath);
+    return true;
+  } catch (error) {
+    if (!isFileNotFoundError(error)) {
+      return true;
+    }
+    return false;
+  }
+}
+
+/**
+ * Write the backup copy atomically (temp file plus rename, mirroring the
+ * credential-file pattern) so a crash mid-write cannot leave a torn backup.
+ */
+async function writeBackupAtomically(
+  agentsPath: string,
+  content: string,
+): Promise<void> {
+  const backupPath = `${agentsPath}${OPENWIKI_AGENTS_BACKUP_SUFFIX}`;
+  const tmpPath = `${backupPath}.${process.pid}.${randomUUID()}.tmp`;
+  try {
+    await writeFile(tmpPath, content, "utf8");
+    await rename(tmpPath, backupPath);
+  } catch (error) {
+    await rm(tmpPath, { force: true }).catch(() => undefined);
+    throw error;
+  }
 }
 
 async function prepareCodeModeAgentSnippet(
   agentsPath: string,
   snippet: string,
-): Promise<{ agentsPath: string; nextContent: string }> {
+): Promise<PreparedAgentFile> {
   let currentContent = "";
 
   try {
@@ -206,6 +309,7 @@ async function prepareCodeModeAgentSnippet(
   if (hasNoMarkers) {
     return {
       agentsPath,
+      originalContent: currentContent,
       nextContent: `${currentContent.trimEnd()}${currentContent.trim().length > 0 ? "\n\n" : ""}${snippet}\n`,
     };
   }
@@ -222,9 +326,31 @@ async function prepareCodeModeAgentSnippet(
     );
   }
 
+  const region = currentContent.slice(
+    startIndex,
+    endIndex + OPENWIKI_AGENTS_SNIPPET_END.length,
+  );
+
+  // Canonical block: leave the file untouched. Skip-write preserves mtime and
+  // line endings and avoids a rewrite on every chat run.
+  if (normalizeLineEndings(region) === normalizeLineEndings(snippet)) {
+    return {
+      agentsPath,
+      originalContent: currentContent,
+      nextContent: currentContent,
+    };
+  }
+
+  // Non-canonical block: user content sits inside the managed region. Back it
+  // up before the refresh replaces it, and say so out loud.
+  const backupPath = `${agentsPath}${OPENWIKI_AGENTS_BACKUP_SUFFIX}`;
+  const overwritingExisting = await pathExists(backupPath);
   return {
     agentsPath,
+    originalContent: currentContent,
     nextContent: `${currentContent.slice(0, startIndex)}${snippet}${currentContent.slice(endIndex + OPENWIKI_AGENTS_SNIPPET_END.length)}`,
+    backupContent: currentContent,
+    warning: `OpenWiki: found content between the managed markers of ${path.basename(agentsPath)} that differs from the generated snippet; backup saved to ${backupPath}${overwritingExisting ? " (previous backup replaced)" : ""}. Move custom content outside the markers to keep it.`,
   };
 }
 
@@ -278,6 +404,8 @@ jobs:
             openwiki
             AGENTS.md
             CLAUDE.md
+            AGENTS.md.openwiki.bak
+            CLAUDE.md.openwiki.bak
             .github/workflows/openwiki-update.yml
           branch: openwiki/update
           commit-message: "docs: update OpenWiki"

--- a/src/code-mode.ts
+++ b/src/code-mode.ts
@@ -1,4 +1,11 @@
-import { mkdir, readFile, rename, rm, writeFile } from "node:fs/promises";
+import {
+  mkdir,
+  readFile,
+  readdir,
+  rename,
+  rm,
+  writeFile,
+} from "node:fs/promises";
 import { randomUUID } from "node:crypto";
 import path from "node:path";
 import { OPENWIKI_VERSION } from "./constants.js";
@@ -49,6 +56,7 @@ export async function ensureCodeModeRepoSetup(
     await ensureCodeModeWorkflow(
       cwd,
       options.cronExpression ?? DEFAULT_CODE_MODE_CRON,
+      createWarningSink(options.onWarning),
     );
   }
   await writeCodeModeAgentSnippets(cwd, options.onWarning);
@@ -62,6 +70,7 @@ export async function ensureCodeModeRepoSetup(
 async function ensureCodeModeWorkflow(
   cwd: string,
   cronExpression: string,
+  warn: (message: string) => void,
 ): Promise<void> {
   const workflowPath = path.join(
     cwd,
@@ -71,7 +80,15 @@ async function ensureCodeModeWorkflow(
   );
 
   try {
-    await readFile(workflowPath, "utf8");
+    const workflowContent = await readFile(workflowPath, "utf8");
+    // An existing workflow is preserved verbatim; older installs' workflows
+    // predate the backup commit paths and would silently discard backups on
+    // every scheduled run unless the operator re-runs --init or adds the paths.
+    if (!workflowContent.includes("AGENTS.md.openwiki.bak")) {
+      warn(
+        "OpenWiki: the existing .github/workflows/openwiki-update.yml does not commit agent-file backups; scheduled CI runs will discard them. Re-run openwiki code --init or add the backup paths to its add-paths.",
+      );
+    }
     return;
   } catch (error) {
     if (!isFileNotFoundError(error)) {
@@ -193,6 +210,7 @@ async function writeCodeModeAgentSnippets(
   cwd: string,
   onWarning?: (message: string) => void,
 ): Promise<void> {
+  await sweepStaleBackupTempFiles(cwd);
   const snippet = createCodeModeAgentsSnippet();
   const normalizedSnippet = normalizeLineEndings(snippet);
   const warn = createWarningSink(onWarning);
@@ -221,11 +239,30 @@ async function writeCodeModeAgentSnippets(
       backup: NonNullable<PreparedAgentFile["backup"]>;
     } => file.backup !== undefined,
   );
-  await Promise.all(
-    toBackUp.map((file) =>
-      writeBackupAtomically(file.agentsPath, file.backup.content),
-    ),
-  );
+  // A backup failure must abort the run before any rewrite; warn for the
+  // backups that already succeeded so the operator knows they exist, then
+  // rethrow with context. The agent files are left unchanged in this path.
+  const backedUpPaths = new Set<string>();
+  try {
+    await Promise.all(
+      toBackUp.map(async (file) => {
+        await writeBackupAtomically(file.agentsPath, file.backup.content);
+        backedUpPaths.add(file.agentsPath);
+      }),
+    );
+  } catch (error) {
+    for (const file of toBackUp) {
+      if (backedUpPaths.has(file.agentsPath)) {
+        warn(file.backup.warning);
+      }
+    }
+    throw new Error(
+      `OpenWiki: could not write agent-file backups; agent files were left unchanged. ${
+        error instanceof Error ? error.message : String(error)
+      }`,
+      { cause: error },
+    );
+  }
   for (const file of toBackUp) {
     warn(file.backup.warning);
   }
@@ -258,6 +295,46 @@ function createWarningSink(
       process.stderr.write(`${message}\n`);
     }
   };
+}
+
+/**
+ * A warning sink that mirrors each warning to both the run log and stderr, so
+ * a TUI run keeps the message even when the run log is discarded (re-render or
+ * error-terminated run). The stderr mirror runs even if the run-log callback
+ * throws, so the warning always reaches at least one channel.
+ */
+export function createMirroredWarningSink(
+  emit: (message: string) => void,
+): (message: string) => void {
+  return (message) => {
+    try {
+      emit(message);
+    } finally {
+      process.stderr.write(`${message}\n`);
+    }
+  };
+}
+
+/**
+ * Best-effort sweep of stale backup temp files left by a crash between a
+ * backup's write and rename in {@link writeBackupAtomically}. Only the
+ * `.openwiki.bak.<pid>.<uuid>.tmp` pattern is removed — never the agent files
+ * or the real backups. Sweep failures must not break the run; errors from the
+ * actual backup writes still propagate.
+ */
+async function sweepStaleBackupTempFiles(cwd: string): Promise<void> {
+  try {
+    const entries = await readdir(cwd);
+    await Promise.all(
+      entries
+        .filter((entry) => /\.openwiki\.bak\..*\.tmp$/.test(entry))
+        .map((entry) =>
+          rm(path.join(cwd, entry), { force: true }).catch(() => undefined),
+        ),
+    );
+  } catch {
+    // Tolerate readdir failures; the sweep is cleanup, not a precondition.
+  }
 }
 
 /**
@@ -295,7 +372,15 @@ async function prepareCodeModeAgentSnippet(
   let currentContent = "";
 
   try {
-    currentContent = await readFile(agentsPath, "utf8");
+    const raw = await readFile(agentsPath);
+    currentContent = raw.toString("utf8");
+    // A lossy round-trip means the file is not valid UTF-8; refusing to
+    // rewrite or back it up lossily preserves the original bytes.
+    if (!Buffer.from(currentContent, "utf8").equals(raw)) {
+      throw new Error(
+        `Cannot update ${path.basename(agentsPath)} because it is not valid UTF-8; refusing to rewrite or back it up lossily.`,
+      );
+    }
   } catch (error) {
     if (!isFileNotFoundError(error)) {
       throw error;

--- a/src/fs-errors.ts
+++ b/src/fs-errors.ts
@@ -39,6 +39,13 @@ export function isExpectedSnapshotRaceError(error: unknown): boolean {
  * True when a file or directory exists at the path. Only ENOENT reports
  * absence; any other error counts as "exists" so callers keep their
  * error-handling semantics (e.g. a directory occupying a file name).
+ *
+ * NOTE: this error policy is intentionally NOT shared by the module-local
+ * copies that predate this helper:
+ *   - src/schedules.ts's pathExists returns false on ANY error (catch-all);
+ *   - src/connectors/tools.ts's pathExists rethrows on non-ENOENT errors.
+ * Those copies are not yet migrated to this helper; treat this policy as the
+ * canonical one and migrate them as follow-up work.
  */
 export async function pathExists(filePath: string): Promise<boolean> {
   try {

--- a/src/fs-errors.ts
+++ b/src/fs-errors.ts
@@ -1,3 +1,5 @@
+import { stat } from "node:fs/promises";
+
 /**
  * Shared helpers for classifying Node.js filesystem errors.
  *
@@ -31,4 +33,18 @@ export function isExpectedSnapshotRaceError(error: unknown): boolean {
   return ["EISDIR", "ENOENT", "ENOTDIR"].includes(
     (error as NodeJS.ErrnoException).code ?? "",
   );
+}
+
+/**
+ * True when a file or directory exists at the path. Only ENOENT reports
+ * absence; any other error counts as "exists" so callers keep their
+ * error-handling semantics (e.g. a directory occupying a file name).
+ */
+export async function pathExists(filePath: string): Promise<boolean> {
+  try {
+    await stat(filePath);
+    return true;
+  } catch (error) {
+    return !isFileNotFoundError(error);
+  }
 }

--- a/test/code-mode.test.ts
+++ b/test/code-mode.test.ts
@@ -3,6 +3,7 @@ import {
   mkdir,
   mkdtemp,
   readFile,
+  readdir,
   rm,
   stat,
   symlink,
@@ -18,7 +19,10 @@ import {
   vi,
   type MockInstance,
 } from "vitest";
-import { ensureCodeModeRepoSetup } from "../src/code-mode.ts";
+import {
+  ensureCodeModeRepoSetup,
+  createMirroredWarningSink,
+} from "../src/code-mode.ts";
 
 const SNIPPET_START = "<!-- OPENWIKI:START -->";
 const SNIPPET_END = "<!-- OPENWIKI:END -->";
@@ -345,6 +349,11 @@ describe("non-canonical block protection", () => {
     expect(stderr).toHaveBeenCalledWith(
       expect.stringContaining("AGENTS.md.openwiki.bak"),
     );
+    // A fresh backup never claims a previous backup was replaced; that suffix
+    // only appears when the backup name was already occupied.
+    expect(stderr).not.toHaveBeenCalledWith(
+      expect.stringContaining("replaced"),
+    );
   });
 
   test("leaves a canonical block untouched: no warning, no backup, no rewrite", async () => {
@@ -468,6 +477,9 @@ describe("non-canonical block protection", () => {
       "hand-edited block content",
     );
     expect(await readIfPresent(path.join(repo, "CLAUDE.md"))).toBeNull();
+    // The temp backup file is cleaned up even though the rename failed.
+    const entries = await readdir(repo);
+    expect(entries.filter((e) => e.endsWith(".tmp"))).toEqual([]);
   });
 
   test("never auto-deletes an orphaned backup once the block is canonical", async () => {
@@ -496,6 +508,8 @@ describe("non-canonical block protection", () => {
     expect(linkStat.isSymbolicLink()).toBe(true);
     const backup = await readIfPresent(backupPathFor(linkPath));
     expect(backup).toBe(nonCanonicalFile());
+    // The refresh propagated through the symlink to its target file.
+    expect(await readIfPresent(targetPath)).toContain("## OpenWiki");
   });
 
   test("marker-less files get the append path with no warning or backup", async () => {
@@ -563,5 +577,29 @@ describe("ensureCodeModeRepoSetup onWarning sink", () => {
     expect(warnings).toHaveLength(2);
     expect(warnings[0]).toContain("AGENTS.md");
     expect(warnings[1]).toContain("CLAUDE.md");
+  });
+});
+
+describe("createMirroredWarningSink", () => {
+  test("emits to the run-log callback and mirrors the line to stderr", () => {
+    const emitted: string[] = [];
+    const stderr = captureStderr();
+
+    const sink = createMirroredWarningSink((message) => emitted.push(message));
+    sink("warning line");
+
+    expect(emitted).toEqual(["warning line"]);
+    expect(stderr).toHaveBeenCalledWith("warning line\n");
+  });
+
+  test("mirrors to stderr even when the run-log callback throws", () => {
+    const stderr = captureStderr();
+
+    const sink = createMirroredWarningSink(() => {
+      throw new Error("log backend down");
+    });
+    expect(() => sink("warning line")).toThrow("log backend down");
+
+    expect(stderr).toHaveBeenCalledWith("warning line\n");
   });
 });

--- a/test/code-mode.test.ts
+++ b/test/code-mode.test.ts
@@ -1,13 +1,41 @@
-import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import {
+  lstat,
+  mkdir,
+  mkdtemp,
+  readFile,
+  rm,
+  stat,
+  symlink,
+  writeFile,
+} from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
-import { afterEach, describe, expect, test } from "vitest";
+import {
+  afterEach,
+  describe,
+  expect,
+  test,
+  vi,
+  type MockInstance,
+} from "vitest";
 import { ensureCodeModeRepoSetup } from "../src/code-mode.ts";
 
 const SNIPPET_START = "<!-- OPENWIKI:START -->";
 const SNIPPET_END = "<!-- OPENWIKI:END -->";
 
 const tempRepos: string[] = [];
+const stderrSpies: MockInstance<typeof process.stderr.write>[] = [];
+
+/**
+ * Capture writes to stderr for the current test. Spies are restored in
+ * `afterEach` so a failed assertion can never leak a live mock that would
+ * swallow stderr for the rest of the worker.
+ */
+function captureStderr(): MockInstance<typeof process.stderr.write> {
+  const spy = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+  stderrSpies.push(spy);
+  return spy;
+}
 
 async function createTempRepo(): Promise<string> {
   const repo = await mkdtemp(path.join(tmpdir(), "openwiki-code-mode-"));
@@ -23,12 +51,44 @@ async function readIfPresent(filePath: string): Promise<string | null> {
   }
 }
 
+function backupPathFor(agentsPath: string): string {
+  return `${agentsPath}.openwiki.bak`;
+}
+
+function canonicalFile(): string {
+  return `# Custom header\n\nKeep me.\n\n${SNIPPET_START}
+
+## OpenWiki
+
+This repository uses OpenWiki for recurring code documentation. Start with \`openwiki/quickstart.md\`, then follow its links to architecture, workflows, domain concepts, operations, integrations, testing guidance, and source maps.
+
+The scheduled OpenWiki GitHub Actions workflow refreshes the repository wiki. Do not hand-edit generated OpenWiki pages unless explicitly asked; prefer updating source code/docs and letting OpenWiki regenerate.
+
+${SNIPPET_END}\n`;
+}
+
+function nonCanonicalFile(): string {
+  return `# Custom header
+
+User content INSIDE the managed block that must not be lost.
+
+${SNIPPET_START}
+hand-edited block content
+${SNIPPET_END}
+
+Trailing notes.
+`;
+}
+
 afterEach(async () => {
   await Promise.all(
     tempRepos
       .splice(0)
       .map((repo) => rm(repo, { force: true, recursive: true })),
   );
+  for (const spy of stderrSpies.splice(0)) {
+    spy.mockRestore();
+  }
 });
 
 describe("ensureCodeModeRepoSetup agent files", () => {
@@ -58,17 +118,25 @@ ${SNIPPET_END}
 
 Trailing notes that must survive.
 `;
-    await writeFile(path.join(repo, "CLAUDE.md"), existing, "utf8");
+    const claudePath = path.join(repo, "CLAUDE.md");
+    await writeFile(claudePath, existing, "utf8");
+    const stderr = captureStderr();
 
     await ensureCodeModeRepoSetup(repo);
 
-    const content = await readIfPresent(path.join(repo, "CLAUDE.md"));
+    const content = await readIfPresent(claudePath);
     expect(content).toContain("# My Project");
     expect(content).toContain("Hand-written guidance for coding agents.");
     expect(content).toContain("Trailing notes that must survive.");
     expect(content).not.toContain("stale OpenWiki content");
     // Exactly one managed block after a refresh.
     expect(content?.match(new RegExp(SNIPPET_START, "g"))).toHaveLength(1);
+    // The stale (non-canonical) block content was backed up, never silently.
+    const backup = await readIfPresent(backupPathFor(claudePath));
+    expect(backup).toBe(existing);
+    expect(stderr).toHaveBeenCalledWith(
+      expect.stringContaining("CLAUDE.md.openwiki.bak"),
+    );
   });
 
   test("appends the block to an existing file without markers, keeping content", async () => {
@@ -155,12 +223,18 @@ ${SNIPPET_END}
       // Both files are prepared before either is written, so a malformed
       // AGENTS.md cannot leave a newly-created CLAUDE.md behind.
       expect(await readIfPresent(path.join(repo, "CLAUDE.md"))).toBeNull();
+      // Validation runs before any backup is written, so an aborted run
+      // leaves no backup for either file.
+      expect(await readIfPresent(backupPathFor(agentsPath))).toBeNull();
+      expect(
+        await readIfPresent(backupPathFor(path.join(repo, "CLAUDE.md"))),
+      ).toBeNull();
     });
   }
 });
 
 describe("ensureCodeModeRepoSetup workflow", () => {
-  test("generated PR includes agent files and the workflow in add-paths", async () => {
+  test("generated PR includes agent files, backups, and the workflow in add-paths", async () => {
     const repo = await createTempRepo();
 
     await ensureCodeModeRepoSetup(repo, { createWorkflow: true });
@@ -174,6 +248,8 @@ describe("ensureCodeModeRepoSetup workflow", () => {
       "openwiki",
       "AGENTS.md",
       "CLAUDE.md",
+      "AGENTS.md.openwiki.bak",
+      "CLAUDE.md.openwiki.bak",
       ".github/workflows/openwiki-update.yml",
     ]) {
       expect(workflow).toContain(managedPath);
@@ -246,5 +322,246 @@ jobs:
     await ensureCodeModeRepoSetup(repo, { createWorkflow: true });
 
     expect(await readIfPresent(workflowPath)).toBe(customizedWorkflow);
+  });
+});
+
+describe("non-canonical block protection", () => {
+  test("backs up a non-canonical block before replacing it and warns", async () => {
+    const repo = await createTempRepo();
+    const agentsPath = path.join(repo, "AGENTS.md");
+    const existing = nonCanonicalFile();
+    await writeFile(agentsPath, existing, "utf8");
+    const stderr = captureStderr();
+
+    await ensureCodeModeRepoSetup(repo);
+
+    const content = await readIfPresent(agentsPath);
+    expect(content).not.toContain("hand-edited block content");
+    expect(content).toContain("## OpenWiki");
+    expect(content).toContain("Trailing notes.");
+    const backup = await readIfPresent(backupPathFor(agentsPath));
+    expect(backup).toBe(existing);
+    expect(stderr).toHaveBeenCalledWith(expect.stringContaining("AGENTS.md"));
+    expect(stderr).toHaveBeenCalledWith(
+      expect.stringContaining("AGENTS.md.openwiki.bak"),
+    );
+  });
+
+  test("leaves a canonical block untouched: no warning, no backup, no rewrite", async () => {
+    const repo = await createTempRepo();
+    const claudePath = path.join(repo, "CLAUDE.md");
+    const canonical = canonicalFile();
+    await writeFile(claudePath, canonical, "utf8");
+    const before = await stat(claudePath);
+    const stderr = captureStderr();
+
+    await ensureCodeModeRepoSetup(repo);
+
+    expect(await readIfPresent(claudePath)).toBe(canonical);
+    const after = await stat(claudePath);
+    expect(after.mtimeMs).toBe(before.mtimeMs);
+    expect(stderr).not.toHaveBeenCalled();
+    expect(await readIfPresent(backupPathFor(claudePath))).toBeNull();
+  });
+
+  test("treats a CRLF canonical block as canonical, preserving line endings", async () => {
+    const repo = await createTempRepo();
+    const claudePath = path.join(repo, "CLAUDE.md");
+    const crlf = canonicalFile().replace(/\n/g, "\r\n");
+    await writeFile(claudePath, crlf, "utf8");
+    const before = await stat(claudePath);
+    const stderr = captureStderr();
+
+    await ensureCodeModeRepoSetup(repo);
+
+    expect(await readIfPresent(claudePath)).toBe(crlf);
+    const after = await stat(claudePath);
+    expect(after.mtimeMs).toBe(before.mtimeMs);
+    expect(stderr).not.toHaveBeenCalled();
+    expect(await readIfPresent(backupPathFor(claudePath))).toBeNull();
+  });
+
+  test("treats a lone-CR canonical block as canonical, preserving line endings", async () => {
+    const repo = await createTempRepo();
+    const claudePath = path.join(repo, "CLAUDE.md");
+    const cr = canonicalFile().replace(/\n/g, "\r");
+    await writeFile(claudePath, cr, "utf8");
+    const before = await stat(claudePath);
+    const stderr = captureStderr();
+
+    await ensureCodeModeRepoSetup(repo);
+
+    expect(await readIfPresent(claudePath)).toBe(cr);
+    const after = await stat(claudePath);
+    expect(after.mtimeMs).toBe(before.mtimeMs);
+    expect(stderr).not.toHaveBeenCalled();
+    expect(await readIfPresent(backupPathFor(claudePath))).toBeNull();
+  });
+
+  test("malformed markers in one file abort before any backup for the sibling", async () => {
+    const repo = await createTempRepo();
+    const agentsPath = path.join(repo, "AGENTS.md");
+    const claudePath = path.join(repo, "CLAUDE.md");
+    await writeFile(
+      agentsPath,
+      `# Project\n\n${SNIPPET_START}\norphaned start marker\n`,
+      "utf8",
+    );
+    await writeFile(claudePath, nonCanonicalFile(), "utf8");
+
+    await expect(ensureCodeModeRepoSetup(repo)).rejects.toThrow(
+      /managed markers are malformed or duplicated/u,
+    );
+
+    expect(await readIfPresent(agentsPath)).toContain("orphaned start marker");
+    expect(await readIfPresent(claudePath)).toContain(
+      "hand-edited block content",
+    );
+    expect(await readIfPresent(backupPathFor(agentsPath))).toBeNull();
+    expect(await readIfPresent(backupPathFor(claudePath))).toBeNull();
+  });
+
+  test("overwrites a previous backup on a second non-canonical run and says so", async () => {
+    const repo = await createTempRepo();
+    const agentsPath = path.join(repo, "AGENTS.md");
+    await writeFile(agentsPath, nonCanonicalFile(), "utf8");
+    await ensureCodeModeRepoSetup(repo);
+    const firstBackup = await readIfPresent(backupPathFor(agentsPath));
+    const secondStale = nonCanonicalFile().replace(
+      "hand-edited block content",
+      "second round of hand edits",
+    );
+    await writeFile(agentsPath, secondStale, "utf8");
+    const stderr = captureStderr();
+
+    await ensureCodeModeRepoSetup(repo);
+
+    expect(await readIfPresent(backupPathFor(agentsPath))).toBe(secondStale);
+    expect(firstBackup).not.toBe(secondStale);
+    expect(stderr).toHaveBeenCalledWith(expect.stringContaining("replaced"));
+  });
+
+  test("clobbering a pre-existing backup file is named in the warning", async () => {
+    const repo = await createTempRepo();
+    const agentsPath = path.join(repo, "AGENTS.md");
+    await writeFile(agentsPath, nonCanonicalFile(), "utf8");
+    const backupPath = backupPathFor(agentsPath);
+    await writeFile(backupPath, "pre-existing user file", "utf8");
+    const stderr = captureStderr();
+
+    await ensureCodeModeRepoSetup(repo);
+
+    expect(await readIfPresent(backupPath)).toBe(nonCanonicalFile());
+    expect(stderr).toHaveBeenCalledWith(expect.stringContaining("replaced"));
+  });
+
+  test("a failing backup aborts the run before any agent file is written", async () => {
+    const repo = await createTempRepo();
+    const agentsPath = path.join(repo, "AGENTS.md");
+    await writeFile(agentsPath, nonCanonicalFile(), "utf8");
+    // A directory occupying the backup name makes the atomic rename fail.
+    await mkdir(backupPathFor(agentsPath));
+
+    await expect(ensureCodeModeRepoSetup(repo)).rejects.toThrow();
+
+    expect(await readIfPresent(agentsPath)).toContain(
+      "hand-edited block content",
+    );
+    expect(await readIfPresent(path.join(repo, "CLAUDE.md"))).toBeNull();
+  });
+
+  test("never auto-deletes an orphaned backup once the block is canonical", async () => {
+    const repo = await createTempRepo();
+    const claudePath = path.join(repo, "CLAUDE.md");
+    await writeFile(claudePath, nonCanonicalFile(), "utf8");
+    await ensureCodeModeRepoSetup(repo);
+    const backup = await readIfPresent(backupPathFor(claudePath));
+    expect(backup).not.toBeNull();
+
+    await ensureCodeModeRepoSetup(repo);
+
+    expect(await readIfPresent(backupPathFor(claudePath))).toBe(backup);
+  });
+
+  test("backs up the target content of a symlinked agent file", async () => {
+    const repo = await createTempRepo();
+    const targetPath = path.join(repo, "real-agents.md");
+    await writeFile(targetPath, nonCanonicalFile(), "utf8");
+    const linkPath = path.join(repo, "AGENTS.md");
+    await symlink(targetPath, linkPath);
+
+    await ensureCodeModeRepoSetup(repo);
+
+    const linkStat = await lstat(linkPath);
+    expect(linkStat.isSymbolicLink()).toBe(true);
+    const backup = await readIfPresent(backupPathFor(linkPath));
+    expect(backup).toBe(nonCanonicalFile());
+  });
+
+  test("marker-less files get the append path with no warning or backup", async () => {
+    const repo = await createTempRepo();
+    const agentsPath = path.join(repo, "AGENTS.md");
+    const existing = "# Existing AGENTS\n\nDo not lose this line.\n";
+    await writeFile(agentsPath, existing, "utf8");
+    const stderr = captureStderr();
+
+    await ensureCodeModeRepoSetup(repo);
+
+    expect(await readIfPresent(agentsPath)).toContain(SNIPPET_START);
+    expect(stderr).not.toHaveBeenCalled();
+    expect(await readIfPresent(backupPathFor(agentsPath))).toBeNull();
+  });
+});
+
+describe("ensureCodeModeRepoSetup onWarning sink", () => {
+  test("delivers warnings to a custom sink instead of stderr", async () => {
+    const repo = await createTempRepo();
+    const agentsPath = path.join(repo, "AGENTS.md");
+    await writeFile(agentsPath, nonCanonicalFile(), "utf8");
+    const warnings: string[] = [];
+    const stderr = captureStderr();
+
+    await ensureCodeModeRepoSetup(repo, {
+      onWarning: (message) => warnings.push(message),
+    });
+
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]).toContain("AGENTS.md.openwiki.bak");
+    expect(stderr).not.toHaveBeenCalled();
+  });
+
+  test("a throwing sink falls back to stderr without breaking the run", async () => {
+    const repo = await createTempRepo();
+    const agentsPath = path.join(repo, "AGENTS.md");
+    await writeFile(agentsPath, nonCanonicalFile(), "utf8");
+    const stderr = captureStderr();
+
+    await ensureCodeModeRepoSetup(repo, {
+      onWarning: () => {
+        throw new Error("sink exploded");
+      },
+    });
+
+    expect(await readIfPresent(agentsPath)).toContain("## OpenWiki");
+    expect(stderr).toHaveBeenCalledWith(
+      expect.stringContaining("AGENTS.md.openwiki.bak"),
+    );
+  });
+
+  test("warns for each affected file, once per file, in agent-file order", async () => {
+    const repo = await createTempRepo();
+    const agentsPath = path.join(repo, "AGENTS.md");
+    const claudePath = path.join(repo, "CLAUDE.md");
+    await writeFile(agentsPath, nonCanonicalFile(), "utf8");
+    await writeFile(claudePath, nonCanonicalFile(), "utf8");
+    const warnings: string[] = [];
+
+    await ensureCodeModeRepoSetup(repo, {
+      onWarning: (message) => warnings.push(message),
+    });
+
+    expect(warnings).toHaveLength(2);
+    expect(warnings[0]).toContain("AGENTS.md");
+    expect(warnings[1]).toContain("CLAUDE.md");
   });
 });

--- a/test/fs-errors.test.ts
+++ b/test/fs-errors.test.ts
@@ -1,8 +1,16 @@
-import { describe, expect, test } from "vitest";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import { mkdir, mkdtemp, rm, stat, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import {
   isExpectedSnapshotRaceError,
   isFileNotFoundError,
+  pathExists,
 } from "../src/fs-errors.ts";
+
+// Spy on the module's stat so pathExists's non-ENOENT error path can be
+// simulated; real calls still pass through to the actual implementation.
+vi.mock("node:fs/promises", { spy: true });
 
 function errnoError(code: string): NodeJS.ErrnoException {
   const error = new Error(code) as NodeJS.ErrnoException;
@@ -49,5 +57,42 @@ describe("isExpectedSnapshotRaceError", () => {
   test("is false for non-error values", () => {
     expect(isExpectedSnapshotRaceError(null)).toBe(false);
     expect(isExpectedSnapshotRaceError({ code: "ENOENT" })).toBe(false);
+  });
+});
+
+describe("pathExists", () => {
+  let dir: string;
+
+  beforeEach(async () => {
+    dir = await mkdtemp(join(tmpdir(), "openwiki-fs-errors-"));
+  });
+
+  afterEach(async () => {
+    await rm(dir, { recursive: true, force: true });
+    vi.mocked(stat).mockRestore();
+  });
+
+  test("is false for a missing path", async () => {
+    expect(await pathExists(join(dir, "missing"))).toBe(false);
+  });
+
+  test("is true for an existing file", async () => {
+    const filePath = join(dir, "file.txt");
+    await writeFile(filePath, "hello");
+    expect(await pathExists(filePath)).toBe(true);
+  });
+
+  test("is true for an existing directory", async () => {
+    const dirPath = join(dir, "subdir");
+    await mkdir(dirPath);
+    expect(await pathExists(dirPath)).toBe(true);
+  });
+
+  test("is true when stat fails with a non-ENOENT error", async () => {
+    const errno = Object.assign(new Error("is a directory"), {
+      code: "EISDIR",
+    });
+    vi.mocked(stat).mockRejectedValueOnce(errno);
+    expect(await pathExists(join(dir, "anywhere"))).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary

`openwiki` code-mode runs can no longer silently destroy custom content in a repo's `AGENTS.md`/`CLAUDE.md`.

Before: any content a user placed inside the managed `<!-- OPENWIKI:START -->…<!-- OPENWIKI:END -->` block was replaced with the generated snippet on the next `init`/`update`/chat run, with no notice (the destructive path behind #573).

After: when the managed block holds content that differs from the generated snippet, the run saves the file to `<file>.openwiki.bak` (atomic temp-plus-rename), prints a warning naming the file and the backup path, then refreshes. Canonical blocks are left completely untouched — no rewrite, no mtime churn, line endings preserved (CRLF and lone-CR files compare equal to the LF snippet). Malformed markers still abort with both files unchanged, and an aborted run never leaves a backup behind.

## Design decisions

- **Warn + backup, then proceed** (over abort-with-error and warn-only): aborting would break the scheduled CI update run for affected repos; warn-only leaves no recovery copy. The scheduled-update workflow now commits the backups in its `add-paths`, so CI users get a durable recovery artifact.
- **Warning channel:** new optional `onWarning` sink on the setup options, defaulting to stderr. The TUI mirrors warnings to the run log and stderr (so they survive a re-render or an error-terminated run); `--print`/CI keeps piped stdout clean.
- **Existing installs:** `openwiki code --init` now warns when an already-present workflow predates the backup commit paths, since a preserved workflow is never silently modified.
- **Integrity guards:** non-UTF-8 agent files are refused (no lossy rewrite or backup); stale backup temp files from a crash are swept at setup; a backup failure aborts before any rewrite and warns for backups that already succeeded.

Session-settled decisions carried from planning: protection posture warn+backup-then-proceed (user-approved, over abort-with-error and warn-only); warning channel onWarning option with stderr default (user-approved, over hardcoded stderr and the shared event stream).

Fixes #573

## Testing

- 917 tests pass (27 in the code-mode suite, including new coverage for: backup+warning on non-canonical blocks, canonical skip-write with mtime checks, CRLF/lone-CR canonical detection, malformed-marker abort leaving no backup, backup overwrite semantics, backup-failure abort, orphan-backup preservation, symlinked files, marker-less append, the warning sink, and the workflow add-paths).
- Manual smoke: `openwiki code --update --print` on a fixture repo with a hand-edited block emits the warning on stderr, keeps stdout clean, writes the `.bak`, and preserves surrounding content; a second run is silent; a malformed-marker sibling aborts with no backup for either file; `--init` against a pre-existing workflow warns about the missing backup paths without touching the customized file.

## Known residuals

- Snippet-drift: if a future openwiki release changes the snippet text, one refresh per repo will read the old canonical block as "user content" and its unconditional single-slot backup would overwrite a prior genuine backup. Bounded by git history; the snippet has been byte-stable since the first release. Version-stamping the snippet is the proposed follow-up.
- Pre-existing read-modify-write TOCTOU between read and write is unchanged.
- The module-local `pathExists` copies in `src/schedules.ts`/`src/connectors/tools.ts` (different error policies) are not yet migrated to the new shared `src/fs-errors.ts` helper.

## Post-Deploy Monitoring & Validation

No additional operational monitoring required. This is a CLI + generated-workflow change; watch scheduled-update PRs of affected repos for the backup files in `add-paths` diffs, and roll back by reverting this commit.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
