### PR TITLE
fix: stream updates instead of messages for openai-compatible providers

### DIFF
--- a/.changeset/lucky-pumas-relax.md
+++ b/.changeset/lucky-pumas-relax.md
@@ -1,0 +1,5 @@
+---
+"openwiki": patch
+---
+
+Fix `openwiki --init` crashing with `Invalid response from "wrapModelCall" in middleware "patchToolCallsMiddleware"` when the openai-compatible provider targets an endpoint that streams reasoning deltas before the first assistant-role delta (e.g. z.ai GLM). OpenAI-compatible runs now stream with `updates` instead of `messages` mode by default; set `OPENWIKI_OPENAI_COMPATIBLE_STREAM_MESSAGES=true` to restore live token streaming on endpoints known to emit a role-bearing first delta.

--- a/.changeset/lucky-pumas-relax.md
+++ b/.changeset/lucky-pumas-relax.md
@@ -2,4 +2,4 @@
 "openwiki": patch
 ---
 
-Fix `openwiki --init` crashing with `Invalid response from "wrapModelCall" in middleware "patchToolCallsMiddleware"` when the openai-compatible provider targets an endpoint that streams reasoning deltas before the first assistant-role delta (e.g. z.ai GLM). OpenAI-compatible runs now stream with `updates` instead of `messages` mode by default; set `OPENWIKI_OPENAI_COMPATIBLE_STREAM_MESSAGES=true` to restore live token streaming on endpoints known to emit a role-bearing first delta.
+fix: stream updates instead of messages for openai-compatible providers

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -116,6 +116,7 @@ import {
   providerUsesExternalCliAuth,
   providerUsesResponsesApi,
   resolveConfiguredProvider,
+  resolveOpenAiCompatibleStreamMessages,
   resolveOpenRouterMaxTokens,
   resolveOpenRouterProviderOnly,
   resolveProviderBaseUrl,
@@ -518,7 +519,21 @@ async function runOpenWikiAgentCore(
     ],
   };
 
-  emitDebug(options, "stream=opening modes=messages,tools subgraphs=true");
+  // "messages" stream mode forces @langchain/core to route the model's
+  // `.invoke()` through chunk aggregation. Providers that stream reasoning
+  // deltas before the first `role: "assistant"` delta (z.ai GLM) aggregate to
+  // a ChatMessageChunk, which the agent loop's wrapModelCall validator
+  // rejects: `expected AIMessage or Command, got object` (issue #659). The
+  // openai-compatible provider can point at any endpoint, so it gets the
+  // safe "updates" mode by default; known-good endpoints can opt back in
+  // with OPENWIKI_OPENAI_COMPATIBLE_STREAM_MESSAGES=true.
+  const streamMessagesEnabled =
+    provider !== "openai-compatible" || resolveOpenAiCompatibleStreamMessages();
+  const streamModes = streamMessagesEnabled
+    ? (["messages", "tools"] as const)
+    : (["updates", "tools"] as const);
+  const streamModesLabel = streamModes.join(",");
+  emitDebug(options, `stream=opening modes=${streamModesLabel} subgraphs=true`);
   const stream = await inStage(
     "build",
     () =>
@@ -526,12 +541,12 @@ async function runOpenWikiAgentCore(
         configurable: {
           thread_id: threadId,
         },
-        streamMode: ["messages", "tools"],
+        streamMode: [...streamModes],
         subgraphs: true,
       }),
     { errorClass: "build_error", errorDetail: "stream_open" },
   );
-  emitDebug(options, "stream=started modes=messages,tools subgraphs=true");
+  emitDebug(options, `stream=started modes=${streamModesLabel} subgraphs=true`);
 
   // Register with the crash guard for exactly the stream-consumption window: a
   // subagent rejection surfaces on the microtask queue during streaming and escapes

--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -16,6 +16,8 @@ export const OPENAI_COMPATIBLE_API_KEY_ENV_KEY = "OPENAI_COMPATIBLE_API_KEY";
 export const OPENAI_COMPATIBLE_BASE_URL_ENV_KEY = "OPENAI_COMPATIBLE_BASE_URL";
 export const OPENAI_COMPATIBLE_USE_RESPONSES_API_ENV_KEY =
   "OPENWIKI_OPENAI_COMPATIBLE_USE_RESPONSES_API";
