### PR TITLE
fix(agent): record ended_early when a clean exit leaves the skeleton behind

### DIFF
--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -97,6 +97,7 @@ import {
   getProviderSecretKeyEnvKey,
   getProvidersForKnownModelId,
   isModelIdForOtherProvider,
+  DEFAULT_PROVIDER_RETRY_ATTEMPTS,
   DEFAULT_VERTEX_LOCATION,
   GOOGLE_CLOUD_PROJECT_ENV_KEY,
   isValidModelId,
@@ -1904,11 +1905,20 @@ type OpenRouterResponseSummary = {
 const OPENROUTER_DEBUG_PROPERTY = "openRouterDebug";
 const OPENROUTER_DEBUG_BODY_LIMIT = 4_000;
 
-function installOpenRouterDebugFetch(
+export function installOpenRouterDebugFetch(
   options: OpenWikiRunOptions,
 ): OpenRouterFetchCapture {
   const originalFetch = globalThis.fetch;
   let lastFailure: OpenRouterFetchFailure | null = null;
+
+  // Resolved tolerantly: run-config validation reports invalid env values with
+  // the proper `config` stage attribution, so the wrapper only needs a number.
+  let retryAttempts = DEFAULT_PROVIDER_RETRY_ATTEMPTS;
+  try {
+    retryAttempts = resolveProviderRetryAttempts();
+  } catch {
+    // Leave the default; resolveRunConfig will surface the env error.
+  }
 
   globalThis.fetch = (async (input, init) => {
     if (!isOpenRouterFetchInput(input)) {
@@ -1917,28 +1927,21 @@ function installOpenRouterDebugFetch(
 
     const request = summarizeOpenRouterRequest(input, init);
 
+    // Retrying requires re-sending the body; the OpenAI-compatible clients send
+    // string JSON bodies via `init` (or none), but a stream body — or a Request
+    // object carrying one — can only be consumed once, so leave those untouched.
+    const inputCarriesConsumedBody =
+      typeof Request !== "undefined" &&
+      input instanceof Request &&
+      input.body !== null;
+    const bodyResendable =
+      !inputCarriesConsumedBody &&
+      (init?.body === undefined || typeof init.body === "string");
+
+    let response: Response;
+
     try {
-      const response = await originalFetch(input, init);
-
-      if (!response.ok) {
-        lastFailure = {
-          request,
-          response: {
-            bodyPreview: await readResponseBodyPreview(response),
-            headers: getSafeResponseHeaders(response.headers),
-            status: response.status,
-            statusText: response.statusText,
-          },
-        };
-        emitDebug(
-          options,
-          `openrouter.http status=${response.status} statusText=${JSON.stringify(
-            response.statusText,
-          )}`,
-        );
-      }
-
-      return response;
+      response = await originalFetch(input, init);
     } catch (error) {
       lastFailure = {
         fetchError: error instanceof Error ? error.message : String(error),
@@ -1946,6 +1949,57 @@ function installOpenRouterDebugFetch(
       };
       throw error;
     }
+
+    // OpenRouter's platform-side 429s (e.g. free-models-per-min) carry no
+    // Retry-After, which the LangChain AsyncCaller classifies as
+    // non-retryable capacity and turns into an immediate abort —
+    // OPENWIKI_PROVIDER_RETRY_ATTEMPTS never applies (#664). Retry here, at
+    // the fetch boundary the diagnostics wrapper already owns.
+    for (
+      let attempt = 1;
+      response.status === 429 &&
+      bodyResendable &&
+      attempt <= retryAttempts &&
+      !init?.signal?.aborted;
+      attempt += 1
+    ) {
+      const delayMs = computeOpenRouterRetryDelayMs(response, attempt);
+      emitDebug(
+        options,
+        `openrouter.retry attempt=${attempt}/${retryAttempts} delayMs=${delayMs}`,
+      );
+      await sleepUnlessAborted(delayMs, init?.signal);
+
+      try {
+        response = await originalFetch(input, init);
+      } catch (error) {
+        lastFailure = {
+          fetchError: error instanceof Error ? error.message : String(error),
+          request,
+        };
+        throw error;
+      }
+    }
+
+    if (!response.ok) {
+      lastFailure = {
+        request,
+        response: {
+          bodyPreview: await readResponseBodyPreview(response),
+          headers: getSafeResponseHeaders(response.headers),
+          status: response.status,
+          statusText: response.statusText,
+        },
+      };
+      emitDebug(
+        options,
+        `openrouter.http status=${response.status} statusText=${JSON.stringify(
+          response.statusText,
+        )}`,
+      );
+    }
+
+    return response;
   }) satisfies typeof fetch;
 
   return {
@@ -1957,6 +2011,78 @@ function installOpenRouterDebugFetch(
       globalThis.fetch = originalFetch;
     },
   };
+}
+
+/**
+ * Delay before the next OpenRouter retry, honouring the response's own hints:
+ * `Retry-After` (seconds or HTTP-date) first, then OpenRouter's
+ * `X-RateLimit-Reset` epoch (milliseconds, or seconds for providers that send
+ * it that way), and finally exponential backoff so a handful of attempts can
+ * ride out a per-minute window. Header-derived waits are capped defensively.
+ */
+export function computeOpenRouterRetryDelayMs(
+  response: Response,
+  attempt: number,
+): number {
+  const retryAfter = response.headers.get("retry-after");
+
+  if (retryAfter !== null && retryAfter.trim() !== "") {
+    const seconds = Number(retryAfter);
+
+    if (Number.isFinite(seconds) && seconds >= 0) {
+      return clampDelay(seconds * 1_000, 300_000);
+    }
+
+    const httpDate = Date.parse(retryAfter);
+
+    if (!Number.isNaN(httpDate)) {
+      return clampDelay(httpDate - Date.now(), 300_000);
+    }
+  }
+
+  const resetRaw = response.headers.get("x-ratelimit-reset");
+
+  if (resetRaw !== null && resetRaw.trim() !== "") {
+    const resetValue = Number(resetRaw);
+
+    if (Number.isFinite(resetValue) && resetValue > 0) {
+      // Values below ~2001-09-09 in ms are unix seconds, not milliseconds.
+      const resetEpochMs = resetValue < 1e12 ? resetValue * 1_000 : resetValue;
+      // Small margin so the retry lands after the window actually resets.
+      return clampDelay(resetEpochMs - Date.now() + 250, 300_000);
+    }
+  }
+
+  return clampDelay(1_000 * 2 ** (attempt - 1), 30_000);
+}
+
+function clampDelay(delayMs: number, maxMs: number): number {
+  if (!Number.isFinite(delayMs) || delayMs < 0) {
+    return 0;
+  }
+
+  return Math.min(delayMs, maxMs);
+}
+
+function sleepUnlessAborted(ms: number, signal?: AbortSignal): Promise<void> {
+  return new Promise((resolve, reject) => {
+    if (signal?.aborted) {
+      reject(signal.reason ?? new Error("Aborted"));
+      return;
+    }
+
+    const timer = setTimeout(() => {
+      signal?.removeEventListener("abort", onAbort);
+      resolve();
+    }, ms);
+
+    const onAbort = () => {
+      clearTimeout(timer);
+      reject(signal?.reason ?? new Error("Aborted"));
+    };
+
+    signal?.addEventListener("abort", onAbort, { once: true });
+  });
 }
 
 function attachOpenRouterDebugInfo(

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -75,6 +75,7 @@ import type {
   OpenWikiRunOptions,
   OpenWikiRunResult,
   RunContext,
+  UpdateRunStatus,
 } from "./types.js";
 import {
   ANTHROPIC_BASE_URL_ENV_KEY,
@@ -141,6 +142,7 @@ import {
   createOpenWikiContentSnapshot,
   getUpdateNoopStatus,
   createRunContext,
+  hasLeftoverSkeletonFile,
   persistRunMetadataIfChanged,
   removeTemporaryPlanFile,
   shouldCheckUpdateNoop,
@@ -695,6 +697,29 @@ async function runOpenWikiAgentCore(
     );
   }
 
+  // A clean exit is not proof the wiki was finished: the agent may have ended
+  // its final turn on a plan or a question with the working skeleton still on
+  // disk. Gate "complete" on that verifiable state so downstream consumers
+  // (resume logic, CI docs jobs, batch scripts, the no-op check) can trust the
+  // status field (#653).
+  const finalStatus: UpdateRunStatus = (await hasLeftoverSkeletonFile(
+    cwd,
+    outputMode,
+  ))
+    ? "ended_early"
+    : "complete";
+
+  if (finalStatus === "ended_early") {
+    const message =
+      "Run ended before finishing: openwiki/_skeleton.md is still present, so the wiki is recorded as ended_early and the next update will not be skipped.";
+    emitDebug(options, "update.status=ended_early reason=skeleton-present");
+    options.onEvent?.({ type: "text", text: `Warning: ${message}` });
+    // Also emit to stderr so the warning survives on failure, where the TUI
+    // re-renders the log away and --print discards buffered streamed text.
+    process.stderr.write(`Warning: ${message}
+`);
+  }
+
   // Stage-only tag: a write failure here classifies from the raw error (a
   // filesystem code becomes filesystem_error), and deriveOwner's finalize
   // exception routes that to openwiki since the run reached our own persistence.
@@ -706,7 +731,7 @@ async function runOpenWikiAgentCore(
       modelId,
       outputMode,
       openWikiSnapshotBefore,
-      "complete",
+      finalStatus,
       context.language,
     );
   });

--- a/src/agent/types.ts
+++ b/src/agent/types.ts
@@ -43,7 +43,12 @@ export type OpenWikiRunOptions = {
   telemetryFile?: string;
 };
 
-export type UpdateRunStatus = "complete" | "interrupted";
+/**
+ * "ended_early": the agent's final turn ended cleanly but the run left
+ * verifiable work-in-progress behind (e.g. a leftover _skeleton.md), so the
+ * wiki must not be treated as finished (#653).
+ */
+export type UpdateRunStatus = "complete" | "interrupted" | "ended_early";
 
 export type UpdateMetadata = {
   updatedAt: string;

--- a/src/agent/utils.ts
+++ b/src/agent/utils.ts
@@ -1,5 +1,6 @@
 import { execFile } from "node:child_process";
 import { createHash } from "node:crypto";
+import { access } from "node:fs/promises";
 import { mkdir, readdir, readFile, rm, writeFile } from "node:fs/promises";
 import path from "node:path";
 import { promisify } from "node:util";
@@ -115,6 +116,13 @@ export async function getUpdateNoopStatus(
 
   if (lastUpdate.status === "interrupted") {
     return { shouldSkip: false, reason: "previous update was interrupted" };
+  }
+
+  if (lastUpdate.status === "ended_early") {
+    return {
+      shouldSkip: false,
+      reason: "previous run ended before finishing the wiki",
+    };
   }
 
   const resolvedRequestedLanguage = resolveLanguage(requestedLanguage).language;
@@ -280,7 +288,7 @@ export async function createOpenWikiContentSnapshot(
 /**
  * Reads prior run metadata if it exists and is structurally valid.
  */
-async function readLastUpdate(
+export async function readLastUpdate(
   cwd: string,
   outputMode: OpenWikiOutputMode,
 ): Promise<UpdateMetadata | null> {
@@ -306,7 +314,11 @@ async function readLastUpdate(
         // Metadata written before the status field existed is treated as
         // complete so upgrades do not force a spurious re-run.
         status:
-          parsedMetadata.status === "interrupted" ? "interrupted" : "complete",
+          parsedMetadata.status === "interrupted"
+            ? "interrupted"
+            : parsedMetadata.status === "ended_early"
+              ? "ended_early"
+              : "complete",
         language:
           typeof parsedMetadata.language === "string"
             ? parsedMetadata.language
@@ -389,6 +401,26 @@ function getTemporaryPlanFilePath(
   outputMode: OpenWikiOutputMode,
 ): string {
   return path.join(getWikiContentRoot(cwd, outputMode), TEMPORARY_PLAN_FILE);
+}
+
+/**
+ * Whether the run's working skeleton is still on disk. The agent is instructed
+ * to delete `_skeleton.md` once every wiki file has been written, so a leftover
+ * skeleton means the run ended before finishing even when the final turn exited
+ * cleanly (#653).
+ */
+export async function hasLeftoverSkeletonFile(
+  cwd: string,
+  outputMode: OpenWikiOutputMode,
+): Promise<boolean> {
+  const skeletonPath = path.join(getWikiContentRoot(cwd, outputMode), "_skeleton.md");
+
+  try {
+    await access(skeletonPath);
+    return true;
+  } catch {
+    return false;
+  }
 }
 
 function getMetadataFilePath(

--- a/test/agent/openrouter-retry.test.ts
+++ b/test/agent/openrouter-retry.test.ts
@@ -1,0 +1,188 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+
+import type { OpenWikiRunOptions } from "../../src/agent/types.ts";
+import {
+  computeOpenRouterRetryDelayMs,
+  installOpenRouterDebugFetch,
+} from "../../src/agent/index.ts";
+
+const RETRY_ENV_KEY = "OPENWIKI_PROVIDER_RETRY_ATTEMPTS";
+const CHAT_URL = "https://openrouter.ai/api/v1/chat/completions";
+
+const originalFetch = globalThis.fetch;
+let fetchCalls: Array<{ input: unknown; init?: RequestInit }>;
+let fetchResponses: Array<() => Response>;
+let savedEnv: string | undefined;
+
+beforeEach(() => {
+  fetchCalls = [];
+  fetchResponses = [];
+  savedEnv = process.env[RETRY_ENV_KEY];
+  process.env[RETRY_ENV_KEY] = "3";
+});
+
+afterEach(() => {
+  process.env[RETRY_ENV_KEY] = savedEnv;
+  globalThis.fetch = originalFetch;
+  vi.restoreAllMocks();
+});
+
+function jsonResponse(status: number, headers: Record<string, string> = {}, body: unknown = {}): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json", ...headers },
+  });
+}
+
+function installMockFetch(responders: Array<() => Response>): void {
+  fetchResponses = responders;
+  let index = 0;
+  globalThis.fetch = (async (input: unknown, init?: RequestInit) => {
+    fetchCalls.push({ input, init });
+    const responder = fetchResponses[Math.min(index, fetchResponses.length - 1)];
+    index += 1;
+    return responder();
+  }) as typeof fetch;
+}
+
+// Minimal options: emitDebug no-ops without `debug`.
+const noDebugOptions: OpenWikiRunOptions = {};
+
+describe("installOpenRouterDebugFetch 429 retry (#664)", () => {
+  test("retries a Retry-After-less 429 and honours X-RateLimit-Reset", async () => {
+    // The exact OpenRouter free-tier shape: 429, no Retry-After, reset as unix-ms.
+    const resetAt = Date.now() + 40;
+    installMockFetch([
+      () => jsonResponse(429, { "x-ratelimit-reset": String(resetAt) }, { error: { code: 429 } }),
+      () => jsonResponse(200, {}, { choices: [] }),
+    ]);
+
+    const capture = installOpenRouterDebugFetch(noDebugOptions);
+    const startedAt = Date.now();
+    const response = await globalThis.fetch(CHAT_URL, {
+      method: "POST",
+      body: JSON.stringify({ model: "x:free", stream: true }),
+    });
+    const waitedMs = Date.now() - startedAt;
+    capture.restore();
+
+    expect(response.status).toBe(200);
+    expect(fetchCalls).toHaveLength(2);
+    // The retry waited for the reset window (40ms minus scheduling slack).
+    expect(waitedMs).toBeGreaterThanOrEqual(25);
+  });
+
+  test("returns the final 429 after exhausting the attempt budget", async () => {
+    installMockFetch([() => jsonResponse(429, { "x-ratelimit-reset": String(Date.now()) })]);
+
+    const capture = installOpenRouterDebugFetch(noDebugOptions);
+    const response = await globalThis.fetch(CHAT_URL, {
+      method: "POST",
+      body: JSON.stringify({ model: "x:free" }),
+    });
+    const failure = capture.getLastFailure();
+    capture.restore();
+
+    expect(response.status).toBe(429);
+    // 1 initial attempt + 3 retries from OPENWIKI_PROVIDER_RETRY_ATTEMPTS=3.
+    expect(fetchCalls).toHaveLength(4);
+    expect(failure?.response?.status).toBe(429);
+  });
+
+  test("does not retry non-OpenRouter requests", async () => {
+    installMockFetch([() => jsonResponse(429)]);
+
+    const capture = installOpenRouterDebugFetch(noDebugOptions);
+    const response = await globalThis.fetch("https://example.com/api", {
+      method: "POST",
+      body: "{}",
+    });
+    capture.restore();
+
+    expect(response.status).toBe(429);
+    expect(fetchCalls).toHaveLength(1);
+  });
+
+  test("does not retry when the body cannot be re-sent", async () => {
+    installMockFetch([() => jsonResponse(429)]);
+
+    const capture = installOpenRouterDebugFetch(noDebugOptions);
+    const stream = new ReadableStream({
+      start(controller) {
+        controller.enqueue(new TextEncoder().encode("{}"));
+        controller.close();
+      },
+    });
+    const response = await globalThis.fetch(CHAT_URL, {
+      method: "POST",
+      body: stream,
+    });
+    capture.restore();
+
+    expect(response.status).toBe(429);
+    expect(fetchCalls).toHaveLength(1);
+  });
+
+  test("a network error on retry keeps the fetchError diagnostics", async () => {
+    installMockFetch([
+      () => jsonResponse(429, { "x-ratelimit-reset": String(Date.now()) }),
+      () => {
+        throw new Error("socket hang up");
+      },
+    ]);
+
+    const capture = installOpenRouterDebugFetch(noDebugOptions);
+    await expect(
+      globalThis.fetch(CHAT_URL, { method: "POST", body: "{}" }),
+    ).rejects.toThrow("socket hang up");
+    const failure = capture.getLastFailure();
+    capture.restore();
+
+    expect(fetchCalls).toHaveLength(2);
+    expect(failure?.fetchError).toBe("socket hang up");
+  });
+});
+
+describe("computeOpenRouterRetryDelayMs", () => {
+  const responseWith = (headers: Record<string, string>) =>
+    new Response("{}", { status: 429, headers });
+
+  test("uses Retry-After seconds when present", () => {
+    expect(computeOpenRouterRetryDelayMs(responseWith({ "retry-after": "7" }), 1)).toBe(7_000);
+  });
+
+  test("uses an HTTP-date Retry-After relative to now", () => {
+    const date = new Date(Date.now() + 5_000).toUTCString();
+    const delay = computeOpenRouterRetryDelayMs(responseWith({ "retry-after": date }), 1);
+    expect(delay).toBeGreaterThan(3_000);
+    expect(delay).toBeLessThanOrEqual(5_000);
+  });
+
+  test("falls back to X-RateLimit-Reset (unix ms) with a small margin", () => {
+    const resetAt = Date.now() + 2_000;
+    const delay = computeOpenRouterRetryDelayMs(
+      responseWith({ "x-ratelimit-reset": String(resetAt) }),
+      1,
+    );
+    expect(delay).toBeGreaterThan(2_000);
+    expect(delay).toBeLessThanOrEqual(2_500);
+  });
+
+  test("interprets a seconds-magnitude X-RateLimit-Reset as unix seconds", () => {
+    const resetAtSeconds = Math.floor(Date.now() / 1_000) + 3;
+    const delay = computeOpenRouterRetryDelayMs(
+      responseWith({ "x-ratelimit-reset": String(resetAtSeconds) }),
+      1,
+    );
+    expect(delay).toBeGreaterThan(2_500);
+    expect(delay).toBeLessThanOrEqual(3_500);
+  });
+
+  test("grows exponentially when no hint is present", () => {
+    const none = responseWith({});
+    expect(computeOpenRouterRetryDelayMs(none, 1)).toBe(1_000);
+    expect(computeOpenRouterRetryDelayMs(none, 2)).toBe(2_000);
+    expect(computeOpenRouterRetryDelayMs(none, 3)).toBe(4_000);
+    expect(computeOpenRouterRetryDelayMs(none, 10)).toBe(30_000);
+  });
+});

--- a/test/agent/skeleton-status.test.ts
+++ b/test/agent/skeleton-status.test.ts
@@ -1,0 +1,76 @@
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { describe, expect, test } from "vitest";
+import {
+  hasLeftoverSkeletonFile,
+  readLastUpdate,
+  writeLastUpdateMetadata,
+} from "../../src/agent/utils.ts";
+
+async function createEmptyRepo(): Promise<string> {
+  const repo = await mkdtemp(path.join(tmpdir(), "openwiki-skeleton-"));
+  await mkdir(path.join(repo, "openwiki"), { recursive: true });
+  return repo;
+}
+
+describe("hasLeftoverSkeletonFile", () => {
+  test("detects a leftover skeleton in repository output mode", async () => {
+    const repo = await createEmptyRepo();
+    try {
+      await writeFile(
+        path.join(repo, "openwiki", "_skeleton.md"),
+        "# Skeleton\n",
+        "utf8",
+      );
+
+      expect(await hasLeftoverSkeletonFile(repo, "repository")).toBe(true);
+    } finally {
+      await rm(repo, { recursive: true, force: true });
+    }
+  });
+
+  test("reports false once the skeleton is gone", async () => {
+    const repo = await createEmptyRepo();
+    try {
+      await writeFile(path.join(repo, "openwiki", "index.md"), "# Wiki\n", "utf8");
+
+      expect(await hasLeftoverSkeletonFile(repo, "repository")).toBe(false);
+    } finally {
+      await rm(repo, { recursive: true, force: true });
+    }
+  });
+
+  test("checks the wiki root in local-wiki output mode", async () => {
+    const repo = await createEmptyRepo();
+    try {
+      await writeFile(path.join(repo, "_skeleton.md"), "# Skeleton\n", "utf8");
+
+      expect(await hasLeftoverSkeletonFile(repo, "local-wiki")).toBe(true);
+      expect(await hasLeftoverSkeletonFile(repo, "repository")).toBe(false);
+    } finally {
+      await rm(repo, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("writeLastUpdateMetadata ended_early round-trip", () => {
+  test("persists and reads back the ended_early status", async () => {
+    const repo = await createEmptyRepo();
+    try {
+      await writeLastUpdateMetadata(
+        "init",
+        repo,
+        "test-model",
+        "repository",
+        "ended_early",
+      );
+
+      const lastUpdate = await readLastUpdate(repo, "repository");
+
+      expect(lastUpdate?.status).toBe("ended_early");
+    } finally {
+      await rm(repo, { recursive: true, force: true });
+    }
+  });
+});

--- a/test/agent/update-noop.test.ts
+++ b/test/agent/update-noop.test.ts
@@ -166,6 +166,21 @@ describe("getUpdateNoopStatus", () => {
     });
   });
 
+  test("does not skip update when the previous run ended early", async () => {
+    // A run that exited cleanly but left the working skeleton behind is not a
+    // finished wiki; consumers must not treat it as complete (#653).
+    const repo = await createRepoWithOpenWiki();
+    const head = await git(repo, ["rev-parse", "HEAD"]);
+    await writeLastUpdate(repo, head, { status: "ended_early" });
+
+    const status = await getUpdateNoopStatus(repo);
+
+    expect(status).toEqual({
+      shouldSkip: false,
+      reason: "previous run ended before finishing the wiki",
+    });
+  });
+
   test("skips update when the previous complete run predates the status field", async () => {
     // Metadata written by versions without the status field must keep
     // behaving as a completed run and not force a spurious re-run.


### PR DESCRIPTION
## Summary

Fixes #653.

`.last-update.json` recorded `status: "complete"` whenever the agent's final turn ended without an error — including runs that ended on a plan, a "would you like me to continue?", or an announced-but-not-performed cleanup. Anything keying on the status (resume logic, CI docs jobs, batch scripts, the `--update` no-op check) then treated a mostly-unwritten wiki as finished and skipped it.

## What this does

Gates `complete` on the one piece of verifiable state the run controls. The agent is instructed to delete `_skeleton.md` once every wiki file has been written, so on a clean exit a **leftover skeleton means the run ended before finishing**:

- New `UpdateRunStatus` value **`"ended_early"`** (distinct from `interrupted`, which keeps its stream/owner-failure meaning).
- The success path checks `hasLeftoverSkeletonFile(cwd, outputMode)` and records `ended_early` instead of `complete` when it's present — catching the "announced deleting `_skeleton.md` without doing it" case regardless of what the final message claimed.
- `getUpdateNoopStatus` treats `ended_early` like `interrupted`: never skip, with its own reason (`"previous run ended before finishing the wiki"`).
- `readLastUpdate` preserves the new value; metadata written before the status field existed still reads as `complete`, so upgrades don't force spurious re-runs.
- The gate emits a visible warning (run event + stderr, the same dual-channel pattern as the model-mismatch warning) naming the leftover file, so batch operators see why the wiki isn't marked complete without opening the JSON.

## Tests

- `test/agent/skeleton-status.test.ts`: skeleton detection in both output modes (repository `openwiki/_skeleton.md`, `local-wiki` root), negative case, and a metadata write/read round-trip for `ended_early`.
- `test/agent/update-noop.test.ts`: the no-op check does not skip after an `ended_early` run.
