### PR TITLE
feat: add apac region support for langsmith

### DIFF
--- a/.changeset/six-houses-crash.md
+++ b/.changeset/six-houses-crash.md
@@ -1,0 +1,5 @@
+---
+"openwiki": patch
+---
+
+feat: add apac region support for langsmith

--- a/src/connectors/sources/langsmith/repo-config.ts
+++ b/src/connectors/sources/langsmith/repo-config.ts
@@ -49,6 +49,7 @@ export interface LangSmithRepoConfig {
 const ALLOWED_API_HOSTS = new Set([
   "api.smith.langchain.com",
   "eu.api.smith.langchain.com",
+  "apac.api.smith.langchain.com",
 ]);
 
 /**

--- a/src/connectors/sources/langsmith/setup.ts
+++ b/src/connectors/sources/langsmith/setup.ts
@@ -5,16 +5,21 @@ import {
 } from "./repo-config.js";
 
 /**
- * LangSmith workspace region. Maps to the two official API hosts the connector
+ * LangSmith workspace region. Maps to the three official API hosts the connector
  * is allowlisted to talk to; the wizard offers this instead of a raw URL.
  */
-export type LangSmithRegion = "us" | "eu";
+export type LangSmithRegion = "us" | "eu" | "apac";
 
 /**
  * EU host, written to apiBaseUrl for EU workspaces. The US host is the connector
  * default, so it is left out of the file entirely.
  */
 const EU_API_BASE_URL = "https://eu.api.smith.langchain.com";
+
+/**
+ * APAC host, written to apiBaseUrl for APAC workspaces.
+ */
+const APAC_API_BASE_URL = "https://apac.api.smith.langchain.com";
 
 /**
  * Base env var name for the first workspace's key. Additional workspaces get
@@ -54,7 +59,12 @@ export async function loadLangSmithSetup(
   return (config?.workspaces ?? []).map((workspace) => ({
     apiKeyEnv: workspace.apiKeyEnv,
     projects: workspace.projects.map((project) => project.name),
-    region: workspace.apiBaseUrl === EU_API_BASE_URL ? "eu" : "us",
+    region:
+      workspace.apiBaseUrl === EU_API_BASE_URL
+        ? "eu"
+        : workspace.apiBaseUrl === APAC_API_BASE_URL
+          ? "apac"
+          : "us",
   }));
 }
 
@@ -87,7 +97,11 @@ export async function saveLangSmithSetup(
     cleaned.push({
       apiKeyEnv: workspace.apiKeyEnv,
       projects,
-      ...(workspace.region === "eu" ? { apiBaseUrl: EU_API_BASE_URL } : {}),
+      ...(workspace.region === "eu"
+        ? { apiBaseUrl: EU_API_BASE_URL }
+        : workspace.region === "apac"
+          ? { apiBaseUrl: APAC_API_BASE_URL }
+          : {}),
     });
   }
   if (cleaned.length === 0 && !existing) {

--- a/src/setup/credentials/constants.ts
+++ b/src/setup/credentials/constants.ts
@@ -81,6 +81,12 @@ export const LANGSMITH_REGION_OPTIONS = [
     id: "eu",
     name: "EU",
   },
+  {
+    description: "APAC workspaces.",
+    host: "https://apac.api.smith.langchain.com",
+    id: "apac",
+    name: "APAC",
+  },
 ] as const satisfies readonly {
   description: string;
   host: string;

--- a/test/connectors/sources/langsmith/repo-config.test.ts
+++ b/test/connectors/sources/langsmith/repo-config.test.ts
@@ -192,6 +192,9 @@ describe("sanitizeLangSmithApiBaseUrl", () => {
     expect(
       sanitizeLangSmithApiBaseUrl("https://eu.api.smith.langchain.com"),
     ).toBe("https://eu.api.smith.langchain.com");
+    expect(
+      sanitizeLangSmithApiBaseUrl("https://apac.api.smith.langchain.com"),
+    ).toBe("https://apac.api.smith.langchain.com");
   });
 
   test.each([

--- a/test/connectors/sources/langsmith/setup.test.ts
+++ b/test/connectors/sources/langsmith/setup.test.ts
@@ -17,6 +17,7 @@ import {
 
 const REPO = "/repo";
 const EU = "https://eu.api.smith.langchain.com";
+const APAC = "https://apac.api.smith.langchain.com";
 
 beforeEach(() => {
   vi.clearAllMocks();
@@ -52,6 +53,26 @@ describe("loadLangSmithSetup", () => {
     ]);
   });
 
+  test("maps an APAC workspace to region apac", async () => {
+    vi.mocked(readLangSmithRepoConfig).mockResolvedValue({
+      workspaces: [
+        {
+          apiBaseUrl: APAC,
+          apiKeyEnv: "OPENWIKI_LANGSMITH_API_KEY",
+          projects: [{ name: "p" }],
+        },
+      ],
+    });
+
+    await expect(loadLangSmithSetup(REPO)).resolves.toEqual([
+      {
+        apiKeyEnv: "OPENWIKI_LANGSMITH_API_KEY",
+        projects: ["p"],
+        region: "apac",
+      },
+    ]);
+  });
+
   test("returns an empty list when the repo has no config", async () => {
     vi.mocked(readLangSmithRepoConfig).mockResolvedValue(undefined);
 
@@ -83,6 +104,28 @@ describe("saveLangSmithSetup", () => {
           apiBaseUrl: EU,
           apiKeyEnv: "OPENWIKI_LANGSMITH_API_KEY_2",
           projects: [{ name: "b" }],
+        },
+      ],
+    });
+  });
+
+  test("writes APAC apiBaseUrl for an APAC workspace", async () => {
+    vi.mocked(readLangSmithRepoConfig).mockResolvedValue(undefined);
+
+    await saveLangSmithSetup(REPO, [
+      {
+        apiKeyEnv: "OPENWIKI_LANGSMITH_API_KEY",
+        projects: ["a"],
+        region: "apac",
+      },
+    ]);
+
+    expect(writeLangSmithRepoConfig).toHaveBeenCalledWith(REPO, {
+      workspaces: [
+        {
+          apiBaseUrl: APAC,
+          apiKeyEnv: "OPENWIKI_LANGSMITH_API_KEY",
+          projects: [{ name: "a" }],
         },
       ],
     });


### PR DESCRIPTION
## Summary

- Extends `LangSmithRegion` type to include `"apac"`
- Adds `https://apac.api.smith.langchain.com` to the `ALLOWED_API_HOSTS` allowlist in `repo-config.ts` (security guard for committed configs)
- Adds `APAC_API_BASE_URL` constant and wires it through `loadLangSmithSetup` / `saveLangSmithSetup` for round-trip serialize/deserialize
- Adds an APAC entry to `LANGSMITH_REGION_OPTIONS` so the setup wizard surfaces it alongside US and EU

## Test plan

- [x] `loadLangSmithSetup` maps an APAC `apiBaseUrl` to region `"apac"`
- [x] `saveLangSmithSetup` writes the APAC `apiBaseUrl` for an APAC workspace
- [x] `sanitizeLangSmithApiBaseUrl` accepts `https://apac.api.smith.langchain.com`
- [x] All 46 existing + new tests pass (`pnpm exec vitest run`)

Fixes #593