### PR TITLE
feat: add static export to openwiki visualizer

### DIFF
--- a/.changeset/sixty-sites-cough.md
+++ b/.changeset/sixty-sites-cough.md
@@ -1,0 +1,5 @@
+---
+"openwiki": patch
+---
+
+feat: add static export to openwiki visualizer

--- a/README.md
+++ b/README.md
@@ -87,8 +87,16 @@ This serves `./openwiki` on a local loopback address (`127.0.0.1`, never exposed
 openwiki visualize openwiki --port 4400 --no-open
 ```
 
+To publish the visualizer beside generated documentation, export a static directory instead of starting the server:
+
+```sh
+openwiki visualize openwiki --export docs/openwiki-visualizer
+```
+
+The export contains `index.html`, `client.js`, `client-lib.js`, and `graph.json`. Its client reads the sibling graph file and does not use live reload, so the directory can be hosted by GitHub Pages, MkDocs, or any other static host. `--export` cannot be combined with `--port` or `--no-open`.
+
 > [!NOTE]
-> The page loads its graph, Markdown, and diagram libraries from a public CDN, so an internet connection is required even though the server itself is local. Press Ctrl-C to stop it.
+> The page loads its graph, Markdown, and diagram libraries from a public CDN, so an internet connection is required for both local and static viewers.
 
 ## Connect your sources
 
@@ -367,6 +375,7 @@ openwiki -p "what can you do?"   # one-shot, print, and exit
 openwiki --init                  # initialize code docs (personal: openwiki personal --init)
 openwiki --update                # update code docs (personal: openwiki personal --update)
 openwiki visualize               # interactive graph + live reader
+openwiki visualize openwiki --export docs/openwiki-visualizer  # static graph + reader
 openwiki auth <provider>         # authenticate a connector (slack, gmail, x, notion)
 openwiki ingest <source>         # run connector ingestion (all, or a connector/instance)
 openwiki --help                  # full help

--- a/src/cli/commands.ts
+++ b/src/cli/commands.ts
@@ -48,6 +48,7 @@ export type CliCommand =
       wikiDir: string;
       port: number;
       open: boolean;
+      exportDir: string | null;
     }
   | {
       kind: "ingest";
@@ -220,6 +221,9 @@ export function parseCommand(argv: string[]): CliCommand {
     let wikiDir = "openwiki";
     let port = 4321;
     let open = true;
+    let exportDir: string | null = null;
+    let sawPort = false;
+    let sawNoOpen = false;
     let sawPositional = false;
     const optionArgs = argv.slice(1);
 
@@ -228,6 +232,7 @@ export function parseCommand(argv: string[]): CliCommand {
 
       if (arg === "--no-open") {
         open = false;
+        sawNoOpen = true;
         continue;
       }
 
@@ -241,12 +246,41 @@ export function parseCommand(argv: string[]): CliCommand {
           };
         }
         port = Number(rawPort);
+        sawPort = true;
         index += 1;
         continue;
       }
 
       if (arg.startsWith("--port=")) {
         port = Number(arg.slice("--port=".length));
+        sawPort = true;
+        continue;
+      }
+
+      if (arg === "--export") {
+        const outputDir = optionArgs[index + 1];
+        if (!outputDir || outputDir.startsWith("-")) {
+          return {
+            kind: "error",
+            exitCode: 1,
+            message: "--export requires a directory.",
+          };
+        }
+        exportDir = outputDir;
+        index += 1;
+        continue;
+      }
+
+      if (arg.startsWith("--export=")) {
+        const outputDir = arg.slice("--export=".length);
+        if (!outputDir) {
+          return {
+            kind: "error",
+            exitCode: 1,
+            message: "--export requires a directory.",
+          };
+        }
+        exportDir = outputDir;
         continue;
       }
 
@@ -263,6 +297,14 @@ export function parseCommand(argv: string[]): CliCommand {
       };
     }
 
+    if (exportDir && (sawPort || sawNoOpen)) {
+      return {
+        kind: "error",
+        exitCode: 1,
+        message: "--export cannot be combined with --port or --no-open.",
+      };
+    }
+
     if (!Number.isInteger(port) || port < 1024 || port > 65535) {
       return {
         kind: "error",
@@ -271,7 +313,7 @@ export function parseCommand(argv: string[]): CliCommand {
       };
     }
 
-    return { kind: "visualize", exitCode: 0, wikiDir, port, open };
+    return { kind: "visualize", exitCode: 0, wikiDir, port, open, exportDir };
   }
 
   if (argv[0] === "ingest") {
@@ -751,7 +793,7 @@ export const helpContent: HelpContent = {
     "openwiki cron resume all",
     "openwiki cron delete all",
     "openwiki ngrok start [url] [--port <port>]",
-    "openwiki visualize [path] [--port <port>] [--no-open]",
+    "openwiki visualize [path] [--port <port>] [--no-open] [--export <dir>]",
   ],
   commands: [
     {
@@ -813,9 +855,9 @@ export const helpContent: HelpContent = {
         "Start an ngrok tunnel for Slack OAuth, optionally using a fixed HTTPS URL.",
     },
     {
-      label: "openwiki visualize [path]",
+      label: "openwiki visualize [path] [--export <dir>]",
       description:
-        "Serve an interactive graph and live docs reader for a generated wiki (defaults to ./openwiki).",
+        "Serve a live graph and reader, or export a static graph for web hosting (defaults to ./openwiki).",
     },
   ],
   options: [
@@ -871,6 +913,11 @@ export const helpContent: HelpContent = {
       label: "--no-open",
       description: "For visualize: do not open the browser automatically.",
     },
+    {
+      label: "--export <dir>",
+      description:
+        "For visualize: write a static visualizer directory instead of starting the local server.",
+    },
   ],
   developmentOptions: [
     {
@@ -906,6 +953,7 @@ export const helpContent: HelpContent = {
     "openwiki ngrok start https://openwiki.ngrok.app",
     "openwiki visualize",
     "openwiki visualize openwiki --port 4400 --no-open",
+    "openwiki visualize openwiki --export docs/openwiki-visualizer",
   ],
   developmentExamples: ["openwiki --dry-run"],
 };

--- a/src/cli/runners.ts
+++ b/src/cli/runners.ts
@@ -30,6 +30,7 @@ import {
   withRunTelemetry,
   type RunTelemetryContext,
 } from "../telemetry/index.js";
+import { exportStaticVisualizer } from "../visualize/static-export.js";
 import { runVisualizeServer } from "../visualize/server.js";
 import type { CliCommand } from "./commands.js";
 import { isDebugMode } from "./debug.js";
@@ -59,14 +60,24 @@ export async function runNgrokCommand(
 }
 
 /**
- * Start the wiki visualizer server for a resolved wiki directory. Blocks until the
- * server is stopped with Ctrl-C; surfaces a missing-directory error cleanly.
+ * Start the wiki visualizer server or export its static files for web hosting.
  */
 export async function runVisualizeCommand(
   command: Extract<CliCommand, { kind: "visualize" }>,
 ): Promise<void> {
   const wikiRoot = path.resolve(process.cwd(), command.wikiDir);
   try {
+    if (command.exportDir) {
+      const result = await exportStaticVisualizer({
+        wikiRoot,
+        outputDir: path.resolve(process.cwd(), command.exportDir),
+      });
+      process.stdout.write(
+        `Exported static visualizer to ${result.outputDir} (${result.graph.nodes.length} pages, ${result.graph.edges.length} links).\n`,
+      );
+      return;
+    }
+
     await runVisualizeServer({
       wikiRoot,
       port: command.port,

--- a/src/visualize/client.ts
+++ b/src/visualize/client.ts
@@ -322,6 +322,12 @@ const filterQ = "";
  */
 const filterType = "";
 
+/** True when this client was emitted as a static visualizer export. */
+const isStaticExport = document.documentElement.dataset.staticExport === "true";
+
+/** Static exports carry their graph beside the client; live mode uses the server route. */
+const graphUrl = isStaticExport ? "./graph.json" : "/api/graph";
+
 /**
  * Persisted render-node objects keyed by id, reused across reloads so layout holds.
  */
@@ -774,7 +780,7 @@ function toggleTheme(): void {
  * when the topology is unchanged, so a live reload does not snap the graph.
  */
 async function load(firstTime: boolean): Promise<void> {
-  const res = await fetch("/api/graph");
+  const res = await fetch(graphUrl);
   graph = (await res.json()) as WikiGraph;
   $("#wiki-name").textContent = `${graph.root} · ${graph.nodes.length} pages`;
   const entry =
@@ -878,9 +884,10 @@ function connectSSE(): void {
 
 // --- Bootstrap --------------------------------------------------------------
 
-// Wire the theme toggle, configure the markdown/diagram libraries, then do the
-// first load and open the live-reload stream.
+// Wire the theme toggle and load the graph. Only the live server supplies SSE reloads.
 $("#theme").addEventListener("click", toggleTheme);
 mermaid.initialize({ startOnLoad: false, theme: "dark" });
 marked.setOptions({ breaks: false, gfm: true });
-void load(true).then(connectSSE);
+void load(true).then(() => {
+  if (!isStaticExport) connectSSE();
+});

--- a/src/visualize/page.ts
+++ b/src/visualize/page.ts
@@ -1,15 +1,34 @@
 /**
- * The branded single-page visualizer app (LangChain design system). Served as-is
- * at "/". Scalar wiki fields (title, type, tags) are HTML-escaped client-side
- * before innerHTML; the page body is rendered as markdown, so any HTML embedded in
- * a body is contained by the server's Content-Security-Policy (no 'unsafe-inline'
- * scripts, no inline event handlers, no javascript: URLs) rather than by escaping.
- * The browser libraries load from cdn.jsdelivr.net at pinned exact versions with
- * SRI hashes, so a tampered CDN response is rejected by the browser.
+ * The branded single-page visualizer app (LangChain design system), rendered for
+ * either the local server or a static export. Scalar wiki fields (title, type,
+ * tags) are HTML-escaped client-side before innerHTML; Markdown bodies are
+ * additionally protected by CSP and DOMPurify. Browser libraries load from
+ * cdn.jsdelivr.net at pinned exact versions with SRI hashes.
  */
-export const PAGE = /* html */ `<!doctype html>
-<html lang="en" data-theme="dark">
+const CDN = "https://cdn.jsdelivr.net";
+export const CSP = [
+  "default-src 'none'",
+  `script-src 'self' ${CDN}`,
+  "style-src 'self' 'unsafe-inline'",
+  "img-src 'self' data:",
+  "font-src 'self'",
+  "connect-src 'self'",
+  "base-uri 'none'",
+  "form-action 'none'",
+].join("; ");
+
+function renderPage(staticExport: boolean): string {
+  const liveStatus = staticExport ? "Static" : "Live";
+  const liveClass = staticExport ? "live-pill stale" : "live-pill";
+  const clientUrl = staticExport ? "./client.js" : "/client.js";
+  const cspMeta = staticExport
+    ? `<meta http-equiv="Content-Security-Policy" content="${CSP}" />`
+    : "";
+
+  return /* html */ `<!doctype html>
+<html lang="en" data-theme="dark" data-static-export="${staticExport}">
 <head>
+${cspMeta}
 <meta charset="utf-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1" />
 <title>OpenWiki visualizer</title>
@@ -226,7 +245,7 @@ hr.rule { border:none; border-top:1px solid var(--edge); margin:22px 0; }
     <div class="title">OpenWiki<small id="wiki-name">wiki visualizer</small></div>
   </div>
   <div class="spacer"></div>
-  <div class="live-pill" id="live"><span class="live-dot"></span><span id="live-text">Live</span></div>
+  <div class="${liveClass}" id="live"><span class="live-dot"></span><span id="live-text">${liveStatus}</span></div>
   <div class="icon-btn" id="theme" title="Toggle theme">◐</div>
 </div>
 <div class="main">
@@ -242,6 +261,13 @@ hr.rule { border:none; border-top:1px solid var(--edge); margin:22px 0; }
   </div>
 </div>
 <div class="toast" id="toast">Wiki updated</div>
-<script type="module" src="/client.js"></script>
+<script type="module" src="${clientUrl}"></script>
 </body>
 </html>`;
+}
+
+/** The live-server page, loaded from fixed absolute routes. */
+export const PAGE = renderPage(false);
+
+/** The static-export page, loaded entirely from sibling files. */
+export const STATIC_PAGE = renderPage(true);

--- a/src/visualize/server.ts
+++ b/src/visualize/server.ts
@@ -5,10 +5,11 @@ import {
   type ServerResponse,
 } from "node:http";
 import { watch } from "node:fs";
-import { readFile, stat } from "node:fs/promises";
+import { stat } from "node:fs/promises";
 import { execFile } from "node:child_process";
 import { buildGraph, type WikiGraph } from "./graph.js";
-import { PAGE } from "./page.js";
+import { CSP, PAGE } from "./page.js";
+import { loadVisualizerAssets } from "./static-export.js";
 
 const HOST = "127.0.0.1"; // loopback only (never expose the wiki on the network)
 const PORT_ATTEMPTS = 20; // ports to try before giving up when the preferred one is busy
@@ -18,17 +19,6 @@ const WATCH_DEBOUNCE_MS = 150; // collapse a burst of file-change events into on
 // jsdelivr CDN origin for the three browser libraries (whose integrity is pinned by the SRI
 // hashes on the <script> tags in page.ts) - no 'unsafe-inline' for scripts. The page still
 // carries one inline <style>, so style-src keeps 'unsafe-inline'.
-const CDN = "https://cdn.jsdelivr.net";
-const CSP = [
-  "default-src 'none'",
-  `script-src 'self' ${CDN}`,
-  "style-src 'self' 'unsafe-inline'",
-  "img-src 'self' data:",
-  "font-src 'self'",
-  "connect-src 'self'",
-  "base-uri 'none'",
-  "form-action 'none'",
-].join("; ");
 
 /**
  * Inputs for a single visualizer server run. Every field is required: the CLI parser
@@ -81,14 +71,7 @@ export async function runVisualizeServer(
   // The compiled client modules sit beside this file in dist/visualize/. They are static,
   // server-owned build artifacts (no user input, never evaluated), read once at startup and
   // served verbatim at fixed routes.
-  const clientJs = await readFile(
-    new URL("./client.js", import.meta.url),
-    "utf8",
-  );
-  const clientLibJs = await readFile(
-    new URL("./client-lib.js", import.meta.url),
-    "utf8",
-  );
+  const { clientJs, clientLibJs } = await loadVisualizerAssets();
 
   const broadcastReload = (): void => {
     for (const res of sseClients) res.write("event: reload\ndata: 1\n\n");

--- a/src/visualize/static-export.ts
+++ b/src/visualize/static-export.ts
@@ -1,0 +1,72 @@
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { buildGraph, type WikiGraph } from "./graph.js";
+import { STATIC_PAGE } from "./page.js";
+
+/** Browser modules emitted alongside the server and copied into static exports. */
+export interface VisualizerAssets {
+  clientJs: string;
+  clientLibJs: string;
+}
+
+/** Inputs for writing a self-contained static visualizer directory. */
+export interface StaticVisualizerExportOptions {
+  /** Absolute path to the generated wiki that supplies graph data. */
+  wikiRoot: string;
+
+  /** Absolute path to the directory receiving the static app. */
+  outputDir: string;
+
+  /** Test seam; production callers load the compiled browser modules. */
+  assets?: VisualizerAssets;
+}
+
+/** Summary of the graph captured by one static export. */
+export interface StaticVisualizerExportResult {
+  outputDir: string;
+  graph: WikiGraph;
+}
+
+/** Read the compiled browser modules that ship beside this module in dist. */
+export async function loadVisualizerAssets(): Promise<VisualizerAssets> {
+  const [clientJs, clientLibJs] = await Promise.all([
+    readFile(new URL("./client.js", import.meta.url), "utf8"),
+    readFile(new URL("./client-lib.js", import.meta.url), "utf8"),
+  ]);
+  return { clientJs, clientLibJs };
+}
+
+/**
+ * Write the visualizer as sibling static files. The client reads ./graph.json and
+ * never opens an SSE connection, so the output can be hosted without OpenWiki.
+ */
+export async function exportStaticVisualizer(
+  options: StaticVisualizerExportOptions,
+): Promise<StaticVisualizerExportResult> {
+  const [graph, assets] = await Promise.all([
+    buildGraph(options.wikiRoot),
+    options.assets ? Promise.resolve(options.assets) : loadVisualizerAssets(),
+  ]);
+
+  await mkdir(options.outputDir, { recursive: true });
+  await Promise.all([
+    writeFile(path.join(options.outputDir, "index.html"), STATIC_PAGE, "utf8"),
+    writeFile(
+      path.join(options.outputDir, "client.js"),
+      assets.clientJs,
+      "utf8",
+    ),
+    writeFile(
+      path.join(options.outputDir, "client-lib.js"),
+      assets.clientLibJs,
+      "utf8",
+    ),
+    writeFile(
+      path.join(options.outputDir, "graph.json"),
+      `${JSON.stringify(graph, null, 2)}\n`,
+      "utf8",
+    ),
+  ]);
+
+  return { outputDir: options.outputDir, graph };
+}

--- a/test/cli/visualize-command.test.ts
+++ b/test/cli/visualize-command.test.ts
@@ -9,6 +9,7 @@ describe("parseCommand visualize", () => {
       wikiDir: "openwiki",
       port: 4321,
       open: true,
+      exportDir: null,
     });
   });
 
