### PR TITLE
fix: exclude runs without measurable latency from the outlier bucket

### DIFF
--- a/.changeset/brave-donkeys-measure.md
+++ b/.changeset/brave-donkeys-measure.md
@@ -1,0 +1,5 @@
+---
+"openwiki": patch
+---
+
+fix: stop labeling LangSmith runs without measurable latency as latency outliers

--- a/src/connectors/sources/langsmith/runs.ts
+++ b/src/connectors/sources/langsmith/runs.ts
@@ -52,13 +52,12 @@ export function selectSampleBuckets(
 
   // Only runs with a measurable latency can be latency outliers; the rest
   // carry no latency evidence and fall through to the baseline backfill.
-  const measurable = nonErrorRuns
-    .filter((run) => !usedIds.has(run.id))
-    .map((run) => ({ latency: latencyMs(run), run }))
-    .filter(
-      (entry): entry is { latency: number; run: Run } =>
-        entry.latency !== undefined,
-    );
+  const measurable = nonErrorRuns.flatMap((run) => {
+    const latency = latencyMs(run);
+    return latency === undefined || usedIds.has(run.id)
+      ? []
+      : [{ latency, run }];
+  });
   // Keep outliers a genuine tail: never more than the flat cap, the remaining
   // budget, or a quarter of the measurable pool (so a small pull stays mostly
   // baseline instead of being relabeled as outliers).

--- a/src/connectors/sources/langsmith/runs.ts
+++ b/src/connectors/sources/langsmith/runs.ts
@@ -21,12 +21,14 @@ export interface SampleCaps {
 /**
  * Selects the sample from two lean root-run pools within the window, biased
  * toward anomalies: errors first (up to errorCap), then latency outliers among
- * the non-errored runs (up to outlierCap, at most a quarter of the non-errored
- * pool so the bucket stays a genuine tail rather than swallowing a small pull,
- * and the remaining budget), then the most-recent non-errored runs to backfill
- * to `total`. With no errors/outliers it degrades to all-baseline — the same
- * recency behavior as before. Runs are deduped by id; `nonErrorRuns` is assumed
- * most-recent-first.
+ * the non-errored runs (up to outlierCap, at most a quarter of the runs with a
+ * measurable latency so the bucket stays a genuine tail rather than swallowing
+ * a small pull, and the remaining budget), then the most-recent non-errored
+ * runs to backfill to `total`. Only runs with a measurable latency are eligible
+ * for the outlier bucket — runs without one (still in flight, or with unusable
+ * timestamps) carry no latency evidence and backfill as baseline instead. With
+ * no errors/outliers it degrades to all-baseline — the same recency behavior as
+ * before. Runs are deduped by id; `nonErrorRuns` is assumed most-recent-first.
  */
 export function selectSampleBuckets(
   errorRuns: Run[],
@@ -48,17 +50,24 @@ export function selectSampleBuckets(
     take(run, "error");
   }
 
+  // Only runs with a measurable latency can be latency outliers; the rest
+  // carry no latency evidence and fall through to the baseline backfill.
+  const measurable = nonErrorRuns
+    .filter((run) => !usedIds.has(run.id))
+    .map((run) => ({ latency: latencyMs(run), run }))
+    .filter(
+      (entry): entry is { latency: number; run: Run } =>
+        entry.latency !== undefined,
+    );
   // Keep outliers a genuine tail: never more than the flat cap, the remaining
-  // budget, or a quarter of the non-errored pool (so a small pull stays mostly
+  // budget, or a quarter of the measurable pool (so a small pull stays mostly
   // baseline instead of being relabeled as outliers).
   const outlierBudget = Math.min(
     caps.outlierCap,
     caps.total - selected.length,
-    Math.floor(nonErrorRuns.length / 4),
+    Math.floor(measurable.length / 4),
   );
-  const byLatencyDesc = nonErrorRuns
-    .filter((run) => !usedIds.has(run.id))
-    .map((run) => ({ latency: latencyMs(run) ?? -1, run }))
+  const byLatencyDesc = measurable
     .sort((left, right) => right.latency - left.latency)
     .slice(0, outlierBudget);
   for (const { run } of byLatencyDesc) {

--- a/test/connectors/sources/langsmith/runs.test.ts
+++ b/test/connectors/sources/langsmith/runs.test.ts
@@ -26,6 +26,13 @@ function root(id: string, latencyMs: number, tokens?: number): Run {
   });
 }
 
+/**
+ * A root run whose latency cannot be computed (no end_time yet).
+ */
+function unmeasured(id: string): Run {
+  return run({ id, start_time: BASE });
+}
+
 describe("compactTrace", () => {
   test("orders root-first then by start time and sets the trace fields", () => {
     const runs = [
@@ -188,10 +195,11 @@ describe("selectSampleBuckets", () => {
     expect(selected).toHaveLength(3);
   });
 
-  test("caps outliers at a quarter of the non-errored pool on a small sample", () => {
-    // 8 non-error runs with a generous flat cap (5): the proportional cap
-    // (floor(8/4)=2) wins, so only the 2 slowest are outliers and the rest stay
-    // baseline instead of the bucket swallowing the small pull.
+  test("caps outliers at a quarter of the measurable pool on a small sample", () => {
+    // 8 measurable non-error runs with a generous flat cap (5): the
+    // proportional cap (floor(8/4)=2) wins, so only the 2 slowest are outliers
+    // and the rest stay baseline instead of the bucket swallowing the small
+    // pull.
     const nonErrorRuns = Array.from({ length: 8 }, (_, i) =>
       root(`n${i}`, i * 10),
     );
@@ -209,6 +217,115 @@ describe("selectSampleBuckets", () => {
     // The 2 slowest (n7=70ms, n6=60ms) are the outliers.
     expect(outliers.map((s) => s.run.id).sort()).toEqual(["n6", "n7"]);
     expect(selected).toHaveLength(8);
+  });
+
+  test("never labels runs without measurable latency as outliers", () => {
+    // All four runs have a start but no end time, so no latency evidence
+    // exists — none of them can be presented as a latency tail.
+    const nonErrorRuns = [
+      unmeasured("u1"),
+      unmeasured("u2"),
+      unmeasured("u3"),
+      unmeasured("u4"),
+    ];
+
+    const selected = selectSampleBuckets([], nonErrorRuns, {
+      errorCap: 2,
+      outlierCap: 1,
+      total: 8,
+    });
+
+    expect(selected.map((s) => [s.run.id, s.bucket])).toEqual([
+      ["u1", "baseline"],
+      ["u2", "baseline"],
+      ["u3", "baseline"],
+      ["u4", "baseline"],
+    ]);
+  });
+
+  test("keeps the outlier bucket empty when measurable runs are too few to have a tail", () => {
+    // 8 candidates but only one with measurable latency: floor(1/4) = 0, so a
+    // run that IS the whole measurable distribution is never called its tail,
+    // and no unmeasurable run backfills the freed slots as an outlier.
+    const nonErrorRuns = [
+      unmeasured("u1"),
+      root("m1", 500),
+      unmeasured("u2"),
+      unmeasured("u3"),
+      unmeasured("u4"),
+      unmeasured("u5"),
+      unmeasured("u6"),
+      unmeasured("u7"),
+    ];
+
+    const selected = selectSampleBuckets([], nonErrorRuns, {
+      errorCap: 0,
+      outlierCap: 2,
+      total: 20,
+    });
+
+    expect(selected.filter((s) => s.bucket === "outlier")).toHaveLength(0);
+    expect(selected.find((s) => s.run.id === "m1")?.bucket).toBe("baseline");
+    expect(selected).toHaveLength(8);
+  });
+
+  test("computes the quarter-of-pool outlier cap over measurable runs only", () => {
+    // 4 measurable + 4 unmeasurable runs: the proportional cap is
+    // floor(4/4) = 1 over the measurable pool (not floor(8/4) = 2 over the
+    // whole pool), so exactly the slowest measurable run is the outlier and
+    // unmeasurable runs stay baseline.
+    const nonErrorRuns = [
+      root("m1", 10),
+      unmeasured("u1"),
+      root("m2", 40),
+      unmeasured("u2"),
+      root("m3", 20),
+      unmeasured("u3"),
+      root("m4", 30),
+      unmeasured("u4"),
+    ];
+
+    const selected = selectSampleBuckets([], nonErrorRuns, {
+      errorCap: 0,
+      outlierCap: 5,
+      total: 20,
+    });
+
+    const outliers = selected.filter((s) => s.bucket === "outlier");
+    expect(outliers.map((s) => s.run.id)).toEqual(["m2"]);
+    expect(
+      selected
+        .filter((s) => s.run.id.startsWith("u"))
+        .every((s) => s.bucket === "baseline"),
+    ).toBe(true);
+    expect(selected).toHaveLength(8);
+  });
+
+  test("a run with a negative latency is not outlier-eligible", () => {
+    // An end time before the start time yields no usable latency, so the run
+    // is treated like any other unmeasurable run.
+    const negative = run({
+      end_time: new Date(Date.parse(BASE) - 1_000).toISOString(),
+      id: "neg",
+      start_time: BASE,
+    });
+    const nonErrorRuns = [
+      negative,
+      root("m1", 10),
+      root("m2", 40),
+      root("m3", 20),
+      root("m4", 30),
+    ];
+
+    const selected = selectSampleBuckets([], nonErrorRuns, {
+      errorCap: 0,
+      outlierCap: 5,
+      total: 20,
+    });
+
+    const outliers = selected.filter((s) => s.bucket === "outlier");
+    expect(outliers.map((s) => s.run.id)).toEqual(["m2"]);
+    expect(selected.find((s) => s.run.id === "neg")?.bucket).toBe("baseline");
   });
 });
 


### PR DESCRIPTION
## What and why

Fixes #544.

LangSmith trace sampling mapped runs without a computable latency to a `-1` sentinel (`latencyMs(run) ?? -1`) in `selectSampleBuckets`, so runs with no latency evidence could fill latency-outlier slots and be described to the synthesis agent as the slowest non-errored roots. This PR makes only runs with a measured latency eligible for the `outlier` bucket; unmeasurable runs (still in flight, or with missing/unparseable/negative timestamps) fall through to the existing recency-ordered `baseline` backfill, so the selected run set and total sample size are unchanged — only the unsupported labels go away.

**One deliberate divergence from the issue's literal mixed-pool repro, flagged for maintainer sign-off:** the quarter-of-pool proportional cap now computes over the *measurable* pool (`floor(measurable/4)`) rather than the full non-error pool. With the full-pool base, a mostly-unmeasurable pull (e.g. 3 measurable + 9 unmeasurable → 3 slots) would label *every* measurable run an outlier — presenting 100% of the measurable distribution as its own tail, the same class of unsupported claim this fix removes. The measurable base preserves the cap's documented intent ("the bucket stays a genuine tail"). Consequence: in the issue's second repro (8 candidates, 1 measurable), the sole measurable run is now `baseline` rather than taking the first outlier slot, since `floor(1/4) = 0`.

## How I tested it

Four new unit tests in `test/connectors/sources/langsmith/runs.test.ts` (reusing the existing `run()`/`root()` fixtures), covering: an all-unmeasurable pool produces zero outliers (issue repro 1); a pool with one measurable run out of eight produces zero outliers with no unmeasurable backfill into the bucket (issue repro 2); the proportional cap counts only measurable runs (4 measurable + 4 unmeasurable → exactly 1 outlier); and a negative-latency run is not outlier-eligible. All three behavioral tests fail against the previous sentinel implementation. Existing tests pass unmodified apart from a comment/title wording update on the quarter-cap test; full `pnpm test` (typecheck, build, Vitest with coverage), `pnpm run lint:check`, and `pnpm run format:check` are green locally.

## Changeset

Patch changeset included (`.changeset/brave-donkeys-measure.md`).

## Post-Deploy Monitoring & Validation

No additional operational monitoring required — this changes bucket labeling inside the LangSmith connector's local sampling only; no runtime service, schema, or API surface is affected. Validation: the next `openwiki --update` run with a LangSmith source labels `outlier` only on runs with measured latency.


