### PR TITLE
feat: add claude-cli provider (Claude Code subscription auth)

### DIFF
--- a/.changeset/claude-cli-tool-refusal.md
+++ b/.changeset/claude-cli-tool-refusal.md
@@ -1,0 +1,15 @@
+---
+"openwiki": patch
+---
+
+claude-cli provider: recover when the model reports its tools are missing.
+
+`claude -p` exposes no native tools, so this provider passes OpenWiki's toolset
+in the prompt and reads tool calls back out of the structured reply. A model
+that distrusts that framing answers with prose about the missing tools instead
+of the calls that would have done the work — and because that prose is a
+well-formed `kind:"text"` reply, the agent loop accepts it as a finished turn.
+The run reports success having written nothing.
+
+Such a reply is now retried once with a correction rather than taken at face
+value.

--- a/src/agent/claude-cli-model.ts
+++ b/src/agent/claude-cli-model.ts
@@ -1,0 +1,327 @@
+import { spawn } from "node:child_process";
+import { randomUUID } from "node:crypto";
+import { tmpdir } from "node:os";
+import {
+  BaseChatModel,
+  type BaseChatModelCallOptions,
+  type BaseChatModelParams,
+} from "@langchain/core/language_models/chat_models";
+import type { BindToolsInput } from "@langchain/core/language_models/chat_models";
+import type { BaseLanguageModelInput } from "@langchain/core/language_models/base";
+import {
+  AIMessage,
+  type AIMessageChunk,
+  type BaseMessage,
+  type ToolMessage,
+} from "@langchain/core/messages";
+import type { ChatResult } from "@langchain/core/outputs";
+import type { Runnable } from "@langchain/core/runnables";
+import { convertToOpenAITool } from "@langchain/core/utils/function_calling";
+
+/**
+ * CLI spawn + agent startup adds seconds over a raw API call, and a
+ * rate-limited plan can queue, so the per-call ceiling is generous.
+ */
+// Late-run turns replay the whole transcript and can exceed 3 minutes on
+// verification passes; 10 minutes matches the CLI's own request ceiling.
+const DEFAULT_TIMEOUT_MS = 600_000;
+
+type ClaudeToolSpec = {
+  name: string;
+  description: string;
+  parameters: Record<string, unknown>;
+};
+
+type StructuredReply = {
+  kind: "text" | "tool_calls";
+  text?: string;
+  tool_calls?: { name: string; arguments: Record<string, unknown> }[];
+};
+
+/**
+ * `claude -p` answers with one final message and cannot hand a tool call back
+ * mid-turn, so tool calling is modelled as structured output instead: the
+ * schema below lets the model either finish with prose or emit the calls it
+ * wants, and `--json-schema` enforces the shape server-side rather than leaving
+ * it to prompt-level parsing.
+ */
+function buildReplySchema(): Record<string, unknown> {
+  return {
+    type: "object",
+    properties: {
+      kind: { type: "string", enum: ["text", "tool_calls"] },
+      text: { type: "string" },
+      tool_calls: {
+        type: "array",
+        items: {
+          type: "object",
+          properties: {
+            name: { type: "string" },
+            arguments: { type: "object", additionalProperties: true },
+          },
+          required: ["name", "arguments"],
+          additionalProperties: false,
+        },
+      },
+    },
+    required: ["kind"],
+    additionalProperties: false,
+  };
+}
+
+function renderTools(tools: ClaudeToolSpec[]): string {
+  if (tools.length === 0) {
+    return "";
+  }
+
+  const rendered = tools
+    .map(
+      (tool) =>
+        `### ${tool.name}\n${tool.description}\nparameters: ${JSON.stringify(tool.parameters)}`,
+    )
+    .join("\n\n");
+
+  // The surrounding agent's system prompt tells the model to invoke these
+  // directly. It cannot: `claude -p` exposes no such tools to the session.
+  // Framing matters here: models that find an empty native roster infer a
+  // misconfigured session and refuse. Explaining the mechanism (rather than
+  // commanding "never report tools missing") is what defuses that inference.
+  return (
+    `## Tools\n\n` +
+    `You are running non-interactively via the Claude Code CLI (\`claude -p\`), ` +
+    `which cannot expose custom tools to a session — so your native tool roster ` +
+    `is empty by design, not by misconfiguration. This process is one step inside ` +
+    `an automated documentation harness that drives you in a loop.\n\n` +
+    `How a tool call executes here:\n` +
+    `1. You respond in the required JSON format with kind "tool_calls", naming a tool below with its arguments.\n` +
+    `2. The harness parses that response, executes the real tool against the actual repository, and starts your next turn with the tool's output in the transcript.\n` +
+    `3. You continue from that result.\n\n` +
+    `Emitting the JSON IS the tool call: the filesystem access is real, it just ` +
+    `happens between your turns instead of inside them. An empty native roster plus ` +
+    `these instructions is the normal, working state of this harness.\n\n` +
+    `There is no human in this session. Never ask for permission or confirmation, ` +
+    `and never end a turn by announcing what you will do next — if work remains, ` +
+    `emit the next tool call.\n\n${rendered}\n\n`
+  );
+}
+
+/**
+ * Flattens the exchange into a single prompt. `claude -p` takes one prompt
+ * rather than a message array, so prior tool calls and their results are
+ * replayed as transcript lines to keep the loop's history intact.
+ */
+function renderMessages(messages: BaseMessage[]): string {
+  const lines: string[] = [];
+
+  for (const message of messages) {
+    const text =
+      typeof message.content === "string"
+        ? message.content
+        : JSON.stringify(message.content);
+
+    switch (message.getType()) {
+      case "system":
+        lines.push(`[instructions]\n${text}`);
+        break;
+      case "human":
+        lines.push(`[user]\n${text}`);
+        break;
+      case "ai": {
+        const calls = (message as AIMessage).tool_calls ?? [];
+
+        if (calls.length > 0) {
+          for (const call of calls) {
+            lines.push(
+              `[assistant called ${call.name}]\n${JSON.stringify(call.args)}`,
+            );
+          }
+        }
+
+        if (text.trim()) {
+          lines.push(`[assistant]\n${text}`);
+        }
+        break;
+      }
+      case "tool": {
+        const toolMessage = message as ToolMessage;
+
+        lines.push(`[result of ${toolMessage.name ?? "tool"}]\n${text}`);
+        break;
+      }
+      default:
+        lines.push(text);
+    }
+  }
+
+  return lines.join("\n\n");
+}
+
+function parseEnvelope(stdout: string): StructuredReply {
+  const envelope = JSON.parse(stdout) as {
+    structured_output?: StructuredReply;
+    result?: string;
+    is_error?: boolean;
+  };
+
+  // The CLI parses the schema-enforced payload for us; `result` is the same
+  // JSON as a string and is only a fallback for older CLI builds.
+  if (envelope.structured_output) {
+    return envelope.structured_output;
+  }
+
+  if (typeof envelope.result === "string") {
+    return JSON.parse(envelope.result) as StructuredReply;
+  }
+
+  throw new Error("claude -p returned no structured output");
+}
+
+export type ChatClaudeCliParams = BaseChatModelParams & {
+  model: string;
+  timeoutMs?: number;
+};
+
+/**
+ * Runs Claude Code headlessly (`claude -p`) as a chat model, authenticating
+ * through the same login as the interactive CLI rather than an API key.
+ */
+export class ChatClaudeCli extends BaseChatModel<BaseChatModelCallOptions> {
+  private readonly model: string;
+  private readonly timeoutMs: number;
+  private readonly boundTools: ClaudeToolSpec[];
+
+  constructor(params: ChatClaudeCliParams, boundTools: ClaudeToolSpec[] = []) {
+    super(params);
+    this.model = params.model;
+    this.timeoutMs = params.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+    this.boundTools = boundTools;
+  }
+
+  _llmType(): string {
+    return "claude-cli";
+  }
+
+  override bindTools(
+    tools: BindToolsInput[],
+  ): Runnable<BaseLanguageModelInput, AIMessageChunk, BaseChatModelCallOptions> {
+    const specs = tools.map((tool) => {
+      const { function: fn } = convertToOpenAITool(tool);
+
+      return {
+        name: fn.name,
+        description: fn.description ?? "",
+        parameters: fn.parameters ?? {},
+      };
+    });
+
+    // Tools are carried on a fresh instance rather than mutated in place, so a
+    // model bound with one toolset never leaks it into another binding.
+    return new ChatClaudeCli(
+      { model: this.model, timeoutMs: this.timeoutMs },
+      specs,
+    );
+  }
+
+  async _generate(messages: BaseMessage[]): Promise<ChatResult> {
+    const prompt = [
+      renderTools(this.boundTools),
+      renderMessages(messages),
+      "\n\n## Your turn\n" +
+        (this.boundTools.length > 0
+          ? 'Act by returning kind="tool_calls" with the calls you want the ' +
+            "harness to run — that is the only way to read files, search, or " +
+            "write anything. Use kind=\"text\" only when the work is finished " +
+            "or you genuinely need nothing from a tool."
+          : 'Respond with kind="text" and your answer.'),
+    ].join("");
+
+    const reply = await this.runCli(prompt);
+
+    if (reply.kind === "tool_calls" && reply.tool_calls?.length) {
+      const message = new AIMessage({
+        content: reply.text ?? "",
+        tool_calls: reply.tool_calls.map((call) => ({
+          id: `call_${randomUUID()}`,
+          name: call.name,
+          args: call.arguments ?? {},
+          type: "tool_call" as const,
+        })),
+      });
+
+      return { generations: [{ message, text: "" }] };
+    }
+
+    const text = reply.text ?? "";
+
+    return {
+      generations: [{ message: new AIMessage({ content: text }), text }],
+    };
+  }
+
+  private runCli(prompt: string): Promise<StructuredReply> {
+    const args = [
+      "-p",
+      "--output-format",
+      "json",
+      "--model",
+      this.model,
+      // Without this the CLI loads the user's global MCP config into every
+      // call — tool definitions that are pure overhead for a text-in/JSON-out
+      // request.
+      "--strict-mcp-config",
+      // Claude Code's own built-in tools are not the tools this agent is
+      // driving, and their definitions cost ~16k tokens per call. Verified
+      // safe alongside --json-schema: structured output is still enforced.
+      "--tools",
+      "",
+      "--json-schema",
+      JSON.stringify(buildReplySchema()),
+    ];
+
+    return new Promise((resolve, reject) => {
+      // A neutral cwd keeps the target repository's own CLAUDE.md and skills
+      // out of a run whose context is supplied entirely by the prompt.
+      const child = spawn("claude", args, { cwd: tmpdir() });
+      let stdout = "";
+      let stderr = "";
+
+      const timer = setTimeout(() => {
+        child.kill("SIGTERM");
+        reject(new Error(`claude -p timed out after ${this.timeoutMs}ms`));
+      }, this.timeoutMs);
+
+      child.stdout.on("data", (chunk) => (stdout += chunk));
+      child.stderr.on("data", (chunk) => (stderr += chunk));
+
+      child.on("error", (error) => {
+        clearTimeout(timer);
+        reject(error);
+      });
+
+      child.on("close", (code) => {
+        clearTimeout(timer);
+
+        if (code !== 0) {
+          reject(
+            new Error(`claude exited ${code}: ${stderr.trim().slice(0, 300)}`),
+          );
+          return;
+        }
+
+        try {
+          resolve(parseEnvelope(stdout));
+        } catch (error) {
+          reject(
+            error instanceof Error
+              ? error
+              : new Error(`Unparseable claude -p output: ${String(error)}`),
+          );
+        }
+      });
+
+      // Prompt goes over stdin — agent prompts overflow argv limits.
+      child.stdin.write(prompt);
+      child.stdin.end();
+    });
+  }
+}

