### PR TITLE
fix: close visualizer resources on Ctrl-C

### DIFF
--- a/.changeset/calm-dragons-stop.md
+++ b/.changeset/calm-dragons-stop.md
@@ -1,0 +1,5 @@
+---
+"openwiki": patch
+---
+
+Stop the visualizer cleanly when live-reload browser clients are connected.

--- a/src/visualize/server.ts
+++ b/src/visualize/server.ts
@@ -45,7 +45,7 @@ export interface VisualizeServerOptions {
 /*
  * Coverage: the server-lifecycle code below (boot, listen/retry, fs watch,
  * browser launch, banner) needs a live HTTP server, a real filesystem, and a
- * SIGINT to exercise - none reachable from a unit test. Its one piece of pure
+ * SIGINT to exercise. Focused integration tests cover the shutdown path, and
  * request logic is extracted into `createRequestHandler` (fully covered), so we
  * exclude the lifecycle glue rather than count it as permanently uncovered.
  */
@@ -68,6 +68,8 @@ export async function runVisualizeServer(
     edges: [],
   };
   const sseClients = new Set<ServerResponse>();
+  let watchHandle: { close(): void } | undefined;
+  let stopping = false;
 
   // The compiled client modules and the stylesheet sit beside this file in dist/visualize/.
   // They are static, server-owned build artifacts (no user input, never evaluated), read once
@@ -103,13 +105,16 @@ export async function runVisualizeServer(
 
   return new Promise<void>((resolve) => {
     process.once("SIGINT", () => {
+      stopping = true;
       process.stdout.write("\n  stopped.\n");
+      closeVisualizerResources(sseClients, watchHandle);
       server.close(() => resolve());
     });
     listen(server, options.port, PORT_ATTEMPTS, (boundPort) => {
       const url = `http://${HOST}:${boundPort}`;
       void rebuild("initial scan").then(() => {
-        startWatch(wikiRoot, rebuild);
+        if (stopping) return;
+        watchHandle = startWatch(wikiRoot, rebuild);
         printBanner(wikiRoot, url);
         if (options.open) openBrowser(url);
       });
@@ -151,6 +156,20 @@ export interface RequestHandlerDeps {
    * `/events` subscribers here and drops them when the connection closes.
    */
   sseClients: Set<ServerResponse>;
+}
+
+/**
+ * Close the long-lived resources owned by the visualizer before stopping its
+ * HTTP server. Ending SSE responses lets `server.close()` finish even while a
+ * browser tab is still connected.
+ */
+export function closeVisualizerResources(
+  sseClients: Set<ServerResponse>,
+  watchHandle?: { close(): void },
+): void {
+  for (const response of sseClients) response.end();
+  sseClients.clear();
+  watchHandle?.close();
 }
 
 /**
@@ -260,18 +279,25 @@ function listen(
 function startWatch(
   wikiRoot: string,
   rebuild: (reason: string) => Promise<void>,
-): void {
+): { close(): void } | undefined {
   let timer: NodeJS.Timeout | undefined;
   try {
-    watch(wikiRoot, { recursive: true }, () => {
+    const watcher = watch(wikiRoot, { recursive: true }, () => {
       clearTimeout(timer);
       timer = setTimeout(
         () => void rebuild("change detected"),
         WATCH_DEBOUNCE_MS,
       );
     });
+    return {
+      close(): void {
+        clearTimeout(timer);
+        watcher.close();
+      },
+    };
   } catch {
     process.stdout.write("  (live watch unavailable on this platform)\n");
+    return undefined;
   }
 }
 

--- a/test/visualize/server.test.ts
+++ b/test/visualize/server.test.ts
@@ -1,6 +1,9 @@
 import type { IncomingMessage, ServerResponse } from "node:http";
 import { beforeEach, describe, expect, test, vi } from "vitest";
-import { createRequestHandler } from "../../src/visualize/server.ts";
+import {
+  closeVisualizerResources,
+  createRequestHandler,
+} from "../../src/visualize/server.ts";
 import type { WikiGraph } from "../../src/visualize/graph.ts";
 import { PAGE } from "../../src/visualize/page.ts";
 
@@ -203,6 +206,30 @@ describe("createRequestHandler", () => {
     // The close listener drops the subscriber so we never write to a dead socket.
     request.closeListener();
     expect(sseClients.has(out.res)).toBe(false);
+  });
+
+  test("shutdown ends active SSE streams and closes the wiki watcher", () => {
+    const disconnectedRequest = makeRequest("/events");
+    const disconnected = makeResponse();
+    handler(disconnectedRequest.req, disconnected.res);
+
+    const activeRequest = makeRequest("/events");
+    const active = makeResponse();
+    handler(activeRequest.req, active.res);
+
+    disconnectedRequest.closeListener();
+    const watchHandle = { close: vi.fn() };
+
+    closeVisualizerResources(sseClients, watchHandle);
+
+    expect(disconnected.ended).toBe(false);
+    expect(active.ended).toBe(true);
+    expect(sseClients.size).toBe(0);
+    expect(watchHandle.close).toHaveBeenCalledOnce();
+
+    // Normal disconnect cleanup remains safe after shutdown clears the set.
+    activeRequest.closeListener();
+    expect(sseClients.size).toBe(0);
   });
 
   test("an unknown route is a 404, never a filesystem read", () => {

--- a/test/visualize/visualize-shutdown.test.ts
+++ b/test/visualize/visualize-shutdown.test.ts
@@ -1,0 +1,194 @@
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { createServer } from "node:http";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, expect, test, vi } from "vitest";
+
+type WatchCallback = (
+  eventType: string,
+  filename: string | Buffer | null,
+) => void;
+
+const watcherState: {
+  close: ReturnType<typeof vi.fn>;
+  callback: WatchCallback | undefined;
+} = vi.hoisted(() => ({
+  close: vi.fn(),
+  callback: undefined as WatchCallback | undefined,
+}));
+
+vi.mock("node:fs", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("node:fs")>()),
+  watch: vi.fn((_path: string, _options: object, listener: WatchCallback) => {
+    watcherState.callback = listener;
+    return { close: watcherState.close };
+  }),
+}));
+
+vi.mock("../../src/visualize/static-export.js", () => ({
+  loadVisualizerAssets: vi.fn(() =>
+    Promise.resolve({
+      clientJs: "/* client */",
+      clientLibJs: "/* client-lib */",
+      stylesCss: "/* styles */",
+    }),
+  ),
+}));
+
+import { runVisualizeServer } from "../../src/visualize/server.ts";
+
+const tempDirs: string[] = [];
+
+beforeEach(() => {
+  watcherState.close.mockReset();
+  watcherState.callback = undefined;
+});
+
+afterEach(async () => {
+  await Promise.all(
+    tempDirs.splice(0).map((dir) => rm(dir, { force: true, recursive: true })),
+  );
+});
+
+async function makeWiki(): Promise<string> {
+  const wikiRoot = await mkdtemp(path.join(tmpdir(), "openwiki-viz-shutdown-"));
+  tempDirs.push(wikiRoot);
+  await writeFile(path.join(wikiRoot, "index.md"), "# Home\n", "utf8");
+  return wikiRoot;
+}
+
+async function findOpenPort(): Promise<number> {
+  const server = createServer();
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", resolve);
+  });
+  const address = server.address();
+  if (typeof address === "string" || address === null) {
+    throw new Error("Expected the probe server to bind a TCP port");
+  }
+  const { port } = address;
+  await new Promise<void>((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()));
+  });
+  return port;
+}
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function waitForServer(baseUrl: string): Promise<void> {
+  const deadline = Date.now() + 2000;
+  let lastError: unknown;
+  while (Date.now() < deadline) {
+    try {
+      const response = await fetch(`${baseUrl}/api/graph`);
+      await response.arrayBuffer();
+      if (response.ok) return;
+    } catch (error) {
+      lastError = error;
+    }
+    await delay(25);
+  }
+  throw new Error(
+    `visualizer server did not start: ${
+      lastError instanceof Error ? lastError.message : String(lastError)
+    }`,
+  );
+}
+
+async function withTimeout<T>(
+  promise: Promise<T>,
+  ms: number,
+  message: string,
+): Promise<T> {
+  return await new Promise<T>((resolve, reject) => {
+    const timer = setTimeout(() => reject(new Error(message)), ms);
+    void promise.then(
+      (value) => {
+        clearTimeout(timer);
+        resolve(value);
+      },
+      (error: unknown) => {
+        clearTimeout(timer);
+        reject(error instanceof Error ? error : new Error(String(error)));
+      },
+    );
+  });
+}
+
+function removeNewSigintListeners(previous: NodeJS.SignalsListener[]): void {
+  for (const listener of process.listeners("SIGINT")) {
+    if (!previous.includes(listener)) {
+      process.removeListener("SIGINT", listener);
+    }
+  }
+}
+
+test("SIGINT resolves the visualizer server while an SSE stream is open", async () => {
+  const previousSigintListeners = process.listeners("SIGINT");
+  const stdout = vi
+    .spyOn(process.stdout, "write")
+    .mockImplementation(() => true);
+  const wikiRoot = await makeWiki();
+  const port = await findOpenPort();
+  const baseUrl = `http://127.0.0.1:${port}`;
+  const controller = new AbortController();
+  let reader: ReadableStreamDefaultReader<Uint8Array> | undefined;
+  const runPromise = runVisualizeServer({ wikiRoot, port, open: false });
+
+  try {
+    await waitForServer(baseUrl);
+    await vi.waitFor(() => expect(watcherState.callback).toBeDefined());
+
+    const response = await fetch(`${baseUrl}/events`, {
+      signal: controller.signal,
+    });
+    expect(response.status).toBe(200);
+    expect(response.headers.get("content-type")).toContain("text/event-stream");
+    expect(response.body).not.toBeNull();
+
+    reader = response.body.getReader();
+    const initial = await withTimeout(
+      reader.read(),
+      1000,
+      "SSE stream did not send its initial retry frame",
+    );
+    expect(new TextDecoder().decode(initial.value)).toContain("retry: 2000");
+    watcherState.callback?.("change", "index.md");
+
+    process.emit("SIGINT");
+
+    await withTimeout(
+      runPromise,
+      1000,
+      "visualizer server did not stop after SIGINT",
+    );
+    const afterShutdown = await withTimeout(
+      reader.read(),
+      1000,
+      "SSE stream did not end after SIGINT",
+    );
+
+    expect(afterShutdown.done).toBe(true);
+    expect(watcherState.close).toHaveBeenCalledOnce();
+    await delay(200);
+    const output = stdout.mock.calls.map(([chunk]) => String(chunk)).join("");
+    expect(output).toContain("stopped.");
+    expect(output).not.toContain("change detected");
+  } finally {
+    controller.abort();
+    reader?.releaseLock();
+    if (
+      process
+        .listeners("SIGINT")
+        .some((listener) => !previousSigintListeners.includes(listener))
+    ) {
+      process.emit("SIGINT");
+    }
+    await Promise.race([runPromise.catch(() => undefined), delay(500)]);
+    removeNewSigintListeners(previousSigintListeners);
+    stdout.mockRestore();
+  }
+});


