### PR TITLE
fix: finalize OKF generated provenance after wiki post-processing so new and changed pages retain accurate stamps across full-file rewrites

### DIFF
--- a/.changeset/tidy-books-prove.md
+++ b/.changeset/tidy-books-prove.md
@@ -2,4 +2,4 @@
 "openwiki": patch
 ---
 
-fix: finalize OKF generated provenance after wiki post-processing so new and changed pages retain accurate stamps across full-file rewrites
+fix: finalize OKF generated provenance after wiki post-processing so every body change, including whitespace, receives an accurate stamp while front-matter-only changes preserve the prior stamp

--- a/.changeset/tidy-books-prove.md
+++ b/.changeset/tidy-books-prove.md
@@ -1,0 +1,5 @@
+---
+"openwiki": patch
+---
+
+fix: finalize OKF generated provenance after wiki post-processing so new and changed pages retain accurate stamps across full-file rewrites

--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ Everything OpenWiki writes is plain Markdown you own and version alongside your 
 OpenWiki emits [Google Open Knowledge Format (OKF) v0.2](https://github.com/GoogleCloudPlatform/knowledge-catalog/blob/main/okf/SPEC.md) bundles in both modes, so your wiki is portable to any OKF-aware tool.
 
 - Every concept document carries YAML front matter with a non-empty `type`; all other standard fields are optional.
-- Pages record their last meaningful change as `generated: {by, at}`; the legacy v0.1 `timestamp` field is still tolerated on existing pages.
+- Pages record their last body change as `generated: {by, at}`; any body change, including whitespace, advances the stamp, while front-matter-only changes do not. The legacy v0.1 `timestamp` field is still tolerated on existing pages.
 - The optional v0.2 provenance, trust, and lifecycle families (`sources`, `verified`, `status`, `stale_after`) are validated when present.
 - Standard Markdown links between concept documents express their relationships.
 - `index.md` and `log.md` are reserved documents rather than concepts. The root index declares `okf_version: "0.2"`.

--- a/src/agent/okf-middleware.ts
+++ b/src/agent/okf-middleware.ts
@@ -4,12 +4,14 @@ import { createMiddleware } from "langchain";
 import path from "node:path";
 import { validateWikiMermaid } from "../mermaid/wiki.js";
 import {
-  conceptBodiesEqual,
-  removeFrontmatterField,
-  setGeneratedEvent,
   validatePersistedFile,
   type FrontmatterIssue,
 } from "../okf/frontmatter.js";
+import {
+  finalizeGeneratedProvenance,
+  snapshotGeneratedProvenance,
+  type GeneratedProvenanceSnapshot,
+} from "../okf/generated-provenance.js";
 import { migrateWikiToOkf, synchronizeWikiIndexes } from "../okf/index-sync.js";
 import {
   ENGLISH_CONCEPT_TYPE,
@@ -17,10 +19,8 @@ import {
   type IndexLabels,
 } from "../okf/index-labels.js";
 import { MUTATION_PATH_METADATA_KEY } from "./docs-only-backend.js";
-import { sanitizeDiagnosticText } from "../platform/diagnostics.js";
 import { inStage } from "../telemetry/index.js";
 import type { OpenWikiOutputMode } from "./types.js";
-import { OPENWIKI_PRODUCER_ACTOR } from "../version.js";
 import { validateWikiInternalLinks } from "./wiki-link-validator.js";
 
 const OKF_RESERVED_FILES = new Set(["index.md", "log.md"]);
@@ -29,8 +29,8 @@ const WRITE_TOOLS = new Set(["write_file", "edit_file"]);
 /**
  * Creates middleware that keeps the wiki OKF-conformant around a run. It
  * migrates existing pages to valid front matter before the agent starts,
- * stamps the code-owned `generated` provenance event on concept writes whose
- * body meaningfully changed, and synchronizes indexes after the run.
+ * snapshots their meaningful bodies, synchronizes indexes after the run, and
+ * stamps final code-owned `generated` provenance on every new or changed page.
  *
  * `now` is the run's single stamp time (an ISO 8601 datetime), computed once by
  * the caller and threaded in so every page written in one run shares one
@@ -45,6 +45,8 @@ export function createOpenWikiIndexMiddleware(
   conceptType: string = ENGLISH_CONCEPT_TYPE,
   now: string = new Date().toISOString(),
 ) {
+  let initialConcepts: GeneratedProvenanceSnapshot | undefined;
+
   return createMiddleware({
     name: "OpenWikiIndexMiddleware",
     beforeAgent: async () => {
@@ -55,6 +57,11 @@ export function createOpenWikiIndexMiddleware(
         "build",
         () => migrateWikiToOkf(backend, outputMode, conceptType),
         { errorClass: "okf_error", errorDetail: "migrate" },
+      );
+      initialConcepts = await inStage(
+        "build",
+        () => snapshotGeneratedProvenance(backend, outputMode),
+        { errorClass: "okf_error", errorDetail: "provenance_snapshot" },
       );
     },
     // Telemetry guard: this wrap only *decorates a successful* tool result with a
@@ -72,18 +79,7 @@ export function createOpenWikiIndexMiddleware(
     // Do not turn this into a catch that rethrows: that would make every recoverable
     // tool error fatal and record otherwise-successful runs as failures.
     wrapToolCall: async (request, handler) => {
-      // Read the target's body just before the write so we can tell a
-      // meaningful content change from a metadata-only or whitespace edit.
-      const before = await readConceptContent(request, backend, outputMode);
       const result = await handler(request);
-      await stampGeneratedProvenance(
-        result,
-        backend,
-        outputMode,
-        request.toolCall.name,
-        before,
-        now,
-      );
       return addFrontmatterWarning(
         result,
         backend,
@@ -109,6 +105,20 @@ export function createOpenWikiIndexMiddleware(
         () => validateWikiInternalLinks(backend, outputMode),
         { errorClass: "okf_error", errorDetail: "link_validation" },
       );
+      const conceptsBeforeRun = initialConcepts;
+      if (conceptsBeforeRun) {
+        await inStage(
+          "finalize",
+          () =>
+            finalizeGeneratedProvenance(
+              backend,
+              outputMode,
+              conceptsBeforeRun,
+              now,
+            ),
+          { errorClass: "okf_error", errorDetail: "generated_provenance" },
+        );
+      }
     },
   });
 }
@@ -145,128 +155,6 @@ export async function addFrontmatterWarning<Result>(
       ? `${mutation.message.content}\n\n${warning}`
       : [...mutation.message.content, { text: warning, type: "text" }];
   return result;
-}
-
-/**
- * Stamps the code-owned OKF `generated` provenance event on a concept write
- * whose body meaningfully changed (SPEC §5.1). OpenWiki owns this field end to
- * end: the model never authors it, so freshness never rests on a hallucinated
- * date. A newly created concept (no `before` content) is always stamped; a write
- * that only reshuffles front matter or whitespace leaves `generated` alone.
- *
- * The stamp writes `generated: {by: openwiki/<version>, at: <run time>}` and
- * drops any superseded legacy `timestamp` on the same page. Reserved documents
- * (`index.md`/`log.md`) and non-wiki paths are skipped by {@link isWikiMarkdownPath}.
- *
- * Stamping is best-effort. The tool's own write has already persisted the page
- * body by the time this runs, so a stamp failure must never take the run down
- * with it: any error is logged and swallowed, leaving the page validly unstamped
- * (`generated` is optional in OKF v0.2) for a later body-changing update to
- * stamp. This guard is load-bearing, not cosmetic: the tool node re-raises a
- * throw from `wrapToolCall` as a fatal `MiddlewareError` rather than feeding it
- * back to the model, so without it a failed provenance write would fail an
- * otherwise-successful run.
- */
-async function stampGeneratedProvenance(
-  result: unknown,
-  backend: BackendProtocolV2,
-  outputMode: OpenWikiOutputMode,
-  toolName: string,
-  before: string | undefined,
-  now: string,
-): Promise<void> {
-  if (!WRITE_TOOLS.has(toolName)) return;
-
-  const mutationPath = getMutationPath(result);
-  if (
-    mutationPath === undefined ||
-    !isWikiMarkdownPath(mutationPath, outputMode)
-  ) {
-    return;
-  }
-
-  try {
-    const after = await readContent(backend, mutationPath);
-    if (after === undefined) return;
-
-    // An unchanged body must not bump the recorded change time. A brand-new page
-    // (no `before`) has no prior body to match, so it always stamps.
-    if (before !== undefined && conceptBodiesEqual(before, after)) return;
-
-    const stamped = removeFrontmatterField(
-      setGeneratedEvent(after, OPENWIKI_PRODUCER_ACTOR, now),
-      "timestamp",
-    );
-    // Re-stamping within one run (same `now`, no `timestamp`) is a no-op; skip the
-    // redundant write so idempotent rewrites do not churn the file.
-    if (stamped !== after) {
-      await backend.write(mutationPath, stamped);
-    }
-  } catch (error) {
-    console.error(
-      `OpenWiki: could not stamp generated provenance on "${mutationPath}": ${sanitizeDiagnosticText(
-        error instanceof Error ? error.message : String(error),
-      )}`,
-    );
-  }
-}
-
-/**
- * Reads the target concept's current content just before a write, or undefined
- * when the request targets no readable wiki concept path (so the caller treats
- * the write as a new file). Path resolution mirrors the deepagents write tools,
- * which key the target as `file_path` (tolerating `path`).
- */
-async function readConceptContent(
-  request: { toolCall: { args?: unknown } },
-  backend: BackendProtocolV2,
-  outputMode: OpenWikiOutputMode,
-): Promise<string | undefined> {
-  const args = request.toolCall.args;
-  if (!isRecord(args)) return undefined;
-  const filePath = args.file_path ?? args.path;
-  if (
-    typeof filePath !== "string" ||
-    !isWikiMarkdownPath(filePath, outputMode)
-  ) {
-    return undefined;
-  }
-  return readContent(backend, filePath);
-}
-
-/**
- * Reads a file's text through the backend, returning undefined when it is
- * missing, unreadable, or binary.
- */
-async function readContent(
-  backend: BackendProtocolV2,
-  filePath: string,
-): Promise<string | undefined> {
-  let read: Awaited<ReturnType<BackendProtocolV2["readRaw"]>>;
-  try {
-    // A not-yet-created file throws rather than returning an error result; that
-    // is the new-file case, where there is no prior body to compare against.
-    read = await backend.readRaw(filePath);
-  } catch {
-    return undefined;
-  }
-  const content = read.data?.content;
-  if (read.error || content === undefined || content instanceof Uint8Array) {
-    return undefined;
-  }
-  return Array.isArray(content) ? content.join("\n") : content;
-}
-
-/**
- * Resolves the persisted path a write tool mutated, from the mutation metadata
- * the docs-only backend stamps on its tool messages.
- */
-function getMutationPath(result: unknown): string | undefined {
-  for (const message of getToolMessages(result)) {
-    const path = message.metadata?.[MUTATION_PATH_METADATA_KEY];
-    if (typeof path === "string") return path;
-  }
-  return undefined;
 }
 
 /**

--- a/src/agent/okf-middleware.ts
+++ b/src/agent/okf-middleware.ts
@@ -29,7 +29,7 @@ const WRITE_TOOLS = new Set(["write_file", "edit_file"]);
 /**
  * Creates middleware that keeps the wiki OKF-conformant around a run. It
  * migrates existing pages to valid front matter before the agent starts,
- * snapshots their meaningful bodies, synchronizes indexes after the run, and
+ * snapshots their exact bodies, synchronizes indexes after the run, and
  * stamps final code-owned `generated` provenance on every new or changed page.
  *
  * `now` is the run's single stamp time (an ISO 8601 datetime), computed once by

--- a/src/agent/prompts/code.ts
+++ b/src/agent/prompts/code.ts
@@ -71,16 +71,16 @@ title: <Optional display name>
 description: <Optional one to two sentence summary (optimized for search & retrieval)>
 resource: <Optional canonical URI for the underlying asset>
 tags: [<tag>, <tag>, …]            # Optional
-# OpenWiki stamps generated provenance (last meaningful change) deterministically; do not write it.
+# OpenWiki stamps generated provenance (last body change) deterministically; do not write it.
 # Producer-defined extension fields are allowed.
 ---
 </okf_front_matter>
 
 - Only \`type\` is required. Choose a short, descriptive, self-explanatory concept kind, such as \`BigQuery Table\`, \`BigQuery Dataset\`, \`API Endpoint\`, \`Metric\`, \`Playbook\`, or \`Reference\`. Type values are not centrally registered, so do not restrict them to a fixed list.
 - Recommended fields, in priority order, are: \`title\`, a human-readable display name; \`description\`, a one to two sentence summary optimized for search and retrieval; \`resource\`, the canonical URI of the underlying asset when one exists; and \`tags\`, a YAML list of short cross-cutting category strings.
-- \`generated\` records the content's last meaningful change (\`by\` names the producing actor, \`at\` is an ISO 8601 datetime). OpenWiki owns this field: it stamps and updates \`generated\` deterministically after every run when a page's body actually changes, and drops the superseded legacy \`timestamp\` at the same time. Do not author, edit, or remove \`generated\` or \`timestamp\` yourself; leave any existing values in place.
+- \`generated\` records the content's last body change (\`by\` names the producing actor, \`at\` is an ISO 8601 datetime). OpenWiki owns this field: it stamps and updates \`generated\` deterministically after every run whenever any part of a page's body changes, including whitespace, and drops the superseded legacy \`timestamp\` at the same time. Do not author, edit, or remove \`generated\` or \`timestamp\` yourself; leave any existing values in place.
 - Produce valid YAML. Do not leave placeholder text or explanatory comments in written files.
-- Preserve all existing producer-defined front matter fields when updating a concept. Unknown extension fields are valid OKF and must survive round trips. Change metadata only when the underlying fact or meaningful content changes.
+- Preserve all existing producer-defined front matter fields when updating a concept. Unknown extension fields are valid OKF and must survive round trips. Change metadata only when the underlying fact or body content changes.
 - The description field is especially useful for retrieval tools. When present, make it clear, detailed, and optimized for search.
 - Use the optional namespaced \`openwiki\` producer extension when source evidence supports it. Keep values concise and omit empty keys:
 
@@ -192,7 +192,7 @@ title: <display name>
 description: <one or two retrieval-optimized sentences>
 resource: <optional canonical URI>
 tags: [<specific-domain-tag>]
-# OpenWiki stamps generated provenance (last meaningful change) deterministically; do not write it.
+# OpenWiki stamps generated provenance (last body change) deterministically; do not write it.
 ---
 \`\`\`
 
@@ -315,16 +315,16 @@ title: <Optional display name>
 description: <Optional one to two sentence summary (optimized for search & retrieval)>
 resource: <Optional canonical URI for the underlying asset>
 tags: [<tag>, <tag>, …]            # Optional
-# OpenWiki stamps generated provenance (last meaningful change) deterministically; do not write it.
+# OpenWiki stamps generated provenance (last body change) deterministically; do not write it.
 # Producer-defined extension fields are allowed.
 ---
 </okf_front_matter>
 
 - Only \`type\` is required. Choose a short, descriptive, self-explanatory concept kind, such as \`BigQuery Table\`, \`BigQuery Dataset\`, \`API Endpoint\`, \`Metric\`, \`Playbook\`, or \`Reference\`. Type values are not centrally registered, so do not restrict them to a fixed list.
 - Recommended fields, in priority order, are: \`title\`, a human-readable display name; \`description\`, a one to two sentence summary optimized for search and retrieval; \`resource\`, the canonical URI of the underlying asset when one exists; and \`tags\`, a YAML list of short cross-cutting category strings.
-- \`generated\` records the content's last meaningful change (\`by\` names the producing actor, \`at\` is an ISO 8601 datetime). OpenWiki owns this field: it stamps and updates \`generated\` deterministically after every run when a page's body actually changes, and drops the superseded legacy \`timestamp\` at the same time. Do not author, edit, or remove \`generated\` or \`timestamp\` yourself; leave any existing values in place.
+- \`generated\` records the content's last body change (\`by\` names the producing actor, \`at\` is an ISO 8601 datetime). OpenWiki owns this field: it stamps and updates \`generated\` deterministically after every run whenever any part of a page's body changes, including whitespace, and drops the superseded legacy \`timestamp\` at the same time. Do not author, edit, or remove \`generated\` or \`timestamp\` yourself; leave any existing values in place.
 - Produce valid YAML. Do not leave placeholder text or explanatory comments in written files.
-- Preserve all existing producer-defined front matter fields when updating a concept. Unknown extension fields are valid OKF and must survive round trips. Change metadata only when the underlying fact or meaningful content changes.
+- Preserve all existing producer-defined front matter fields when updating a concept. Unknown extension fields are valid OKF and must survive round trips. Change metadata only when the underlying fact or body content changes.
 - The description field is especially useful for retrieval tools. When present, make it clear, detailed, and optimized for search.
 - Use the optional namespaced \`openwiki\` producer extension when source evidence supports it. Keep values concise and omit empty keys:
 

--- a/src/agent/prompts/personal.ts
+++ b/src/agent/prompts/personal.ts
@@ -105,16 +105,16 @@ title: <Optional display name>
 description: <Optional one to two sentence summary (optimized for search & retrieval)>
 resource: <Optional canonical URI for the underlying asset>
 tags: [<tag>, <tag>, …]            # Optional
-# OpenWiki stamps generated provenance (last meaningful change) deterministically; do not write it.
+# OpenWiki stamps generated provenance (last body change) deterministically; do not write it.
 # Producer-defined extension fields are allowed.
 ---
 </okf_front_matter>
 
 - Only \`type\` is required. Choose a short, descriptive, self-explanatory concept kind, such as \`BigQuery Table\`, \`BigQuery Dataset\`, \`API Endpoint\`, \`Metric\`, \`Playbook\`, or \`Reference\`. Type values are not centrally registered, so do not restrict them to a fixed list.
 - Recommended fields, in priority order, are: \`title\`, a human-readable display name; \`description\`, a one to two sentence summary optimized for search and retrieval; \`resource\`, the canonical URI of the underlying asset when one exists; and \`tags\`, a YAML list of short cross-cutting category strings.
-- \`generated\` records the content's last meaningful change (\`by\` names the producing actor, \`at\` is an ISO 8601 datetime). OpenWiki owns this field: it stamps and updates \`generated\` deterministically after every run when a page's body actually changes, and drops the superseded legacy \`timestamp\` at the same time. Do not author, edit, or remove \`generated\` or \`timestamp\` yourself; leave any existing values in place.
+- \`generated\` records the content's last body change (\`by\` names the producing actor, \`at\` is an ISO 8601 datetime). OpenWiki owns this field: it stamps and updates \`generated\` deterministically after every run whenever any part of a page's body changes, including whitespace, and drops the superseded legacy \`timestamp\` at the same time. Do not author, edit, or remove \`generated\` or \`timestamp\` yourself; leave any existing values in place.
 - Produce valid YAML. Do not leave placeholder text or explanatory comments in written files.
-- Preserve all existing producer-defined front matter fields when updating a concept. Unknown extension fields are valid OKF and must survive round trips. Change metadata only when the underlying fact or meaningful content changes.
+- Preserve all existing producer-defined front matter fields when updating a concept. Unknown extension fields are valid OKF and must survive round trips. Change metadata only when the underlying fact or body content changes.
 - The description field is especially useful for retrieval tools. When present, make it clear, detailed, and optimized for search.
 
 - When updating an existing Markdown concept, preserve accurate body content and correct its opening front matter only when needed for compliance or accuracy.
@@ -297,16 +297,16 @@ title: <Optional display name>
 description: <Optional one to two sentence summary (optimized for search & retrieval)>
 resource: <Optional canonical URI for the underlying asset>
 tags: [<tag>, <tag>, …]            # Optional
-# OpenWiki stamps generated provenance (last meaningful change) deterministically; do not write it.
+# OpenWiki stamps generated provenance (last body change) deterministically; do not write it.
 # Producer-defined extension fields are allowed.
 ---
 </okf_front_matter>
 
 - Only \`type\` is required. Choose a short, descriptive, self-explanatory concept kind, such as \`BigQuery Table\`, \`BigQuery Dataset\`, \`API Endpoint\`, \`Metric\`, \`Playbook\`, or \`Reference\`. Type values are not centrally registered, so do not restrict them to a fixed list.
 - Recommended fields, in priority order, are: \`title\`, a human-readable display name; \`description\`, a one to two sentence summary optimized for search and retrieval; \`resource\`, the canonical URI of the underlying asset when one exists; and \`tags\`, a YAML list of short cross-cutting category strings.
-- \`generated\` records the content's last meaningful change (\`by\` names the producing actor, \`at\` is an ISO 8601 datetime). OpenWiki owns this field: it stamps and updates \`generated\` deterministically after every run when a page's body actually changes, and drops the superseded legacy \`timestamp\` at the same time. Do not author, edit, or remove \`generated\` or \`timestamp\` yourself; leave any existing values in place.
+- \`generated\` records the content's last body change (\`by\` names the producing actor, \`at\` is an ISO 8601 datetime). OpenWiki owns this field: it stamps and updates \`generated\` deterministically after every run whenever any part of a page's body changes, including whitespace, and drops the superseded legacy \`timestamp\` at the same time. Do not author, edit, or remove \`generated\` or \`timestamp\` yourself; leave any existing values in place.
 - Produce valid YAML. Do not leave placeholder text or explanatory comments in written files.
-- Preserve all existing producer-defined front matter fields when updating a concept. Unknown extension fields are valid OKF and must survive round trips. Change metadata only when the underlying fact or meaningful content changes.
+- Preserve all existing producer-defined front matter fields when updating a concept. Unknown extension fields are valid OKF and must survive round trips. Change metadata only when the underlying fact or body content changes.
 - The description field is especially useful for retrieval tools. When present, make it clear, detailed, and optimized for search.
 
 - When updating an existing Markdown concept, preserve accurate body content and correct its opening front matter only when needed for compliance or accuracy.
@@ -525,16 +525,16 @@ title: <Optional display name>
 description: <Optional one to two sentence summary (optimized for search & retrieval)>
 resource: <Optional canonical URI for the underlying asset>
 tags: [<tag>, <tag>, …]            # Optional
-# OpenWiki stamps generated provenance (last meaningful change) deterministically; do not write it.
+# OpenWiki stamps generated provenance (last body change) deterministically; do not write it.
 # Producer-defined extension fields are allowed.
 ---
 </okf_front_matter>
 
 - Only \`type\` is required. Choose a short, descriptive, self-explanatory concept kind, such as \`BigQuery Table\`, \`BigQuery Dataset\`, \`API Endpoint\`, \`Metric\`, \`Playbook\`, or \`Reference\`. Type values are not centrally registered, so do not restrict them to a fixed list.
 - Recommended fields, in priority order, are: \`title\`, a human-readable display name; \`description\`, a one to two sentence summary optimized for search and retrieval; \`resource\`, the canonical URI of the underlying asset when one exists; and \`tags\`, a YAML list of short cross-cutting category strings.
-- \`generated\` records the content's last meaningful change (\`by\` names the producing actor, \`at\` is an ISO 8601 datetime). OpenWiki owns this field: it stamps and updates \`generated\` deterministically after every run when a page's body actually changes, and drops the superseded legacy \`timestamp\` at the same time. Do not author, edit, or remove \`generated\` or \`timestamp\` yourself; leave any existing values in place.
+- \`generated\` records the content's last body change (\`by\` names the producing actor, \`at\` is an ISO 8601 datetime). OpenWiki owns this field: it stamps and updates \`generated\` deterministically after every run whenever any part of a page's body changes, including whitespace, and drops the superseded legacy \`timestamp\` at the same time. Do not author, edit, or remove \`generated\` or \`timestamp\` yourself; leave any existing values in place.
 - Produce valid YAML. Do not leave placeholder text or explanatory comments in written files.
-- Preserve all existing producer-defined front matter fields when updating a concept. Unknown extension fields are valid OKF and must survive round trips. Change metadata only when the underlying fact or meaningful content changes.
+- Preserve all existing producer-defined front matter fields when updating a concept. Unknown extension fields are valid OKF and must survive round trips. Change metadata only when the underlying fact or body content changes.
 - The description field is especially useful for retrieval tools. When present, make it clear, detailed, and optimized for search.
 
 - When updating an existing Markdown concept, preserve accurate body content and correct its opening front matter only when needed for compliance or accuracy.

--- a/src/okf/frontmatter.ts
+++ b/src/okf/frontmatter.ts
@@ -438,25 +438,6 @@ export function setGeneratedEvent(
 }
 
 /**
- * Reports whether two documents have the same concept body, ignoring their
- * front-matter blocks and treating a run of whitespace as equal to a single
- * space. This is the "meaningful change" test that gates {@link setGeneratedEvent}:
- * a write that only reshuffles front matter or reflows whitespace does not bump
- * the recorded change time.
- */
-export function conceptBodiesEqual(before: string, after: string): boolean {
-  return normalizeBody(before) === normalizeBody(after);
-}
-
-/**
- * Strips a document's front matter and collapses whitespace so two bodies that
- * differ only in spacing or blank lines compare equal.
- */
-function normalizeBody(content: string): string {
-  return splitFrontmatter(content).body.replace(/\s+/gu, " ").trim();
-}
-
-/**
  * Removes a single field from a page's front matter, preserving every other line
  * byte-for-byte, and returns the content unchanged when the field is absent. If
  * the field was the block's only line, the now-empty block is dropped entirely.

--- a/src/okf/generated-provenance.ts
+++ b/src/okf/generated-provenance.ts
@@ -1,0 +1,198 @@
+import { createHash } from "node:crypto";
+import type { BackendProtocolV2 } from "deepagents";
+import type { OpenWikiOutputMode } from "../agent/types.js";
+import { OPENWIKI_PRODUCER_ACTOR } from "../version.js";
+import {
+  parseFrontmatterFields,
+  removeFrontmatterField,
+  setGeneratedEvent,
+  splitFrontmatter,
+} from "./frontmatter.js";
+import { listWikiConceptPaths } from "./index-sync.js";
+
+/**
+ * Persisted producer event captured before an agent run.
+ */
+interface GeneratedEvent {
+  /**
+   * Producer actor responsible for the prior meaningful change.
+   */
+  by: string;
+
+  /**
+   * Producer-recorded time of the prior meaningful change.
+   *
+   * @default undefined - the prior event did not record a time.
+   */
+  at?: string;
+}
+
+/**
+ * Minimal pre-run state needed to finalize one concept's provenance.
+ */
+interface ConceptSnapshot {
+  /**
+   * Hash of the normalized Markdown body, excluding front matter.
+   */
+  bodyHash: string;
+
+  /**
+   * Valid producer event present before the run.
+   *
+   * @default undefined - the page had no valid generated event.
+   */
+  generated?: GeneratedEvent;
+}
+
+/**
+ * Run-scoped provenance baseline keyed by virtual concept path.
+ */
+export type GeneratedProvenanceSnapshot = ReadonlyMap<string, ConceptSnapshot>;
+
+/**
+ * Captures finalization inputs for every concept present before the agent runs.
+ * Only hashes and the prior producer event are retained, keeping the snapshot
+ * bounded without creating temporary files beside generated documentation.
+ *
+ * @param backend - Active wiki filesystem abstraction.
+ * @param outputMode - Current wiki target.
+ * @returns Pre-run concept state keyed by virtual page path.
+ */
+export async function snapshotGeneratedProvenance(
+  backend: BackendProtocolV2,
+  outputMode: OpenWikiOutputMode,
+): Promise<GeneratedProvenanceSnapshot> {
+  const snapshots = new Map<string, ConceptSnapshot>();
+  for (const page of await listWikiConceptPaths(backend, outputMode)) {
+    const content = await readRequiredContent(backend, page);
+    snapshots.set(page, {
+      bodyHash: hashConceptBody(content),
+      generated: readGeneratedEvent(content),
+    });
+  }
+  return snapshots;
+}
+
+/**
+ * Reconciles producer provenance against the final post-processed wiki.
+ * New or meaningfully changed bodies receive the run stamp. An unchanged page
+ * receives its prior stamp back when an agent rewrite removed or altered it;
+ * pages that were previously unstamped remain unstamped.
+ *
+ * @param backend - Active wiki filesystem abstraction.
+ * @param outputMode - Current wiki target.
+ * @param initialConcepts - Pre-run state keyed by virtual page path.
+ * @param now - Shared run timestamp used for new generated events.
+ */
+export async function finalizeGeneratedProvenance(
+  backend: BackendProtocolV2,
+  outputMode: OpenWikiOutputMode,
+  initialConcepts: GeneratedProvenanceSnapshot,
+  now: string,
+): Promise<void> {
+  for (const page of await listWikiConceptPaths(backend, outputMode)) {
+    const content = await readRequiredContent(backend, page);
+    const initial = initialConcepts.get(page);
+    const bodyChanged =
+      initial === undefined || initial.bodyHash !== hashConceptBody(content);
+    const reconciled = bodyChanged
+      ? removeFrontmatterField(
+          setGeneratedEvent(content, OPENWIKI_PRODUCER_ACTOR, now),
+          "timestamp",
+        )
+      : restoreGeneratedEvent(content, initial.generated);
+
+    if (reconciled !== content) {
+      const result = await backend.write(page, reconciled);
+      if (result.error) {
+        throw new Error(
+          `Unable to finalize generated provenance for ${page}: ${result.error}`,
+        );
+      }
+    }
+  }
+}
+
+/**
+ * Reads one required concept as UTF-8-compatible text.
+ *
+ * @param backend - Active wiki filesystem abstraction.
+ * @param filePath - Virtual concept path to read.
+ * @returns Complete persisted concept content.
+ */
+async function readRequiredContent(
+  backend: BackendProtocolV2,
+  filePath: string,
+): Promise<string> {
+  const read = await backend.readRaw(filePath);
+  const content = read.data?.content;
+  if (read.error || content === undefined || content instanceof Uint8Array) {
+    throw new Error(
+      `Unable to read concept ${filePath}: ${read.error ?? "not text"}`,
+    );
+  }
+  return Array.isArray(content) ? content.join("\n") : content;
+}
+
+/**
+ * Hashes the meaningful Markdown body while ignoring front matter and
+ * insignificant whitespace, matching the existing generated-event semantics.
+ *
+ * @param content - Complete concept document.
+ * @returns Stable SHA-256 body fingerprint.
+ */
+function hashConceptBody(content: string): string {
+  const normalized = splitFrontmatter(content)
+    .body.replace(/\s+/gu, " ")
+    .trim();
+  return createHash("sha256").update(normalized).digest("hex");
+}
+
+/**
+ * Reads a valid producer event from a page's front matter.
+ *
+ * @param content - Complete concept document.
+ * @returns Parsed producer event, or `undefined` when absent or invalid.
+ */
+function readGeneratedEvent(content: string): GeneratedEvent | undefined {
+  const value = parseFrontmatterFields(content)?.generated;
+  if (
+    !isRecord(value) ||
+    typeof value.by !== "string" ||
+    value.by.trim().length === 0 ||
+    (value.at !== undefined &&
+      (typeof value.at !== "string" || value.at.trim().length === 0))
+  ) {
+    return undefined;
+  }
+  return {
+    by: value.by,
+    ...(typeof value.at === "string" ? { at: value.at } : {}),
+  };
+}
+
+/**
+ * Restores the pre-run producer event without advancing its timestamp.
+ *
+ * @param content - Final concept document.
+ * @param generated - Valid pre-run producer event, when one existed.
+ * @returns Content with the code-owned field restored or removed.
+ */
+function restoreGeneratedEvent(
+  content: string,
+  generated?: GeneratedEvent,
+): string {
+  return generated
+    ? setGeneratedEvent(content, generated.by, generated.at)
+    : removeFrontmatterField(content, "generated");
+}
+
+/**
+ * Narrows an unknown value to a non-array object record.
+ *
+ * @param value - Unknown candidate value.
+ * @returns Whether the value is a record.
+ */
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}

--- a/src/okf/generated-provenance.ts
+++ b/src/okf/generated-provenance.ts
@@ -15,12 +15,12 @@ import { listWikiConceptPaths } from "./index-sync.js";
  */
 interface GeneratedEvent {
   /**
-   * Producer actor responsible for the prior meaningful change.
+   * Producer actor responsible for the prior body change.
    */
   by: string;
 
   /**
-   * Producer-recorded time of the prior meaningful change.
+   * Producer-recorded time of the prior body change.
    *
    * @default undefined - the prior event did not record a time.
    */
@@ -32,7 +32,7 @@ interface GeneratedEvent {
  */
 interface ConceptSnapshot {
   /**
-   * Hash of the normalized Markdown body, excluding front matter.
+   * Hash of the exact Markdown body, excluding front matter.
    */
   bodyHash: string;
 
@@ -75,9 +75,9 @@ export async function snapshotGeneratedProvenance(
 
 /**
  * Reconciles producer provenance against the final post-processed wiki.
- * New or meaningfully changed bodies receive the run stamp. An unchanged page
- * receives its prior stamp back when an agent rewrite removed or altered it;
- * pages that were previously unstamped remain unstamped.
+ * New pages and pages whose bodies changed in any way receive the run stamp.
+ * An unchanged body receives its prior stamp back when an agent rewrite removed
+ * or altered it; pages that were previously unstamped remain unstamped.
  *
  * @param backend - Active wiki filesystem abstraction.
  * @param outputMode - Current wiki target.
@@ -135,17 +135,15 @@ async function readRequiredContent(
 }
 
 /**
- * Hashes the meaningful Markdown body while ignoring front matter and
- * insignificant whitespace, matching the existing generated-event semantics.
+ * Hashes the exact Markdown body while excluding front matter. Whitespace is
+ * retained so any body change advances the generated event.
  *
  * @param content - Complete concept document.
  * @returns Stable SHA-256 body fingerprint.
  */
 function hashConceptBody(content: string): string {
-  const normalized = splitFrontmatter(content)
-    .body.replace(/\s+/gu, " ")
-    .trim();
-  return createHash("sha256").update(normalized).digest("hex");
+  const body = splitFrontmatter(content).body;
+  return createHash("sha256").update(body).digest("hex");
 }
 
 /**

--- a/src/okf/index-sync.ts
+++ b/src/okf/index-sync.ts
@@ -84,26 +84,38 @@ export async function migrateWikiToOkf(
   outputMode: OpenWikiOutputMode,
   conceptType: string = ENGLISH_CONCEPT_TYPE,
 ): Promise<void> {
-  const root = outputMode === "local-wiki" ? "/" : "/openwiki";
-  for (const directory of await collectDirectories(backend, root, true)) {
-    for (const entry of directory.entries) {
-      const name = entryName(entry);
-      if (
-        entry.is_dir ||
-        !name ||
-        name.startsWith(".") ||
-        path.posix.extname(name).toLowerCase() !== ".md" ||
-        EXCLUDED_FILES.has(name)
-      ) {
-        continue;
-      }
-      await normalizeConceptFile(
-        backend,
-        path.posix.join(directory.path, name),
-        conceptType,
-      );
-    }
+  for (const filePath of await listWikiConceptPaths(backend, outputMode)) {
+    await normalizeConceptFile(backend, filePath, conceptType);
   }
+}
+
+/**
+ * Lists the non-structural Markdown concepts currently present in the wiki.
+ *
+ * @param backend - Filesystem abstraction rooted at the active wiki target.
+ * @param outputMode - Whether the wiki lives at `/` or `/openwiki`.
+ * @returns Stable, sorted virtual paths for every concept page.
+ */
+export async function listWikiConceptPaths(
+  backend: BackendProtocolV2,
+  outputMode: OpenWikiOutputMode,
+): Promise<string[]> {
+  const root = outputMode === "local-wiki" ? "/" : "/openwiki";
+  const directories = await collectDirectories(backend, root, true);
+  return directories
+    .flatMap((directory) =>
+      directory.entries.flatMap((entry) => {
+        const name = entryName(entry);
+        return !entry.is_dir &&
+          name &&
+          !name.startsWith(".") &&
+          path.posix.extname(name).toLowerCase() === ".md" &&
+          !EXCLUDED_FILES.has(name)
+          ? [path.posix.join(directory.path, name)]
+          : [];
+      }),
+    )
+    .sort((left, right) => left.localeCompare(right));
 }
 
 /**

--- a/test/agent/index-middleware.test.ts
+++ b/test/agent/index-middleware.test.ts
@@ -634,7 +634,7 @@ describe("createOpenWikiIndexMiddleware generated finalization", () => {
     expect(page.match(/^generated:/gmu)).toHaveLength(1);
   });
 
-  test("does not bump generated when only the body whitespace changes", async () => {
+  test("bumps generated when only the body whitespace changes", async () => {
     const { backend, rootDir } = await setup();
     const middleware = createOpenWikiIndexMiddleware(
       backend,
@@ -650,7 +650,7 @@ describe("createOpenWikiIndexMiddleware generated finalization", () => {
     await runBeforeAgent(middleware);
 
     // A full-file rewrite omits the code-owned field and only reflows body
-    // whitespace. Finalization must restore the old event without advancing it.
+    // whitespace. That is still a body change and must advance the event.
     await driveWrite(
       middleware,
       backend,
@@ -660,8 +660,37 @@ describe("createOpenWikiIndexMiddleware generated finalization", () => {
     await runAfterAgent(middleware);
 
     const page = await readFile(path.join(rootDir, "openwiki/page.md"), "utf8");
+    expect(page).toContain(`at: "${LATER}"`);
+    expect(page).not.toContain(NOW);
+  });
+
+  test("does not bump generated when only front matter changes", async () => {
+    const { backend, rootDir } = await setup();
+    const middleware = createOpenWikiIndexMiddleware(
+      backend,
+      "repository",
+      ENGLISH_INDEX_LABELS,
+      "Reference",
+      LATER,
+    );
+    await backend.write(
+      "/openwiki/page.md",
+      `---\ntype: Reference\ngenerated: {by: "openwiki/${OPENWIKI_VERSION}", at: "${NOW}"}\n---\n\n# Page\n\nSame body.\n`,
+    );
+    await runBeforeAgent(middleware);
+
+    await driveWrite(
+      middleware,
+      backend,
+      "/openwiki/page.md",
+      "---\ntype: Guide\ntitle: Page\n---\n\n# Page\n\nSame body.\n",
+    );
+    await runAfterAgent(middleware);
+
+    const page = await readFile(path.join(rootDir, "openwiki/page.md"), "utf8");
     expect(page).toContain(`at: "${NOW}"`);
     expect(page).not.toContain(LATER);
+    expect(page).toContain("type: Guide");
   });
 
   test("stamps a nested concept but never a reserved document", async () => {

--- a/test/agent/index-middleware.test.ts
+++ b/test/agent/index-middleware.test.ts
@@ -38,6 +38,34 @@ async function setup(outputMode: "local-wiki" | "repository" = "repository") {
   return { backend, rootDir };
 }
 
+/**
+ * Runs the middleware's pre-agent lifecycle hook.
+ */
+async function runBeforeAgent(
+  middleware: ReturnType<typeof createOpenWikiIndexMiddleware>,
+): Promise<void> {
+  const hook =
+    typeof middleware.beforeAgent === "function"
+      ? middleware.beforeAgent
+      : middleware.beforeAgent?.hook;
+  expect(hook).toBeTypeOf("function");
+  await (hook as () => Promise<unknown>)();
+}
+
+/**
+ * Runs the middleware's post-agent lifecycle hook.
+ */
+async function runAfterAgent(
+  middleware: ReturnType<typeof createOpenWikiIndexMiddleware>,
+): Promise<void> {
+  const hook =
+    typeof middleware.afterAgent === "function"
+      ? middleware.afterAgent
+      : middleware.afterAgent?.hook;
+  expect(hook).toBeTypeOf("function");
+  await (hook as () => Promise<unknown>)();
+}
+
 describe("synchronizeWikiIndexes", () => {
   test("creates deterministic indexes for every directory", async () => {
     const { backend, rootDir } = await setup();
@@ -420,12 +448,7 @@ describe("createOpenWikiIndexMiddleware beforeAgent", () => {
     await backend.write("/openwiki/legacy.md", "# Legacy\n\nBody.\n");
 
     const middleware = createOpenWikiIndexMiddleware(backend, "repository");
-    const beforeAgent =
-      typeof middleware.beforeAgent === "function"
-        ? middleware.beforeAgent
-        : middleware.beforeAgent?.hook;
-    expect(beforeAgent).toBeTypeOf("function");
-    await (beforeAgent as () => Promise<unknown>)();
+    await runBeforeAgent(middleware);
 
     const legacy = await readFile(
       path.join(rootDir, "openwiki/legacy.md"),
@@ -445,12 +468,7 @@ describe("createOpenWikiIndexMiddleware beforeAgent", () => {
       ENGLISH_INDEX_LABELS,
       "Referenca",
     );
-    const beforeAgent =
-      typeof middleware.beforeAgent === "function"
-        ? middleware.beforeAgent
-        : middleware.beforeAgent?.hook;
-    expect(beforeAgent).toBeTypeOf("function");
-    await (beforeAgent as () => Promise<unknown>)();
+    await runBeforeAgent(middleware);
 
     const legacy = await readFile(
       path.join(rootDir, "openwiki/legacy.md"),
@@ -469,12 +487,8 @@ describe("createOpenWikiIndexMiddleware afterAgent", () => {
     );
 
     const middleware = createOpenWikiIndexMiddleware(backend, "repository");
-    const afterAgent =
-      typeof middleware.afterAgent === "function"
-        ? middleware.afterAgent
-        : middleware.afterAgent?.hook;
-    expect(afterAgent).toBeTypeOf("function");
-    await (afterAgent as () => Promise<unknown>)();
+    await runBeforeAgent(middleware);
+    await runAfterAgent(middleware);
 
     const page = await readFile(
       path.join(rootDir, "openwiki/quickstart.md"),
@@ -488,6 +502,7 @@ describe("createOpenWikiIndexMiddleware afterAgent", () => {
     // The mermaid pass ran: the broken fence is now a degraded text fence.
     expect(page).toContain("```text");
     expect(page).toContain("openwiki: mermaid parse failed");
+    expect(page).toContain("generated:");
     // The index pass also ran over the same tree.
     expect(index).toContain("- [Quickstart](quickstart.md) - Start here.");
   });
@@ -500,14 +515,8 @@ describe("createOpenWikiIndexMiddleware afterAgent", () => {
     );
 
     const middleware = createOpenWikiIndexMiddleware(backend, "repository");
-    const afterAgent =
-      typeof middleware.afterAgent === "function"
-        ? middleware.afterAgent
-        : middleware.afterAgent?.hook;
-    expect(afterAgent).toBeTypeOf("function");
-    await expect(
-      (afterAgent as () => Promise<unknown>)(),
-    ).resolves.toBeUndefined();
+    await runBeforeAgent(middleware);
+    await expect(runAfterAgent(middleware)).resolves.toBeUndefined();
 
     const page = await readFile(
       path.join(rootDir, "openwiki/quickstart.md"),
@@ -515,10 +524,11 @@ describe("createOpenWikiIndexMiddleware afterAgent", () => {
     );
     expect(page).toContain("openwiki: broken internal link [./missing.md]");
     expect(page).toContain("See [missing](./missing.md).");
+    expect(page).toContain("generated:");
   });
 });
 
-describe("createOpenWikiIndexMiddleware wrapToolCall generated stamping", () => {
+describe("createOpenWikiIndexMiddleware generated finalization", () => {
   const NOW = "2026-08-18T09:00:00.000Z";
   const LATER = "2026-08-19T10:00:00.000Z";
 
@@ -553,7 +563,7 @@ describe("createOpenWikiIndexMiddleware wrapToolCall generated stamping", () => 
     return wrap(request, handler);
   }
 
-  test("stamps a run-timed generated event on a newly created concept", async () => {
+  test("stamps a newly created concept after its final full-file rewrite", async () => {
     const { backend, rootDir } = await setup();
     const middleware = createOpenWikiIndexMiddleware(
       backend,
@@ -562,6 +572,7 @@ describe("createOpenWikiIndexMiddleware wrapToolCall generated stamping", () => 
       "Reference",
       NOW,
     );
+    await runBeforeAgent(middleware);
 
     await driveWrite(
       middleware,
@@ -569,6 +580,20 @@ describe("createOpenWikiIndexMiddleware wrapToolCall generated stamping", () => 
       "/openwiki/page.md",
       "---\ntype: Reference\ntitle: Page\n---\n\n# Page\n\nBody.\n",
     );
+    await driveWrite(
+      middleware,
+      backend,
+      "/openwiki/page.md",
+      "---\ntype: Reference\ntitle: Page\n---\n\n# Page\n\nBody.\n",
+    );
+
+    const beforeFinalization = await readFile(
+      path.join(rootDir, "openwiki/page.md"),
+      "utf8",
+    );
+    expect(beforeFinalization).not.toContain("generated:");
+
+    await runAfterAgent(middleware);
 
     const page = await readFile(path.join(rootDir, "openwiki/page.md"), "utf8");
     expect(page).toContain(
@@ -590,6 +615,7 @@ describe("createOpenWikiIndexMiddleware wrapToolCall generated stamping", () => 
       "/openwiki/page.md",
       '---\ntype: Reference\ntitle: Page\ntimestamp: "2026-07-16T20:00:00Z"\n---\n\n# Page\n\nOld body.\n',
     );
+    await runBeforeAgent(middleware);
 
     await driveWrite(
       middleware,
@@ -597,6 +623,7 @@ describe("createOpenWikiIndexMiddleware wrapToolCall generated stamping", () => 
       "/openwiki/page.md",
       '---\ntype: Reference\ntitle: Page\ntimestamp: "2026-07-16T20:00:00Z"\n---\n\n# Page\n\nNew body.\n',
     );
+    await runAfterAgent(middleware);
 
     const page = await readFile(path.join(rootDir, "openwiki/page.md"), "utf8");
     expect(page).toContain(
@@ -620,14 +647,17 @@ describe("createOpenWikiIndexMiddleware wrapToolCall generated stamping", () => 
       "/openwiki/page.md",
       `---\ntype: Reference\ngenerated: {by: "openwiki/${OPENWIKI_VERSION}", at: "${NOW}"}\n---\n\n# Page\n\nSame body.\n`,
     );
+    await runBeforeAgent(middleware);
 
-    // Only the body's whitespace is reflowed; the meaning is unchanged.
+    // A full-file rewrite omits the code-owned field and only reflows body
+    // whitespace. Finalization must restore the old event without advancing it.
     await driveWrite(
       middleware,
       backend,
       "/openwiki/page.md",
-      `---\ntype: Reference\ngenerated: {by: "openwiki/${OPENWIKI_VERSION}", at: "${NOW}"}\n---\n\n#   Page\n\n\nSame   body.\n`,
+      "---\ntype: Reference\n---\n\n#   Page\n\n\nSame   body.\n",
     );
+    await runAfterAgent(middleware);
 
     const page = await readFile(path.join(rootDir, "openwiki/page.md"), "utf8");
     expect(page).toContain(`at: "${NOW}"`);
@@ -643,34 +673,30 @@ describe("createOpenWikiIndexMiddleware wrapToolCall generated stamping", () => 
       "Reference",
       NOW,
     );
+    await runBeforeAgent(middleware);
 
-    // A nested concept IS stamped (one handler write plus one stamp write).
-    const nestedWrites = vi.spyOn(backend, "write");
     await driveWrite(
       middleware,
       backend,
       "/openwiki/notes/scratch.md",
       "---\ntype: Reference\n---\n\n# Scratch\n\nBody.\n",
     );
-    const nested = await readFile(
-      path.join(rootDir, "openwiki/notes/scratch.md"),
-      "utf8",
-    );
-    expect(nested).toContain(`at: "${NOW}"`);
-    expect(nestedWrites).toHaveBeenCalledTimes(2);
-
-    // A reserved document is skipped: only the handler's own write happens.
-    const reservedWrites = vi.spyOn(backend, "write");
-    reservedWrites.mockClear();
     await driveWrite(
       middleware,
       backend,
       "/openwiki/log.md",
       "# Directory Update Log\n\n## 2026-08-18\n- Changed page.\n",
     );
+    await runAfterAgent(middleware);
+
+    const nested = await readFile(
+      path.join(rootDir, "openwiki/notes/scratch.md"),
+      "utf8",
+    );
+    expect(nested).toContain(`at: "${NOW}"`);
+
     const log = await readFile(path.join(rootDir, "openwiki/log.md"), "utf8");
     expect(log).not.toContain("generated:");
-    expect(reservedWrites).toHaveBeenCalledTimes(1);
   });
 
   test("does not stamp a non-Markdown file written under the wiki", async () => {
@@ -682,26 +708,29 @@ describe("createOpenWikiIndexMiddleware wrapToolCall generated stamping", () => 
       "Reference",
       NOW,
     );
+    await runBeforeAgent(middleware);
 
-    const writes = vi.spyOn(backend, "write");
     await driveWrite(
       middleware,
       backend,
       "/openwiki/data.json",
       '{"stamped": false}\n',
     );
+    await runAfterAgent(middleware);
 
     const data = await readFile(
       path.join(rootDir, "openwiki/data.json"),
       "utf8",
     );
     expect(data).not.toContain("generated:");
-    // Only the handler's own write; the stamp path is skipped for non-.md files.
-    expect(writes).toHaveBeenCalledTimes(1);
   });
 
-  test("keeps an otherwise-successful write when the stamp write fails", async () => {
+  test("leaves a preserved unstamped page unstamped", async () => {
     const { backend, rootDir } = await setup();
+    await backend.write(
+      "/openwiki/page.md",
+      "---\ntype: Reference\n---\n\n# Page\n\nStable body.\n",
+    );
     const middleware = createOpenWikiIndexMiddleware(
       backend,
       "repository",
@@ -710,33 +739,46 @@ describe("createOpenWikiIndexMiddleware wrapToolCall generated stamping", () => 
       NOW,
     );
 
-    // The handler's own write (call 1) persists the page; the stamp's write
-    // (call 2) fails. Stamping is best-effort, so the failure must be logged
-    // and swallowed rather than propagate out of wrapToolCall as a fatal error.
+    await runBeforeAgent(middleware);
+    await runAfterAgent(middleware);
+
+    const page = await readFile(path.join(rootDir, "openwiki/page.md"), "utf8");
+    expect(page).not.toContain("generated:");
+  });
+
+  test("fails finalization when the generated event cannot be persisted", async () => {
+    const { backend, rootDir } = await setup();
+    const middleware = createOpenWikiIndexMiddleware(
+      backend,
+      "repository",
+      ENGLISH_INDEX_LABELS,
+      "Reference",
+      NOW,
+    );
+    await runBeforeAgent(middleware);
+
+    const body = "---\ntype: Reference\ntitle: Page\n---\n\n# Page\n\nBody.\n";
+    await driveWrite(middleware, backend, "/openwiki/page.md", body);
+
     const realWrite = backend.write.bind(backend);
-    let calls = 0;
     const writeSpy = vi
       .spyOn(backend, "write")
       .mockImplementation(async (p: string, c: string) => {
-        calls += 1;
-        if (calls === 1) return realWrite(p, c);
-        throw new Error("disk full");
+        return p === "/openwiki/page.md" && c.includes("generated:")
+          ? { error: "disk full" }
+          : realWrite(p, c);
       });
-    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
 
-    const body = "---\ntype: Reference\ntitle: Page\n---\n\n# Page\n\nBody.\n";
-    await expect(
-      driveWrite(middleware, backend, "/openwiki/page.md", body),
-    ).resolves.toBeInstanceOf(ToolMessage);
+    try {
+      await expect(runAfterAgent(middleware)).rejects.toThrow(
+        "Unable to finalize generated provenance for /openwiki/page.md: disk full",
+      );
+    } finally {
+      writeSpy.mockRestore();
+    }
 
-    expect(errorSpy).toHaveBeenCalledWith(
-      expect.stringContaining("could not stamp generated provenance"),
-    );
-    writeSpy.mockRestore();
-    errorSpy.mockRestore();
-
-    // The content the handler wrote survives; the page is simply left unstamped
-    // for a later body-changing update to pick up.
+    // The model-authored content survives, but the run cannot claim successful
+    // finalization while its code-owned provenance is absent.
     const page = await readFile(path.join(rootDir, "openwiki/page.md"), "utf8");
     expect(page).toBe(body);
     expect(page).not.toContain("generated:");

--- a/test/agent/prompt-okf.test.ts
+++ b/test/agent/prompt-okf.test.ts
@@ -39,7 +39,7 @@ describe("createSystemPrompt OKF guidance", () => {
       expect(prompt).not.toContain("by: openwiki/");
       expect(prompt).not.toContain("{OKF_PRODUCER_ACTOR}");
       expect(prompt).toContain(
-        "OpenWiki stamps generated provenance (last meaningful change) deterministically",
+        "OpenWiki stamps generated provenance (last body change) deterministically",
       );
     }
     expect(init).toContain("valid OKF v0.2 YAML front matter");

--- a/test/okf/frontmatter.test.ts
+++ b/test/okf/frontmatter.test.ts
@@ -1,7 +1,6 @@
 import type { BackendProtocolV2 } from "deepagents";
 import { describe, expect, test, vi } from "vitest";
 import {
-  conceptBodiesEqual,
   deriveMinimalFrontmatter,
   normalizeConceptContent,
   parseFrontmatterFields,
@@ -197,35 +196,6 @@ describe("setGeneratedEvent", () => {
       "2026-08-18T09:00:00.000Z",
     );
     expect(validateOkfFrontmatter(stamped)).toEqual({ valid: true });
-  });
-});
-
-describe("conceptBodiesEqual", () => {
-  test("ignores front-matter differences", () => {
-    expect(
-      conceptBodiesEqual(
-        "---\ntype: Reference\n---\n\n# Page\n\nSame body.\n",
-        "---\ntype: Reference\ngenerated: {by: openwiki/0.3.1}\n---\n\n# Page\n\nSame body.\n",
-      ),
-    ).toBe(true);
-  });
-
-  test("ignores whitespace-only reflows in the body", () => {
-    expect(
-      conceptBodiesEqual(
-        "---\ntype: Reference\n---\n\n# Page\n\nSame body.\n",
-        "---\ntype: Reference\n---\n\n#   Page\n\n\nSame   body.\n\n",
-      ),
-    ).toBe(true);
-  });
-
-  test("detects a meaningful body change", () => {
-    expect(
-      conceptBodiesEqual(
-        "---\ntype: Reference\n---\n\n# Page\n\nOld body.\n",
-        "---\ntype: Reference\n---\n\n# Page\n\nNew body.\n",
-      ),
-    ).toBe(false);
   });
 });
 


### PR DESCRIPTION
## Summary

Move OKF generated provenance stamping to finalization.

OpenWiki now compares final pages against an in-memory pre-run snapshot, stamps new or changed pages after post-processing, and preserves prior stamps across full-file rewrites.