### PR TITLE
fix(agent): retry OpenRouter 429s at the fetch boundary

### DIFF
--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -97,6 +97,7 @@ import {
   getProviderSecretKeyEnvKey,
   getProvidersForKnownModelId,
   isModelIdForOtherProvider,
+  DEFAULT_PROVIDER_RETRY_ATTEMPTS,
   DEFAULT_VERTEX_LOCATION,
   GOOGLE_CLOUD_PROJECT_ENV_KEY,
   isValidModelId,
@@ -1904,11 +1905,20 @@ type OpenRouterResponseSummary = {
 const OPENROUTER_DEBUG_PROPERTY = "openRouterDebug";
 const OPENROUTER_DEBUG_BODY_LIMIT = 4_000;
 
-function installOpenRouterDebugFetch(
+export function installOpenRouterDebugFetch(
   options: OpenWikiRunOptions,
 ): OpenRouterFetchCapture {
   const originalFetch = globalThis.fetch;
   let lastFailure: OpenRouterFetchFailure | null = null;
+
+  // Resolved tolerantly: run-config validation reports invalid env values with
+  // the proper `config` stage attribution, so the wrapper only needs a number.
+  let retryAttempts = DEFAULT_PROVIDER_RETRY_ATTEMPTS;
+  try {
+    retryAttempts = resolveProviderRetryAttempts();
+  } catch {
+    // Leave the default; resolveRunConfig will surface the env error.
+  }
 
   globalThis.fetch = (async (input, init) => {
     if (!isOpenRouterFetchInput(input)) {
@@ -1917,28 +1927,21 @@ function installOpenRouterDebugFetch(
 
     const request = summarizeOpenRouterRequest(input, init);
 
+    // Retrying requires re-sending the body; the OpenAI-compatible clients send
+    // string JSON bodies via `init` (or none), but a stream body — or a Request
+    // object carrying one — can only be consumed once, so leave those untouched.
+    const inputCarriesConsumedBody =
+      typeof Request !== "undefined" &&
+      input instanceof Request &&
+      input.body !== null;
+    const bodyResendable =
+      !inputCarriesConsumedBody &&
+      (init?.body === undefined || typeof init.body === "string");
+
+    let response: Response;
+
     try {
-      const response = await originalFetch(input, init);
-
-      if (!response.ok) {
-        lastFailure = {
-          request,
-          response: {
-            bodyPreview: await readResponseBodyPreview(response),
-            headers: getSafeResponseHeaders(response.headers),
-            status: response.status,
-            statusText: response.statusText,
-          },
-        };
-        emitDebug(
-          options,
-          `openrouter.http status=${response.status} statusText=${JSON.stringify(
-            response.statusText,
-          )}`,
-        );
-      }
-
-      return response;
+      response = await originalFetch(input, init);
     } catch (error) {
       lastFailure = {
         fetchError: error instanceof Error ? error.message : String(error),
@@ -1946,6 +1949,57 @@ function installOpenRouterDebugFetch(
       };
       throw error;
     }
+
+    // OpenRouter's platform-side 429s (e.g. free-models-per-min) carry no
+    // Retry-After, which the LangChain AsyncCaller classifies as
+    // non-retryable capacity and turns into an immediate abort —
+    // OPENWIKI_PROVIDER_RETRY_ATTEMPTS never applies (#664). Retry here, at
+    // the fetch boundary the diagnostics wrapper already owns.
+    for (
+      let attempt = 1;
+      response.status === 429 &&
+      bodyResendable &&
+      attempt <= retryAttempts &&
+      !init?.signal?.aborted;
+      attempt += 1
+    ) {
+      const delayMs = computeOpenRouterRetryDelayMs(response, attempt);
+      emitDebug(
+        options,
+        `openrouter.retry attempt=${attempt}/${retryAttempts} delayMs=${delayMs}`,
+      );
+      await sleepUnlessAborted(delayMs, init?.signal);
+
+      try {
+        response = await originalFetch(input, init);
+      } catch (error) {
+        lastFailure = {
+          fetchError: error instanceof Error ? error.message : String(error),
+          request,
+        };
+        throw error;
+      }
+    }
+
+    if (!response.ok) {
+      lastFailure = {
+        request,
+        response: {
+          bodyPreview: await readResponseBodyPreview(response),
+          headers: getSafeResponseHeaders(response.headers),
+          status: response.status,
+          statusText: response.statusText,
+        },
+      };
+      emitDebug(
+        options,
+        `openrouter.http status=${response.status} statusText=${JSON.stringify(
+          response.statusText,
+        )}`,
+      );
+    }
+
+    return response;
   }) satisfies typeof fetch;
 
   return {
@@ -1957,6 +2011,78 @@ function installOpenRouterDebugFetch(
       globalThis.fetch = originalFetch;
     },
   };
+}
+
+/**
+ * Delay before the next OpenRouter retry, honouring the response's own hints:
+ * `Retry-After` (seconds or HTTP-date) first, then OpenRouter's
+ * `X-RateLimit-Reset` epoch (milliseconds, or seconds for providers that send
+ * it that way), and finally exponential backoff so a handful of attempts can
+ * ride out a per-minute window. Header-derived waits are capped defensively.
+ */
+export function computeOpenRouterRetryDelayMs(
+  response: Response,
+  attempt: number,
+): number {
+  const retryAfter = response.headers.get("retry-after");
+
+  if (retryAfter !== null && retryAfter.trim() !== "") {
+    const seconds = Number(retryAfter);
+
+    if (Number.isFinite(seconds) && seconds >= 0) {
+      return clampDelay(seconds * 1_000, 300_000);
+    }
+
+    const httpDate = Date.parse(retryAfter);
+
+    if (!Number.isNaN(httpDate)) {
+      return clampDelay(httpDate - Date.now(), 300_000);
+    }
+  }
+
+  const resetRaw = response.headers.get("x-ratelimit-reset");
+
+  if (resetRaw !== null && resetRaw.trim() !== "") {
+    const resetValue = Number(resetRaw);
+
+    if (Number.isFinite(resetValue) && resetValue > 0) {
+      // Values below ~2001-09-09 in ms are unix seconds, not milliseconds.
+      const resetEpochMs = resetValue < 1e12 ? resetValue * 1_000 : resetValue;
+      // Small margin so the retry lands after the window actually resets.
+      return clampDelay(resetEpochMs - Date.now() + 250, 300_000);
+    }
+  }
+
+  return clampDelay(1_000 * 2 ** (attempt - 1), 30_000);
+}
+
+function clampDelay(delayMs: number, maxMs: number): number {
+  if (!Number.isFinite(delayMs) || delayMs < 0) {
+    return 0;
+  }
+
+  return Math.min(delayMs, maxMs);
+}
+
+function sleepUnlessAborted(ms: number, signal?: AbortSignal): Promise<void> {
+  return new Promise((resolve, reject) => {
+    if (signal?.aborted) {
+      reject(signal.reason ?? new Error("Aborted"));
+      return;
+    }
+
+    const timer = setTimeout(() => {
+      signal?.removeEventListener("abort", onAbort);
+      resolve();
+    }, ms);
+
+    const onAbort = () => {
+      clearTimeout(timer);
+      reject(signal?.reason ?? new Error("Aborted"));
+    };
+
+    signal?.addEventListener("abort", onAbort, { once: true });
+  });
 }
 
 function attachOpenRouterDebugInfo(

--- a/test/agent/openrouter-retry.test.ts
+++ b/test/agent/openrouter-retry.test.ts
@@ -1,0 +1,188 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+
+import type { OpenWikiRunOptions } from "../../src/agent/types.ts";
+import {
+  computeOpenRouterRetryDelayMs,
+  installOpenRouterDebugFetch,
+} from "../../src/agent/index.ts";
+
+const RETRY_ENV_KEY = "OPENWIKI_PROVIDER_RETRY_ATTEMPTS";
+const CHAT_URL = "https://openrouter.ai/api/v1/chat/completions";
+
+const originalFetch = globalThis.fetch;
+let fetchCalls: Array<{ input: unknown; init?: RequestInit }>;
+let fetchResponses: Array<() => Response>;
+let savedEnv: string | undefined;
+
+beforeEach(() => {
+  fetchCalls = [];
+  fetchResponses = [];
+  savedEnv = process.env[RETRY_ENV_KEY];
+  process.env[RETRY_ENV_KEY] = "3";
+});
+
+afterEach(() => {
+  process.env[RETRY_ENV_KEY] = savedEnv;
+  globalThis.fetch = originalFetch;
+  vi.restoreAllMocks();
+});
+
+function jsonResponse(status: number, headers: Record<string, string> = {}, body: unknown = {}): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json", ...headers },
+  });
+}
+
+function installMockFetch(responders: Array<() => Response>): void {
+  fetchResponses = responders;
+  let index = 0;
+  globalThis.fetch = (async (input: unknown, init?: RequestInit) => {
+    fetchCalls.push({ input, init });
+    const responder = fetchResponses[Math.min(index, fetchResponses.length - 1)];
+    index += 1;
+    return responder();
+  }) as typeof fetch;
+}
+
+// Minimal options: emitDebug no-ops without `debug`.
+const noDebugOptions: OpenWikiRunOptions = {};
+
+describe("installOpenRouterDebugFetch 429 retry (#664)", () => {
+  test("retries a Retry-After-less 429 and honours X-RateLimit-Reset", async () => {
+    // The exact OpenRouter free-tier shape: 429, no Retry-After, reset as unix-ms.
+    const resetAt = Date.now() + 40;
+    installMockFetch([
+      () => jsonResponse(429, { "x-ratelimit-reset": String(resetAt) }, { error: { code: 429 } }),
+      () => jsonResponse(200, {}, { choices: [] }),
+    ]);
+
+    const capture = installOpenRouterDebugFetch(noDebugOptions);
+    const startedAt = Date.now();
+    const response = await globalThis.fetch(CHAT_URL, {
+      method: "POST",
+      body: JSON.stringify({ model: "x:free", stream: true }),
+    });
+    const waitedMs = Date.now() - startedAt;
+    capture.restore();
+
+    expect(response.status).toBe(200);
+    expect(fetchCalls).toHaveLength(2);
+    // The retry waited for the reset window (40ms minus scheduling slack).
+    expect(waitedMs).toBeGreaterThanOrEqual(25);
+  });
+
+  test("returns the final 429 after exhausting the attempt budget", async () => {
+    installMockFetch([() => jsonResponse(429, { "x-ratelimit-reset": String(Date.now()) })]);
+
+    const capture = installOpenRouterDebugFetch(noDebugOptions);
+    const response = await globalThis.fetch(CHAT_URL, {
+      method: "POST",
+      body: JSON.stringify({ model: "x:free" }),
+    });
+    const failure = capture.getLastFailure();
+    capture.restore();
+
+    expect(response.status).toBe(429);
+    // 1 initial attempt + 3 retries from OPENWIKI_PROVIDER_RETRY_ATTEMPTS=3.
+    expect(fetchCalls).toHaveLength(4);
+    expect(failure?.response?.status).toBe(429);
+  });
+
+  test("does not retry non-OpenRouter requests", async () => {
+    installMockFetch([() => jsonResponse(429)]);
+
+    const capture = installOpenRouterDebugFetch(noDebugOptions);
+    const response = await globalThis.fetch("https://example.com/api", {
+      method: "POST",
+      body: "{}",
+    });
+    capture.restore();
+
+    expect(response.status).toBe(429);
+    expect(fetchCalls).toHaveLength(1);
+  });
+
+  test("does not retry when the body cannot be re-sent", async () => {
+    installMockFetch([() => jsonResponse(429)]);
+
+    const capture = installOpenRouterDebugFetch(noDebugOptions);
+    const stream = new ReadableStream({
+      start(controller) {
+        controller.enqueue(new TextEncoder().encode("{}"));
+        controller.close();
+      },
+    });
+    const response = await globalThis.fetch(CHAT_URL, {
+      method: "POST",
+      body: stream,
+    });
+    capture.restore();
+
+    expect(response.status).toBe(429);
+    expect(fetchCalls).toHaveLength(1);
+  });
+
+  test("a network error on retry keeps the fetchError diagnostics", async () => {
+    installMockFetch([
+      () => jsonResponse(429, { "x-ratelimit-reset": String(Date.now()) }),
+      () => {
+        throw new Error("socket hang up");
+      },
+    ]);
+
+    const capture = installOpenRouterDebugFetch(noDebugOptions);
+    await expect(
+      globalThis.fetch(CHAT_URL, { method: "POST", body: "{}" }),
+    ).rejects.toThrow("socket hang up");
+    const failure = capture.getLastFailure();
+    capture.restore();
+
+    expect(fetchCalls).toHaveLength(2);
+    expect(failure?.fetchError).toBe("socket hang up");
+  });
+});
+
+describe("computeOpenRouterRetryDelayMs", () => {
+  const responseWith = (headers: Record<string, string>) =>
+    new Response("{}", { status: 429, headers });
+
+  test("uses Retry-After seconds when present", () => {
+    expect(computeOpenRouterRetryDelayMs(responseWith({ "retry-after": "7" }), 1)).toBe(7_000);
+  });
+
+  test("uses an HTTP-date Retry-After relative to now", () => {
+    const date = new Date(Date.now() + 5_000).toUTCString();
+    const delay = computeOpenRouterRetryDelayMs(responseWith({ "retry-after": date }), 1);
+    expect(delay).toBeGreaterThan(3_000);
+    expect(delay).toBeLessThanOrEqual(5_000);
+  });
+
+  test("falls back to X-RateLimit-Reset (unix ms) with a small margin", () => {
+    const resetAt = Date.now() + 2_000;
+    const delay = computeOpenRouterRetryDelayMs(
+      responseWith({ "x-ratelimit-reset": String(resetAt) }),
+      1,
+    );
+    expect(delay).toBeGreaterThan(2_000);
+    expect(delay).toBeLessThanOrEqual(2_500);
+  });
+
+  test("interprets a seconds-magnitude X-RateLimit-Reset as unix seconds", () => {
+    const resetAtSeconds = Math.floor(Date.now() / 1_000) + 3;
+    const delay = computeOpenRouterRetryDelayMs(
+      responseWith({ "x-ratelimit-reset": String(resetAtSeconds) }),
+      1,
+    );
+    expect(delay).toBeGreaterThan(2_500);
+    expect(delay).toBeLessThanOrEqual(3_500);
+  });
+
+  test("grows exponentially when no hint is present", () => {
+    const none = responseWith({});
+    expect(computeOpenRouterRetryDelayMs(none, 1)).toBe(1_000);
+    expect(computeOpenRouterRetryDelayMs(none, 2)).toBe(2_000);
+    expect(computeOpenRouterRetryDelayMs(none, 3)).toBe(4_000);
+    expect(computeOpenRouterRetryDelayMs(none, 10)).toBe(30_000);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #664.

An OpenRouter free-tier `429` (no `Retry-After`) aborted the whole run on first occurrence: LangChain's `AsyncCaller` classifies a `Retry-After`-less 429 as non-retryable capacity and throws immediately, so `OPENWIKI_PROVIDER_RETRY_ATTEMPTS` was never spent. #461's `createProviderRetryFetch` can't help here — it rides the OpenAI SDK `configuration` option, which `ChatOpenRouter` doesn't accept — and its flat 1 s fallback couldn't ride out a per-minute window regardless.

## What this does

Retries at the fetch boundary `installOpenRouterDebugFetch` already owns (it wraps every OpenRouter chat-completions fetch):

- **Delay hints, in priority order**: `Retry-After` (seconds or HTTP-date) → `X-RateLimit-Reset` (unix-ms epoch, with seconds-magnitude detection for providers that send seconds, plus a 250 ms margin so the retry lands after the window actually resets) → exponential backoff (1 s doubling, capped at 30 s). Header-derived waits are defensively capped at 5 minutes.
- **Budget**: the existing `OPENWIKI_PROVIDER_RETRY_ATTEMPTS` (default 3), resolved tolerantly at install time so an invalid env value still surfaces through run-config validation with its `config` stage attribution.
- **Re-send safety**: retries only run when the request is re-sendable — string/absent body in `init`, and `input` isn't a `Request` object carrying a body (a consumed stream body can't be re-sent).
- **Abort propagation**: the wait rejects with the abort signal's reason, so cancellation stays prompt mid-backoff.
- **Diagnostics contract unchanged**: the final non-ok response is still captured for `attachOpenRouterDebugInfo` (`Error Diagnostics` block), and each retry emits a debug line (`openrouter.retry attempt=N/M delayMs=…`).

## Tests

`test/agent/openrouter-retry.test.ts` (vitest, follows `gemini-retry.test.ts` conventions):

- end-to-end through the wrapper: a `Retry-After`-less 429 with `X-RateLimit-Reset` is retried and the wait honours the reset instant;
- attempt-budget exhaustion: `1 + N` fetch calls, final 429 returned to the caller with diagnostics captured;
- non-OpenRouter URLs and non-resendable bodies pass through without retry;
- a network error during retry keeps the `fetchError` diagnostics;
- unit coverage of `computeOpenRouterRetryDelayMs`: `Retry-After` seconds and HTTP-date, ms- and seconds-epoch resets, exponential growth with caps.