### PR DESCRIPTION
## Summary

- end active live-reload SSE responses before closing the visualizer HTTP server
- close the recursive file watcher and pending debounce timer, including the initial-scan shutdown race
- add shutdown-path regression coverage and a patch changeset

## Testing

- `corepack pnpm exec vitest run test/visualize/visualize-shutdown.test.ts` (1 passed)
- `corepack pnpm exec vitest run test/visualize/server.test.ts test/visualize/visualize-shutdown.test.ts` (17 passed)
- `corepack pnpm exec vitest run test/visualize/server.test.ts test/visualize/visualize-shutdown.test.ts test/visualize/visualize-server.test.ts test/visualize/static-export.test.ts test/visualize/page.test.ts test/visualize/visualize-client-lib.test.ts` (45 passed)
- `corepack pnpm run typecheck`
- `corepack pnpm run lint:check`
- `corepack pnpm run format:check`
- manual build path: clean `dist`, run both TypeScript projects, copy visualizer assets, and chmod the CLI entrypoint
- `git diff --check`

`corepack pnpm exec vitest run test/visualize` reaches the existing local Windows symlink permission issue in `visualize-graph.test.ts:119` before that test body runs (`EPERM` creating a symlink). The shutdown regression and the other visualizer tests listed above pass locally.

Fixes #623