### PR TITLE
fix: make the residual agent_error telemetry bucket diagnostic

### DIFF
--- a/.changeset/telemetry-agent-error-visibility.md
+++ b/.changeset/telemetry-agent-error-visibility.md
@@ -1,0 +1,5 @@
+---
+"openwiki": patch
+---
+
+fix: make the residual agent_error telemetry bucket diagnostic

--- a/src/agent/crash-guard.ts
+++ b/src/agent/crash-guard.ts
@@ -1,0 +1,179 @@
+import { describeErrorForTelemetry } from "../telemetry/errors.js";
+import { recordRunSafe } from "../telemetry/record-run-safe.js";
+
+import type { OpenWikiCommand, OpenWikiOutputMode } from "./types.js";
+import {
+  persistRunMetadataIfChanged,
+  type OpenWikiContentSnapshot,
+} from "./utils.js";
+
+/**
+ * Everything the crash guard needs to record and stamp an interrupted run
+ * post-mortem, captured when a run starts. A run registers this on entry so that a
+ * rejection escaping every catch can still be attributed to the run that caused it.
+ */
+export interface ActiveRunRecord {
+  /**
+   * Command of the in-flight run. Only init/update reach telemetry; chat is dropped
+   * downstream by `recordRunSafe`, but the stamp still runs for it.
+   */
+  command: OpenWikiCommand;
+
+  /**
+   * Repo (or local-wiki) root the run writes into.
+   */
+  cwd: string;
+
+  /**
+   * Resolved model id, written into the interrupted stamp.
+   */
+  modelId: string;
+
+  /**
+   * Output mode; decides where the stamp lives and the recorded run's brain mode.
+   */
+  outputMode: OpenWikiOutputMode;
+
+  /**
+   * Content snapshot taken before the run; the stamp writes only if content changed
+   * since.
+   *
+   * @default undefined - no snapshot was captured before the run (e.g. chat), so the
+   * interrupted stamp is skipped.
+   */
+  snapshotBefore?: OpenWikiContentSnapshot;
+
+  /**
+   * Effective wiki language, preserved in the stamp.
+   *
+   * @default undefined - the run has no explicit wiki language; the stamp omits it.
+   */
+  language?: string;
+}
+
+/**
+ * The single in-flight run, or undefined when idle. OpenWiki executes one run per
+ * process by design, so a module-level slot is sufficient and there is no registry
+ * to key.
+ */
+let activeRun: ActiveRunRecord | undefined;
+
+/**
+ * Registers the run the process is currently executing, so a fatal signal can
+ * attribute the crash. Call once a run's pre-flight snapshot exists.
+ *
+ * @param record - The in-flight run's post-mortem facts.
+ */
+export function registerActiveRun(record: ActiveRunRecord): void {
+  activeRun = record;
+}
+
+/**
+ * Clears the registration. Call in the run's `finally` so a clean run leaves no
+ * stale record for a later crash to misattribute.
+ */
+export function clearActiveRun(): void {
+  activeRun = undefined;
+}
+
+/**
+ * The registered run, or undefined when the process is idle.
+ */
+export function getActiveRun(): ActiveRunRecord | undefined {
+  return activeRun;
+}
+
+/**
+ * Shared post-mortem for both fatal signals. Best-effort throughout: the crash may
+ * have destroyed state the recorder or stamper wants, so each side effect is wrapped
+ * and swallowed independently, and the process still exits non-zero regardless.
+ * Telemetry is awaited only so its flush has a chance to complete before the exit;
+ * a failure in it never blocks the stamp or the exit.
+ *
+ * A rejection that reaches here would otherwise kill the process with a raw stack, no
+ * stamp, and no telemetry. Recording it means an escaped subagent rejection finally
+ * appears in the data, classified and (when residual) fingerprinted by the same
+ * boundary as every other failure; stamping it `interrupted` means the next
+ * scheduled update retries instead of no-opping against a half-written wiki.
+ *
+ * @param source - Which handler fired (`unhandledRejection`/`uncaughtException`);
+ *   used only for the local stderr line.
+ * @param error - The escaped rejection or exception.
+ */
+export async function handleFatal(
+  source: string,
+  error: unknown,
+): Promise<void> {
+  const active = getActiveRun();
+
+  if (active) {
+    // Record the crash as a failure so it finally appears in the data, classified
+    // and fingerprinted by the same boundary as every other failure.
+    try {
+      await recordRunSafe(
+        active.command,
+        { outputMode: active.outputMode },
+        { outcome: "failure", ...describeErrorForTelemetry(error) },
+      );
+    } catch {
+      // Intentionally ignored: telemetry must never block the exit.
+    }
+
+    // Stamp interrupted so the next scheduled update does not no-op against a
+    // half-written wiki.
+    try {
+      await persistRunMetadataIfChanged(
+        active.command,
+        active.cwd,
+        active.modelId,
+        active.outputMode,
+        active.snapshotBefore ?? null,
+        "interrupted",
+        active.language,
+      );
+    } catch {
+      // Intentionally ignored: the stamp is best-effort during a crash.
+    }
+
+    clearActiveRun();
+  }
+
+  // The local stderr line intentionally carries the raw message: it is the user's
+  // own failure UX on their own terminal and never enters telemetry.
+  const message = error instanceof Error ? error.message : String(error);
+  process.stderr.write(`OpenWiki run failed (${source}): ${message}\n`);
+
+  if (error instanceof Error && error.stack && process.env.OPENWIKI_DEBUG) {
+    process.stderr.write(`${error.stack}\n`);
+  }
+
+  // Give stderr a tick to flush, then exit non-zero. Without the explicit exit Node
+  // would continue with undefined state after an uncaught exception.
+  setImmediate(() => process.exit(1));
+}
+
+/**
+ * Whether {@link installCrashGuard} has already registered its handlers. The guard
+ * is a process-global singleton; installing twice would double-record and
+ * double-exit, so repeat calls are no-ops.
+ */
+let installed = false;
+
+/**
+ * Installs the last-resort handlers for rejections and exceptions that bypass every
+ * catch in the run. Idempotent, and meant to be called once at CLI startup, before
+ * any run begins.
+ */
+export function installCrashGuard(): void {
+  if (installed) {
+    return;
+  }
+  installed = true;
+
+  process.on("unhandledRejection", (reason) => {
+    void handleFatal("unhandledRejection", reason);
+  });
+  process.on("uncaughtException", (error) => {
+    void handleFatal("uncaughtException", error);
+  });
+}

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -127,6 +127,7 @@ import {
   removeTemporaryPlanFile,
   shouldCheckUpdateNoop,
 } from "./utils.js";
