### PR TITLE
fix: harden error classification and run accounting

### DIFF
--- a/.changeset/silver-breads-serve.md
+++ b/.changeset/silver-breads-serve.md
@@ -1,0 +1,5 @@
+---
+"openwiki": patch
+---
+
+fix: harden error classification and run accounting

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,3 +63,10 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_CONFIG_PROVENANCE: true
+          # Bake the distribution channel into the published build. Only the
+          # upstream repo stamps "official"; a fork that opts into releasing
+          # (OPENWIKI_ENABLE_RELEASE) still publishes "community", so its
+          # telemetry stays filterable. The stamp runs inside `pnpm release`
+          # (publish path only), never on the version-PR path, so it is never
+          # committed back to the repo.
+          OPENWIKI_BUILD_CHANNEL: ${{ github.repository == 'langchain-ai/openwiki' && 'official' || 'community' }}

--- a/package.json
+++ b/package.json
@@ -46,7 +46,8 @@
     "lint:check": "eslint .",
     "prebuild": "pnpm run clean",
     "prepack": "pnpm run build",
-    "release": "pnpm run build && changeset publish",
+    "release": "pnpm run stamp:channel && pnpm run build && changeset publish",
+    "stamp:channel": "node scripts/stamp-build-channel.cjs",
     "start": "node dist/cli.js",
     "test": "vitest run",
     "typecheck": "tsc --noEmit -p tsconfig.json && tsc --noEmit -p tsconfig.client.json"

--- a/scripts/stamp-build-channel.cjs
+++ b/scripts/stamp-build-channel.cjs
@@ -1,0 +1,91 @@
+/**
+ * Bakes the distribution channel into the build. Run only on the official
+ * release path (via the `release` npm script, before `tsc`): it rewrites the one
+ * `BUILD_CHANNEL` assignment in `src/telemetry/gates.ts` from the committed
+ * `"community"` default to the value of `OPENWIKI_BUILD_CHANNEL`. Any unset or
+ * unrecognized value resolves to `"community"`, so an unexpected env value can
+ * never mint an `"official"` build. The rewrite is ephemeral in CI (a throwaway
+ * checkout that is never committed back), so the committed source stays
+ * `"community"` for forks, local builds, and dev runs.
+ *
+ * Usage: `node scripts/stamp-build-channel.cjs [targetFile]`. The optional target
+ * defaults to the real gates.ts; tests pass a temp file.
+ */
+const { readFileSync, writeFileSync } = require("node:fs");
+const path = require("node:path");
+
+/** The closed set of channels a build may be stamped with. */
+const BUILD_CHANNELS = ["community", "official"];
+
+/** Where the constant lives when no explicit target is given. */
+const DEFAULT_TARGET = path.resolve(
+  __dirname,
+  "..",
+  "src",
+  "telemetry",
+  "gates.ts",
+);
+
+/**
+ * Matches the committed `const BUILD_CHANNEL: BuildChannel = "…"` assignment,
+ * capturing everything up to the string literal so only the value is rewritten.
+ */
+const ASSIGNMENT = /(const BUILD_CHANNEL: BuildChannel = )"[^"]*"/u;
+
+/**
+ * Resolves a requested channel to a member of the closed set, defaulting any
+ * unset or unrecognized value to "community". Fail-safe: only an explicit,
+ * recognized "official" ever produces an official build.
+ */
+function resolveBuildChannel(requested) {
+  return BUILD_CHANNELS.includes(requested) ? requested : "community";
+}
+
+/**
+ * Rewrites the BUILD_CHANNEL assignment in `source` to `channel`, leaving the
+ * rest of the file (docstring, imports, the other gates) untouched. Throws if the
+ * expected assignment is not present exactly once, so a drifted file fails the
+ * release loudly instead of silently publishing an unstamped build.
+ */
+function stampSource(source, channel) {
+  const occurrences = source.match(new RegExp(ASSIGNMENT, "gu"));
+  if (!occurrences || occurrences.length !== 1) {
+    throw new Error(
+      `expected exactly one BUILD_CHANNEL assignment to stamp, found ${
+        occurrences ? occurrences.length : 0
+      }`,
+    );
+  }
+  return source.replace(ASSIGNMENT, `$1"${channel}"`);
+}
+
+/**
+ * Reads the target, stamps it with the resolved channel, and writes it back only
+ * when the content actually changes (so a no-op community stamp leaves the file
+ * byte-identical and the working tree clean).
+ */
+function main(targetFile) {
+  const target = targetFile ? path.resolve(targetFile) : DEFAULT_TARGET;
+  const channel = resolveBuildChannel(process.env.OPENWIKI_BUILD_CHANNEL);
+  const source = readFileSync(target, "utf8");
+  const stamped = stampSource(source, channel);
+  if (stamped !== source) {
+    writeFileSync(target, stamped, "utf8");
+  }
+  console.log(`stamp-build-channel: ${channel} (${target})`);
+}
+
+if (require.main === module) {
+  try {
+    main(process.argv[2]);
+  } catch (error) {
+    console.error(
+      `stamp-build-channel failed: ${
+        error instanceof Error ? error.message : String(error)
+      }`,
+    );
+    process.exit(1);
+  }
+}
+
+module.exports = { BUILD_CHANNELS, resolveBuildChannel, stampSource };