+export const OPENAI_COMPATIBLE_STREAM_MESSAGES_ENV_KEY =
+  "OPENWIKI_OPENAI_COMPATIBLE_STREAM_MESSAGES";
 export const OPENAI_CHATGPT_ACCESS_TOKEN_ENV_KEY =
   "OPENAI_CHATGPT_ACCESS_TOKEN";
 export const OPENAI_CHATGPT_REFRESH_TOKEN_ENV_KEY =
@@ -922,6 +924,27 @@ export function resolveOpenAiCompatibleUseResponsesApi(
 ): boolean {
   return (
     env[OPENAI_COMPATIBLE_USE_RESPONSES_API_ENV_KEY]?.trim().toLowerCase() ===
+    TRUE_ENV_VALUE
+  );
+}
+
+// Opt-in to keep "messages" stream mode for openai-compatible endpoints.
+//
+// The "messages" stream mode makes @langchain/core route `.invoke()`
+// through `_streamResponseChunks` chunk aggregation. Providers that emit
+// reasoning deltas before the first `role: "assistant"` delta (z.ai GLM
+// via https://api.z.ai/api/coding/paas/v4) aggregate to a
+// ChatMessageChunk instead of an AIMessage, which the agent loop's
+// wrapModelCall validator rejects ("expected AIMessage or Command, got
+// object" — issue #659). Dropping "messages" forces the non-streaming
+// `_generate` path, which returns a proper AIMessage at the cost of
+// live token streaming in the TUI. Endpoints known to emit a
+// role:"assistant" first delta can opt back in with the env below.
+export function resolveOpenAiCompatibleStreamMessages(
+  env: NodeJS.ProcessEnv = process.env,
+): boolean {
+  return (
+    env[OPENAI_COMPATIBLE_STREAM_MESSAGES_ENV_KEY]?.trim().toLowerCase() ===
     TRUE_ENV_VALUE
   );
 }

