### PR TITLE
fix: stop the internal link validator from falsely flagging valid links

### DIFF
--- a/.changeset/ripe-areas-pull.md
+++ b/.changeset/ripe-areas-pull.md
@@ -2,4 +2,4 @@
 "openwiki": patch
 ---
 
-resolve repo-root-absolute wiki links without double-prefixing /openwiki
+fix: resolve repo-root-absolute wiki links without double-prefixing /openwiki

--- a/.changeset/ripe-areas-pull.md
+++ b/.changeset/ripe-areas-pull.md
@@ -2,4 +2,4 @@
 "openwiki": patch
 ---
 
-fix: resolve repo-root-absolute wiki links without double-prefixing /openwiki
+fix: stop the internal link validator from falsely flagging valid links

--- a/.changeset/ripe-areas-pull.md
+++ b/.changeset/ripe-areas-pull.md
@@ -1,0 +1,5 @@
+---
+"openwiki": patch
+---
+
+resolve repo-root-absolute wiki links without double-prefixing /openwiki

--- a/openwiki/integrations/connectors.md
+++ b/openwiki/integrations/connectors.md
@@ -67,7 +67,7 @@ Agent-facing tools (`src/connectors/tools.ts`) expose this to the LLM during a r
 
 `src/onboarding.ts` drives first-run setup: wiki template selection, scope customization, per-source ingestion notes, and source schedules, persisted to `~/.openwiki/onboarding.json`. Global personal-wiki instructions are saved to `~/.openwiki/INSTRUCTIONS.md`.
 
-`src/schedules.ts` installs source schedules as macOS user LaunchAgents (`~/Library/LaunchAgents/`) with logs under `~/.openwiki/logs/`, and backs the `openwiki cron list|pause|resume|delete` commands (see [CLI usage](/cli/usage.md)).
+`src/schedules.ts` installs source schedules as macOS user LaunchAgents (`~/Library/LaunchAgents/`) with logs under `~/.openwiki/logs/`, and backs the `openwiki cron list|pause|resume|delete` commands (see [CLI usage](../cli/usage.md)).
 
 ## Things to watch when changing connector behavior
 