--- a/src/agent/crash-guard.ts
+++ b/src/agent/crash-guard.ts
@@ -104,7 +104,15 @@ export async function handleFatal(
   source: string,
   error: unknown,
 ): Promise<void> {
+  // Claim the active run synchronously, before any await. The installer fires one
+  // `void handleFatal(...)` per escaped rejection, and a burst of subagent rejections
+  // lands on the microtask queue together; reading and clearing here with no await
+  // between the two statements makes the claim atomic for the event loop, so the first
+  // handler owns the crash and every later one sees `undefined` and only exits. Do not
+  // move any await above this pair: doing so reintroduces the race where every
+  // rejection records the same run and one crash produces hundreds of events.
   const active = getActiveRun();
+  clearActiveRun();
 
   if (active) {
     // Record the crash as a failure so it finally appears in the data, classified
@@ -134,8 +142,6 @@ export async function handleFatal(
     } catch {
       // Intentionally ignored: the stamp is best-effort during a crash.
     }
-
-    clearActiveRun();
   }
 
   // The local stderr line intentionally carries the raw message: it is the user's

--- a/src/telemetry/errors.ts
+++ b/src/telemetry/errors.ts
@@ -627,23 +627,38 @@ export function innermostErrorName(error: unknown): string | undefined {
  * one object, ready to spread into the run facts. The class and detail come from the
  * origin tag when the throw site owned the classification (build/connector/okf/
  * checkpointer, or a tagged config/tool detail), otherwise from {@link classifyError}
- * walking the unwrap chain. For the residual `agent_error` bucket the detail is
- * instead the innermost error's own name, the one signal that bucket carries, read
- * from the cause chain so a framework envelope like LangChain's `MiddlewareError`
- * does not collapse every root cause to the wrapper's name. The detail is normalized
- * against its family's allowlist (or the identifier allowlist for `agent_error`), so
- * an off-list value is dropped rather than emitted. Never leaks the message.
+ * walking the unwrap chain. The one exception is the `build_error/stream_open` tag:
+ * that stage is the first provider round trip, so a failure there carrying a provider
+ * signal is a disguised provider error and the raw classification wins over the tag
+ * (see {@link streamOpenDisguisesProvider}). For the residual `agent_error` bucket the
+ * detail is instead the innermost error's own name, the one signal that bucket
+ * carries, read from the cause chain so a framework envelope like LangChain's
+ * `MiddlewareError` does not collapse every root cause to the wrapper's name. The
+ * detail is normalized against its family's allowlist (or the identifier allowlist for
+ * `agent_error`), so an off-list value is dropped rather than emitted. Never leaks the
+ * message.
  */
 export function describeErrorForTelemetry(error: unknown): ErrorTelemetry {
   const origin = readErrorOrigin(error);
   const classified = classifyError(error);
+  const httpStatus = firstStatusInChain(error);
 
   // An origin tag that names a class owns both class and detail; a stage-only tag
-  // leaves both to the raw-error classifier.
-  const errorClass = origin?.errorClass ?? classified.errorClass;
-  const rawDetail = origin?.errorClass
-    ? origin.errorDetail
-    : classified.errorDetail;
+  // leaves both to the raw-error classifier. The lone override is a stream-open tag
+  // over a disguised provider failure, which defers to the raw classifier so the
+  // failure lands on the provider instead of being counted as our build bug.
+  let errorClass: TelemetryErrorClass;
+  let rawDetail: string | undefined;
+  if (
+    origin?.errorClass !== undefined &&
+    !streamOpenDisguisesProvider(origin, classified, httpStatus)
+  ) {
+    errorClass = origin.errorClass;
+    rawDetail = origin.errorDetail;
+  } else {
+    errorClass = classified.errorClass;
+    rawDetail = classified.errorDetail;
+  }
 
   // The residual bucket carries no origin/classified detail; its one signal is the
   // innermost error's own name. Every named class keeps its taxonomy detail.
@@ -660,6 +675,40 @@ export function describeErrorForTelemetry(error: unknown): ErrorTelemetry {
     errorOwner: deriveOwner(errorClass, errorDetail, errorStage),
     // Surfaced from the chain so a wrapped provider error still emits its status
     // even when an origin tag already named the class.
-    httpStatus: firstStatusInChain(error),
+    httpStatus,
   };
+}
+
+/**
+ * Whether a `build_error/stream_open` origin tag is really masking a provider
+ * failure. The stream-open call is the only build stage that crosses into provider
+ * territory (the first token/HTTP round trip), so a throw there that carries a
+ * provider signal — the raw classifier already naming it `provider_error`, or an HTTP
+ * status on the chain paired with any named (non-residual) classification — is the
+ * provider's fault, not ours, and the raw classification should win over the tag.
+ * Guarded to a named class so a genuine stream-setup failure with no provider signal
+ * (which classifies as the residual `agent_error`) keeps its informative
+ * `build_error/stream_open` tag instead of regressing to the residual bucket.
+ *
+ * @param origin - The origin tag read off the error, if any.
+ * @param classified - The raw-error classification of the same error.
+ * @param httpStatus - The first HTTP status found on the chain, or undefined.
+ * @returns True when the raw classification should override the tag.
+ */
+function streamOpenDisguisesProvider(
+  origin: ErrorOriginTag | undefined,
+  classified: ErrorClassification,
+  httpStatus: number | undefined,
+): boolean {
+  if (
+    origin?.errorClass !== "build_error" ||
+    origin.errorDetail !== "stream_open"
+  ) {
+    return false;
+  }
+
+  return (
+    classified.errorClass === "provider_error" ||
+    (httpStatus !== undefined && classified.errorClass !== "agent_error")
+  );
 }

--- a/src/telemetry/errors.ts
+++ b/src/telemetry/errors.ts
@@ -1,4 +1,8 @@
-import { deriveOwner, normalizeErrorDetail } from "./taxonomy.js";
+import {
+  deriveOwner,
+  isSafeErrorIdentifier,
+  normalizeErrorDetail,
+} from "./taxonomy.js";
 import type {
   TelemetryErrorClass,
   TelemetryErrorOwner,
@@ -62,9 +66,12 @@ const PROVIDER_ERROR_CODES: Readonly<Record<string, ErrorClassification>> = {
 
 /**
  * Max links followed when unwrapping a nested error. Bounds the walk so a long or
- * cyclic `cause` chain cannot turn classification into a denial of service.
+ * cyclic `cause` chain cannot turn classification into a denial of service. Set well
+ * above real nesting depth so a provider error buried under several framework
+ * envelopes (agent -> middleware -> retry wrapper -> SDK error) still reaches its root
+ * cause; the cycle-safe BFS makes a high bound cheap on well-formed chains.
  */
-const MAX_UNWRAP_DEPTH = 5;
+const MAX_UNWRAP_DEPTH = 32;
 
 /**
  * Flattens a possibly-wrapped error into the chain of links to inspect, nearest
@@ -518,29 +525,14 @@ export interface ErrorTelemetry {
    * The provider's numeric status, or undefined. A bare integer.
    */
   httpStatus: number | undefined;
-
-  /**
-   * Constructor name of the thrown error, allowlisted to a bare ASCII identifier.
-   * The only signal the residual `agent_error` bucket carries: it turns "unknown"
-   * into a ranked list of unhandled error types. Present only when the class stayed
-   * `agent_error`; undefined for every named class and for a name that failed the
-   * allowlist.
-   */
-  errorName: string | undefined;
 }
 
 /**
- * A bare code identifier: an ASCII constructor name, nothing else. A subclass whose
- * `.name` was set to a template string containing a path, URL, or user value fails
- * this and is dropped, keeping the anonymity envelope closed.
- */
-const CONSTRUCTOR_NAME = /^[A-Za-z][A-Za-z0-9]{0,63}$/u;
-
-/**
- * The constructor name of `value`, but only if it is a plain ASCII identifier;
- * otherwise undefined. Reads the name through the prototype (not an own
- * `constructor` property) so a tampered own `constructor` cannot smuggle a value
- * past the allowlist. Non-objects have no constructor name and yield undefined.
+ * The constructor name of `value`, but only if it is a bare identifier; otherwise
+ * undefined. Reads the name through the prototype (not an own `constructor` property)
+ * so a tampered own `constructor` cannot smuggle a value past the allowlist.
+ * Non-objects have no constructor name and yield undefined. Gated by the shared
+ * {@link isSafeErrorIdentifier}.
  *
  * @param value - The value to fingerprint.
  * @returns The allowlisted constructor name, or undefined.
@@ -555,31 +547,73 @@ export function safeConstructorName(value: unknown): string | undefined {
   } | null;
   const raw = proto?.constructor?.name;
 
-  return typeof raw === "string" && CONSTRUCTOR_NAME.test(raw)
-    ? raw
-    : undefined;
+  return isSafeErrorIdentifier(raw) ? raw : undefined;
 }
 
 /**
- * The allowlisted constructor name of the innermost error in the unwrap chain, or
+ * The `.name` property of `value`, but only if it is a bare identifier; otherwise
+ * undefined. This is the identity a framework deliberately sets: LangChain's
+ * `MiddlewareError.wrap` copies the inner error's `.name` up onto the wrapper, so
+ * reading `.name` recovers the real failure's identity even when `constructor.name`
+ * reports the envelope class. Gated by the shared {@link isSafeErrorIdentifier}.
+ *
+ * @param value - The value to fingerprint.
+ * @returns The allowlisted `.name`, or undefined.
+ */
+export function safeErrorName(value: unknown): string | undefined {
+  if (typeof value !== "object" || value === null) {
+    return undefined;
+  }
+
+  const raw = (value as { name?: unknown }).name;
+  return isSafeErrorIdentifier(raw) ? raw : undefined;
+}
+
+/**
+/**
+ * The most specific allowlisted identifier for a single chain link, or undefined.
+ * Reconciles the two identity sources: a link's own `.name`, which a framework like
+ * LangChain's `MiddlewareError` deliberately sets to the inner error's name, and its
+ * `constructor.name`. The `.name` wins because it is the identity a wrapper copies up
+ * (e.g. `AI_APICallError` on a `MiddlewareError`), except when it is the bare base
+ * `"Error"`: an `Error` subclass that never sets `this.name` inherits `"Error"`, which
+ * says less than the constructor (e.g. a `ProviderCrash` subclass), so there the
+ * constructor is preferred. Both candidates pass the same allowlist.
+ *
+ * @param link - One error in the unwrap chain.
+ * @returns The link's most specific allowlisted identifier, or undefined.
+ */
+function linkErrorName(link: unknown): string | undefined {
+  const name = safeErrorName(link);
+  const constructorName = safeConstructorName(link);
+
+  if (name !== undefined && name !== "Error") {
+    return name;
+  }
+  return constructorName ?? name;
+}
+
+/**
+ * The allowlisted identifier of the innermost error in the unwrap chain, or
  * undefined. This is the one signal the residual `agent_error` bucket carries, so it
- * must name the real failure and not a wrapper: a framework envelope like LangChain's
- * `MiddlewareError` copies the inner message but reports its own constructor, so
- * fingerprinting the outermost link collapses every distinct root cause to the
- * wrapper's name. Walking to the deepest link recovers the actual failure's identity
- * (e.g. the provider SDK's own error class) while the same {@link safeConstructorName}
- * allowlist keeps the anonymity envelope closed. Falls back to the outermost
- * allowlisted name when only the wrapper has one. The walk reuses the read-only,
- * cycle-safe {@link unwrapErrorChain}.
+ * must name the real failure and not a wrapper: a framework envelope copies the inner
+ * message but reports its own constructor, so fingerprinting the outermost link
+ * collapses every distinct root cause to the wrapper's name. Each link is resolved by
+ * {@link linkErrorName} (its deliberately-set `.name`, else its constructor), and the
+ * deepest link that yields a name wins. Walking to the deepest link recovers the
+ * actual failure's identity (e.g. the provider SDK's own error class) while the shared
+ * {@link isSafeErrorIdentifier} allowlist keeps the anonymity envelope closed. Falls
+ * back to the outermost allowlisted name when only the wrapper has one. The walk
+ * reuses the read-only, cycle-safe {@link unwrapErrorChain}.
  *
  * @param error - The thrown value to fingerprint.
- * @returns The innermost allowlisted constructor name, or undefined.
+ * @returns The innermost allowlisted identifier, or undefined.
  */
-export function innermostConstructorName(error: unknown): string | undefined {
+export function innermostErrorName(error: unknown): string | undefined {
   let deepest: string | undefined;
 
   for (const link of unwrapErrorChain(error)) {
-    const name = safeConstructorName(link);
+    const name = linkErrorName(link);
     if (name !== undefined) {
       deepest = name;
     }
@@ -589,14 +623,16 @@ export function innermostConstructorName(error: unknown): string | undefined {
 }
 
 /**
- * The single call the failure path uses: class, detail, owner, stage, status, and
- * (residual only) the error-name fingerprint in one object, ready to spread into the
- * run facts. The class and detail come from the origin tag when the throw site owned
- * the classification (build/connector/okf/checkpointer, or a tagged config/tool
- * detail), otherwise from {@link classifyError} walking the unwrap chain. The detail
- * is normalized against its family's allowlist, so an off-list value is dropped
- * rather than emitted. `errorName` is attached only when the class stayed
- * `agent_error`, since every other class is already named. Never leaks the message.
+ * The single call the failure path uses: class, detail, owner, stage, and status in
+ * one object, ready to spread into the run facts. The class and detail come from the
+ * origin tag when the throw site owned the classification (build/connector/okf/
+ * checkpointer, or a tagged config/tool detail), otherwise from {@link classifyError}
+ * walking the unwrap chain. For the residual `agent_error` bucket the detail is
+ * instead the innermost error's own name, the one signal that bucket carries, read
+ * from the cause chain so a framework envelope like LangChain's `MiddlewareError`
+ * does not collapse every root cause to the wrapper's name. The detail is normalized
+ * against its family's allowlist (or the identifier allowlist for `agent_error`), so
+ * an off-list value is dropped rather than emitted. Never leaks the message.
  */
 export function describeErrorForTelemetry(error: unknown): ErrorTelemetry {
   const origin = readErrorOrigin(error);
@@ -609,7 +645,12 @@ export function describeErrorForTelemetry(error: unknown): ErrorTelemetry {
     ? origin.errorDetail
     : classified.errorDetail;
 
-  const errorDetail = normalizeErrorDetail(errorClass, rawDetail);
+  // The residual bucket carries no origin/classified detail; its one signal is the
+  // innermost error's own name. Every named class keeps its taxonomy detail.
+  const detailInput =
+    errorClass === "agent_error" ? innermostErrorName(error) : rawDetail;
+
+  const errorDetail = normalizeErrorDetail(errorClass, detailInput);
   const errorStage = origin?.stage;
 
   return {
@@ -620,12 +661,5 @@ export function describeErrorForTelemetry(error: unknown): ErrorTelemetry {
     // Surfaced from the chain so a wrapped provider error still emits its status
     // even when an origin tag already named the class.
     httpStatus: firstStatusInChain(error),
-    // Only the residual bucket pays for a fingerprint; named classes stay undefined.
-    // Reads the innermost cause, not the outer wrapper, so a framework envelope like
-    // LangChain's `MiddlewareError` does not collapse every root cause to one name.
-    errorName:
-      errorClass === "agent_error"
-        ? innermostConstructorName(error)
-        : undefined,
   };
 }

--- a/src/telemetry/gates.ts
+++ b/src/telemetry/gates.ts
@@ -1,5 +1,27 @@
 import ciInfo from "ci-info";
 
+import type { BuildChannel } from "./types.js";
+
+/**
+ * The distribution channel baked into this build. Committed as `"community"`;
+ * the official release pipeline rewrites this one assignment via
+ * `scripts/stamp-build-channel.cjs` (driven by `OPENWIKI_BUILD_CHANNEL`) so only
+ * npm-published upstream builds report `"official"`. Do not edit by hand, and
+ * keep the committed value `"community"` — the stamp targets this exact line.
+ */
+const BUILD_CHANNEL: BuildChannel = "community";
+
+/**
+ * The distribution channel this build was produced for (see {@link BuildChannel}).
+ * `"official"` only for npm-published upstream builds, `"community"` for
+ * everything else (forks, local builds, source/dev runs). Stamped on every event
+ * so fork-originated telemetry can be filtered out from the official-release
+ * signal.
+ */
+export function buildChannel(): BuildChannel {
+  return BUILD_CHANNEL;
+}
+
 /**
  * True when the user has opted out via OpenWiki's switch or DO_NOT_TRACK.
  */

--- a/src/telemetry/record-run-safe.ts
+++ b/src/telemetry/record-run-safe.ts
@@ -44,7 +44,6 @@ export async function recordRunSafe(
     errorOwner?: TelemetryErrorOwner;
     errorStage?: TelemetryErrorStage;
     httpStatus?: number;
-    errorName?: string;
   },
 ): Promise<void> {
   // Chat is deliberately not recorded: it is interactive and would emit one
@@ -63,7 +62,6 @@ export async function recordRunSafe(
     errorOwner: facts.errorOwner,
     errorStage: facts.errorStage,
     httpStatus: facts.httpStatus,
-    errorName: facts.errorName,
     // Setup choices are captured on init only (the configuration moment); on
     // updates these are omitted entirely.
     ...(command === "init"

--- a/src/telemetry/senders.ts
+++ b/src/telemetry/senders.ts
@@ -73,8 +73,9 @@ export function buildRunEvent(
       outcome: details.outcome,
       ...(details.errorClass ? { error_class: details.errorClass } : {}),
       // The specific failure within the family and who owns the fix. Detail is an
-      // allowlisted word (dropped upstream if off-list); owner is derived from
-      // (class, detail, stage) so the dashboard can roll up by who must act,
+      // allowlisted word (or, for the residual `agent_error` bucket, the innermost
+      // error's allowlisted name), dropped upstream if off-list; owner is derived
+      // from (class, detail, stage) so the dashboard can roll up by who must act,
       // including the cross-owner exceptions PostHog cannot derive. Failure-only.
       ...(details.errorDetail ? { error_detail: details.errorDetail } : {}),
       ...(details.errorOwner ? { error_owner: details.errorOwner } : {}),
@@ -86,10 +87,6 @@ export function buildRunEvent(
       ...(details.httpStatus !== undefined
         ? { http_status: details.httpStatus }
         : {}),
-      // Residual-only fingerprint: an allowlisted constructor identifier, the one
-      // signal the `agent_error` bucket carries. Omitted for every named class, so
-      // the null bucket reads as "already classified" rather than a value.
-      ...(details.errorName ? { error_name: details.errorName } : {}),
       ...(details.mode ? { mode: details.mode } : {}),
       ...(details.provider ? { provider: details.provider } : {}),
       ...connectorProperties(details.configuredConnectors ?? []),

--- a/src/telemetry/senders.ts
+++ b/src/telemetry/senders.ts
@@ -6,13 +6,14 @@ import { fileURLToPath } from "node:url";
 import { capture } from "./client.js";
 import { DEFAULT_POSTHOG_HOST, TELEMETRY_RUN_EVENT } from "./config.js";
 import {
+  buildChannel,
   ciSentinelId,
   isCiEnvironment,
   isProductionBuild,
   isTelemetryDisabled,
 } from "./gates.js";
 import { getOrCreateInstallId } from "./install-id.js";
-import type { RunTelemetry, TelemetryEvent } from "./types.js";
+import type { BuildChannel, RunTelemetry, TelemetryEvent } from "./types.js";
 
 /**
  * Environment and identity inputs that are not part of a run's own facts:
@@ -34,6 +35,14 @@ export interface RunEventContext {
    * dev/source or seed run.
    */
   production: boolean;
+
+  /**
+   * The distribution channel this build was produced for (see
+   * {@link BuildChannel}). Baked at build time, so the caller resolves it (via
+   * `buildChannel()`) and the builder stays pure. Stamped on every event so
+   * fork-originated telemetry can be separated from the official-release signal.
+   */
+  buildChannel: BuildChannel;
 
   /**
    * Identity the event is attributed to: an install id (human) or the CI
@@ -93,6 +102,11 @@ export function buildRunEvent(
       // True for the published build, false for dev/source/seed runs; lets real
       // usage be separated from local testing and pre-launch seed data.
       production: context.production,
+      // Distribution channel baked at build time: "official" only for npm-published
+      // upstream builds, "community" for forks/local/dev. Lets the dashboard scope
+      // the official-release signal and drop fork-originated telemetry. A closed
+      // two-value enum; no free strings.
+      build_channel: context.buildChannel,
       // Distribution provenance: the OpenWiki version from the bundled
       // package.json, stamped on every event so adoption and per-version
       // breakage are readable. Omitted when the caller could not resolve it.
@@ -132,6 +146,7 @@ export async function recordRun(details: RunTelemetry): Promise<void> {
     const event = buildRunEvent(details, {
       ci,
       production: isProductionBuild(),
+      buildChannel: buildChannel(),
       distinctId,
       appVersion: packageProvenance().appVersion,
     });

--- a/src/telemetry/taxonomy.ts
+++ b/src/telemetry/taxonomy.ts
@@ -45,6 +45,8 @@ const FIXED_ERROR_DETAILS: Readonly<
   output_error: ["json_parse", "schema"],
   // No detail split: the family is the whole signal.
   context_limit_error: [],
+  // The residual bucket's detail is not a fixed word: it is the innermost error's own
+  // name, gated by the identifier allowlist in `normalizeErrorDetail`, not this list.
   agent_error: [],
   aborted: [],
 };
@@ -59,6 +61,34 @@ const OPEN_DETAIL_CLASSES: ReadonlySet<TelemetryErrorClass> = new Set([
   "connector_error",
   "tool_error",
 ]);
+
+/**
+ * A bare code identifier: an ASCII letter, then letters/digits with single interior
+ * underscores (e.g. `TypeError`, `AI_APICallError`, `OUTPUT_PARSING_FAILURE`). The
+ * anonymity gate for any error-name-shaped value: a `.name` or `constructor.name` set
+ * to a template string carrying a path, URL, space, or user value fails this and is
+ * dropped, keeping the envelope closed. Leading, trailing, and doubled underscores
+ * are rejected so nothing but a plain identifier survives.
+ */
+const SAFE_ERROR_IDENTIFIER = /^[A-Za-z][A-Za-z0-9]*(?:_[A-Za-z0-9]+)*$/u;
+
+/**
+ * Whether `value` is a bare code identifier safe to emit: a string of at most 64
+ * characters matching {@link SAFE_ERROR_IDENTIFIER}. The length bound caps how much a
+ * single name can weigh and closes the door on a giant synthesized name. The one gate
+ * every error identifier passes through before it can leave the process, whether it
+ * is read from `.name`, `constructor.name`, or the residual `agent_error` detail.
+ *
+ * @param value - The candidate identifier, or any non-string value.
+ * @returns True only for an allowlisted bare identifier.
+ */
+export function isSafeErrorIdentifier(value: unknown): value is string {
+  return (
+    typeof value === "string" &&
+    value.length <= 64 &&
+    SAFE_ERROR_IDENTIFIER.test(value)
+  );
+}
 
 /**
  * Provider-error details that are really the user's key or account, not a transient
@@ -84,7 +114,10 @@ const NETWORK_ENVIRONMENT_DETAILS: ReadonlySet<string> = new Set([
  * detail property's anonymity: a fixed-family detail must be on the family's
  * hardcoded list; an open-family detail (connector/tool id) is trusted as a
  * non-empty string because its tag site already validated it against the registry;
- * a no-detail family always yields undefined.
+ * the residual `agent_error` family carries the innermost error's own name as its
+ * detail, so it accepts any bare identifier that passes {@link isSafeErrorIdentifier}
+ * (not a fixed word list) and drops anything else; a no-detail family always yields
+ * undefined.
  *
  * @param errorClass - The failure family the detail belongs to.
  * @param detail - The observed detail, or undefined when none was resolved.
@@ -96,6 +129,12 @@ export function normalizeErrorDetail(
 ): string | undefined {
   if (detail === undefined || detail === "") {
     return undefined;
+  }
+
+  // The residual bucket's detail is the innermost error's name, an open value gated
+  // by the identifier allowlist rather than a fixed word list.
+  if (errorClass === "agent_error") {
+    return isSafeErrorIdentifier(detail) ? detail : undefined;
   }
 
   if (OPEN_DETAIL_CLASSES.has(errorClass)) {

--- a/src/telemetry/types.ts
+++ b/src/telemetry/types.ts
@@ -82,9 +82,13 @@ export interface RunTelemetry {
 
   /**
    * The specific failure within `errorClass`, from that family's hardcoded
-   * allowlist (see `taxonomy.ts`), e.g. `auth` inside `provider_error`. One shared
-   * property across all families. Anything off the family's allowlist is dropped to
-   * undefined rather than sent raw, so the anonymity envelope stays closed.
+   * allowlist (see `taxonomy.ts`), e.g. `auth` inside `provider_error`. For the
+   * residual `agent_error` family it is instead the innermost error's own name (a
+   * bare identifier), the one signal that bucket carries, so it can be broken down
+   * into a ranked list of unhandled error types. One shared property across all
+   * families. Anything off the family's allowlist (or the identifier allowlist for
+   * `agent_error`) is dropped to undefined rather than sent raw, so the anonymity
+   * envelope stays closed.
    *
    * @default undefined - the family has no detail split, or the observed detail was
    * not on the family's allowlist; the field is omitted rather than sent raw.
@@ -116,17 +120,6 @@ export interface RunTelemetry {
    * @default undefined - the error exposed no numeric status.
    */
   httpStatus?: number;
-
-  /**
-   * Constructor name of a residual (`agent_error`) failure's thrown error, a bare
-   * ASCII identifier. The only signal the residual bucket carries, so it can be
-   * broken down into a ranked list of unhandled error types. Present only on a
-   * failure that stayed `agent_error`.
-   *
-   * @default undefined - the failure was classified into a named family, or the
-   * constructor name failed the identifier allowlist.
-   */
-  errorName?: string;
 
   /**
    * Which brain was set up (code = repository, personal = local wiki). Init

--- a/src/telemetry/types.ts
+++ b/src/telemetry/types.ts
@@ -54,6 +54,16 @@ export type TelemetryErrorStage = "config" | "build" | "run" | "finalize";
 export type TelemetryMode = "code" | "personal";
 
 /**
+ * The distribution channel a build was produced for, baked in at build time and
+ * stamped on every event so fork-originated telemetry can be filtered out from
+ * the official-release signal on the dashboard.
+ *
+ * - `official`: an npm-published upstream build (the release pipeline bakes this).
+ * - `community`: anything else — a fork, a local build, or a source/dev run.
+ */
+export type BuildChannel = "official" | "community";
+
+/**
  * Everything the run event reports, assembled by the agent run lifecycle.
  *
  * Two tiers: `command`, `outcome`, and `errorClass` ride on every run

--- a/test/crash-guard.test.ts
+++ b/test/crash-guard.test.ts
@@ -170,4 +170,24 @@ describe("handleFatal", () => {
     expect(line).toContain("unhandledRejection");
     expect(line).toContain("visible message");
   });
+
+  test("a burst of concurrent fatal signals records the crash exactly once", async () => {
+    registerActiveRun(ACTIVE);
+
+    // The installer fires `void handleFatal(...)` fire-and-forget, once per escaped
+    // rejection, so a burst arrives with no await between calls and every handler runs
+    // its synchronous prefix back-to-back. The first must claim the run; every later
+    // one must see it already cleared. Before the sync-claim fix each of the 50 read
+    // the still-set run and recorded it, which is the one-crash-261-events bug.
+    await Promise.all(
+      Array.from({ length: 50 }, (_unused, index) =>
+        handleFatal("unhandledRejection", new Error(`boom ${index}`)),
+      ),
+    );
+    await new Promise((resolve) => setImmediate(resolve));
+
+    expect(recordRunSafe).toHaveBeenCalledTimes(1);
+    expect(persistRunMetadataIfChanged).toHaveBeenCalledTimes(1);
+    expect(getActiveRun()).toBeUndefined();
+  });
 });

--- a/test/crash-guard.test.ts
+++ b/test/crash-guard.test.ts
@@ -11,7 +11,7 @@ import {
 // The crash guard's two side effects are mocked so the post-mortem can be asserted
 // without a real telemetry send or a metadata write. describeErrorForTelemetry is
 // left REAL, so these tests also prove a residual crash is classified and
-// fingerprinted (agent_error + error_name) on the way through the guard.
+// fingerprinted (agent_error + its error_detail name) on the way through the guard.
 const recordRunSafe = vi.fn(() => Promise.resolve(undefined));
 const persistRunMetadataIfChanged = vi.fn(() => Promise.resolve(true));
 
@@ -96,11 +96,11 @@ describe("handleFatal", () => {
     expect(command).toBe("init");
     expect(options).toEqual({ outputMode: "repository" });
     // The real describeErrorForTelemetry ran: a residual crash is agent_error with
-    // its constructor name as the fingerprint.
+    // the thrown error's name as its error_detail fingerprint.
     expect(facts).toMatchObject({
       outcome: "failure",
       errorClass: "agent_error",
-      errorName: "TypeError",
+      errorDetail: "TypeError",
     });
   });
 

--- a/test/stamp-build-channel.test.ts
+++ b/test/stamp-build-channel.test.ts
@@ -1,0 +1,100 @@
+import { execFileSync } from "node:child_process";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { afterEach, beforeEach, describe, expect, test } from "vitest";
+
+// The release-time channel stamp is exercised end-to-end against a temp copy of
+// the constant, so the test proves the real .cjs artifact the release runs — not
+// a re-implementation — and never mutates the repo's own gates.ts.
+const SCRIPT = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "..",
+  "scripts",
+  "stamp-build-channel.cjs",
+);
+
+/**
+ * A minimal fixture with the exact assignment the stamp targets, wrapped in a
+ * docstring and neighboring code so the test also proves the rest of the file is
+ * left untouched.
+ */
+const FIXTURE = [
+  "/** Baked at build time; do not edit by hand. */",
+  'const BUILD_CHANNEL: BuildChannel = "community";',
+  "",
+  "export function buildChannel(): BuildChannel {",
+  "  return BUILD_CHANNEL;",
+  "}",
+  "",
+].join("\n");
+
+let dir: string;
+let target: string;
+
+beforeEach(async () => {
+  dir = await mkdtemp(path.join(tmpdir(), "openwiki-stamp-"));
+  target = path.join(dir, "gates.ts");
+  await writeFile(target, FIXTURE, "utf8");
+});
+
+afterEach(async () => {
+  await rm(dir, { recursive: true, force: true });
+});
+
+/**
+ * Runs the stamp script against the temp target with `channel` as the env value
+ * (omitted entirely when undefined), then returns the rewritten file contents.
+ */
+function stamp(channel: string | undefined): void {
+  const env = { ...process.env };
+  if (channel === undefined) {
+    delete env.OPENWIKI_BUILD_CHANNEL;
+  } else {
+    env.OPENWIKI_BUILD_CHANNEL = channel;
+  }
+  execFileSync(process.execPath, [SCRIPT, target], { env, encoding: "utf8" });
+}
+
+describe("stamp-build-channel", () => {
+  test('bakes "official" when the env asks for it', async () => {
+    stamp("official");
+
+    const result = await readFile(target, "utf8");
+    expect(result).toContain('const BUILD_CHANNEL: BuildChannel = "official";');
+    // The surrounding file is untouched: docstring and the accessor survive.
+    expect(result).toContain("do not edit by hand");
+    expect(result).toContain("export function buildChannel()");
+  });
+
+  test("defaults to community when the env is unset", async () => {
+    stamp(undefined);
+
+    const result = await readFile(target, "utf8");
+    expect(result).toContain(
+      'const BUILD_CHANNEL: BuildChannel = "community";',
+    );
+  });
+
+  test("an unrecognized channel falls back to community", async () => {
+    // Fail-safe: a typo or an injected value can never mint an official build.
+    stamp("official-ish");
+
+    const result = await readFile(target, "utf8");
+    expect(result).toContain(
+      'const BUILD_CHANNEL: BuildChannel = "community";',
+    );
+    expect(result).not.toContain("official");
+  });
+
+  test("a source missing the assignment fails loudly and is left unchanged", async () => {
+    await writeFile(target, "const something = 1;\n", "utf8");
+
+    expect(() => stamp("official")).toThrow();
+
+    const result = await readFile(target, "utf8");
+    expect(result).toBe("const something = 1;\n");
+  });
+});

--- a/test/telemetry.test.ts
+++ b/test/telemetry.test.ts
@@ -32,11 +32,13 @@ import {
   inStage,
   inStageSync,
   safeConstructorName,
+  safeErrorName,
   tagErrorStage,
   unwrapErrorChain,
 } from "../src/telemetry/errors.ts";
 import {
   deriveOwner,
+  isSafeErrorIdentifier,
   normalizeErrorDetail,
 } from "../src/telemetry/taxonomy.ts";
 import {
@@ -267,12 +269,13 @@ describe("classifyError - unwrapping wrapped errors", () => {
   });
 
   test("stops at the depth bound: a signal below it is not reached", () => {
-    // Six nested wrappers put the only real signal (a 429) below MAX_UNWRAP_DEPTH
-    // (5), so the walk bounds out at the residual rather than recovering it. This
-    // is the DoS guard: a pathologically deep chain costs at most five links.
+    // A run of wrappers longer than MAX_UNWRAP_DEPTH (32) puts the only real signal
+    // (a 429) past the bound, so the walk bounds out at the residual rather than
+    // recovering it. This is the DoS guard: a pathologically deep chain costs at
+    // most the bounded number of links.
     let deep: { message: string; cause?: unknown } = { message: "w0" };
     const root = deep;
-    for (let i = 1; i <= 5; i++) {
+    for (let i = 1; i <= 40; i++) {
       const next = { message: `w${i}` };
       deep.cause = next;
       deep = next;
@@ -351,6 +354,14 @@ describe("safeConstructorName allowlist", () => {
     expect(safeConstructorName(withName("a".repeat(65)))).toBeUndefined();
     // A 64-char identifier is the longest allowed and still passes.
     expect(safeConstructorName(withName("a".repeat(64)))).toBe("a".repeat(64));
+    // Interior underscores are allowed (real SDK error names carry them), but a
+    // leading, trailing, or doubled underscore is not a bare identifier.
+    expect(safeConstructorName(withName("AI_APICallError"))).toBe(
+      "AI_APICallError",
+    );
+    expect(safeConstructorName(withName("_leading"))).toBeUndefined();
+    expect(safeConstructorName(withName("trailing_"))).toBeUndefined();
+    expect(safeConstructorName(withName("double__underscore"))).toBeUndefined();
   });
 
   test("non-objects have no constructor name", () => {
@@ -361,24 +372,66 @@ describe("safeConstructorName allowlist", () => {
   });
 });
 
+describe("safeErrorName allowlist", () => {
+  test("reads the deliberately-set .name a framework copies up", () => {
+    // LangChain's MiddlewareError copies the inner error's .name onto the wrapper,
+    // so .name names the real failure even when the constructor is the envelope.
+    const wrapper = Object.assign(new Error("wrapModelCall failed"), {
+      name: "AI_APICallError",
+    });
+
+    expect(safeErrorName(wrapper)).toBe("AI_APICallError");
+    // A stock Error's .name is its constructor name, so both agree.
+    expect(safeErrorName(new TypeError("x"))).toBe("TypeError");
+  });
+
+  test("drops a .name that is not a bare identifier", () => {
+    const tampered = Object.assign(new Error("x"), {
+      name: "/Users/me/secret error",
+    });
+
+    expect(safeErrorName(tampered)).toBeUndefined();
+  });
+
+  test("non-objects and nameless objects yield undefined", () => {
+    expect(safeErrorName("string")).toBeUndefined();
+    expect(safeErrorName(null)).toBeUndefined();
+    expect(safeErrorName({})).toBeUndefined();
+  });
+});
+
+describe("isSafeErrorIdentifier", () => {
+  test("accepts bare identifiers with interior underscores, rejects the rest", () => {
+    expect(isSafeErrorIdentifier("TypeError")).toBe(true);
+    expect(isSafeErrorIdentifier("OUTPUT_PARSING_FAILURE")).toBe(true);
+    expect(isSafeErrorIdentifier("a".repeat(64))).toBe(true);
+    expect(isSafeErrorIdentifier("a".repeat(65))).toBe(false);
+    expect(isSafeErrorIdentifier("has space")).toBe(false);
+    expect(isSafeErrorIdentifier("_leading")).toBe(false);
+    expect(isSafeErrorIdentifier("")).toBe(false);
+    expect(isSafeErrorIdentifier(42)).toBe(false);
+  });
+});
+
 describe("describeErrorForTelemetry - residual fingerprint", () => {
-  test("a residual failure carries its error_name and no status", () => {
+  test("a residual failure carries its name as error_detail and no status", () => {
     const described = describeErrorForTelemetry(new TypeError("boom"));
 
     expect(described.errorClass).toBe("agent_error");
-    expect(described.errorName).toBe("TypeError");
+    expect(described.errorDetail).toBe("TypeError");
     expect(described.httpStatus).toBeUndefined();
   });
 
-  test("a named class carries no error_name", () => {
-    // Only the residual bucket pays for a fingerprint; a real 401 is already named.
+  test("a named class carries its family detail, not a name fingerprint", () => {
+    // The fingerprint only rides for the residual bucket; a real 401 is already
+    // named, so its detail is the taxonomy word, not the error's constructor.
     const described = describeErrorForTelemetry({ status: 401 });
 
     expect(described.errorClass).toBe("provider_error");
-    expect(described.errorName).toBeUndefined();
+    expect(described.errorDetail).toBe("auth");
   });
 
-  test("fingerprints the innermost cause, not the outer wrapper", () => {
+  test("fingerprints the innermost cause's name, not the outer wrapper", () => {
     // A framework envelope (e.g. LangChain's MiddlewareError) copies the inner
     // message onto a fresh wrapper but reports its own constructor. The fingerprint
     // must reach the real cause so the residual bucket ranks by actual failure type
@@ -392,17 +445,31 @@ describe("describeErrorForTelemetry - residual fingerprint", () => {
     const described = describeErrorForTelemetry(outer);
 
     expect(described.errorClass).toBe("agent_error");
-    expect(described.errorName).toBe("ProviderCrash");
+    expect(described.errorDetail).toBe("ProviderCrash");
   });
 
-  test("a residual with an un-allowlisted name drops error_name to undefined", () => {
+  test("prefers the deliberately-set .name over the wrapper's constructor", () => {
+    // The core MiddlewareError case: the wrapper's constructor is the envelope
+    // class, but its .name was set to the inner error's identity. Reading .name
+    // recovers the real failure even with no cause link to walk.
+    const wrapper = Object.assign(new Error("wrapModelCall failed"), {
+      name: "AI_APICallError",
+    });
+
+    const described = describeErrorForTelemetry(wrapper);
+
+    expect(described.errorClass).toBe("agent_error");
+    expect(described.errorDetail).toBe("AI_APICallError");
+  });
+
+  test("a residual with an un-allowlisted name drops error_detail to undefined", () => {
     class Weird {}
     Object.defineProperty(Weird, "name", { value: "weird name/with space" });
 
     const described = describeErrorForTelemetry(new Weird());
 
     expect(described.errorClass).toBe("agent_error");
-    expect(described.errorName).toBeUndefined();
+    expect(described.errorDetail).toBeUndefined();
   });
 
   test("http_status is surfaced from a wrapped provider error", () => {
@@ -416,8 +483,6 @@ describe("describeErrorForTelemetry - residual fingerprint", () => {
     expect(described.errorClass).toBe("provider_error");
     expect(described.errorDetail).toBe("overloaded");
     expect(described.httpStatus).toBe(503);
-    // A recovered (named) class is not fingerprinted.
-    expect(described.errorName).toBeUndefined();
   });
 
   test("firstStatusInChain returns undefined when no link exposes a status", () => {
@@ -570,17 +635,16 @@ describe("error origin tags", () => {
     });
   });
 
-  test("leaves detail, stage, and status undefined when absent", () => {
-    // A bare residual Error carries no detail/stage/status, but it is still
-    // fingerprinted: "Error" is an allowlisted constructor name, so the residual
-    // agent_error bucket gains an error_name to slice on.
+  test("leaves stage and status undefined when absent, detail is the name", () => {
+    // A bare residual Error carries no stage/status, but it is still fingerprinted:
+    // "Error" is an allowlisted name, so the residual agent_error bucket carries it
+    // as error_detail to slice on.
     expect(describeErrorForTelemetry(new Error("boom"))).toEqual({
       errorClass: "agent_error",
-      errorDetail: undefined,
+      errorDetail: "Error",
       errorStage: undefined,
       errorOwner: "unowned",
       httpStatus: undefined,
-      errorName: "Error",
     });
   });
 });
@@ -974,38 +1038,27 @@ describe("buildRunEvent diagnostics", () => {
     expect(event.properties).not.toHaveProperty("error_owner");
     expect(event.properties).not.toHaveProperty("error_stage");
     expect(event.properties).not.toHaveProperty("http_status");
+    // The residual fingerprint never rode as its own property; it is folded into
+    // error_detail, so error_name must never appear on any event.
     expect(event.properties).not.toHaveProperty("error_name");
   });
 
-  test("the residual fingerprint rides only when error_name is present", () => {
-    // A residual failure carries error_name; a named class leaves it undefined so
-    // the property is absent and the PostHog null bucket reads as "classified".
+  test("the residual fingerprint rides as error_detail", () => {
+    // The residual bucket carries the innermost error's name as error_detail; it is
+    // never emitted under a separate error_name property.
     const residual = buildRunEvent(
       {
         command: "init",
         outcome: "failure",
         errorClass: "agent_error",
+        errorDetail: "TypeError",
         errorOwner: "unowned",
         errorStage: "run",
-        errorName: "TypeError",
       },
       baseContext,
     );
-    expect(residual.properties).toMatchObject({ error_name: "TypeError" });
-
-    const named = buildRunEvent(
-      {
-        command: "init",
-        outcome: "failure",
-        errorClass: "provider_error",
-        errorDetail: "rate_limit",
-        errorOwner: "provider",
-        errorStage: "run",
-        httpStatus: 429,
-      },
-      baseContext,
-    );
-    expect(named.properties).not.toHaveProperty("error_name");
+    expect(residual.properties).toMatchObject({ error_detail: "TypeError" });
+    expect(residual.properties).not.toHaveProperty("error_name");
   });
 
   test("http_status of 0 would still ride, but omission is by undefined only", () => {
@@ -1166,7 +1219,13 @@ describe("anonymity envelope: one representative failure per reachable family", 
           expect(ENUM_ALLOWLISTS[key].has(value as string)).toBe(true);
           break;
         case "error_detail":
-          expect(DETAIL_ALLOWLIST.has(value as string)).toBe(true);
+          // A fixed-family detail is an allowlisted word; the residual agent_error
+          // bucket instead carries the innermost error's name, gated to a bare
+          // identifier. Either shape is inside the envelope; nothing else is.
+          expect(
+            DETAIL_ALLOWLIST.has(value as string) ||
+              isSafeErrorIdentifier(value),
+          ).toBe(true);
           break;
         case "provider":
           expect(PROVIDER_ALLOWLIST.has(value as string)).toBe(true);
@@ -1174,11 +1233,6 @@ describe("anonymity envelope: one representative failure per reachable family", 
         case "http_status":
           // A bare integer; no provider strings ride with it.
           expect(Number.isInteger(value)).toBe(true);
-          break;
-        case "error_name":
-          // A bare ASCII constructor identifier, nothing else: the residual
-          // fingerprint is gated to exactly this shape before it can leave.
-          expect(value).toMatch(/^[A-Za-z][A-Za-z0-9]{0,63}$/u);
           break;
         case "app_version":
           expect(value).toMatch(/^\d+\.\d+\.\d+/u);
@@ -1312,7 +1366,6 @@ describe("anonymity envelope: one representative failure per reachable family", 
           errorOwner: described.errorOwner,
           errorStage: described.errorStage,
           httpStatus: described.httpStatus,
-          errorName: described.errorName,
         },
         sweepContext,
       );

--- a/test/telemetry.test.ts
+++ b/test/telemetry.test.ts
@@ -42,6 +42,7 @@ import {
   normalizeErrorDetail,
 } from "../src/telemetry/taxonomy.ts";
 import {
+  buildChannel,
   ciSentinelId,
   isCiEnvironment,
   isTelemetryDisabled,
@@ -1071,6 +1072,7 @@ describe("buildRunEvent diagnostics", () => {
   const baseContext: RunEventContext = {
     ci: false,
     production: true,
+    buildChannel: "official",
     distinctId: "install-abc",
   };
 
@@ -1172,6 +1174,31 @@ describe("buildRunEvent diagnostics", () => {
 
     expect(event.properties).not.toHaveProperty("app_version");
   });
+
+  test("build_channel is stamped from the context on every event", () => {
+    // The channel is a peer of production/ci: baked at build time, resolved by
+    // the caller, and it rides both success and failure events verbatim.
+    const official = buildRunEvent(
+      { command: "init", outcome: "success" },
+      { ...baseContext, buildChannel: "official" },
+    );
+    const community = buildRunEvent(
+      { command: "update", outcome: "failure", errorClass: "agent_error" },
+      { ...baseContext, buildChannel: "community" },
+    );
+
+    expect(official.properties.build_channel).toBe("official");
+    expect(community.properties.build_channel).toBe("community");
+  });
+});
+
+describe("buildChannel", () => {
+  test("the committed default is community", () => {
+    // The stamp script rewrites this to "official" only on the official release
+    // path; the committed source must always resolve to "community" so a fork or
+    // local build never mislabels its telemetry as official.
+    expect(buildChannel()).toBe("community");
+  });
 });
 
 describe("anonymity envelope: one representative failure per reachable family", () => {
@@ -1258,6 +1285,7 @@ describe("anonymity envelope: one representative failure per reachable family", 
   const sweepContext: RunEventContext = {
     ci: false,
     production: true,
+    buildChannel: "official",
     // An anonymous install UUID, exactly the shape recordRun attributes to.
     distinctId: "0f9a2c1e-4b3d-4e5f-8a1b-2c3d4e5f6a7b",
     appVersion: "0.2.3",
@@ -1310,6 +1338,10 @@ describe("anonymity envelope: one representative failure per reachable family", 
           break;
         case "app_version":
           expect(value).toMatch(/^\d+\.\d+\.\d+/u);
+          break;
+        case "build_channel":
+          // A closed two-value enum baked at build time; never a free string.
+          expect(["official", "community"]).toContain(value);
           break;
         case "production":
         case "ci":

--- a/test/telemetry.test.ts
+++ b/test/telemetry.test.ts
@@ -493,6 +493,80 @@ describe("describeErrorForTelemetry - residual fingerprint", () => {
   });
 });
 
+describe("describeErrorForTelemetry - stream_open de-own", () => {
+  /**
+   * Tags `thrown` exactly as the production stream-open call site does — through
+   * inStageSync with the { build_error, stream_open } origin — and returns the tagged
+   * error, so these tests exercise the real tag, not a hand-built one.
+   */
+  function taggedStreamOpen(thrown: unknown): unknown {
+    try {
+      inStageSync(
+        "build",
+        () => {
+          throw thrown;
+        },
+        {
+          errorClass: "build_error",
+          errorDetail: "stream_open",
+        },
+      );
+    } catch (error) {
+      return error;
+    }
+    throw new Error("expected the staged fn to throw");
+  }
+
+  test("a provider failure disguised as stream_open lands on the provider", () => {
+    // A 503 thrown during the first provider round trip is the provider's fault, not
+    // our stream-setup bug: the raw classification wins over the build_error tag.
+    const described = describeErrorForTelemetry(
+      taggedStreamOpen(Object.assign(new Error("upstream"), { status: 503 })),
+    );
+
+    expect(described).toMatchObject({
+      errorClass: "provider_error",
+      errorDetail: "overloaded",
+      errorOwner: "provider",
+      // The stage still records where it happened; only the class/owner move.
+      errorStage: "build",
+      httpStatus: 503,
+    });
+  });
+
+  test("a genuine stream-setup failure keeps its build_error tag", () => {
+    // No provider signal (no status, classifies as the residual): this really is our
+    // stream-setup path, so the tag stands and the owner stays openwiki.
+    const described = describeErrorForTelemetry(
+      taggedStreamOpen(new Error("stream handshake failed")),
+    );
+
+    expect(described).toMatchObject({
+      errorClass: "build_error",
+      errorDetail: "stream_open",
+      errorOwner: "openwiki",
+      errorStage: "build",
+    });
+    expect(described.httpStatus).toBeUndefined();
+  });
+
+  test("an unclassifiable status does not regress build_error to the residual", () => {
+    // A status is present but unmapped (418), so the raw classifier returns the
+    // residual agent_error. De-owning here would trade an informative build_error for
+    // the residual bucket, so the guard keeps the tag; the status still rides.
+    const described = describeErrorForTelemetry(
+      taggedStreamOpen(Object.assign(new Error("teapot"), { status: 418 })),
+    );
+
+    expect(described).toMatchObject({
+      errorClass: "build_error",
+      errorDetail: "stream_open",
+      errorOwner: "openwiki",
+      httpStatus: 418,
+    });
+  });
+});
+
 describe("taxonomy", () => {
   test("deriveOwner encodes the default owners", () => {
     expect(deriveOwner("config_error", "missing_credentials", "config")).toBe(


### PR DESCRIPTION
## Summary

Init-failure telemetry was over-counting and mis-attributing, making the dashboards unactionable. Four fixes:

1. **Crash-guard race** — `handleFatal` claims and clears the active run synchronously before any await, so a burst of N escaped rejections for one crash records one failure, not N. This alone was inflating every failure count.

2. **Pierce MiddlewareError + fold the fingerprint** — fingerprint the inner error's `.name` (not the always-`"MiddlewareError"` constructor name), fold it into `error_detail` (drops the separate `error_name` field), and deepen the unwrap bound 5→32 so the real cause is reachable.

3. **stream_open de-own** — a provider failure during the first HTTP round trip no longer hides as `build_error/stream_open`; when the chain carries a provider signal, raw classification wins. Genuine no-status stream-setup failures keep the tag.

4. **build_channel marker** — stamp every event `official` vs `community` so fork telemetry is filterable. Baked via a committed constant flipped on the release path only (plain-tsc build, no bundler); fork releases stay `community`.