+import { clearActiveRun, registerActiveRun } from "./crash-guard.js";
 import { inStage, inStageSync, tagErrorStage } from "../telemetry/index.js";
 import type { RunTelemetryContext } from "../telemetry/index.js";
 import { OpenWikiIgnore } from "./openwiki-ignore.js";
@@ -508,6 +509,20 @@ async function runOpenWikiAgentCore(
   );
   emitDebug(options, "stream=started protocol=events version=v3");
 
+  // Register with the crash guard for exactly the stream-consumption window: a
+  // subagent rejection surfaces on the microtask queue during streaming and escapes
+  // the for-await catch below, so the guard is what turns that escape into a
+  // recorded, interrupted-stamped failure instead of a silent process abort. The
+  // finally clears the registration so a clean run leaves nothing stale behind.
+  registerActiveRun({
+    command,
+    cwd,
+    modelId,
+    outputMode,
+    snapshotBefore: openWikiSnapshotBefore ?? undefined,
+    language: context.language,
+  });
+
   let unhandledChunkCount = 0;
 
   try {
@@ -563,6 +578,7 @@ async function runOpenWikiAgentCore(
 
     throw error;
   } finally {
+    clearActiveRun();
     prunePersistentCheckpointHistory(
       checkpointTarget,
       checkpointer,

--- a/src/cli.tsx
+++ b/src/cli.tsx
@@ -36,6 +36,7 @@ import {
   type CredentialDiagnostic,
 } from "./env.js";
 import { createOpenWikiThreadId, runOpenWikiAgent } from "./agent/index.js";
+import { installCrashGuard } from "./agent/crash-guard.js";
 import { formatChatGptAccountFromEnv } from "./agent/openai-chatgpt-oauth.js";
 import {
   getErrorMessage,
@@ -99,6 +100,11 @@ import {
   withRunTelemetry,
   type RunTelemetryContext,
 } from "./telemetry/index.js";
+
+// Register the last-resort handlers before any run starts, so a rejection that
+// escapes every catch (e.g. a subagent error surfacing on the microtask queue) is
+// recorded and stamped instead of hard-killing the process with no telemetry.
+installCrashGuard();
 
 type RunState =
   | { status: "idle" }

--- a/src/telemetry/errors.ts
+++ b/src/telemetry/errors.ts
@@ -61,19 +61,96 @@ const PROVIDER_ERROR_CODES: Readonly<Record<string, ErrorClassification>> = {
 };
 
 /**
- * Maps an unknown error to a closed {@link ErrorClassification} from the raw error
- * alone (status, provider code, message, filesystem code). Priority runs
- * most-specific to least: abort, recognized provider code, HTTP status, tool shape,
- * message regexes, filesystem code, then the single `agent_error` catch-all.
+ * Max links followed when unwrapping a nested error. Bounds the walk so a long or
+ * cyclic `cause` chain cannot turn classification into a denial of service.
+ */
+const MAX_UNWRAP_DEPTH = 5;
+
+/**
+ * Flattens a possibly-wrapped error into the chain of links to inspect, nearest
+ * first: the error itself, then its `cause`, its single nested `error`, and any
+ * `AggregateError.errors`. Read-only and cycle-safe: it only reads own properties,
+ * never assigns, tracks visited objects, and stops at {@link MAX_UNWRAP_DEPTH}. The
+ * original value is always the first link even when it is not an object (a thrown
+ * string still gets classified), so callers see identical behavior for unwrapped
+ * errors.
  *
- * This reads only the raw signal; the owned families whose class comes from where
- * the error was thrown (`build_error`, `connector_error`, `okf_error`,
- * `checkpointer_error`, plus tagged `config_error`/`tool_error` details) are
- * resolved from the origin tag by {@link describeErrorForTelemetry}, which prefers
- * the tag over this. Never leaks the message: it is read to test regexes in-process,
- * but only an enum member is ever returned.
+ * @param error - The thrown value to flatten.
+ * @returns The nearest-first list of links, at most {@link MAX_UNWRAP_DEPTH} long.
+ */
+export function unwrapErrorChain(error: unknown): unknown[] {
+  const chain: unknown[] = [];
+  const visited = new Set<object>();
+  const queue: unknown[] = [error];
+
+  while (queue.length > 0 && chain.length < MAX_UNWRAP_DEPTH) {
+    const current = queue.shift();
+    chain.push(current);
+
+    if (
+      typeof current !== "object" ||
+      current === null ||
+      visited.has(current)
+    ) {
+      continue;
+    }
+    visited.add(current);
+
+    const node = current as {
+      cause?: unknown;
+      error?: unknown;
+      errors?: unknown;
+    };
+
+    if (node.cause !== undefined) {
+      queue.push(node.cause);
+    }
+    if (node.error !== undefined) {
+      queue.push(node.error);
+    }
+    if (Array.isArray(node.errors)) {
+      for (const nested of node.errors) {
+        queue.push(nested);
+      }
+    }
+  }
+
+  return chain;
+}
+
+/**
+ * Maps a possibly-wrapped error to a closed {@link ErrorClassification}. Walks the
+ * unwrap chain nearest-first and returns the first link that yields a named class,
+ * so a provider error hidden inside a tool-error wrapper or an `AggregateError` is
+ * recovered instead of collapsing into the residual. Returns `agent_error` only when
+ * no link in the chain carries a recognizable signal. Never leaks the message: links
+ * are read to test regexes in-process, but only an enum member is ever returned.
  */
 export function classifyError(error: unknown): ErrorClassification {
+  for (const link of unwrapErrorChain(error)) {
+    const result = classifyErrorLink(link);
+
+    if (result.errorClass !== "agent_error") {
+      return result;
+    }
+  }
+
+  return { errorClass: "agent_error" };
+}
+
+/**
+ * Classifies a single error link from the raw signal alone (status, provider code,
+ * message, filesystem code). Priority runs most-specific to least: abort, recognized
+ * provider code, HTTP status, tool shape, message regexes, filesystem code, then the
+ * single `agent_error` catch-all.
+ *
+ * This reads only the raw signal of the one link it is given; the owned families
+ * whose class comes from where the error was thrown (`build_error`, `connector_error`,
+ * `okf_error`, `checkpointer_error`, plus tagged `config_error`/`tool_error` details)
+ * are resolved from the origin tag by {@link describeErrorForTelemetry}, which prefers
+ * the tag over this.
+ */
+function classifyErrorLink(error: unknown): ErrorClassification {
   if (error instanceof Error && error.name === "AbortError") {
     return { errorClass: "aborted" };
   }
@@ -183,6 +260,23 @@ export function extractStatus(error: unknown): number | undefined {
     candidate.status ?? candidate.statusCode ?? candidate.response?.status;
 
   return typeof raw === "number" ? raw : undefined;
+}
+
+/**
+ * The provider status read from the nearest link in the unwrap chain that exposes
+ * one, or undefined. Lets a wrapped provider error still emit its numeric status even
+ * when the top-level wrapper carries none.
+ */
+export function firstStatusInChain(error: unknown): number | undefined {
+  for (const link of unwrapErrorChain(error)) {
+    const status = extractStatus(link);
+
+    if (status !== undefined) {
+      return status;
+    }
+  }
+
+  return undefined;
 }
 
 /**
@@ -384,15 +478,57 @@ export interface ErrorTelemetry {
    * The provider's numeric status, or undefined. A bare integer.
    */
   httpStatus: number | undefined;
+
+  /**
+   * Constructor name of the thrown error, allowlisted to a bare ASCII identifier.
+   * The only signal the residual `agent_error` bucket carries: it turns "unknown"
+   * into a ranked list of unhandled error types. Present only when the class stayed
+   * `agent_error`; undefined for every named class and for a name that failed the
+   * allowlist.
+   */
+  errorName: string | undefined;
 }
 
 /**
- * The single call the failure path uses: class, detail, owner, stage, and status in
- * one object, ready to spread into the run facts. The class and detail come from the
- * origin tag when the throw site owned the classification (build/connector/okf/
- * checkpointer, or a tagged config/tool detail), otherwise from {@link classifyError}
- * reading the raw error. The detail is normalized against its family's allowlist, so
- * an off-list value is dropped rather than emitted. Never leaks the message.
+ * A bare code identifier: an ASCII constructor name, nothing else. A subclass whose
+ * `.name` was set to a template string containing a path, URL, or user value fails
+ * this and is dropped, keeping the anonymity envelope closed.
+ */
+const CONSTRUCTOR_NAME = /^[A-Za-z][A-Za-z0-9]{0,63}$/u;
+
+/**
+ * The constructor name of `value`, but only if it is a plain ASCII identifier;
+ * otherwise undefined. Reads the name through the prototype (not an own
+ * `constructor` property) so a tampered own `constructor` cannot smuggle a value
+ * past the allowlist. Non-objects have no constructor name and yield undefined.
+ *
+ * @param value - The value to fingerprint.
+ * @returns The allowlisted constructor name, or undefined.
+ */
+export function safeConstructorName(value: unknown): string | undefined {
+  if (typeof value !== "object" || value === null) {
+    return undefined;
+  }
+
+  const proto = Object.getPrototypeOf(value) as {
+    constructor?: { name?: unknown };
+  } | null;
+  const raw = proto?.constructor?.name;
+
+  return typeof raw === "string" && CONSTRUCTOR_NAME.test(raw)
+    ? raw
+    : undefined;
+}
+
+/**
+ * The single call the failure path uses: class, detail, owner, stage, status, and
+ * (residual only) the error-name fingerprint in one object, ready to spread into the
+ * run facts. The class and detail come from the origin tag when the throw site owned
+ * the classification (build/connector/okf/checkpointer, or a tagged config/tool
+ * detail), otherwise from {@link classifyError} walking the unwrap chain. The detail
+ * is normalized against its family's allowlist, so an off-list value is dropped
+ * rather than emitted. `errorName` is attached only when the class stayed
+ * `agent_error`, since every other class is already named. Never leaks the message.
  */
 export function describeErrorForTelemetry(error: unknown): ErrorTelemetry {
   const origin = readErrorOrigin(error);
@@ -413,6 +549,11 @@ export function describeErrorForTelemetry(error: unknown): ErrorTelemetry {
     errorDetail,
     errorStage,
     errorOwner: deriveOwner(errorClass, errorDetail, errorStage),
-    httpStatus: extractStatus(error),
+    // Surfaced from the chain so a wrapped provider error still emits its status
+    // even when an origin tag already named the class.
+    httpStatus: firstStatusInChain(error),
+    // Only the residual bucket pays for a fingerprint; named classes stay undefined.
+    errorName:
+      errorClass === "agent_error" ? safeConstructorName(error) : undefined,
   };
 }

--- a/src/telemetry/record-run-safe.ts
+++ b/src/telemetry/record-run-safe.ts
@@ -44,6 +44,7 @@ export async function recordRunSafe(
     errorOwner?: TelemetryErrorOwner;
     errorStage?: TelemetryErrorStage;
     httpStatus?: number;
+    errorName?: string;
   },
 ): Promise<void> {
   // Chat is deliberately not recorded: it is interactive and would emit one
@@ -62,6 +63,7 @@ export async function recordRunSafe(
     errorOwner: facts.errorOwner,
     errorStage: facts.errorStage,
     httpStatus: facts.httpStatus,
+    errorName: facts.errorName,
     // Setup choices are captured on init only (the configuration moment); on
     // updates these are omitted entirely.
     ...(command === "init"

--- a/src/telemetry/senders.ts
+++ b/src/telemetry/senders.ts
@@ -86,6 +86,10 @@ export function buildRunEvent(
       ...(details.httpStatus !== undefined
         ? { http_status: details.httpStatus }
         : {}),
+      // Residual-only fingerprint: an allowlisted constructor identifier, the one
+      // signal the `agent_error` bucket carries. Omitted for every named class, so
+      // the null bucket reads as "already classified" rather than a value.
+      ...(details.errorName ? { error_name: details.errorName } : {}),
       ...(details.mode ? { mode: details.mode } : {}),
       ...(details.provider ? { provider: details.provider } : {}),
       ...connectorProperties(details.configuredConnectors ?? []),

--- a/src/telemetry/types.ts
+++ b/src/telemetry/types.ts
@@ -118,6 +118,17 @@ export interface RunTelemetry {
   httpStatus?: number;
 
   /**
+   * Constructor name of a residual (`agent_error`) failure's thrown error, a bare
+   * ASCII identifier. The only signal the residual bucket carries, so it can be
+   * broken down into a ranked list of unhandled error types. Present only on a
+   * failure that stayed `agent_error`.
+   *
+   * @default undefined - the failure was classified into a named family, or the
+   * constructor name failed the identifier allowlist.
+   */
+  errorName?: string;
+
+  /**
    * Which brain was set up (code = repository, personal = local wiki). Init
    * only; undefined on updates.
    */

--- a/test/crash-guard.test.ts
+++ b/test/crash-guard.test.ts
@@ -1,0 +1,173 @@
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  type MockInstance,
+  test,
+  vi,
+} from "vitest";
+
+// The crash guard's two side effects are mocked so the post-mortem can be asserted
+// without a real telemetry send or a metadata write. describeErrorForTelemetry is
+// left REAL, so these tests also prove a residual crash is classified and
+// fingerprinted (agent_error + error_name) on the way through the guard.
+const recordRunSafe = vi.fn(() => Promise.resolve(undefined));
+const persistRunMetadataIfChanged = vi.fn(() => Promise.resolve(true));
+
+vi.mock("../src/telemetry/record-run-safe.ts", () => ({
+  recordRunSafe: (...args: unknown[]) => recordRunSafe(...args),
+}));
+vi.mock("../src/agent/utils.ts", () => ({
+  persistRunMetadataIfChanged: (...args: unknown[]) =>
+    persistRunMetadataIfChanged(...args),
+}));
+
+import {
+  clearActiveRun,
+  getActiveRun,
+  handleFatal,
+  registerActiveRun,
+  type ActiveRunRecord,
+} from "../src/agent/crash-guard.ts";
+
+const ACTIVE: ActiveRunRecord = {
+  command: "init",
+  cwd: "/repo",
+  modelId: "some-model",
+  outputMode: "repository",
+  snapshotBefore: "snapshot-hash",
+  language: "en",
+};
+
+/**
+ * Awaits handleFatal, then flushes the one setImmediate it schedules for the exit,
+ * so process.exit can be asserted synchronously afterward.
+ */
+async function runFatal(source: string, error: unknown): Promise<void> {
+  await handleFatal(source, error);
+  await new Promise((resolve) => setImmediate(resolve));
+}
+
+let exitSpy: MockInstance;
+let stderrSpy: MockInstance;
+
+beforeEach(() => {
+  recordRunSafe.mockClear();
+  persistRunMetadataIfChanged.mockClear();
+  // Neutralize the two process-level effects so a test never actually exits or
+  // spams the reporter.
+  exitSpy = vi
+    .spyOn(process, "exit")
+    .mockImplementation(() => undefined as never);
+  stderrSpy = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+});
+
+afterEach(() => {
+  clearActiveRun();
+  exitSpy.mockRestore();
+  stderrSpy.mockRestore();
+});
+
+describe("active-run registry", () => {
+  test("round-trips a registration and clears it", () => {
+    expect(getActiveRun()).toBeUndefined();
+
+    registerActiveRun(ACTIVE);
+    expect(getActiveRun()).toEqual(ACTIVE);
+
+    clearActiveRun();
+    expect(getActiveRun()).toBeUndefined();
+  });
+});
+
+describe("handleFatal", () => {
+  test("records the crash as a classified, fingerprinted failure", async () => {
+    registerActiveRun(ACTIVE);
+
+    await runFatal("unhandledRejection", new TypeError("boom"));
+
+    expect(recordRunSafe).toHaveBeenCalledTimes(1);
+    const [command, options, facts] = recordRunSafe.mock.calls[0] as [
+      string,
+      { outputMode: string },
+      Record<string, unknown>,
+    ];
+    expect(command).toBe("init");
+    expect(options).toEqual({ outputMode: "repository" });
+    // The real describeErrorForTelemetry ran: a residual crash is agent_error with
+    // its constructor name as the fingerprint.
+    expect(facts).toMatchObject({
+      outcome: "failure",
+      errorClass: "agent_error",
+      errorName: "TypeError",
+    });
+  });
+
+  test("stamps the interrupted run so the next update retries", async () => {
+    registerActiveRun(ACTIVE);
+
+    await runFatal("uncaughtException", new Error("boom"));
+
+    expect(persistRunMetadataIfChanged).toHaveBeenCalledWith(
+      "init",
+      "/repo",
+      "some-model",
+      "repository",
+      "snapshot-hash",
+      "interrupted",
+      "en",
+    );
+  });
+
+  test("clears the active run and exits non-zero", async () => {
+    registerActiveRun(ACTIVE);
+
+    await runFatal("unhandledRejection", new Error("boom"));
+
+    expect(getActiveRun()).toBeUndefined();
+    expect(exitSpy).toHaveBeenCalledWith(1);
+  });
+
+  test("a failing recorder does not skip the stamp or the exit", async () => {
+    registerActiveRun(ACTIVE);
+    recordRunSafe.mockRejectedValueOnce(new Error("telemetry down"));
+
+    await runFatal("unhandledRejection", new Error("boom"));
+
+    // Each side effect is independently guarded: the recorder throwing must not
+    // prevent the interrupted stamp or the exit.
+    expect(persistRunMetadataIfChanged).toHaveBeenCalledTimes(1);
+    expect(exitSpy).toHaveBeenCalledWith(1);
+  });
+
+  test("a failing stamp does not prevent the exit", async () => {
+    registerActiveRun(ACTIVE);
+    persistRunMetadataIfChanged.mockRejectedValueOnce(new Error("disk full"));
+
+    await runFatal("unhandledRejection", new Error("boom"));
+
+    expect(exitSpy).toHaveBeenCalledWith(1);
+  });
+
+  test("with no active run it still exits but records nothing", async () => {
+    // A crash before any run registered (or after it cleared): there is nothing to
+    // attribute, but the process must still exit rather than limp on.
+    await runFatal("uncaughtException", new Error("early boom"));
+
+    expect(recordRunSafe).not.toHaveBeenCalled();
+    expect(persistRunMetadataIfChanged).not.toHaveBeenCalled();
+    expect(exitSpy).toHaveBeenCalledWith(1);
+  });
+
+  test("writes exactly one stderr line for the local failure UX", async () => {
+    registerActiveRun(ACTIVE);
+
+    await runFatal("unhandledRejection", new Error("visible message"));
+
+    expect(stderrSpy).toHaveBeenCalledTimes(1);
+    const line = stderrSpy.mock.calls[0]?.[0] as string;
+    expect(line).toContain("unhandledRejection");
+    expect(line).toContain("visible message");
+  });
+});

--- a/test/telemetry.test.ts
+++ b/test/telemetry.test.ts
@@ -28,9 +28,12 @@ import { DEFAULT_POSTHOG_KEY } from "../src/telemetry/config.ts";
 import {
   classifyError,
   describeErrorForTelemetry,
+  firstStatusInChain,
   inStage,
   inStageSync,
+  safeConstructorName,
   tagErrorStage,
+  unwrapErrorChain,
 } from "../src/telemetry/errors.ts";
 import {
   deriveOwner,
@@ -215,6 +218,199 @@ describe("classifyError - provider granularity", () => {
   });
 });
 
+describe("classifyError - unwrapping wrapped errors", () => {
+  test("recovers a provider status from a cause chain", () => {
+    // The top-level wrapper carries no status; the real signal is one `cause`
+    // deep. This is the tool-error-wrapping-a-429 shape that today falls through.
+    const wrapped = new Error("tool failed");
+    (wrapped as { cause?: unknown }).cause = { status: 429 };
+
+    expect(classifyError(wrapped)).toEqual({
+      errorClass: "provider_error",
+      errorDetail: "rate_limit",
+    });
+  });
+
+  test("recovers a signal from AggregateError.errors", () => {
+    // Parallel subagents can surface as an AggregateError; the classifiable link
+    // is inside the `errors` array, not on the aggregate itself.
+    const aggregate = new AggregateError(
+      [new Error("wrapper"), new Error("getaddrinfo ENOTFOUND api.host")],
+      "all failed",
+    );
+
+    expect(classifyError(aggregate)).toEqual({
+      errorClass: "network_error",
+      errorDetail: "dns",
+    });
+  });
+
+  test("nearest classifiable link wins over a deeper one", () => {
+    // A 401 wrapping a 429 classifies as auth: the walk is nearest-first, so the
+    // outer recognized signal is returned before the inner one is reached.
+    const outer = Object.assign(new Error("auth wrapper"), { status: 401 });
+    (outer as { cause?: unknown }).cause = { status: 429 };
+
+    expect(classifyError(outer)).toEqual({
+      errorClass: "provider_error",
+      errorDetail: "auth",
+    });
+  });
+
+  test("terminates on a cyclic cause chain and returns the residual", () => {
+    // A self-referential cause must not hang the walk; with no signal it stays
+    // residual.
+    const cyclic = new Error("loop");
+    (cyclic as { cause?: unknown }).cause = cyclic;
+
+    expect(classifyError(cyclic)).toEqual({ errorClass: "agent_error" });
+  });
+
+  test("stops at the depth bound: a signal below it is not reached", () => {
+    // Six nested wrappers put the only real signal (a 429) below MAX_UNWRAP_DEPTH
+    // (5), so the walk bounds out at the residual rather than recovering it. This
+    // is the DoS guard: a pathologically deep chain costs at most five links.
+    let deep: { message: string; cause?: unknown } = { message: "w0" };
+    const root = deep;
+    for (let i = 1; i <= 5; i++) {
+      const next = { message: `w${i}` };
+      deep.cause = next;
+      deep = next;
+    }
+    deep.cause = { status: 429 };
+
+    expect(classifyError(root)).toEqual({ errorClass: "agent_error" });
+  });
+
+  test("a signal within the depth bound is still recovered", () => {
+    // The same shape but with the 429 at depth 3 is found: the bound only drops
+    // signals genuinely past five links.
+    const l0 = new Error("w0");
+    const l1 = new Error("w1");
+    const l2 = { status: 429 };
+    (l0 as { cause?: unknown }).cause = l1;
+    (l1 as { cause?: unknown }).cause = l2;
+
+    expect(classifyError(l0)).toEqual({
+      errorClass: "provider_error",
+      errorDetail: "rate_limit",
+    });
+  });
+
+  test("an unwrapped error still classifies exactly as before", () => {
+    // A chain of length one must behave identically to the pre-unwrap classifier.
+    expect(classifyError({ status: 401 })).toEqual({
+      errorClass: "provider_error",
+      errorDetail: "auth",
+    });
+    expect(classifyError(new Error("nothing recognizable"))).toEqual({
+      errorClass: "agent_error",
+    });
+  });
+
+  test("unwrapErrorChain is read-only, cycle-safe, and depth-bounded", () => {
+    const cyclic = new Error("a");
+    (cyclic as { cause?: unknown }).cause = cyclic;
+
+    const chain = unwrapErrorChain(cyclic);
+    // Never longer than the bound, even for a cycle.
+    expect(chain.length).toBeLessThanOrEqual(5);
+    // The first link is always the original value.
+    expect(chain[0]).toBe(cyclic);
+    // A thrown non-object is still the sole link, so classification is unchanged.
+    expect(unwrapErrorChain("boom")).toEqual(["boom"]);
+  });
+});
+
+describe("safeConstructorName allowlist", () => {
+  test("accepts a plain ASCII constructor name", () => {
+    expect(safeConstructorName(new TypeError("x"))).toBe("TypeError");
+    expect(safeConstructorName(new Error("x"))).toBe("Error");
+  });
+
+  test("reads the prototype, ignoring a tampered own constructor", () => {
+    // An own `constructor` property must not smuggle a value past the allowlist:
+    // the name comes from the prototype chain (here, Object), not the own prop.
+    const tampered = { constructor: { name: "PwnedError/../etc" } };
+
+    expect(safeConstructorName(tampered)).toBe("Object");
+  });
+
+  test("drops names that are not bare identifiers", () => {
+    const withName = (name: string): unknown => {
+      class Custom {}
+      Object.defineProperty(Custom, "name", { value: name });
+      return new Custom();
+    };
+
+    expect(safeConstructorName(withName("has space"))).toBeUndefined();
+    expect(safeConstructorName(withName("a/b"))).toBeUndefined();
+    expect(
+      safeConstructorName(withName("/Users/me/secret/path")),
+    ).toBeUndefined();
+    expect(safeConstructorName(withName("a".repeat(65)))).toBeUndefined();
+    // A 64-char identifier is the longest allowed and still passes.
+    expect(safeConstructorName(withName("a".repeat(64)))).toBe("a".repeat(64));
+  });
+
+  test("non-objects have no constructor name", () => {
+    expect(safeConstructorName("string")).toBeUndefined();
+    expect(safeConstructorName(42)).toBeUndefined();
+    expect(safeConstructorName(null)).toBeUndefined();
+    expect(safeConstructorName(undefined)).toBeUndefined();
+  });
+});
+
+describe("describeErrorForTelemetry - residual fingerprint", () => {
+  test("a residual failure carries its error_name and no status", () => {
+    const described = describeErrorForTelemetry(new TypeError("boom"));
+
+    expect(described.errorClass).toBe("agent_error");
+    expect(described.errorName).toBe("TypeError");
+    expect(described.httpStatus).toBeUndefined();
+  });
+
+  test("a named class carries no error_name", () => {
+    // Only the residual bucket pays for a fingerprint; a real 401 is already named.
+    const described = describeErrorForTelemetry({ status: 401 });
+
+    expect(described.errorClass).toBe("provider_error");
+    expect(described.errorName).toBeUndefined();
+  });
+
+  test("a residual with an un-allowlisted name drops error_name to undefined", () => {
+    class Weird {}
+    Object.defineProperty(Weird, "name", { value: "weird name/with space" });
+
+    const described = describeErrorForTelemetry(new Weird());
+
+    expect(described.errorClass).toBe("agent_error");
+    expect(described.errorName).toBeUndefined();
+  });
+
+  test("http_status is surfaced from a wrapped provider error", () => {
+    // firstStatusInChain reaches the status one cause deep even though the class
+    // was recovered from the same link.
+    const wrapped = new Error("tool failed");
+    (wrapped as { cause?: unknown }).cause = { status: 503 };
+
+    const described = describeErrorForTelemetry(wrapped);
+
+    expect(described.errorClass).toBe("provider_error");
+    expect(described.errorDetail).toBe("overloaded");
+    expect(described.httpStatus).toBe(503);
+    // A recovered (named) class is not fingerprinted.
+    expect(described.errorName).toBeUndefined();
+  });
+
+  test("firstStatusInChain returns undefined when no link exposes a status", () => {
+    const wrapped = new Error("outer");
+    (wrapped as { cause?: unknown }).cause = new Error("inner");
+
+    expect(firstStatusInChain(wrapped)).toBeUndefined();
+  });
+});
+
 describe("taxonomy", () => {
   test("deriveOwner encodes the default owners", () => {
     expect(deriveOwner("config_error", "missing_credentials", "config")).toBe(
@@ -333,12 +529,16 @@ describe("error origin tags", () => {
   });
 
   test("leaves detail, stage, and status undefined when absent", () => {
+    // A bare residual Error carries no detail/stage/status, but it is still
+    // fingerprinted: "Error" is an allowlisted constructor name, so the residual
+    // agent_error bucket gains an error_name to slice on.
     expect(describeErrorForTelemetry(new Error("boom"))).toEqual({
       errorClass: "agent_error",
       errorDetail: undefined,
       errorStage: undefined,
       errorOwner: "unowned",
       httpStatus: undefined,
+      errorName: "Error",
     });
   });
 });
@@ -732,6 +932,38 @@ describe("buildRunEvent diagnostics", () => {
     expect(event.properties).not.toHaveProperty("error_owner");
     expect(event.properties).not.toHaveProperty("error_stage");
     expect(event.properties).not.toHaveProperty("http_status");
+    expect(event.properties).not.toHaveProperty("error_name");
+  });
+
+  test("the residual fingerprint rides only when error_name is present", () => {
+    // A residual failure carries error_name; a named class leaves it undefined so
+    // the property is absent and the PostHog null bucket reads as "classified".
+    const residual = buildRunEvent(
+      {
+        command: "init",
+        outcome: "failure",
+        errorClass: "agent_error",
+        errorOwner: "unowned",
+        errorStage: "run",
+        errorName: "TypeError",
+      },
+      baseContext,
+    );
+    expect(residual.properties).toMatchObject({ error_name: "TypeError" });
+
+    const named = buildRunEvent(
+      {
+        command: "init",
+        outcome: "failure",
+        errorClass: "provider_error",
+        errorDetail: "rate_limit",
+        errorOwner: "provider",
+        errorStage: "run",
+        httpStatus: 429,
+      },
+      baseContext,
+    );
+    expect(named.properties).not.toHaveProperty("error_name");
   });
 
   test("http_status of 0 would still ride, but omission is by undefined only", () => {
@@ -901,6 +1133,11 @@ describe("anonymity envelope: one representative failure per reachable family", 
           // A bare integer; no provider strings ride with it.
           expect(Number.isInteger(value)).toBe(true);
           break;
+        case "error_name":
+          // A bare ASCII constructor identifier, nothing else: the residual
+          // fingerprint is gated to exactly this shape before it can leave.
+          expect(value).toMatch(/^[A-Za-z][A-Za-z0-9]{0,63}$/u);
+          break;
         case "app_version":
           expect(value).toMatch(/^\d+\.\d+\.\d+/u);
           break;
@@ -1033,6 +1270,7 @@ describe("anonymity envelope: one representative failure per reachable family", 
           errorOwner: described.errorOwner,
           errorStage: described.errorStage,
           httpStatus: described.httpStatus,
+          errorName: described.errorName,
         },
         sweepContext,
       );


### PR DESCRIPTION
## Summary

Our telemetry lumps most failures into an opaque agent_error bucket so we can't tell what's actually breaking during init and update. This PR is about visibility, not lowering the failure rate. Three changes:

- Unwrap before classifying. Errors often arrive wrapped, with the real provider status on a cause or errors link. We now walk that chain so a wrapped rate-limit or DNS failure gets classified correctly instead of falling through to agent_error.
- Fingerprint the residual bucket. Anything still landing in agent_error now carries an error_name (the error's constructor, run through a strict ASCII allowlist so no raw strings leak). That gives us something to slice the bucket by.
- Catch escaped crashes. A subagent rejection can escape the stream loop as a process-level unhandledRejection and hard-kill the run with nothing recorded. A crash guard now catches it, records it as a classified failure, stamps the run interrupted so the next update retries, and exits cleanly.

## Tests

- Unit tests for chain unwrapping, the error_name allowlist, and the residual fingerprint in test/telemetry.test.ts.
- New test/crash-guard.test.ts covering the active-run registry and the crash handler: records the failure, stamps interrupted, guards each side effect independently, and always exits non-zero.

---

Closes #494