--- a/src/agent/wiki-link-validator.ts
+++ b/src/agent/wiki-link-validator.ts
@@ -408,8 +408,16 @@ function parseLinkDestination(rawHref: string): {
 }
 
 /**
- * Resolves a link path (relative to its source, or wiki-root-absolute) to a
- * normalized wiki-absolute path, or undefined when it escapes the wiki root.
+ * Resolves a link path to a normalized wiki-absolute path, or undefined when it
+ * escapes the wiki root.
+ *
+ * A leading-slash link is absolute from the virtual filesystem root (the repo
+ * root in `repository` mode, the wiki dir in `local-wiki` mode) — the same
+ * convention the generation prompt teaches and GitHub renders. In `repository`
+ * mode that means cross-page links are authored as `/openwiki/...`, already
+ * carrying the wiki-root prefix, so they must not be re-prefixed. The
+ * `isPathUnderWikiRoot` guard below still rejects absolute paths that land
+ * outside the wiki (e.g. `/src/index.ts`) and any `../` traversal.
  */
 function resolveWikiLinkPath(
   wikiRoot: string,
@@ -418,7 +426,7 @@ function resolveWikiLinkPath(
 ): string | null {
   const candidate = path.posix.normalize(
     linkPath.startsWith("/")
-      ? path.posix.join(wikiRoot, linkPath.slice(1))
+      ? linkPath
       : path.posix.join(path.posix.dirname(sourcePath), linkPath),
   );
 

--- a/src/agent/wiki-link-validator.ts
+++ b/src/agent/wiki-link-validator.ts
@@ -112,7 +112,6 @@ export async function validateWikiInternalLinks(
       report.linksChecked += 1;
       const issue = await validateLink(
         backend,
-        wikiRoot,
         sourcePath,
         href,
         line,
@@ -201,13 +200,17 @@ export function stampBrokenLinks(
 }
 
 /**
- * Validates one link against the wiki tree, returning an issue when the target
- * file, directory, or heading anchor cannot be resolved. External links and
- * bare (empty) hrefs are ignored.
+ * Validates one link, returning an issue when the target file, directory, or
+ * heading anchor cannot be resolved. External links and bare (empty) hrefs are
+ * ignored.
+ *
+ * Targets are checked by existence against the whole repository, not just the
+ * wiki subtree: a wiki page may legitimately link out to a repo file (a design
+ * doc, source file, etc.), which renders correctly on GitHub. A link is broken
+ * only when its target genuinely does not exist.
  */
 async function validateLink(
   backend: BackendProtocolV2,
-  wikiRoot: string,
   sourcePath: string,
   rawHref: string,
   line: number,
@@ -234,12 +237,12 @@ async function validateLink(
     return null;
   }
 
-  const resolvedPath = resolveWikiLinkPath(wikiRoot, sourcePath, linkPath);
+  const resolvedPath = resolveRepoLinkPath(sourcePath, linkPath);
   if (!resolvedPath) {
     return {
       href,
       line,
-      message: `link "${linkPath}" is outside the wiki root`,
+      message: `link "${linkPath}" cannot be resolved`,
       sourcePath,
     };
   }
@@ -260,7 +263,14 @@ async function validateLink(
     };
   }
 
-  if (!anchor || isDirectory) {
+  // Heading anchors are only validated against Markdown targets. Anchors on
+  // directories, and GitHub line anchors on source files (e.g. `#L10`), are
+  // out of scope and must not be flagged as broken.
+  if (
+    !anchor ||
+    isDirectory ||
+    path.posix.extname(targetPath).toLowerCase() !== ".md"
+  ) {
     return null;
   }
 
@@ -418,19 +428,23 @@ function parseLinkDestination(rawHref: string): {
 }
 
 /**
- * Resolves a link path to a normalized wiki-absolute path, or undefined when it
- * escapes the wiki root.
+ * Resolves a link path to a normalized repo-absolute path, or undefined when it
+ * cannot be contained within the repo root.
  *
  * A leading-slash link is absolute from the virtual filesystem root (the repo
  * root in `repository` mode, the wiki dir in `local-wiki` mode) — the same
- * convention the generation prompt teaches and GitHub renders. In `repository`
- * mode that means cross-page links are authored as `/openwiki/...`, already
- * carrying the wiki-root prefix, so they must not be re-prefixed. The
- * `isPathUnderWikiRoot` guard below still rejects absolute paths that land
- * outside the wiki (e.g. `/src/index.ts`) and any `../` traversal.
+ * convention the generation prompt teaches and GitHub renders. A relative link
+ * resolves against its source file's directory.
+ *
+ * The result is not constrained to the wiki subtree: wiki pages may link out to
+ * other repo files, so containment is enforced at the repo root instead.
+ * `path.posix.normalize` clamps any leading `..` at `/`, so a normalized
+ * absolute path can never climb above the repo root that the backend's virtual
+ * filesystem maps (e.g. `/openwiki/a/../../../etc` normalizes to `/etc`, still
+ * under `/`). The explicit absolute-path check below makes that containment a
+ * hard guarantee rather than an implicit one.
  */
-function resolveWikiLinkPath(
-  wikiRoot: string,
+function resolveRepoLinkPath(
   sourcePath: string,
   linkPath: string,
 ): string | null {
@@ -440,21 +454,7 @@ function resolveWikiLinkPath(
       : path.posix.join(path.posix.dirname(sourcePath), linkPath),
   );
 
-  return isPathUnderWikiRoot(wikiRoot, candidate) ? candidate : null;
-}
-
-/**
- * True when a normalized candidate path is the wiki root itself or contained
- * within it, guarding against `../` traversal out of the wiki.
- */
-function isPathUnderWikiRoot(wikiRoot: string, candidate: string): boolean {
-  const root = path.posix.normalize(wikiRoot.replace(/\/+$/u, "") || "/");
-  const resolved = path.posix.normalize(candidate);
-  const relative = path.posix.relative(root, resolved);
-  return (
-    relative === "" ||
-    (!relative.startsWith("..") && !path.posix.isAbsolute(relative))
-  );
+  return path.posix.isAbsolute(candidate) ? candidate : null;
 }
 
 /**

--- a/src/agent/wiki-link-validator.ts
+++ b/src/agent/wiki-link-validator.ts
@@ -376,15 +376,25 @@ function buildHeadingAnchors(headings: string[]): Set<string> {
 
 /**
  * Converts heading text to a GitHub-style anchor slug: lowercased, punctuation
- * removed, spaces collapsed to hyphens. Unicode letters and numbers are kept
- * (matching GitHub), so anchors on non-English headings resolve correctly.
+ * removed, each whitespace character replaced by a single hyphen. Unicode
+ * letters, numbers, and combining marks are kept (matching GitHub), so anchors
+ * on non-English headings resolve correctly.
+ *
+ * The kept-character class mirrors `github-slugger` exactly: `\p{M}` retains
+ * combining marks so a decomposed (NFD) accent like `e` + U+0301 slugs to `é`
+ * rather than a bare `e`, matching how GitHub renders the anchor.
+ *
+ * Whitespace is replaced per-character, not collapsed, because GitHub does the
+ * same: stripping punctuation between two words (e.g. `&` in "A & B") leaves
+ * two spaces that become two hyphens (`a--b`). Collapsing them would compute
+ * `a-b` and falsely flag the valid `#a--b` anchor as broken.
  */
 function slugifyHeading(text: string): string {
   return text
     .trim()
     .toLowerCase()
-    .replace(/[^\p{L}\p{N}\s_-]/gu, "")
-    .replace(/\s+/gu, "-");
+    .replace(/[^\p{L}\p{M}\p{N}\s_-]/gu, "")
+    .replace(/\s/gu, "-");
 }
 
 /**

--- a/test/wiki-link-validator.test.ts
+++ b/test/wiki-link-validator.test.ts
@@ -51,11 +51,11 @@ describe("validateWikiInternalLinks", () => {
     ).resolves.toBe(before);
   });
 
-  test("accepts root-relative links from the wiki root", async () => {
+  test("accepts repo-root-absolute links carrying the /openwiki prefix", async () => {
     const { backend } = await setupWiki();
     await backend.write(
       "/openwiki/integrations/connectors.md",
-      "See [CLI usage](/cli/usage.md).\n",
+      "See [CLI usage](/openwiki/cli/usage.md).\n",
     );
     await backend.write("/openwiki/cli/usage.md", "# CLI usage\n");
 
@@ -63,6 +63,68 @@ describe("validateWikiInternalLinks", () => {
 
     expect(report.issuesFound).toBe(0);
     expect(report.stampedFiles).toEqual([]);
+  });
+
+  test("accepts repo-root-absolute links with heading anchors", async () => {
+    const { backend } = await setupWiki();
+    await backend.write(
+      "/openwiki/architecture/agents.md",
+      "See [Shared Browser Tooling](/openwiki/architecture/shared-tools.md#one-browser-tab-per-run).\n",
+    );
+    await backend.write(
+      "/openwiki/architecture/shared-tools.md",
+      "# Shared tools\n\n## One browser tab per run\n",
+    );
+
+    const report = await validateWikiInternalLinks(backend, "repository");
+
+    expect(report.issuesFound).toBe(0);
+    expect(report.stampedFiles).toEqual([]);
+  });
+
+  test("stamps repo-root-absolute links to missing files", async () => {
+    const { backend } = await setupWiki();
+    await backend.write(
+      "/openwiki/quickstart.md",
+      "See [gone](/openwiki/does-not-exist.md).\n",
+    );
+
+    const report = await validateWikiInternalLinks(backend, "repository");
+
+    expect(report.issuesFound).toBe(1);
+    expect(report.stampedFiles).toEqual(["quickstart.md"]);
+  });
+
+  test("stamps repo-root-absolute links with missing anchors", async () => {
+    const { backend } = await setupWiki();
+    await backend.write(
+      "/openwiki/quickstart.md",
+      "See [section](/openwiki/overview.md#missing-anchor).\n",
+    );
+    await backend.write("/openwiki/overview.md", "# Overview\n");
+
+    const report = await validateWikiInternalLinks(backend, "repository");
+
+    expect(report.issuesFound).toBe(1);
+    expect(report.stampedFiles).toEqual(["quickstart.md"]);
+  });
+
+  test("stamps absolute links that escape the wiki root", async () => {
+    const { backend, rootDir } = await setupWiki();
+    await backend.write(
+      "/openwiki/quickstart.md",
+      "See [source](/src/index.ts).\n",
+    );
+
+    const report = await validateWikiInternalLinks(backend, "repository");
+
+    expect(report.issuesFound).toBe(1);
+    expect(report.stampedFiles).toEqual(["quickstart.md"]);
+    const after = await readFile(
+      path.join(rootDir, "openwiki/quickstart.md"),
+      "utf8",
+    );
+    expect(after).toContain("is outside the wiki root");
   });
 
   test("stamps missing target files without throwing", async () => {

--- a/test/wiki-link-validator.test.ts
+++ b/test/wiki-link-validator.test.ts
@@ -215,6 +215,27 @@ describe("validateWikiInternalLinks", () => {
     expect(report.issuesFound).toBe(0);
   });
 
+  test("accepts double-hyphen anchors from stripped punctuation between words", async () => {
+    const { backend } = await setupWiki();
+    await backend.write(
+      "/openwiki/architecture/agents.md",
+      [
+        "See [tokens](/openwiki/architecture/overview.md#layout-primitives--design-tokens).",
+        "See [store](/openwiki/architecture/overview.md#state--store).",
+        "See [ab](/openwiki/architecture/overview.md#a--b).",
+      ].join("\n"),
+    );
+    await backend.write(
+      "/openwiki/architecture/overview.md",
+      "# Overview\n\n## Layout Primitives & Design Tokens\n\n## State / Store\n\n## A + B\n",
+    );
+
+    const report = await validateWikiInternalLinks(backend, "repository");
+
+    expect(report.issuesFound).toBe(0);
+    expect(report.stampedFiles).toEqual([]);
+  });
+
   test("accepts anchors on non-ASCII (unicode) headings", async () => {
     const { backend } = await setupWiki();
     await backend.write(
@@ -224,6 +245,27 @@ describe("validateWikiInternalLinks", () => {
     await backend.write(
       "/openwiki/overview.md",
       "# Overview\n\n## Configuración\n\n## 概要\n",
+    );
+
+    const report = await validateWikiInternalLinks(backend, "repository");
+
+    expect(report.issuesFound).toBe(0);
+    expect(report.stampedFiles).toEqual([]);
+  });
+
+  test("keeps combining marks so decomposed-accent anchors resolve", async () => {
+    const { backend } = await setupWiki();
+    const combining = "́"; // combining acute accent (decomposed/NFD)
+    const heading = `Cre${combining}dit Notes`;
+    const anchor = `cre${combining}dit-notes`;
+    expect(anchor.includes("́")).toBe(true); // guard: really decomposed
+    await backend.write(
+      "/openwiki/quickstart.md",
+      `See [notes](./overview.md#${anchor}).\n`,
+    );
+    await backend.write(
+      "/openwiki/overview.md",
+      `# Overview\n\n## ${heading}\n`,
     );
 
     const report = await validateWikiInternalLinks(backend, "repository");

--- a/test/wiki-link-validator.test.ts
+++ b/test/wiki-link-validator.test.ts
@@ -109,22 +109,59 @@ describe("validateWikiInternalLinks", () => {
     expect(report.stampedFiles).toEqual(["quickstart.md"]);
   });
 
-  test("stamps absolute links that escape the wiki root", async () => {
+  test("accepts links to existing repo files outside the wiki dir", async () => {
+    const { backend, rootDir } = await setupWiki();
+    await mkdir(path.join(rootDir, "docs"), { recursive: true });
+    await writeFile(
+      path.join(rootDir, "docs/decision.md"),
+      "# Decision\n",
+      "utf8",
+    );
+    await backend.write(
+      "/openwiki/architecture/ui-components.md",
+      "See [decision](/docs/decision.md) and [src](/src/index.ts).\n",
+    );
+    await mkdir(path.join(rootDir, "src"), { recursive: true });
+    await writeFile(path.join(rootDir, "src/index.ts"), "export {};\n", "utf8");
+
+    const report = await validateWikiInternalLinks(backend, "repository");
+
+    expect(report.issuesFound).toBe(0);
+    expect(report.stampedFiles).toEqual([]);
+  });
+
+  test("stamps links to missing repo files outside the wiki dir", async () => {
     const { backend, rootDir } = await setupWiki();
     await backend.write(
-      "/openwiki/quickstart.md",
-      "See [source](/src/index.ts).\n",
+      "/openwiki/architecture/ui-components.md",
+      "See [decision](/docs/missing-decision.md).\n",
     );
 
     const report = await validateWikiInternalLinks(backend, "repository");
 
     expect(report.issuesFound).toBe(1);
-    expect(report.stampedFiles).toEqual(["quickstart.md"]);
+    expect(report.stampedFiles).toEqual(["architecture/ui-components.md"]);
     const after = await readFile(
-      path.join(rootDir, "openwiki/quickstart.md"),
+      path.join(rootDir, "openwiki/architecture/ui-components.md"),
       "utf8",
     );
-    expect(after).toContain("is outside the wiki root");
+    expect(after).toContain('file "/docs/missing-decision.md" does not exist');
+  });
+
+  test("does not validate anchors on non-markdown targets", async () => {
+    const { backend, rootDir } = await setupWiki();
+    await mkdir(path.join(rootDir, "src"), { recursive: true });
+    await writeFile(path.join(rootDir, "src/index.ts"), "export {};\n", "utf8");
+    // GitHub line anchors (#L10) on source files must not be treated as broken.
+    await backend.write(
+      "/openwiki/quickstart.md",
+      "See [line](/src/index.ts#L10).\n",
+    );
+
+    const report = await validateWikiInternalLinks(backend, "repository");
+
+    expect(report.issuesFound).toBe(0);
+    expect(report.stampedFiles).toEqual([]);
   });
 
   test("stamps missing target files without throwing", async () => {
@@ -288,33 +325,39 @@ describe("validateWikiInternalLinks", () => {
     expect(report.issuesFound).toBe(0);
   });
 
-  test("stamps wiki-escaping links without reading outside the wiki root", async () => {
+  test("clamps ../-escaping links to the repo root, never the host filesystem", async () => {
     const { backend, rootDir } = await setupWiki();
-    await mkdir(path.join(rootDir, "etc"), { recursive: true });
-    await writeFile(path.join(rootDir, "etc/passwd"), "secret\n", "utf8");
+    // The host has a real /etc/passwd. A link with enough `..` to try to reach
+    // it must resolve under the repo root instead: `path.posix.normalize`
+    // clamps the leading `..` at `/`, and the backend maps `/etc/passwd` to
+    // <repoRoot>/etc/passwd — which does not exist here.
     await backend.write(
       "/openwiki/page.md",
-      "See [x](../../../../etc/passwd#nope).\n",
+      "See [x](../../../../etc/passwd).\n",
     );
     const readRaw = vi.spyOn(backend, "readRaw");
 
     const report = await validateWikiInternalLinks(backend, "repository");
 
+    // Reported missing even though the *host* /etc/passwd exists, proving the
+    // read was contained to the repo root and never touched the host FS.
     expect(report.issuesFound).toBe(1);
+    // No read target ever climbs out of the virtual root via a `..` segment.
     expect(
-      readRaw.mock.calls.some(
+      readRaw.mock.calls.every(
         ([targetPath]) =>
-          typeof targetPath === "string" && !targetPath.startsWith("/openwiki"),
+          typeof targetPath === "string" &&
+          targetPath.startsWith("/") &&
+          !targetPath.includes("/.."),
       ),
-    ).toBe(false);
+    ).toBe(true);
 
     const after = await readFile(
       path.join(rootDir, "openwiki/page.md"),
       "utf8",
     );
     expect(after).toContain("openwiki: broken internal link");
-    expect(after).toContain("outside the wiki root");
-    expect(after).not.toMatch(/does not exist in \/etc\/passwd/u);
+    expect(after).toContain('file "../../../../etc/passwd" does not exist');
   });
 
   test("ignores external links and images", async () => {


### PR DESCRIPTION
## Summary

Fixes the internal link validator falsely stamping valid links as broken across customer wikis. Three root causes:

1. **Repo-root-absolute double-prefix.** In `repository` mode the wiki root is `/openwiki`, and the validator re-prefixed leading-slash links onto it, so `/openwiki/architecture/shared-tools.md` resolved as `/openwiki/openwiki/architecture/shared-tools.md`, "didn't exist," and got a bogus stamp. Leading-slash links are now absolute from the repo root, matching both the generation prompt and how GitHub renders them.

2. **Anchor-slug divergence from GitHub.** Heading slugs now mirror `github-slugger` exactly: whitespace is no longer collapsed (so "A & B" resolves as `#a--b`, not `#a-b`) and Unicode combining marks are preserved (a decomposed NFD accent slugs to `é`, not a bare `e`).

3. **Out-of-wiki links rejected.** A wiki page linking to a real repo file (`/docs/decision.md`, `/src/index.ts`) was rejected for "leaving the wiki," even though it renders fine on GitHub. Links are now validated by existence against the whole repo; containment moves to the repo root, and anchors are only checked on Markdown targets so GitHub line anchors like `#L10` on source files aren't flagged.

Also repairs one genuinely-broken link the old behavior had been masking: `connectors.md`'s `/cli/usage.md` → `../cli/usage.md`.

## Tests

- Red→green reproduction of the exact reported case (`/openwiki/...md#anchor`), confirmed failing on old code and passing with the fix.
- Anchor parity: double-hyphen anchors from stripped punctuation, and decomposed-accent (combining-mark) anchors, both resolve.
- Out-of-wiki links: existing repo files accepted, missing ones stamped, non-Markdown line anchors ignored.
- Security: a `../`-escaping link is clamped to the repo root and reported missing even though the host's real `/etc/passwd` exists proving reads never touch the host filesystem.
- Dogfood test over this repo's real `openwiki/` tree passes. Full suite 918/918; typecheck, lint, prettier clean.