--- a/test/agent/stream-modes.test.ts
+++ b/test/agent/stream-modes.test.ts
@@ -1,0 +1,48 @@
+import { afterEach, describe, expect, test } from "vitest";
+import { resolveOpenAiCompatibleStreamMessages } from "../../src/config/constants.ts";
+import { OPENAI_COMPATIBLE_STREAM_MESSAGES_ENV_KEY } from "../../src/config/constants.ts";
+
+const original = process.env[OPENAI_COMPATIBLE_STREAM_MESSAGES_ENV_KEY];
+
+afterEach(() => {
+  if (original === undefined) {
+    delete process.env[OPENAI_COMPATIBLE_STREAM_MESSAGES_ENV_KEY];
+  } else {
+    process.env[OPENAI_COMPATIBLE_STREAM_MESSAGES_ENV_KEY] = original;
+  }
+});
+
+// Issue #659: openai-compatible endpoints that stream reasoning deltas before
+// the first role:"assistant" delta (z.ai GLM) crash the agent loop when the
+// "messages" stream mode forces chunk aggregation
+// (ChatMessageChunk fails the wrapModelCall AIMessage check). The env opt-out
+// must default to disabled and parse robustly.
+describe("resolveOpenAiCompatibleStreamMessages", () => {
+  test("defaults to false (safe non-streaming path)", () => {
+    delete process.env[OPENAI_COMPATIBLE_STREAM_MESSAGES_ENV_KEY];
+
+    expect(resolveOpenAiCompatibleStreamMessages()).toBe(false);
+  });
+
+  test("explicit true restores messages stream mode", () => {
+    process.env[OPENAI_COMPATIBLE_STREAM_MESSAGES_ENV_KEY] = "true";
+
+    expect(resolveOpenAiCompatibleStreamMessages()).toBe(true);
+  });
+
+  test("TRUE with surrounding whitespace is accepted", () => {
+    process.env[OPENAI_COMPATIBLE_STREAM_MESSAGES_ENV_KEY] = "  TRUE  ";
+
+    expect(resolveOpenAiCompatibleStreamMessages()).toBe(true);
+  });
+
+  test("any other value is treated as false", () => {
+    for (const value of ["false", "1", "yes", "garbage", ""]) {
+      expect(
+        resolveOpenAiCompatibleStreamMessages({
+          [OPENAI_COMPATIBLE_STREAM_MESSAGES_ENV_KEY]: value,
+        }),
+      ).toBe(false);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #659 (regression of #213). `openwiki --init` crashes on the first model call when the `openai-compatible` provider targets an endpoint that streams reasoning deltas before the first `role: "assistant"` delta (z.ai GLM via `https://api.z.ai/api/coding/paas/v4`):

```
* Error Invalid response from "wrapModelCall" in middleware "patchToolCallsMiddleware": expected AIMessage or Command, got object
```

## Root cause (verified against openwiki 0.3.3's installed dependency tree)

1. `src/agent/index.ts` streams with `streamMode: ["messages", "tools"]`. The `"messages"` mode installs langgraph's legacy `StreamMessagesHandler` (`lc_prefer_streaming = true`), which routes `@langchain/core`'s internal `invoke()` through `_streamResponseChunks` chunk aggregation instead of `_generate`.
2. GLM emits `reasoning_content` deltas **before** the first `role: "assistant"` delta. A roleless delta falls through `@langchain/openai`'s converter to the generic `ChatMessageChunk` branch.
3. Chunk `concat` preserves the **first** chunk's class, so the aggregated result is a `ChatMessageChunk`, not an `AIMessage`.
4. langchain's `AgentNode` validates `wrapModelCall` returns with `AIMessage.isInstance() || isCommand() || {structuredResponse, messages}` → the `ChatMessageChunk` fails all three → the reported error. `patchToolCallsMiddleware` is only named because it's the outermost wrapper; it passes the object through untouched.

Minimal repro of step 3 (run against openwiki 0.3.3's own `node_modules`, `@langchain/core` 1.2.8):

```js
import { AIMessageChunk, ChatMessageChunk, AIMessage } from "@langchain/core/messages";

const roleless  = new ChatMessageChunk({ content: "", role: undefined,
  additional_kwargs: { reasoning_content: "thinking..." } });
const assistant = new AIMessageChunk({ content: "Hello" });

AIMessage.isInstance(roleless.concat(assistant));  // false ← GLM order
AIMessage.isInstance(assistant.concat(roleless));  // true  ← OpenAI order
```

Why the #213 fix didn't cover this: the v3 `StreamProtocolMessagesHandler` is only installed for `streamEvents(..., { version: "v3" })`. The run path calls `agent.stream()` with no version, so it always gets the legacy handler.

## Change

- `openai-compatible` runs now stream with `["updates", "tools"]` instead of `["messages", "tools"]`. Without `"messages"`, the model stays on the non-streaming `_generate` path, which returns a proper `AIMessage`.
- `OPENWIKI_OPENAI_COMPATIBLE_STREAM_MESSAGES=true` opts back into live token streaming for endpoints known to emit a role-bearing first delta (mirrors the existing `OPENWIKI_OPENAI_COMPATIBLE_USE_RESPONSES_API` opt-in convention).
- All other providers keep `messages` mode — this is scoped to the provider whose endpoint is arbitrary.
- `updates` chunks are inert for the TUI: `parseAgentStreamChunk`'s type guard only accepts `"messages" | "tools"` tuples, so they're ignored (at most 3 debug lines in `--debug`). Tool activity still streams via `"tools"` mode.

Trade-off: openai-compatible runs lose live streamed text in the TUI (the same trade-off as the community workaround in #213, which this makes official and reversible). The proper long-term fix belongs in `@langchain/openai` (default `role: "assistant"` for assistant-stream deltas) or `@langchain/core` (aggregation promoting to the most specific message class).

## Testing

- New `test/agent/stream-modes.test.ts` covers the resolver: default off, `true`/`TRUE` with whitespace on, garbage values off.
- Full suite: **2337 passed, 3 skipped, 0 failed** (`pnpm test`), `pnpm run lint` and `pnpm run format` clean.
- Manual: workaround verified end-to-end on z.ai GLM-5.3 — with `messages` dropped from streamMode the run proceeds and generates the wiki (matches the #213 report's verification on Windows/GLM-5.2).

## Notes for reviewers

One PR = one change: this is deliberately the openwiki-side mitigation only. The class-identity aggregation bug is upstream in `@langchain/openai`/`@langchain/core` and worth a separate fix there; happy to open that follow-up too.
