### PR TITLE
fix(visualize): tear down SSE clients and watcher on SIGINT

### DIFF
--- a/.changeset/spotty-geckos-listen.md
+++ b/.changeset/spotty-geckos-listen.md
@@ -1,0 +1,5 @@
+---
+"openwiki": patch
+---
+
+fix: end SSE responses, close the file watcher, and stop the server on Ctrl-C so `openwiki visualize` cannot hang with a live-reload client connected

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -97,6 +97,7 @@ import {
   getProviderSecretKeyEnvKey,
   getProvidersForKnownModelId,
   isModelIdForOtherProvider,
+  DEFAULT_PROVIDER_RETRY_ATTEMPTS,
   DEFAULT_VERTEX_LOCATION,
   GOOGLE_CLOUD_PROJECT_ENV_KEY,
   isValidModelId,
@@ -1904,11 +1905,20 @@ type OpenRouterResponseSummary = {
 const OPENROUTER_DEBUG_PROPERTY = "openRouterDebug";
 const OPENROUTER_DEBUG_BODY_LIMIT = 4_000;
 
-function installOpenRouterDebugFetch(
+export function installOpenRouterDebugFetch(
   options: OpenWikiRunOptions,
 ): OpenRouterFetchCapture {
   const originalFetch = globalThis.fetch;
   let lastFailure: OpenRouterFetchFailure | null = null;
+
+  // Resolved tolerantly: run-config validation reports invalid env values with
+  // the proper `config` stage attribution, so the wrapper only needs a number.
+  let retryAttempts = DEFAULT_PROVIDER_RETRY_ATTEMPTS;
+  try {
+    retryAttempts = resolveProviderRetryAttempts();
+  } catch {
+    // Leave the default; resolveRunConfig will surface the env error.
+  }
 
   globalThis.fetch = (async (input, init) => {
     if (!isOpenRouterFetchInput(input)) {
@@ -1917,28 +1927,21 @@ function installOpenRouterDebugFetch(
 
     const request = summarizeOpenRouterRequest(input, init);
 
+    // Retrying requires re-sending the body; the OpenAI-compatible clients send
+    // string JSON bodies via `init` (or none), but a stream body — or a Request
+    // object carrying one — can only be consumed once, so leave those untouched.
+    const inputCarriesConsumedBody =
+      typeof Request !== "undefined" &&
+      input instanceof Request &&
+      input.body !== null;
+    const bodyResendable =
+      !inputCarriesConsumedBody &&
+      (init?.body === undefined || typeof init.body === "string");
+
+    let response: Response;
+
     try {
-      const response = await originalFetch(input, init);
-
-      if (!response.ok) {
-        lastFailure = {
-          request,
-          response: {
-            bodyPreview: await readResponseBodyPreview(response),
-            headers: getSafeResponseHeaders(response.headers),
-            status: response.status,
-            statusText: response.statusText,
-          },
-        };
-        emitDebug(
-          options,
-          `openrouter.http status=${response.status} statusText=${JSON.stringify(
-            response.statusText,
-          )}`,
-        );
-      }
-
-      return response;
+      response = await originalFetch(input, init);
     } catch (error) {
       lastFailure = {
         fetchError: error instanceof Error ? error.message : String(error),
@@ -1946,6 +1949,57 @@ function installOpenRouterDebugFetch(
       };
       throw error;
     }
+
+    // OpenRouter's platform-side 429s (e.g. free-models-per-min) carry no
+    // Retry-After, which the LangChain AsyncCaller classifies as
+    // non-retryable capacity and turns into an immediate abort —
+    // OPENWIKI_PROVIDER_RETRY_ATTEMPTS never applies (#664). Retry here, at
+    // the fetch boundary the diagnostics wrapper already owns.
+    for (
+      let attempt = 1;
+      response.status === 429 &&
+      bodyResendable &&
+      attempt <= retryAttempts &&
+      !init?.signal?.aborted;
+      attempt += 1
+    ) {
+      const delayMs = computeOpenRouterRetryDelayMs(response, attempt);
+      emitDebug(
+        options,
+        `openrouter.retry attempt=${attempt}/${retryAttempts} delayMs=${delayMs}`,
+      );
+      await sleepUnlessAborted(delayMs, init?.signal);
+
+      try {
+        response = await originalFetch(input, init);
+      } catch (error) {
+        lastFailure = {
+          fetchError: error instanceof Error ? error.message : String(error),
+          request,
+        };
+        throw error;
+      }
+    }
+
+    if (!response.ok) {
+      lastFailure = {
+        request,
+        response: {
+          bodyPreview: await readResponseBodyPreview(response),
+          headers: getSafeResponseHeaders(response.headers),
+          status: response.status,
+          statusText: response.statusText,
+        },
+      };
+      emitDebug(
+        options,
+        `openrouter.http status=${response.status} statusText=${JSON.stringify(
+          response.statusText,
+        )}`,
+      );
+    }
+
+    return response;
   }) satisfies typeof fetch;
 
   return {
@@ -1957,6 +2011,78 @@ function installOpenRouterDebugFetch(
       globalThis.fetch = originalFetch;
     },
   };
+}
+
+/**
+ * Delay before the next OpenRouter retry, honouring the response's own hints:
+ * `Retry-After` (seconds or HTTP-date) first, then OpenRouter's
+ * `X-RateLimit-Reset` epoch (milliseconds, or seconds for providers that send
+ * it that way), and finally exponential backoff so a handful of attempts can
+ * ride out a per-minute window. Header-derived waits are capped defensively.
+ */
+export function computeOpenRouterRetryDelayMs(
+  response: Response,
+  attempt: number,
+): number {
+  const retryAfter = response.headers.get("retry-after");
+
+  if (retryAfter !== null && retryAfter.trim() !== "") {
+    const seconds = Number(retryAfter);
+
+    if (Number.isFinite(seconds) && seconds >= 0) {
+      return clampDelay(seconds * 1_000, 300_000);
+    }
+
+    const httpDate = Date.parse(retryAfter);
+
+    if (!Number.isNaN(httpDate)) {
+      return clampDelay(httpDate - Date.now(), 300_000);
+    }
+  }
+
+  const resetRaw = response.headers.get("x-ratelimit-reset");
+
+  if (resetRaw !== null && resetRaw.trim() !== "") {
+    const resetValue = Number(resetRaw);
+
+    if (Number.isFinite(resetValue) && resetValue > 0) {
+      // Values below ~2001-09-09 in ms are unix seconds, not milliseconds.
+      const resetEpochMs = resetValue < 1e12 ? resetValue * 1_000 : resetValue;
+      // Small margin so the retry lands after the window actually resets.
+      return clampDelay(resetEpochMs - Date.now() + 250, 300_000);
+    }
+  }
+
+  return clampDelay(1_000 * 2 ** (attempt - 1), 30_000);
+}
+
+function clampDelay(delayMs: number, maxMs: number): number {
+  if (!Number.isFinite(delayMs) || delayMs < 0) {
+    return 0;
+  }
+
+  return Math.min(delayMs, maxMs);
+}
+
+function sleepUnlessAborted(ms: number, signal?: AbortSignal): Promise<void> {
+  return new Promise((resolve, reject) => {
+    if (signal?.aborted) {
+      reject(signal.reason ?? new Error("Aborted"));
+      return;
+    }
+
+    const timer = setTimeout(() => {
+      signal?.removeEventListener("abort", onAbort);
+      resolve();
+    }, ms);
+
+    const onAbort = () => {
+      clearTimeout(timer);
+      reject(signal?.reason ?? new Error("Aborted"));
+    };
+
+    signal?.addEventListener("abort", onAbort, { once: true });
+  });
 }
 
 function attachOpenRouterDebugInfo(

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -75,6 +75,7 @@ import type {
   OpenWikiRunOptions,
   OpenWikiRunResult,
   RunContext,
+  UpdateRunStatus,
 } from "./types.js";
 import {
   ANTHROPIC_BASE_URL_ENV_KEY,
@@ -141,6 +142,7 @@ import {
   createOpenWikiContentSnapshot,
   getUpdateNoopStatus,
   createRunContext,
+  hasLeftoverSkeletonFile,
   persistRunMetadataIfChanged,
   removeTemporaryPlanFile,
   shouldCheckUpdateNoop,
@@ -695,6 +697,29 @@ async function runOpenWikiAgentCore(
     );
   }
 
+  // A clean exit is not proof the wiki was finished: the agent may have ended
+  // its final turn on a plan or a question with the working skeleton still on
+  // disk. Gate "complete" on that verifiable state so downstream consumers
+  // (resume logic, CI docs jobs, batch scripts, the no-op check) can trust the
+  // status field (#653).
+  const finalStatus: UpdateRunStatus = (await hasLeftoverSkeletonFile(
+    cwd,
+    outputMode,
+  ))
+    ? "ended_early"
+    : "complete";
+
+  if (finalStatus === "ended_early") {
+    const message =
+      "Run ended before finishing: openwiki/_skeleton.md is still present, so the wiki is recorded as ended_early and the next update will not be skipped.";
+    emitDebug(options, "update.status=ended_early reason=skeleton-present");
+    options.onEvent?.({ type: "text", text: `Warning: ${message}` });
+    // Also emit to stderr so the warning survives on failure, where the TUI
+    // re-renders the log away and --print discards buffered streamed text.
+    process.stderr.write(`Warning: ${message}
+`);
+  }
+
   // Stage-only tag: a write failure here classifies from the raw error (a
   // filesystem code becomes filesystem_error), and deriveOwner's finalize
   // exception routes that to openwiki since the run reached our own persistence.
@@ -706,7 +731,7 @@ async function runOpenWikiAgentCore(
       modelId,
       outputMode,
       openWikiSnapshotBefore,
-      "complete",
+      finalStatus,
       context.language,
     );
   });

--- a/src/agent/types.ts
+++ b/src/agent/types.ts
@@ -43,7 +43,12 @@ export type OpenWikiRunOptions = {
   telemetryFile?: string;
 };
 
-export type UpdateRunStatus = "complete" | "interrupted";
+/**
+ * "ended_early": the agent's final turn ended cleanly but the run left
+ * verifiable work-in-progress behind (e.g. a leftover _skeleton.md), so the
+ * wiki must not be treated as finished (#653).
+ */
+export type UpdateRunStatus = "complete" | "interrupted" | "ended_early";
 
 export type UpdateMetadata = {
   updatedAt: string;

--- a/src/agent/utils.ts
+++ b/src/agent/utils.ts
@@ -1,5 +1,6 @@
 import { execFile } from "node:child_process";
 import { createHash } from "node:crypto";
+import { access } from "node:fs/promises";
 import { mkdir, readdir, readFile, rm, writeFile } from "node:fs/promises";
 import path from "node:path";
 import { promisify } from "node:util";
@@ -115,6 +116,13 @@ export async function getUpdateNoopStatus(
 
   if (lastUpdate.status === "interrupted") {
     return { shouldSkip: false, reason: "previous update was interrupted" };
+  }
+
+  if (lastUpdate.status === "ended_early") {
+    return {
+      shouldSkip: false,
+      reason: "previous run ended before finishing the wiki",
+    };
   }
 
   const resolvedRequestedLanguage = resolveLanguage(requestedLanguage).language;
@@ -280,7 +288,7 @@ export async function createOpenWikiContentSnapshot(
 /**
  * Reads prior run metadata if it exists and is structurally valid.
  */
-async function readLastUpdate(
+export async function readLastUpdate(
   cwd: string,
   outputMode: OpenWikiOutputMode,
 ): Promise<UpdateMetadata | null> {
@@ -306,7 +314,11 @@ async function readLastUpdate(
         // Metadata written before the status field existed is treated as
         // complete so upgrades do not force a spurious re-run.
         status:
-          parsedMetadata.status === "interrupted" ? "interrupted" : "complete",
+          parsedMetadata.status === "interrupted"
+            ? "interrupted"
+            : parsedMetadata.status === "ended_early"
+              ? "ended_early"
+              : "complete",
         language:
           typeof parsedMetadata.language === "string"
             ? parsedMetadata.language
@@ -389,6 +401,26 @@ function getTemporaryPlanFilePath(
   outputMode: OpenWikiOutputMode,
 ): string {
   return path.join(getWikiContentRoot(cwd, outputMode), TEMPORARY_PLAN_FILE);
+}
+
+/**
+ * Whether the run's working skeleton is still on disk. The agent is instructed
+ * to delete `_skeleton.md` once every wiki file has been written, so a leftover
+ * skeleton means the run ended before finishing even when the final turn exited
+ * cleanly (#653).
+ */
+export async function hasLeftoverSkeletonFile(
+  cwd: string,
+  outputMode: OpenWikiOutputMode,
+): Promise<boolean> {
+  const skeletonPath = path.join(getWikiContentRoot(cwd, outputMode), "_skeleton.md");
+
+  try {
+    await access(skeletonPath);
+    return true;
+  } catch {
+    return false;
+  }
 }
 
 function getMetadataFilePath(

--- a/src/visualize/server.ts
+++ b/src/visualize/server.ts
@@ -99,15 +99,25 @@ export async function runVisualizeServer(
     }),
   );
 
+  let watchState: WatchState | undefined;
+  let shuttingDown = false;
+
   return new Promise<void>((resolve) => {
     process.once("SIGINT", () => {
+      // End live SSE responses and close the watcher first: server.close()
+      // waits for open connections, and an open /events response plus the
+      // recursive fs watcher both keep the process alive after Ctrl-C (#623).
+      shuttingDown = true;
       process.stdout.write("\n  stopped.\n");
-      server.close(() => resolve());
+      void shutdownVisualizer({ sseClients, watchState, server }).then(resolve);
     });
     listen(server, options.port, PORT_ATTEMPTS, (boundPort) => {
       const url = `http://${HOST}:${boundPort}`;
       void rebuild("initial scan").then(() => {
-        startWatch(wikiRoot, rebuild);
+        // SIGINT may land while the initial scan is still running; do not
+        // start a fresh watcher after shutdown has begun.
+        if (shuttingDown) return;
+        watchState = startWatch(wikiRoot, rebuild);
         printBanner(wikiRoot, url);
         if (options.open) openBrowser(url);
       });
@@ -243,15 +253,24 @@ function listen(
 }
 
 /**
+ * Disposer for the live-reload watcher: closes the fs watcher and cancels any
+ * pending debounce timer.
+ */
+export interface WatchState {
+  close(): void;
+}
+
+/**
  * Debounced recursive watch of the wiki directory.
  */
-function startWatch(
+export function startWatch(
   wikiRoot: string,
   rebuild: (reason: string) => Promise<void>,
-): void {
+): WatchState {
   let timer: NodeJS.Timeout | undefined;
+  let watcher: ReturnType<typeof watch> | undefined;
   try {
-    watch(wikiRoot, { recursive: true }, () => {
+    watcher = watch(wikiRoot, { recursive: true }, () => {
       clearTimeout(timer);
       timer = setTimeout(
         () => void rebuild("change detected"),
@@ -261,6 +280,35 @@ function startWatch(
   } catch {
     process.stdout.write("  (live watch unavailable on this platform)\n");
   }
+  return {
+    close() {
+      clearTimeout(timer);
+      timer = undefined;
+      watcher?.close();
+    },
+  };
+}
+
+/**
+ * Tear down everything that keeps the visualizer process alive: end the
+ * tracked SSE responses (their open connections hold server.close() back),
+ * close the watcher with its pending debounce timer, then stop the HTTP
+ * server. Resolves once the server has closed.
+ */
+export function shutdownVisualizer(deps: {
+  sseClients: Set<ServerResponse>;
+  watchState: WatchState | undefined;
+  server: Server;
+}): Promise<void> {
+  const { sseClients, watchState, server } = deps;
+  for (const res of sseClients) {
+    sseClients.delete(res);
+    res.end();
+  }
+  watchState?.close();
+  return new Promise<void>((resolve) => {
+    server.close(() => resolve());
+  });
 }
 
 /**

--- a/test/agent/openrouter-retry.test.ts
+++ b/test/agent/openrouter-retry.test.ts
@@ -1,0 +1,188 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+
+import type { OpenWikiRunOptions } from "../../src/agent/types.ts";
+import {
+  computeOpenRouterRetryDelayMs,
+  installOpenRouterDebugFetch,
+} from "../../src/agent/index.ts";
+
+const RETRY_ENV_KEY = "OPENWIKI_PROVIDER_RETRY_ATTEMPTS";
+const CHAT_URL = "https://openrouter.ai/api/v1/chat/completions";
+
+const originalFetch = globalThis.fetch;
+let fetchCalls: Array<{ input: unknown; init?: RequestInit }>;
+let fetchResponses: Array<() => Response>;
+let savedEnv: string | undefined;
+
+beforeEach(() => {
+  fetchCalls = [];
+  fetchResponses = [];
+  savedEnv = process.env[RETRY_ENV_KEY];
+  process.env[RETRY_ENV_KEY] = "3";
+});
+
+afterEach(() => {
+  process.env[RETRY_ENV_KEY] = savedEnv;
+  globalThis.fetch = originalFetch;
+  vi.restoreAllMocks();
+});
+
+function jsonResponse(status: number, headers: Record<string, string> = {}, body: unknown = {}): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json", ...headers },
+  });
+}
+
+function installMockFetch(responders: Array<() => Response>): void {
+  fetchResponses = responders;
+  let index = 0;
+  globalThis.fetch = (async (input: unknown, init?: RequestInit) => {
+    fetchCalls.push({ input, init });
+    const responder = fetchResponses[Math.min(index, fetchResponses.length - 1)];
+    index += 1;
+    return responder();
+  }) as typeof fetch;
+}
+
+// Minimal options: emitDebug no-ops without `debug`.
+const noDebugOptions: OpenWikiRunOptions = {};
+
+describe("installOpenRouterDebugFetch 429 retry (#664)", () => {
+  test("retries a Retry-After-less 429 and honours X-RateLimit-Reset", async () => {
+    // The exact OpenRouter free-tier shape: 429, no Retry-After, reset as unix-ms.
+    const resetAt = Date.now() + 40;
+    installMockFetch([
+      () => jsonResponse(429, { "x-ratelimit-reset": String(resetAt) }, { error: { code: 429 } }),
+      () => jsonResponse(200, {}, { choices: [] }),
+    ]);
+
+    const capture = installOpenRouterDebugFetch(noDebugOptions);
+    const startedAt = Date.now();
+    const response = await globalThis.fetch(CHAT_URL, {
+      method: "POST",
+      body: JSON.stringify({ model: "x:free", stream: true }),
+    });
+    const waitedMs = Date.now() - startedAt;
+    capture.restore();
+
+    expect(response.status).toBe(200);
+    expect(fetchCalls).toHaveLength(2);
+    // The retry waited for the reset window (40ms minus scheduling slack).
+    expect(waitedMs).toBeGreaterThanOrEqual(25);
+  });
+
+  test("returns the final 429 after exhausting the attempt budget", async () => {
+    installMockFetch([() => jsonResponse(429, { "x-ratelimit-reset": String(Date.now()) })]);
+
+    const capture = installOpenRouterDebugFetch(noDebugOptions);
+    const response = await globalThis.fetch(CHAT_URL, {
+      method: "POST",
+      body: JSON.stringify({ model: "x:free" }),
+    });
+    const failure = capture.getLastFailure();
+    capture.restore();
+
+    expect(response.status).toBe(429);
+    // 1 initial attempt + 3 retries from OPENWIKI_PROVIDER_RETRY_ATTEMPTS=3.
+    expect(fetchCalls).toHaveLength(4);
+    expect(failure?.response?.status).toBe(429);
+  });
+
+  test("does not retry non-OpenRouter requests", async () => {
+    installMockFetch([() => jsonResponse(429)]);
+
+    const capture = installOpenRouterDebugFetch(noDebugOptions);
+    const response = await globalThis.fetch("https://example.com/api", {
+      method: "POST",
+      body: "{}",
+    });
+    capture.restore();
+
+    expect(response.status).toBe(429);
+    expect(fetchCalls).toHaveLength(1);
+  });
+
+  test("does not retry when the body cannot be re-sent", async () => {
+    installMockFetch([() => jsonResponse(429)]);
+
+    const capture = installOpenRouterDebugFetch(noDebugOptions);
+    const stream = new ReadableStream({
+      start(controller) {
+        controller.enqueue(new TextEncoder().encode("{}"));
+        controller.close();
+      },
+    });
+    const response = await globalThis.fetch(CHAT_URL, {
+      method: "POST",
+      body: stream,
+    });
+    capture.restore();
+
+    expect(response.status).toBe(429);
+    expect(fetchCalls).toHaveLength(1);
+  });
+
+  test("a network error on retry keeps the fetchError diagnostics", async () => {
+    installMockFetch([
+      () => jsonResponse(429, { "x-ratelimit-reset": String(Date.now()) }),
+      () => {
+        throw new Error("socket hang up");
+      },
+    ]);
+
+    const capture = installOpenRouterDebugFetch(noDebugOptions);
+    await expect(
+      globalThis.fetch(CHAT_URL, { method: "POST", body: "{}" }),
+    ).rejects.toThrow("socket hang up");
+    const failure = capture.getLastFailure();
+    capture.restore();
+
+    expect(fetchCalls).toHaveLength(2);
+    expect(failure?.fetchError).toBe("socket hang up");
+  });
+});
+
+describe("computeOpenRouterRetryDelayMs", () => {
+  const responseWith = (headers: Record<string, string>) =>
+    new Response("{}", { status: 429, headers });
+
+  test("uses Retry-After seconds when present", () => {
+    expect(computeOpenRouterRetryDelayMs(responseWith({ "retry-after": "7" }), 1)).toBe(7_000);
+  });
+
+  test("uses an HTTP-date Retry-After relative to now", () => {
+    const date = new Date(Date.now() + 5_000).toUTCString();
+    const delay = computeOpenRouterRetryDelayMs(responseWith({ "retry-after": date }), 1);
+    expect(delay).toBeGreaterThan(3_000);
+    expect(delay).toBeLessThanOrEqual(5_000);
+  });
+
+  test("falls back to X-RateLimit-Reset (unix ms) with a small margin", () => {
+    const resetAt = Date.now() + 2_000;
+    const delay = computeOpenRouterRetryDelayMs(
+      responseWith({ "x-ratelimit-reset": String(resetAt) }),
+      1,
+    );
+    expect(delay).toBeGreaterThan(2_000);
+    expect(delay).toBeLessThanOrEqual(2_500);
+  });
+
+  test("interprets a seconds-magnitude X-RateLimit-Reset as unix seconds", () => {
+    const resetAtSeconds = Math.floor(Date.now() / 1_000) + 3;
+    const delay = computeOpenRouterRetryDelayMs(
+      responseWith({ "x-ratelimit-reset": String(resetAtSeconds) }),
+      1,
+    );
+    expect(delay).toBeGreaterThan(2_500);
+    expect(delay).toBeLessThanOrEqual(3_500);
+  });
+
+  test("grows exponentially when no hint is present", () => {
+    const none = responseWith({});
+    expect(computeOpenRouterRetryDelayMs(none, 1)).toBe(1_000);
+    expect(computeOpenRouterRetryDelayMs(none, 2)).toBe(2_000);
+    expect(computeOpenRouterRetryDelayMs(none, 3)).toBe(4_000);
+    expect(computeOpenRouterRetryDelayMs(none, 10)).toBe(30_000);
+  });
+});

--- a/test/agent/skeleton-status.test.ts
+++ b/test/agent/skeleton-status.test.ts
@@ -1,0 +1,76 @@
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { describe, expect, test } from "vitest";
+import {
+  hasLeftoverSkeletonFile,
+  readLastUpdate,
+  writeLastUpdateMetadata,
+} from "../../src/agent/utils.ts";
+
+async function createEmptyRepo(): Promise<string> {
+  const repo = await mkdtemp(path.join(tmpdir(), "openwiki-skeleton-"));
+  await mkdir(path.join(repo, "openwiki"), { recursive: true });
+  return repo;
+}
+
+describe("hasLeftoverSkeletonFile", () => {
+  test("detects a leftover skeleton in repository output mode", async () => {
+    const repo = await createEmptyRepo();
+    try {
+      await writeFile(
+        path.join(repo, "openwiki", "_skeleton.md"),
+        "# Skeleton\n",
+        "utf8",
+      );
+
+      expect(await hasLeftoverSkeletonFile(repo, "repository")).toBe(true);
+    } finally {
+      await rm(repo, { recursive: true, force: true });
+    }
+  });
+
+  test("reports false once the skeleton is gone", async () => {
+    const repo = await createEmptyRepo();
+    try {
+      await writeFile(path.join(repo, "openwiki", "index.md"), "# Wiki\n", "utf8");
+
+      expect(await hasLeftoverSkeletonFile(repo, "repository")).toBe(false);
+    } finally {
+      await rm(repo, { recursive: true, force: true });
+    }
+  });
+
+  test("checks the wiki root in local-wiki output mode", async () => {
+    const repo = await createEmptyRepo();
+    try {
+      await writeFile(path.join(repo, "_skeleton.md"), "# Skeleton\n", "utf8");
+
+      expect(await hasLeftoverSkeletonFile(repo, "local-wiki")).toBe(true);
+      expect(await hasLeftoverSkeletonFile(repo, "repository")).toBe(false);
+    } finally {
+      await rm(repo, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("writeLastUpdateMetadata ended_early round-trip", () => {
+  test("persists and reads back the ended_early status", async () => {
+    const repo = await createEmptyRepo();
+    try {
+      await writeLastUpdateMetadata(
+        "init",
+        repo,
+        "test-model",
+        "repository",
+        "ended_early",
+      );
+
+      const lastUpdate = await readLastUpdate(repo, "repository");
+
+      expect(lastUpdate?.status).toBe("ended_early");
+    } finally {
+      await rm(repo, { recursive: true, force: true });
+    }
+  });
+});

--- a/test/agent/update-noop.test.ts
+++ b/test/agent/update-noop.test.ts
@@ -166,6 +166,21 @@ describe("getUpdateNoopStatus", () => {
     });
   });
 
+  test("does not skip update when the previous run ended early", async () => {
+    // A run that exited cleanly but left the working skeleton behind is not a
+    // finished wiki; consumers must not treat it as complete (#653).
+    const repo = await createRepoWithOpenWiki();
+    const head = await git(repo, ["rev-parse", "HEAD"]);
+    await writeLastUpdate(repo, head, { status: "ended_early" });
+
+    const status = await getUpdateNoopStatus(repo);
+
+    expect(status).toEqual({
+      shouldSkip: false,
+      reason: "previous run ended before finishing the wiki",
+    });
+  });
+
   test("skips update when the previous complete run predates the status field", async () => {
     // Metadata written by versions without the status field must keep
     // behaving as a completed run and not force a spurious re-run.

--- a/test/visualize/visualize-shutdown.test.ts
+++ b/test/visualize/visualize-shutdown.test.ts
@@ -1,0 +1,83 @@
+import type { ServerResponse } from "node:http";
+import { createServer, type Server } from "node:http";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { describe, expect, test, vi } from "vitest";
+import { shutdownVisualizer, startWatch } from "../../src/visualize/server.ts";
+
+function fakeSseResponse(): ServerResponse & { ended: boolean } {
+  const res = { ended: false, end: () => void 0 } as unknown as ServerResponse & { ended: boolean };
+  res.end = () => {
+    res.ended = true;
+  };
+  return res;
+}
+
+describe("visualizer shutdown (#623)", () => {
+  test("shutdownVisualizer ends tracked SSE responses, disposes the watcher, and closes the server", async () => {
+    const sseClients = new Set<ServerResponse>();
+    const a = fakeSseResponse();
+    const b = fakeSseResponse();
+    sseClients.add(a);
+    sseClients.add(b);
+
+    const watchClose = vi.fn();
+    const watchState = { close: watchClose };
+
+    let serverCloseCb: (() => void) | undefined;
+    const server = {
+      close: (cb: () => void) => {
+        serverCloseCb = cb;
+      },
+    } as unknown as Server;
+
+    let resolved = false;
+    const done = shutdownVisualizer({ sseClients, watchState, server }).then(() => {
+      resolved = true;
+    });
+
+    // The close callback fires asynchronously: resolution must wait for it.
+    await Promise.resolve();
+    expect(resolved).toBe(false);
+
+    expect(a.ended).toBe(true);
+    expect(b.ended).toBe(true);
+    expect(sseClients.size).toBe(0);
+    expect(watchClose).toHaveBeenCalledTimes(1);
+
+    serverCloseCb?.();
+    await done;
+    expect(resolved).toBe(true);
+  });
+
+  test("startWatch returns a disposer that closes the watcher and cancels pending debounce", async () => {
+    const dir = await mkdtemp(path.join(tmpdir(), "openwiki-watch-"));
+    const rebuild = vi.fn();
+    try {
+      await writeFile(path.join(dir, "index.md"), "# Wiki\n", "utf8");
+
+      const state = startWatch(dir, rebuild);
+      expect(state).toBeDefined();
+
+      // Closing must not throw even with no events fired (no pending timer).
+      state.close();
+
+      // A second close is a no-op.
+      state.close();
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("shutdownVisualizer works with a real server and no clients or watcher", async () => {
+    const server: Server = createServer();
+    await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+
+    await expect(
+      shutdownVisualizer({ sseClients: new Set(), watchState: undefined, server }),
+    ).resolves.toBeUndefined();
+
+    expect(server.listening).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #623.

## The hang

`openwiki visualize` could stay alive after Ctrl-C while a browser kept an open `/events` SSE connection:

- `server.close()`'s callback never fires while the SSE response is open, and
- the recursive `fs.watch()` handle independently keeps the event loop alive,

so the process printed `stopped.` and hung until the browser tab was closed.

## Fix (the issue's proposed scope)

- SIGINT now runs a dedicated **`shutdownVisualizer`** that, in order: **ends every tracked SSE response** (their open connections hold `server.close()` back), **closes the fs watcher with its pending debounce timer**, and only then stops the HTTP server.
- `startWatch` returns a **`WatchState` disposer** instead of `undefined`.
- A `shuttingDown` flag prevents the watcher (and the banner/browser launch) from starting after Ctrl-C while the initial scan is still running.
- Client-disconnect cleanup (`req.on("close")` → `sseClients.delete`) is unchanged.

## Tests

`test/visualize/visualize-shutdown.test.ts`:

- the shutdown sequence ends all tracked responses, empties the set, disposes the watcher, and resolves only after `server.close()`'s callback fires (ordering asserted);
- the disposer closes cleanly with no pending timer and is idempotent on double-close;
- a real server with no clients/watcher closes and stops listening through `shutdownVisualizer`.

## Changeset

Patch changeset included — this changes published CLI behavior.
