### PR TITLE
fix(visualize): resolve OKF wikilinks in the reader

### DIFF
--- a/src/visualize/client-lib.ts
+++ b/src/visualize/client-lib.ts
@@ -154,3 +154,35 @@ export function normalize(baseDir: string, rel: string): string {
   }
   return out.join("/");
 }
+
+/**
+ * Replace Open Knowledge Format wikilinks — `[[target]]` and `[[target|label]]`
+ * — before a page body reaches marked, which does not know the syntax and would
+ * render them as literal brackets. `resolve` maps a target to a node id; a
+ * resolved wikilink becomes a standard markdown link to `<id>.md` (rooted at the
+ * wiki, so the anchor-rewrite pass can upgrade it to in-app navigation), while
+ * an unresolved one degrades to its label as plain text rather than a dead link.
+ * Backtick code spans and fences are passed through untouched — a lexer-free
+ * approximation that covers the generator's output, though exotic fences (tilde
+ * or four-plus-backtick) are not recognised.
+ */
+export function resolveWikilinks(
+  body: string,
+  resolve: (target: string) => string | undefined,
+): string {
+  // Odd-index chunks are the captured code spans/fences; even-index are prose.
+  return body
+    .split(/(```[\s\S]*?(?:```|$)|`[^`\n]*`)/g)
+    .map((chunk, i) => {
+      if (i % 2 === 1) return chunk;
+      return chunk.replace(
+        /\[\[([^[\]|\n]+)(?:\|([^[\]\n]*))?\]\]/g,
+        (_match, target: string, label?: string) => {
+          const text = (label ?? "").trim() || target.trim();
+          const id = resolve(target.trim());
+          return id ? `[${text}](${id}.md)` : text;
+        },
+      );
+    })
+    .join("");
+}

--- a/src/visualize/client.ts
+++ b/src/visualize/client.ts
@@ -6,6 +6,7 @@ import {
   matchesFilter,
   nodeRadius,
   normalize,
+  resolveWikilinks,
   signature,
   stripFrontmatter,
 } from "./client-lib.js";
@@ -352,6 +353,24 @@ const byId = (id: string): WikiNode | undefined =>
   graph.nodes.find((n) => n.id === id);
 
 /**
+ * Resolve an OKF wikilink target to a node id. The generator writes targets as
+ * wiki-root-relative paths without .md, but be lenient: match the id
+ * case-insensitively, tolerate a stray .md extension, and fall back to a unique
+ * final-path-segment match so short targets like `[[overview]]` still land.
+ */
+function resolveWikiTarget(target: string): string | undefined {
+  const want = target.replace(/\.md$/i, "").toLowerCase();
+  if (!want) return undefined;
+  const exact = graph.nodes.find((n) => n.id.toLowerCase() === want);
+  if (exact) return exact.id;
+  const tail = want.split("/").pop() ?? want;
+  const byTail = graph.nodes.filter(
+    (n) => n.id.toLowerCase().split("/").pop() === tail,
+  );
+  return byTail.length === 1 ? byTail[0].id : undefined;
+}
+
+/**
  * Read a CSS custom property off the body, so colors follow the active theme.
  */
 const cssVar = (name: string): string =>
@@ -678,10 +697,13 @@ function renderReader(id: string): void {
   const back = n.backlinks.length
     ? `<div class="backlinks"><span class="eyebrow">Referenced by</span>${backEls}</div>`
     : "";
+  // The generator emits OKF [[wikilinks]], which marked would render as literal
+  // brackets; resolve them into markdown links (or plain text) before parsing.
+  const md = resolveWikilinks(stripFrontmatter(n.body), resolveWikiTarget);
   // The page body is rendered as markdown, and marked passes raw HTML through, so
   // sanitize before innerHTML: DOMPurify strips scripts, event handlers, and unsafe
   // URL schemes. This is defense in depth on top of the server's CSP.
-  const html = DOMPurify.sanitize(marked.parse(stripFrontmatter(n.body)));
+  const html = DOMPurify.sanitize(marked.parse(md));
   $("#detail").innerHTML =
     `<div class="eyebrow">${escapeHtml(n.type)}</div>` +
     `<h1 class="doc-title">${escapeHtml(n.title)}</h1>` +
@@ -717,7 +739,12 @@ function rewriteLinks(node: WikiNode): void {
       const href = a.getAttribute("href") ?? "";
       if (!href.endsWith(".md") && !href.includes(".md#")) return;
       const clean = href.split("#")[0];
-      const target = normalize(dir, clean).replace(/\.md$/, "");
+      // Hand-written links are page-relative, but wikilink-derived hrefs are
+      // rooted at the wiki, so try the root-relative reading as a fallback.
+      const rel = normalize(dir, clean).replace(/\.md$/, "");
+      const target = byId(rel)
+        ? rel
+        : normalize("", clean).replace(/\.md$/, "");
       if (byId(target)) {
         a.classList.add("wikilink");
         a.addEventListener("click", (e) => {

--- a/test/visualize/visualize-client-lib.test.ts
+++ b/test/visualize/visualize-client-lib.test.ts
@@ -7,6 +7,7 @@ import {
   matchesFilter,
   nodeRadius,
   normalize,
+  resolveWikilinks,
   signature,
   stripFrontmatter,
 } from "../../src/visualize/client-lib.ts";
@@ -119,6 +120,46 @@ describe("stripFrontmatter", () => {
 
   test("returns a body without frontmatter unchanged", () => {
     expect(stripFrontmatter("# Body\n")).toBe("# Body\n");
+  });
+});
+
+describe("resolveWikilinks", () => {
+  const resolve = (target: string): string | undefined =>
+    target === "arch/server" ? "arch/server" : undefined;
+
+  test("turns a resolved [[target]] into a markdown link to its page", () => {
+    expect(resolveWikilinks("See [[arch/server]].", resolve)).toBe(
+      "See [arch/server](arch/server.md).",
+    );
+  });
+
+  test("uses the label from [[target|label]]", () => {
+    expect(resolveWikilinks("See [[arch/server|the server]].", resolve)).toBe(
+      "See [the server](arch/server.md).",
+    );
+  });
+
+  test("degrades an unresolved wikilink to plain text, not a dead link", () => {
+    expect(resolveWikilinks("See [[missing/page|Missing]].", resolve)).toBe(
+      "See Missing.",
+    );
+    expect(resolveWikilinks("See [[missing/page]].", resolve)).toBe(
+      "See missing/page.",
+    );
+  });
+
+  test("leaves wikilinks inside code spans and fences untouched", () => {
+    expect(resolveWikilinks("Use `[[arch/server]]` syntax.", resolve)).toBe(
+      "Use `[[arch/server]]` syntax.",
+    );
+    const fenced = "```md\n[[arch/server]]\n```\n";
+    expect(resolveWikilinks(fenced, resolve)).toBe(fenced);
+  });
+
+  test("returns a body without wikilinks unchanged", () => {
+    expect(resolveWikilinks("Just [a link](x.md).", resolve)).toBe(
+      "Just [a link](x.md).",
+    );
   });
 });
 


### PR DESCRIPTION
## The bug

The doc generator emits Open Knowledge Format wikilinks in its markdown — `[[path/to/page]]` and `[[path/to/page|label]]` — but the bundled visualizer (`openwiki visualize`) never resolves them. The reader renders page bodies with marked, which does not know the wikilink syntax, and `rewriteLinks` only handles standard `[text](x.md)` anchors, so wikilinks show up as literal `[[...]]` text in the official UI.

Found while generating and browsing wikis for 14 repositories — pages that lean on wikilinks for cross-references are noticeably degraded in the reader.

## The fix

- New `resolveWikilinks` helper in `client-lib.ts` rewrites `[[target]]` / `[[target|label]]` before the body reaches `marked.parse`.
- **Resolved targets** (matching a known node id case-insensitively, tolerating a stray `.md` extension, with a unique final-path-segment fallback for short targets like `[[overview]]`) become standard markdown links, which the existing `rewriteLinks` pass upgrades to in-app navigation.
- **Unresolved targets** degrade to their label as plain text — no dead links, no raw brackets.
- Backtick code spans and fences are passed through untouched, so documentation *about* wikilink syntax renders literally (tilde and 4+-backtick fences are not recognised by this lexer-free pass; noted in the doc comment).
- `rewriteLinks` additionally tries a wiki-root-relative reading of an href when the page-relative one misses, since wikilink targets are rooted at the wiki while hand-written links are page-relative.

Unit tests added for `resolveWikilinks` alongside the other `client-lib` helper tests; also verified end-to-end with a headless browser against a generated wiki (resolved wikilink navigates in-app, unresolved renders as plain text, no `[[` remains in the reader).

🤖 Generated with [Claude Code](https://claude.com/claude-code)