### PR TITLE
fix: gate connector tools to personal/local-wiki runs

### DIFF
--- a/.changeset/fix-connector-tool-mode-gating.md
+++ b/.changeset/fix-connector-tool-mode-gating.md
@@ -2,4 +2,4 @@
 "openwiki": patch
 ---
 
-Gate OpenWiki connector tools by run mode. `createOpenWikiConnectorTools` now takes an `outputMode` and returns no connector tools for `repository` (code) mode, so code-mode agents are no longer offered credentialed external ingestion tools (Gmail, Slack, X, ...) that throw on missing credentials. Personal/local-wiki runs are unchanged. Fixes #444.
+fix: gate connector tools to personal/local-wiki runs

--- a/.changeset/fix-connector-tool-mode-gating.md
+++ b/.changeset/fix-connector-tool-mode-gating.md
@@ -1,0 +1,5 @@
+---
+"openwiki": patch
+---
+
+Gate OpenWiki connector tools by run mode. `createOpenWikiConnectorTools` now takes an `outputMode` and returns no connector tools for `repository` (code) mode, so code-mode agents are no longer offered credentialed external ingestion tools (Gmail, Slack, X, ...) that throw on missing credentials. Personal/local-wiki runs are unchanged. Fixes #444.

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -367,7 +367,7 @@ function createOpenWikiAgentGraph(
 
   return createDeepAgent({
     model: options.model,
-    tools: createOpenWikiConnectorTools(),
+    tools: createOpenWikiConnectorTools(options.outputMode),
     checkpointer: options.checkpointer,
     backend,
     middleware:

--- a/src/connectors/tools.ts
+++ b/src/connectors/tools.ts
@@ -5,6 +5,7 @@ import {
 import { constants as fsConstants } from "node:fs";
 import { lstat, open, readdir, stat } from "node:fs/promises";
 import path from "node:path";
+import type { OpenWikiOutputMode } from "../agent/types.js";
 import {
   getConnectorConfigPath,
   getConnectorRawDir,
@@ -20,7 +21,18 @@ import {
 } from "./mcp-runtime.js";
 import type { ConnectorId, ConnectorIngestOptions } from "./types.js";
 
-export function createOpenWikiConnectorTools(): StructuredToolInterface[] {
+export function createOpenWikiConnectorTools(
+  outputMode: OpenWikiOutputMode = "local-wiki",
+): StructuredToolInterface[] {
+  // Connector tools perform credentialed external fetches (Gmail, Slack, X, ...)
+  // and write raw data under the OpenWiki home. They are a personal/local-wiki
+  // capability: a code-mode run documents a codebase and must never be handed
+  // connector ingestion, which otherwise throws on missing credentials and
+  // wastes tokens discovering sources it has no business touching. See #444.
+  if (outputMode === "repository") {
+    return [];
+  }
+
   return [
     new DynamicStructuredTool({
       name: "openwiki_list_connectors",

--- a/test/connectors/raw-connector-tools.test.ts
+++ b/test/connectors/raw-connector-tools.test.ts
@@ -165,8 +165,7 @@ interface RawReadResult {
 async function loadConnectorTools(
   home: string,
 ): Promise<StructuredToolInterface[]> {
-  const { createOpenWikiConnectorTools } =
-    await loadConnectorToolsModule(home);
+  const { createOpenWikiConnectorTools } = await loadConnectorToolsModule(home);
 
   return createOpenWikiConnectorTools();
 }
@@ -175,8 +174,7 @@ async function loadConnectorToolsForMode(
   home: string,
   outputMode: "local-wiki" | "repository",
 ): Promise<StructuredToolInterface[]> {
-  const { createOpenWikiConnectorTools } =
-    await loadConnectorToolsModule(home);
+  const { createOpenWikiConnectorTools } = await loadConnectorToolsModule(home);
 
   return createOpenWikiConnectorTools(outputMode);
 }

--- a/test/connectors/raw-connector-tools.test.ts
+++ b/test/connectors/raw-connector-tools.test.ts
@@ -119,6 +119,37 @@ describe("raw connector tools", () => {
   });
 });
 
+describe("connector tool run-mode gating (#444)", () => {
+  test("personal/local-wiki mode exposes connector ingest tools", async () => {
+    const home = await createTempHome();
+    const tools = await loadConnectorToolsForMode(home, "local-wiki");
+
+    expect(tools.map((tool) => tool.name)).toContain(
+      "openwiki_ingest_connector",
+    );
+    expect(tools.map((tool) => tool.name)).toContain(
+      "openwiki_ingest_all_connectors",
+    );
+  });
+
+  test("code/repository mode is not offered any connector tools", async () => {
+    const home = await createTempHome();
+    const tools = await loadConnectorToolsForMode(home, "repository");
+
+    expect(tools).toEqual([]);
+  });
+
+  test("defaulting without a mode behaves like local-wiki", async () => {
+    const home = await createTempHome();
+    const tools = await loadConnectorTools(home);
+
+    expect(tools.length).toBeGreaterThan(0);
+    expect(tools.map((tool) => tool.name)).toContain(
+      "openwiki_ingest_connector",
+    );
+  });
+});
+
 interface RawItemsResult {
   files: string[];
   latestFiles: string[];
@@ -134,13 +165,30 @@ interface RawReadResult {
 async function loadConnectorTools(
   home: string,
 ): Promise<StructuredToolInterface[]> {
+  const { createOpenWikiConnectorTools } =
+    await loadConnectorToolsModule(home);
+
+  return createOpenWikiConnectorTools();
+}
+
+async function loadConnectorToolsForMode(
+  home: string,
+  outputMode: "local-wiki" | "repository",
+): Promise<StructuredToolInterface[]> {
+  const { createOpenWikiConnectorTools } =
+    await loadConnectorToolsModule(home);
+
+  return createOpenWikiConnectorTools(outputMode);
+}
+
+async function loadConnectorToolsModule(
+  home: string,
+): Promise<typeof import("../../src/connectors/tools.ts")> {
   vi.resetModules();
   process.env.HOME = home;
   process.env.USERPROFILE = home;
-  const { createOpenWikiConnectorTools } =
-    await import("../../src/connectors/tools.ts");
 
-  return createOpenWikiConnectorTools();
+  return import("../../src/connectors/tools.ts");
 }
 
 function getTool(


### PR DESCRIPTION
## Summary

Fixes #444 — connector ingest tools are exposed to `code`-mode agents even though a codebase-documentation run has no business ingesting Gmail/Slack/X.

- `createOpenWikiConnectorTools` now accepts an `outputMode` and returns `[]` for `repository` (code) mode.
- The single call site (`src/agent/index.ts`) passes `options.outputMode`, which is already `"repository"` for code mode and `"local-wiki"` for personal/chat (see `getRunModeOutputMode`).
- Personal/local-wiki runs are unchanged — they keep the full connector toolset.

## Why

In code mode the agent documents a repo and writes `openwiki/*.md`. With the full connector toolset present, a subagent can call e.g. `openwiki_ingest_connector({connectorId:"google"})`, which throws `Gmail refresh token is required for OAuth refresh` because no connector credentials are configured (a normal state for a pure codebase-doc run / CI). It also wastes tokens discovering external sources it should not touch.

## Test plan

- Added `test/raw-connector-tools.test.ts` cases asserting:
  - `local-wiki` mode exposes `openwiki_ingest_connector` / `openwiki_ingest_all_connectors`
  - `repository` mode returns no connector tools
  - defaulting (no mode arg) behaves like `local-wiki` (preserves existing raw-tool tests)
- `npx tsc -p tsconfig.json --noEmit` and `tsconfig.client.json` pass.
- `npx eslint` clean on changed files.
- All 9 tests in `test/raw-connector-tools.test.ts` pass.

## Notes

This is distinct from #449 (operator allow/deny + graceful connector-tool failures) — that PR makes connector tools *fail gracefully* and adds operator tooling, whereas this PR *gates them by run mode* so code-mode agents are never offered them in the first place. The two are complementary.