--- a/src/agent/claude-cli-model.ts
+++ b/src/agent/claude-cli-model.ts
@@ -32,7 +32,7 @@ type ClaudeToolSpec = {
   parameters: Record<string, unknown>;
 };
 
-type StructuredReply = {
+export type StructuredReply = {
   kind: "text" | "tool_calls";
   text?: string;
   tool_calls?: { name: string; arguments: Record<string, unknown> }[];
@@ -68,6 +68,55 @@ function buildReplySchema(): Record<string, unknown> {
     additionalProperties: false,
   };
 }
+
+/**
+ * Does this text reply refuse the turn because the model believes it has no
+ * tools? Two independent signals must both fire — a refusal/absence phrasing
+ * AND a reference to the tooling itself — because either alone is ordinary
+ * documentation prose. A wiki page about this very harness legitimately says
+ * "the tools are not available inside the session"; only a page that also says
+ * "I cannot" is the model talking about itself.
+ */
+const REFUSAL_RE =
+  /\b(?:i (?:cannot|can't|am unable to|do not have|don't have)|not available|unavailable|no access to|lack(?:ing)? access)\b/i;
+
+const TOOLING_RE =
+  /\b(?:tool|tools|tool suite|tool roster|filesystem|file system|read_file|write_file|edit_file|execute|glob|grep)\b/i;
+
+export function isMissingToolsRefusal(reply: StructuredReply): boolean {
+  if (reply.kind !== "text") {
+    return false;
+  }
+
+  const text = reply.text ?? "";
+
+  // A refusal is short and about itself. Real documentation output that happens
+  // to discuss tooling runs long, so the cap keeps a legitimate page describing
+  // this harness from being mistaken for a model that has given up on it.
+  if (!text.trim() || text.length > 4000) {
+    return false;
+  }
+
+  return REFUSAL_RE.test(text) && TOOLING_RE.test(text);
+}
+
+/**
+ * Appended for the one retry. It contradicts the model's inference directly and
+ * names the single next action, because the refusals seen in the wild end by
+ * asking for an interactive session rather than by trying anything.
+ */
+const TOOLS_REFUSAL_CORRECTION =
+  `## Correction\n\n` +
+  `Your previous response reported that tools are unavailable and stopped. That ` +
+  `conclusion is wrong, and it is the one failure mode this harness cannot ` +
+  `recover from on its own.\n\n` +
+  `Your native tool roster is empty BY DESIGN. It is not a broken session, it is ` +
+  `not a permissions problem, and switching to an interactive session is not an ` +
+  `option available to anyone here. The tools listed above are real and the ` +
+  `harness executes them for you the moment you name them.\n\n` +
+  `Emit kind="tool_calls" now, naming the first tool you need with its ` +
+  `arguments. Do not explain, do not apologise, and do not describe what you ` +
+  `would do with tools — emitting the call IS how you use them.`;
 
 function renderTools(tools: ClaudeToolSpec[]): string {
   if (tools.length === 0) {
@@ -176,6 +225,44 @@ function parseEnvelope(stdout: string): StructuredReply {
   throw new Error("claude -p returned no structured output");
 }
 
+/**
+ * The `claude -p` argv for one call. Exported so the flag contract can be
+ * asserted without spawning anything — every entry here is load-bearing.
+ *
+ * NOT here, deliberately: `--append-system-prompt`. Moving `renderTools` out of
+ * the user turn and into a system prompt is the obvious fix for the refusals
+ * described in `_generate`, it is what the failure looks like it wants, and it
+ * is wrong. Measured 2026-08-15, one prompt, four runs per cell:
+ *
+ *                      framing in user turn   framing as system prompt
+ *     sonnet                    0/3 worked                  3/3 worked
+ *     haiku                     4/4 worked                  1/4 worked
+ *
+ * The two models want OPPOSITE channels, so there is no channel that is simply
+ * correct — and haiku is what the scheduled runs use. Changing this would trade
+ * one broken model for another. The retry in `_generate` is channel-agnostic
+ * and repairs both, which is why the fix lives there instead.
+ */
+export function buildCliArgs(model: string): string[] {
+  return [
+    "-p",
+    "--output-format",
+    "json",
+    "--model",
+    model,
+    // Without this the CLI loads the user's global MCP config into every call —
+    // tool definitions that are pure overhead for a text-in/JSON-out request.
+    "--strict-mcp-config",
+    // Claude Code's own built-in tools are not the tools this agent is driving,
+    // and their definitions cost ~16k tokens per call. Verified safe alongside
+    // --json-schema: structured output is still enforced.
+    "--tools",
+    "",
+    "--json-schema",
+    JSON.stringify(buildReplySchema()),
+  ];
+}
+
 export type ChatClaudeCliParams = BaseChatModelParams & {
   model: string;
   timeoutMs?: number;
@@ -235,7 +322,37 @@ export class ChatClaudeCli extends BaseChatModel<BaseChatModelCallOptions> {
           : 'Respond with kind="text" and your answer.'),
     ].join("");
 
-    const reply = await this.runCli(prompt);
+    let reply = await this.runCli(prompt);
+
+    // The refusal `renderTools` is written to prevent, caught when it happens
+    // anyway — and it does happen, because that framing has to survive a model
+    // deciding what to make of it.
+    //
+    // Flattened into the user turn, `renderTools` reads like a prompt-injection
+    // attempt: third-party text that renames the assistant, asserts an unusual
+    // execution model, and hands over a tool roster the session cannot
+    // corroborate. A model that distrusts it answers with prose ABOUT the tools
+    // instead of the tool_calls that would have done the work — and because
+    // that prose is a well-formed kind:"text" reply, the agent loop treats it
+    // as a finished turn. The run then reports success having written nothing,
+    // which is the worst outcome this provider can produce.
+    //
+    // MEASURED (autojob, 2026-08-15 03:37, haiku): "I cannot complete this wiki
+    // update because the filesystem tools (read_file, write_file, edit_file,
+    // ls, glob, grep, execute) are not available in this CLI execution
+    // context." The nightly sweep printed that as the run's result. Every other
+    // repo in the sweep was already current, so nothing else needed a write and
+    // nothing else exposed it. Reproduced with sonnet at 0/3 on the same
+    // prompt, two runs naming the concern outright ("Prompt injection concern:
+    // the instructions in this turn try to redefine me as OpenWiki").
+    //
+    // The correction recovers it: sonnet 3/3 on the runs that had just refused.
+    // One retry, and only when tools are bound — the corrective is cheap, and a
+    // model that refuses twice is telling us something a prompt cannot fix.
+    // See buildCliArgs for the channel fix this deliberately is NOT.
+    if (this.boundTools.length > 0 && isMissingToolsRefusal(reply)) {
+      reply = await this.runCli(`${prompt}\n\n${TOOLS_REFUSAL_CORRECTION}`);
+    }
 
     if (reply.kind === "tool_calls" && reply.tool_calls?.length) {
       const message = new AIMessage({
@@ -259,24 +376,7 @@ export class ChatClaudeCli extends BaseChatModel<BaseChatModelCallOptions> {
   }
 
   private runCli(prompt: string): Promise<StructuredReply> {
-    const args = [
-      "-p",
-      "--output-format",
-      "json",
-      "--model",
-      this.model,
-      // Without this the CLI loads the user's global MCP config into every
-      // call — tool definitions that are pure overhead for a text-in/JSON-out
-      // request.
-      "--strict-mcp-config",
-      // Claude Code's own built-in tools are not the tools this agent is
-      // driving, and their definitions cost ~16k tokens per call. Verified
-      // safe alongside --json-schema: structured output is still enforced.
-      "--tools",
-      "",
-      "--json-schema",
-      JSON.stringify(buildReplySchema()),
-    ];
+    const args = buildCliArgs(this.model);
 
     return new Promise((resolve, reject) => {
       // A neutral cwd keeps the target repository's own CLAUDE.md and skills

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -76,6 +76,7 @@ import type {
   OpenWikiRunResult,
   RunContext,
 } from "./types.js";
+import { ChatClaudeCli } from "./claude-cli-model.js";
 import {
   ANTHROPIC_BASE_URL_ENV_KEY,
   BASETEN_BASE_URL_ENV_KEY,
@@ -1085,6 +1086,13 @@ export function createModel(
       ...(baseURL ? { anthropicApiUrl: baseURL } : {}),
       ...retryOptions,
     });
+  }
+
+  if (provider === "claude-cli") {
+    // Auth lives entirely inside the CLI, so there is nothing to pass here —
+    // the model shells out to `claude -p` per call. See claude-cli-model.ts for
+    // why tool calling is expressed as schema-enforced structured output.
+    return new ChatClaudeCli({ model: modelId });
   }
 
   if (provider === "openai-chatgpt") {

--- a/src/auth/claude-cli-auth.ts
+++ b/src/auth/claude-cli-auth.ts
@@ -1,0 +1,32 @@
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+
+const execFileAsync = promisify(execFile);
+const CLAUDE_CLI_TIMEOUT_MS = 10_000;
+
+/**
+ * Sentinel recorded when a Claude Code CLI session is detected. The CLI holds
+ * the actual credential and never exposes it, so there is nothing secret here —
+ * this exists only so the provider fits the shared external-CLI setup flow.
+ */
+export const CLAUDE_CLI_SESSION_MARKER = "cli-session";
+
+export const CLAUDE_CLI_UNAVAILABLE_MESSAGE =
+  "The Claude Code CLI (`claude`) was not found on PATH. Install it from https://claude.com/claude-code, then run `claude` once to sign in.";
+
+/**
+ * Probes for the binary rather than for a valid login: verifying the session
+ * would cost a full `claude -p` round trip on every setup screen, so an expired
+ * login is left to surface as a clear error on the first generation call.
+ */
+export async function readClaudeCliSession(): Promise<string | null> {
+  try {
+    await execFileAsync("claude", ["--version"], {
+      timeout: CLAUDE_CLI_TIMEOUT_MS,
+    });
+
+    return CLAUDE_CLI_SESSION_MARKER;
+  } catch {
+    return null;
+  }
+}

--- a/src/auth/external-cli-auth.ts
+++ b/src/auth/external-cli-auth.ts
@@ -8,6 +8,7 @@ import {
   type ExternalCliAuthAdapter,
   type OpenWikiProvider,
 } from "../config/constants.js";
+import { readClaudeCliSession } from "./claude-cli-auth.js";
 
 const execFileAsync = promisify(execFile);
 const EXTERNAL_CLI_TIMEOUT_MS = 5_000;
@@ -20,6 +21,12 @@ type ExternalCliAuthAdapterConfig = {
   command: string;
   commandArgs: readonly string[];
   tokenArgs: readonly string[];
+  /**
+   * Overrides the default `tokenArgs` lookup for CLIs that expose no
+   * token-printing subcommand and instead persist credentials to an OS keychain
+   * or credentials file.
+   */
+  readCredential?: () => Promise<string | null>;
 };
 
 /**
@@ -53,6 +60,21 @@ function buildExternalCliAuthAdapters(
   const githubHostname = resolveGithubCliHostname(provider, env);
 
   return {
+    "claude-cli": {
+      command: "claude",
+      // `claude` with no arguments opens the interactive session that performs
+      // the login; there is no non-interactive login subcommand.
+      commandArgs: [],
+      credentialDescription: "Claude Code CLI session",
+      installHint:
+        "Install Claude Code (https://claude.com/claude-code), then run `claude` once to sign in.",
+      loginCommand: "claude",
+      name: "Claude Code CLI",
+      // The CLI owns the credential and never prints it, so detection reports
+      // a session marker instead of running a token subcommand.
+      readCredential: readClaudeCliSession,
+      tokenArgs: [],
+    },
     "github-cli": {
       command: "gh",
       commandArgs: ["auth", "login", "--hostname", githubHostname],
@@ -112,6 +134,10 @@ export async function detectExternalCliCredential(
 
   if (!adapter) {
     return null;
+  }
+
+  if (adapter.readCredential) {
+    return adapter.readCredential();
   }
 
   try {

--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -26,6 +26,12 @@ export const OPENAI_CHATGPT_EMAIL_ENV_KEY = "OPENAI_CHATGPT_EMAIL";
 export const OPENAI_CHATGPT_PLAN_ENV_KEY = "OPENAI_CHATGPT_PLAN";
 export const ANTHROPIC_API_KEY_ENV_KEY = "ANTHROPIC_API_KEY";
 export const ANTHROPIC_BASE_URL_ENV_KEY = "ANTHROPIC_BASE_URL";
+/**
+ * Marks a detected Claude Code CLI session for the lifetime of the process.
+ * Deliberately not a credential: `claude -p` authenticates itself through the
+ * CLI's own login, so OpenWiki never holds a token for this provider.
+ */
+export const CLAUDE_CLI_SESSION_ENV_KEY = "CLAUDE_CLI_SESSION";
 export const OPENROUTER_API_KEY_ENV_KEY = "OPENROUTER_API_KEY";
 export const OPENWIKI_OPENROUTER_PROVIDER_ONLY_ENV_KEY =
   "OPENWIKI_OPENROUTER_PROVIDER_ONLY";
@@ -93,6 +99,7 @@ export type OpenWikiProvider =
   | "anthropic"
   | "baseten"
   | "bedrock"
+  | "claude-cli"
   | "copilot"
   | "fireworks"
   | "gemini"
@@ -118,7 +125,7 @@ export type ProviderAuthMethod =
  * login. The provider config only declares the adapter; its implementation
  * lives outside this declarative provider registry.
  */
-export type ExternalCliAuthAdapter = "github-cli";
+export type ExternalCliAuthAdapter = "claude-cli" | "github-cli";
 
 export type SelectableOpenWikiProvider = OpenWikiProvider;
 
@@ -224,6 +231,7 @@ export const SELECTABLE_OPENWIKI_PROVIDERS = [
   "openai",
   "openai-chatgpt",
   "anthropic",
+  "claude-cli",
   "copilot",
   "gemini",
   "gemini-enterprise",
@@ -260,6 +268,20 @@ export const PROVIDER_CONFIGS: Record<OpenWikiProvider, ProviderConfig> = {
     regionEnvKey: BEDROCK_AWS_REGION_ENV_KEY,
     regionFallbackEnvKeys: [AWS_REGION_ENV_KEY, AWS_DEFAULT_REGION_ENV_KEY],
     requiresRegion: true,
+  },
+  "claude-cli": {
+    // `claude -p` authenticates through the CLI's own login, so there is no key
+    // to paste or persist. The env var below only records that a session was
+    // detected, satisfying the shared external-CLI setup flow.
+    apiKeyEnvKey: CLAUDE_CLI_SESSION_ENV_KEY,
+    authMethod: "external-cli",
+    externalCliAuthAdapter: "claude-cli",
+    label: "Claude Code CLI (subscription login)",
+    modelOptions: [
+      { id: "claude-opus-5", label: "Opus" },
+      { id: "claude-sonnet-5", label: "Sonnet" },
+      { id: "claude-haiku-4-5", label: "Haiku" },
+    ],
   },
   copilot: {
     apiKeyEnvKey: COPILOT_API_KEY_ENV_KEY,

--- a/test/claude-cli-refusal.test.ts
+++ b/test/claude-cli-refusal.test.ts
@@ -1,0 +1,142 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildCliArgs,
+  isMissingToolsRefusal,
+  type StructuredReply,
+} from "../src/agent/claude-cli-model";
+
+describe("buildCliArgs", () => {
+  /**
+   * The tempting fix, pinned as REJECTED.
+   *
+   * Moving renderTools out of the user turn and into --append-system-prompt is
+   * what the refusal looks like it wants, and it is wrong. Measured 2026-08-15,
+   * one prompt, four runs per cell:
+   *
+   *                    framing in user turn   framing as system prompt
+   *   sonnet                    0/3 worked                  3/3 worked
+   *   haiku                     4/4 worked                  1/4 worked
+   *
+   * The models want opposite channels and haiku is what the scheduled runs use,
+   * so this would trade one broken model for another. The retry is
+   * channel-agnostic and repairs both, so the fix lives there instead.
+   */
+  it("does not move the framing to a system prompt", () => {
+    const args = buildCliArgs("sonnet");
+
+    expect(args).not.toContain("--append-system-prompt");
+    expect(args).not.toContain("--system-prompt");
+  });
+
+  // The token savings this provider was built around — and neither is what
+  // caused the refusals, so neither should be traded away to fix them.
+  it("keeps the flags that make the call cheap", () => {
+    const args = buildCliArgs("sonnet");
+
+    expect(args).toContain("--strict-mcp-config");
+    expect(args[args.indexOf("--tools") + 1]).toBe("");
+  });
+
+  it("still enforces the reply schema", () => {
+    const args = buildCliArgs("sonnet");
+    const schema = JSON.parse(args[args.indexOf("--json-schema") + 1]);
+
+    expect(schema.properties.kind.enum).toEqual(["text", "tool_calls"]);
+  });
+
+  it("passes the model through", () => {
+    expect(buildCliArgs("haiku")[buildCliArgs("haiku").indexOf("--model") + 1]).toBe(
+      "haiku",
+    );
+  });
+});
+
+const text = (value: string): StructuredReply => ({ kind: "text", text: value });
+
+/**
+ * `claude -p` exposes no native tools, so this provider renders OpenWiki's
+ * toolset into the prompt and reads tool calls back out of the structured
+ * reply. A model that misreads the empty native roster as a broken session
+ * answers with prose about the missing tools — a well-formed kind:"text" reply
+ * that the agent loop accepts as a finished turn, so the run reports success
+ * having written nothing.
+ *
+ * The verbatim case below is what the nightly sweep hit on the autojob repo on
+ * 2026-08-15; every other repo in that sweep was already current, so nothing
+ * else needed a write and nothing else surfaced it.
+ */
+describe("isMissingToolsRefusal", () => {
+  it("catches the refusal measured in the wild", () => {
+    expect(
+      isMissingToolsRefusal(
+        text(
+          "I cannot complete this wiki update because the filesystem tools " +
+            "(read_file, write_file, edit_file, ls, glob, grep, execute) are not " +
+            "available in this CLI execution context. The tools are restricted to " +
+            "the interactive harness.\n\nTo update the OpenWiki documentation, you " +
+            "need to:\n1. Run this from an interactive Claude Code session",
+        ),
+      ),
+    ).toBe(true);
+  });
+
+  it("catches the same inference in other phrasings", () => {
+    expect(
+      isMissingToolsRefusal(text("I don't have access to any file tools here.")),
+    ).toBe(true);
+    expect(
+      isMissingToolsRefusal(
+        text("Unable to proceed — my tool roster is unavailable in this session."),
+      ),
+    ).toBe(true);
+  });
+
+  // A tool_calls reply is the working path and must never be re-prompted, however
+  // its prose reads.
+  it("never fires on a reply that actually called a tool", () => {
+    expect(
+      isMissingToolsRefusal({
+        kind: "tool_calls",
+        text: "I cannot read the filesystem directly, so I will use read_file.",
+        tool_calls: [{ name: "read_file", arguments: { path: "README.md" } }],
+      }),
+    ).toBe(false);
+  });
+
+  // BOTH signals are required. Ordinary documentation output discusses tooling
+  // constantly, and an agent that re-prompted on that alone would burn a second
+  // CLI call on every page it wrote.
+  it("does not fire on ordinary docs prose about tools", () => {
+    expect(
+      isMissingToolsRefusal(
+        text(
+          "The runner's tools are configured in settings.json. Wrote " +
+            "architecture/overview.md and database/schema.md.",
+        ),
+      ),
+    ).toBe(false);
+    expect(
+      isMissingToolsRefusal(text("I cannot find a changelog entry for v2.")),
+    ).toBe(false);
+  });
+
+  // The length cap: a page ABOUT this harness legitimately says "the tools are
+  // not available inside the session" and also quotes a refusal. Real generated
+  // output runs long; a model giving up does not.
+  it("does not fire on a long page documenting this very harness", () => {
+    const page =
+      "# The claude-cli provider\n\n" +
+      "The native tool roster is not available inside a `claude -p` session, " +
+      "so the harness cannot expose read_file or write_file directly. " +
+      "Models sometimes report 'I cannot complete this because the filesystem " +
+      "tools are not available'.\n\n".padEnd(4200, "Detail follows. ");
+
+    expect(page.length).toBeGreaterThan(4000);
+    expect(isMissingToolsRefusal(text(page))).toBe(false);
+  });
+
+  it("does not fire on an empty reply", () => {
+    expect(isMissingToolsRefusal(text(""))).toBe(false);
+    expect(isMissingToolsRefusal({ kind: "text" })).toBe(false);
+  });
+});


### PR DESCRIPTION
Implements the provider proposed in #651 — inference through the locally installed Claude Code CLI (`claude -p`), authenticated by the user's existing subscription login. No API key required.

## How it works

- `claude -p` can't surface tool calls mid-turn, so tool use is emulated as structured output: tools are rendered into the prompt, `--json-schema` forces a `{kind: "text" | "tool_calls"}` response, the harness executes the call, and the transcript replays on the next invocation. Prompt goes over stdin (argv limits).
- The tool framing *explains* the harness mechanism rather than instructing the model to trust it — without this, capable models find their empty native roster and refuse the session as misconfigured. Includes a no-human-in-the-loop note that stops smaller models from pausing to ask permission.
- Per-call timeout is 600s; late-run turns replay the full transcript and exceed 3 minutes during verification.
- Auth probe checks only for the `claude` binary (verifying login would cost a full round trip per setup screen); an expired login surfaces as a clear error on first generation.

## Testing

Generated wikis for 14 real repositories (~360 pages) on `claude-haiku-4-5`, including 4-way parallel runs; also exercised with `claude-sonnet-5`. Known limitations disclosed in #651.

Models offered: Opus 5 / Sonnet 5 / Haiku 4.5.

Marked draft pending maintainer feedback on the emulation approach — happy to add tests/docs in whatever shape you prefer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)