@@ -21,12 +22,51 @@ describe("parseCommand visualize", () => {
       wikiDir: "docs/wiki",
       port: 4400,
       open: false,
+      exportDir: null,
     });
   });
 
   test("supports --port=NNNN form", () => {
     const command = parseCommand(["visualize", "--port=5000"]);
     expect(command.kind === "visualize" && command.port).toBe(5000);
+    expect(command.kind === "visualize" && command.exportDir).toBeNull();
+  });
+
+  test("accepts a static export directory", () => {
+    expect(
+      parseCommand(["visualize", "openwiki", "--export", "docs/visualizer"]),
+    ).toEqual({
+      kind: "visualize",
+      exitCode: 0,
+      wikiDir: "openwiki",
+      port: 4321,
+      open: true,
+      exportDir: "docs/visualizer",
+    });
+  });
+
+  test("rejects an export without a directory", () => {
+    expect(parseCommand(["visualize", "--export"])).toEqual({
+      kind: "error",
+      exitCode: 1,
+      message: "--export requires a directory.",
+    });
+  });
+
+  test("rejects server options with a static export", () => {
+    expect(
+      parseCommand([
+        "visualize",
+        "--export",
+        "docs/visualizer",
+        "--port",
+        "4400",
+      ]),
+    ).toEqual({
+      kind: "error",
+      exitCode: 1,
+      message: "--export cannot be combined with --port or --no-open.",
+    });
   });
 
   test("rejects an out-of-range port", () => {

--- a/test/visualize/static-export.test.ts
+++ b/test/visualize/static-export.test.ts
@@ -1,0 +1,78 @@
+import {
+  mkdtemp,
+  mkdir,
+  readdir,
+  readFile,
+  rm,
+  writeFile,
+} from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterEach, expect, test } from "vitest";
+import { exportStaticVisualizer } from "../../src/visualize/static-export.ts";
+
+const tempDirs: string[] = [];
+
+async function makeTempDir(): Promise<string> {
+  const dir = await mkdtemp(path.join(tmpdir(), "openwiki-static-viz-"));
+  tempDirs.push(dir);
+  return dir;
+}
+
+afterEach(async () => {
+  await Promise.all(
+    tempDirs.splice(0).map((dir) => rm(dir, { force: true, recursive: true })),
+  );
+});
+
+test("exports a static visualizer with sibling graph and browser assets", async () => {
+  const root = await makeTempDir();
+  const wikiRoot = path.join(root, "wiki");
+  const outputDir = path.join(root, "docs", "visualizer");
+  await mkdir(wikiRoot);
+  await writeFile(
+    path.join(wikiRoot, "quickstart.md"),
+    "---\ntitle: Quickstart\ntype: Guide\n---\n# Quickstart\n\nSee [Overview](overview.md).\n",
+  );
+  await writeFile(
+    path.join(wikiRoot, "overview.md"),
+    "---\ntitle: Overview\ntype: Guide\n---\n# Overview\n",
+  );
+
+  const result = await exportStaticVisualizer({
+    wikiRoot,
+    outputDir,
+    assets: {
+      clientJs: 'export const client = "static";\n',
+      clientLibJs: 'export const library = "static";\n',
+    },
+  });
+
+  expect(result.outputDir).toBe(outputDir);
+  expect(result.graph.nodes).toHaveLength(2);
+  expect(result.graph.edges).toEqual([
+    { source: "quickstart", target: "overview" },
+  ]);
+  expect(await readdir(outputDir)).toEqual([
+    "client-lib.js",
+    "client.js",
+    "graph.json",
+    "index.html",
+  ]);
+  expect(await readFile(path.join(outputDir, "client.js"), "utf8")).toBe(
+    'export const client = "static";\n',
+  );
+  expect(await readFile(path.join(outputDir, "client-lib.js"), "utf8")).toBe(
+    'export const library = "static";\n',
+  );
+
+  const page = await readFile(path.join(outputDir, "index.html"), "utf8");
+  expect(page).toContain('data-static-export="true"');
+  expect(page).toContain('src="./client.js"');
+  expect(page).toContain('id="live-text">Static<');
+  expect(page).toContain(`http-equiv="Content-Security-Policy"`);
+
+  expect(
+    JSON.parse(await readFile(path.join(outputDir, "graph.json"), "utf8")),
+  ).toEqual(result.graph);
+});


### PR DESCRIPTION
## Summary

 Adds a static-export mode for the native OpenWiki visualizer.
 closes #587 

 ```sh
openwiki visualize openwiki --export docs/openwiki-visualizer
 ```

 The command writes a deployable static visualizer directory:

 ```text
docs/openwiki-visualizer/
├── index.html
├── client.js
├── client-lib.js
└── graph.json
 ```

 The exported client loads ./graph.json directly and does not connect to the local server’s /api/graph or SSE /events endpoints. This allows generated visualizer output to be
 hosted through GitHub Pages, MkDocs, or other static hosting.

## Changes

 - Adds --export <dir> to openwiki visualize.
 - Writes static HTML, compiled browser assets, and a serialized graph snapshot.
 - Preserves the live visualizer:
   - no --export continues to run the loopback server with live reload.
 - Static page uses relative sibling asset paths and includes a CSP meta policy.
 - Static UI shows Static rather than the live-reload status.
 - Rejects incompatible server-only flags when exporting:
   - --port
   - --no-open
 - Updates CLI help and README usage documentation.
 - Adds parser and static-export artifact tests.

## Verification

 - Targeted visualizer tests: 29 passing.
 - TypeScript/client build: pnpm run build passed.
 - Built CLI smoke test exported the repository wiki successfully:
   - 15 pages
   - 27 links
 - Browser smoke test confirmed:
   - graph.json loads successfully.
   - graph canvas and Markdown reader render.
   - static mode is displayed.
   - no SSE /events connection is created.
   
## Preview
   <img width="3638" height="2544" alt="image" src="https://github.com/user-attachments/assets/52c58370-c186-4207-9618-3c3745466c35" />