### PR TITLE
feat: disable the general-purpose subagent for repository init

### DIFF
--- a/.changeset/disable-general-purpose-subagent.md
+++ b/.changeset/disable-general-purpose-subagent.md
@@ -1,0 +1,5 @@
+---
+"openwiki": patch
+---
+
+feat: disable the general-purpose subagent for repository init runs

--- a/.changeset/disable-general-purpose-subagent.md
+++ b/.changeset/disable-general-purpose-subagent.md
@@ -1,5 +1,5 @@
 ---
-"openwiki": patch
+"openwiki": minor
 ---
 
 feat: disable the general-purpose subagent for repository init runs

--- a/src/agent/general-purpose-guard.ts
+++ b/src/agent/general-purpose-guard.ts
@@ -1,0 +1,192 @@
+/**
+ * Removes DeepAgents' auto-added `general-purpose` subagent from an init run.
+ *
+ * A repository init has a named subagent for every fan-out it wants: authors
+ * write pages against a supplied brief and establish their own Claims,
+ * reviewers read and never write, question-finders return a fixed text shape.
+ * `general-purpose` is none of those. It inherits the main agent's whole tool
+ * set - the connector tools, the Claims tools, and a filesystem middleware
+ * carrying the agent's own write permissions - with a prompt that says only
+ * "research complex questions". So it is the one dispatch target that can
+ * author a page without a brief, without edges, and without the claim
+ * discipline every other authoring path enforces, and the coordinator reaches
+ * for it precisely when a task does not fit a named subagent.
+ *
+ * DeepAgents can drop it at construction, but only through a harness profile
+ * (`generalPurposeSubagent: { enabled: false }`), and profiles resolve off a
+ * model instance through `getModelProvider`, which recognizes ChatAnthropic,
+ * ChatOpenAI and ChatGoogleGenerativeAI and nothing else. Measured against
+ * deepagents 1.12.0, that leaves the subagent in place for `gemini`,
+ * `openrouter` and `bedrock` while removing it for `anthropic` and the
+ * ChatOpenAI-backed providers - a boundary that holds or not depending on which
+ * `--provider` the run was started with. This closes it the same way for all of
+ * them.
+ *
+ * The enforcement is on the `task` tool itself rather than on either caller,
+ * because there are two callers and only one of them is interceptable. The REPL
+ * reaches subagents through `@langchain/quickjs`'s `task()` global, which
+ * resolves the tool out of `request.tools` in `wrapModelCall` and invokes it
+ * directly; no `wrapToolCall` runs on that path, and LangChain rejects
+ * substituting a wrapper into `request.tools` outright ("You have modified a
+ * tool in `wrapModelCall`") to keep ToolNode's execution identity intact. The
+ * one object both callers share is the registered tool, so the guard patches
+ * that in place. Order in the middleware list is therefore irrelevant: whoever
+ * holds a reference holds the guarded tool.
+ */
+
+import { ToolMessage } from "@langchain/core/messages";
+import { GENERAL_PURPOSE_SUBAGENT } from "deepagents";
+import { createMiddleware } from "langchain";
+
+/** The subagent name to refuse, read from DeepAgents so a rename cannot silently disarm this. */
+const GENERAL_PURPOSE = GENERAL_PURPOSE_SUBAGENT.name;
+
+/**
+ * What the coordinator gets back instead of a subagent.
+ *
+ * It names the constraint rather than the failure, because the model recovers
+ * by picking a different `subagentType`, and the roster it should pick from is
+ * already in the task tool's description.
+ */
+const REFUSAL = `The "${GENERAL_PURPOSE}" subagent is not available in this run. Dispatch one of the named subagents listed in the task tool description instead, or do the work yourself.`;
+
+/** The registered `task` tool, narrowed to the two members the guard touches. */
+export interface GuardableTaskTool {
+  name: string;
+  description: string;
+  invoke: (input: unknown, config?: unknown) => Promise<unknown>;
+}
+
+/**
+ * Drops every line of the task tool's description that names the subagent.
+ *
+ * DeepAgents renders one `- <name>: <description>` line per subagent and closes
+ * with a usage note that reads "When only general-purpose is available, ...".
+ * Both mention it and neither survives its removal, so the filter is by mention
+ * rather than by position - the roster's exact layout is not ours to depend on.
+ *
+ * @param description - The task tool's rendered description.
+ * @returns The description with every general-purpose line removed.
+ */
+export function stripGeneralPurpose(description: string): string {
+  return description
+    .split("\n")
+    .filter((line) => !line.includes(GENERAL_PURPOSE))
+    .join("\n");
+}
+
+/**
+ * Reads the requested subagent name, and which caller asked for it.
+ *
+ * The two callers are distinguishable by shape and have to fail differently, so
+ * the same read reports both. ToolNode invokes with the tool call itself
+ * (`{ name, args, id, type: "tool_call" }`); the REPL bridge invokes with the
+ * arguments directly, having stripped the tool call so the task tool returns
+ * text rather than a Command. A shape neither recognizes yields no subagent
+ * name and is passed through - the tool's own schema is what rejects malformed
+ * input.
+ *
+ * @param input - Whatever the caller passed to `task.invoke`.
+ * @returns The requested subagent name and the originating tool call, if any.
+ */
+export function readSubagentType(input: unknown): {
+  subagentType?: string;
+  toolCallId?: string;
+} {
+  if (!isRecord(input)) {
+    return {};
+  }
+  const fromToolNode = input.type === "tool_call" && isRecord(input.args);
+  const args = fromToolNode ? (input.args as Record<string, unknown>) : input;
+  return {
+    subagentType:
+      typeof args.subagent_type === "string" ? args.subagent_type : undefined,
+    toolCallId:
+      fromToolNode && typeof input.id === "string" ? input.id : undefined,
+  };
+}
+
+/**
+ * Patches one `task` tool in place so general-purpose is neither offered nor
+ * dispatchable.
+ *
+ * In place, and not a clone, for the reason in the module comment: the REPL
+ * bridge and ToolNode both hold this object, and LangChain refuses a
+ * substitution.
+ *
+ * The refusal takes the form each caller can act on, which is not the same
+ * form. A model tool call gets an error ToolMessage: throwing there ends the
+ * run, because ToolNode classifies anything raised under a `wrapToolCall` -
+ * and DeepAgents always installs one - as a middleware error and rethrows it
+ * past `handleToolErrors`, so a bad `subagentType` would discard a wiki instead
+ * of costing a turn. The REPL gets a rejection, because its `task()` returns a
+ * promise into guest code: a refusal string would arrive as though the subagent
+ * had produced it, and be parsed, indexed, or written into a page.
+ *
+ * @param taskTool - The registered subagent task tool.
+ */
+export function applyGeneralPurposeGuard(taskTool: GuardableTaskTool): void {
+  taskTool.description = stripGeneralPurpose(taskTool.description);
+
+  const dispatch = taskTool.invoke.bind(taskTool);
+  taskTool.invoke = async (input: unknown, config?: unknown) => {
+    const { subagentType, toolCallId } = readSubagentType(input);
+    if (subagentType !== GENERAL_PURPOSE) {
+      return dispatch(input, config);
+    }
+    if (toolCallId === undefined) {
+      throw new Error(REFUSAL);
+    }
+    return new ToolMessage({
+      content: REFUSAL,
+      name: taskTool.name,
+      status: "error",
+      tool_call_id: toolCallId,
+    });
+  };
+}
+
+/**
+ * Creates the middleware that applies the guard once per agent.
+ *
+ * `wrapModelCall` is the hook because `request.tools` is the only place the
+ * task tool is exposed - it is contributed by DeepAgents' subagent middleware
+ * and never appears on the agent's own tool list. This is the same source
+ * `@langchain/quickjs` and {@link createOpenWikiAuthoringPoolMiddleware} read
+ * it from.
+ *
+ * A missing task tool throws. The guard's only failure mode worth defending
+ * against is applying to nothing while a run proceeds as though the boundary
+ * held, so it fails at the first model call instead.
+ *
+ * @returns LangChain middleware that disables the general-purpose subagent.
+ */
+export function createOpenWikiGeneralPurposeGuardMiddleware() {
+  let guarded: GuardableTaskTool | null = null;
+
+  return createMiddleware({
+    name: "OpenWikiGeneralPurposeGuardMiddleware",
+    wrapModelCall: (request, handler) => {
+      if (!guarded) {
+        const found = (request.tools ?? []).find(
+          (candidate: { name?: string }) => candidate.name === "task",
+        );
+        if (!found) {
+          throw new Error(
+            "Disabling the general-purpose subagent requires the subagent task tool.",
+          );
+        }
+        guarded = found as unknown as GuardableTaskTool;
+        applyGeneralPurposeGuard(guarded);
+      }
+      return handler(request);
+    },
+  });
+}
+
+/**
+ * Narrows an unknown value to a non-array object record.
+ */
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -59,6 +59,7 @@ import {
   createQaGate,
 } from "./wiki-verification.js";
 import { createOpenWikiCodeInterpreterMiddleware } from "./code-interpreter.js";
+import { createOpenWikiGeneralPurposeGuardMiddleware } from "./general-purpose-guard.js";
 import { createOpenWikiIndexMiddleware } from "./okf-middleware.js";
 import {
   createWikiTranslationMiddleware,
@@ -581,6 +582,13 @@ function createOpenWikiAgentGraph(
             ...(options.command === "init" &&
             options.outputMode === "repository"
               ? [
+                  // Scoped here because this is where the named subagents are:
+                  // an update or a local-wiki run has general-purpose and
+                  // nothing else, and refusing it there would leave `task()`
+                  // with no target rather than a better one. Position in this
+                  // list does not matter - the guard patches the shared task
+                  // tool rather than the request.
+                  createOpenWikiGeneralPurposeGuardMiddleware(),
                   createOpenWikiAuthoringPoolMiddleware(
                     planStore,
                     () => planReadiness(planStore, wikiBackend),

--- a/src/agent/page-author.ts
+++ b/src/agent/page-author.ts
@@ -51,6 +51,21 @@ const PAGE_AUTHOR_DESCRIPTION = [
   "Dispatch concurrently through author_pages, one page per task. It establishes its claims and then writes its page, and returns a short plain-text note rather than JSON: how many claims a page established comes from the claim store.",
 ].join(" ");
 
+/**
+ * Batching is a hard constraint rather than a preference.
+ *
+ * An author's cost is not the evidence it reads, it is that evidence resent once
+ * per turn: the transcript carries every prior result forward, so turn count
+ * multiplies the whole accumulated context. A page gathered one call per turn and
+ * the same page gathered several calls per turn read identical files and produce
+ * identical claims, at several times the tokens and several times the wall clock
+ * for the serial one - and the wall clock is what puts a slow author, and the
+ * pages behind it in the pool, past the run's budget.
+ *
+ * The assignment is what makes this available. It names the evidence paths,
+ * symbols and tests up front, so the first wave of reads is knowable before any
+ * of them return; only the follow-up reads are genuinely sequential.
+ */
 const PAGE_AUTHOR_SYSTEM_PROMPT = `You author exactly one wiki page and report what you established.
 
 Your assignment names one canonical page path, its inventory unit, the evidence paths and symbols to inspect, its focused tests, and its relationship edges. Write that page and nothing else.
@@ -60,6 +75,7 @@ Hard constraints:
 - Do not read /openwiki/_plan.md or any other wiki page. Your assignment is complete by construction: if something you need is missing from it, say so in your report rather than going to look for it. Your neighbours' pages are being written while you work, so what you would read is half-finished.
 - Read repository source and tests as evidence, starting from the paths and symbols your assignment names. Never document a secret, credential, token, or .env value.
 - Prefer grep and targeted reads over reading a large file whole.
+- Issue every independent search and read in the same turn. Your assignment names its evidence up front, so most of what you have to inspect does not depend on what you find: put those greps, globs, ls calls and reads in one turn together rather than one per turn, and spend a following turn only on the reads a previous result actually determined. Everything you have read so far is resent on every turn you take, so the same evidence gathered one call at a time costs several times what it costs gathered in parallel.
 - Do not invent files, modules, APIs, or behavior. Every material proposition must be supported by source or tests you inspected.
 
 Establish the claims first, then write the page from them:

--- a/src/claims/brains/code/tools.ts
+++ b/src/claims/brains/code/tools.ts
@@ -105,7 +105,7 @@ export const InspectClaimsInputSchema = z
  */
 export const RESOLVE_CLAIMS_DESCRIPTION = `${CLAIMS_SUBSTANCE_GUIDANCE}
 
-Maintain those Claims for one or more wiki pages in one call. Put every affected page in pages: a whole authoring or repair phase is one call, and calling this once per page in a loop is always wrong. Each page's operations apply atomically and each page succeeds or fails on its own - successful pages come back under pages, failures under failed with their own error - so retry only the failures and never replay a page that already succeeded. Keep each statement concise, not an excerpt, list, compound summary, or paragraph. Use confirm when a claim remains true, update to change its statement or evidence, retract when it is obsolete, and add for a new material fact. For an update, call this tool before writing the corresponding new or materially changed factual prose; scope an existing page to facts changed by the update rather than backfilling untouched prose. Style- or navigation-only edits need no Claims call. Claims currently support repository evidence only; do not invent repository evidence for connector-derived facts, and leave LangSmith-only facts unclaimed. Cite bounded language-agnostic line ranges as repo://path#L10-L24. Use repo://path only when the whole file is the evidence.`;
+Maintain those Claims for one or more wiki pages in one call. Put every affected page in pages: a whole authoring or repair phase is one call, and calling this once per page in a loop is always wrong. Each page's operations apply atomically and each page succeeds or fails on its own - successful pages come back under pages, failures under failed with their own error - so retry only the failures and never replay a page that already succeeded. Keep each statement concise, not an excerpt, list, compound summary, or paragraph. Use confirm when a claim remains true, update to change its statement or evidence, retract when it is obsolete, and add for a new material fact. An update must carry at least one of statement or evidence. For an update, call this tool before writing the corresponding new or materially changed factual prose; scope an existing page to facts changed by the update rather than backfilling untouched prose. Style- or navigation-only edits need no Claims call. Claims currently support repository evidence only; do not invent repository evidence for connector-derived facts, and leave LangSmith-only facts unclaimed. Cite bounded language-agnostic line ranges as repo://path#L10-L24. Use repo://path only when the whole file is the evidence.`;
 
 /**
  * Shared model guidance for Claims inspection tools across agent transports.
@@ -194,10 +194,14 @@ export function createClaimsTools(
                           evidence: evidenceArraySchema(),
                         },
                         required: ["op", "id"],
-                        anyOf: [
-                          { required: ["statement"] },
-                          { required: ["evidence"] },
-                        ],
+                        // "at least one of statement or evidence" is stated in the
+                        // description and enforced by ClaimOperationSchema rather than
+                        // expressed here as an anyOf of required-only branches. That is
+                        // valid JSON Schema, but a provider is free to reject a keyword
+                        // combination it does not implement, and one that refuses the
+                        // branches rejects the whole tool on the first call - so the
+                        // constraint would cost every Claims tool rather than guard one
+                        // field. The refine still rejects an update carrying neither.
                         additionalProperties: false,
                       },
                       {

--- a/test/agent/claims-agent-integration.test.ts
+++ b/test/agent/claims-agent-integration.test.ts
@@ -133,9 +133,21 @@ describe("Claims agent graph integration", () => {
         expect(pool.tools.map((pooled) => pooled.name)).toEqual([
           "author_pages",
         ]);
+        // DeepAgents adds general-purpose unless a harness profile disables it,
+        // and profiles resolve off the model instance for only some providers.
+        // Nothing fails when the guard is missing - the run simply regains a
+        // subagent that authors without a brief or claims - so assert it here.
+        expect(middlewareNames).toContain(
+          "OpenWikiGeneralPurposeGuardMiddleware",
+        );
       } else {
         expect(middlewareNames).not.toContain(
           "OpenWikiAuthoringPoolMiddleware",
+        );
+        // An update has no named subagents at all, so refusing general-purpose
+        // would leave `task()` with no target rather than a better one.
+        expect(middlewareNames).not.toContain(
+          "OpenWikiGeneralPurposeGuardMiddleware",
         );
       }
       expect(

--- a/test/agent/general-purpose-guard.test.ts
+++ b/test/agent/general-purpose-guard.test.ts
@@ -1,0 +1,241 @@
+import { AIMessage, HumanMessage, ToolMessage } from "@langchain/core/messages";
+import { BaseChatModel } from "@langchain/core/language_models/chat_models";
+import type { ChatResult } from "@langchain/core/outputs";
+import type { StructuredToolInterface } from "@langchain/core/tools";
+import { createDeepAgent } from "deepagents";
+import { describe, expect, test } from "vitest";
+import {
+  applyGeneralPurposeGuard,
+  createOpenWikiGeneralPurposeGuardMiddleware,
+  readSubagentType,
+  stripGeneralPurpose,
+  type GuardableTaskTool,
+} from "../../src/agent/general-purpose-guard.ts";
+
+/** The task tool description DeepAgents renders, abridged to the lines that matter. */
+const TASK_DESCRIPTION = [
+  "Launch an ephemeral subagent to handle a complex, multi-step task.",
+  "",
+  "Available agent types and the tools they have access to:",
+  "- general-purpose: General-purpose agent for researching complex questions.",
+  "- page-author: Writes one assigned wiki page.",
+  "",
+  "Specify subagent_type to select the agent. Usage notes:",
+  "- Each invocation is stateless.",
+  "- When only general-purpose is available, use it for any complex task.",
+].join("\n");
+
+/** A stand-in task tool that records what reached the real dispatch. */
+function stubTaskTool(): GuardableTaskTool & { dispatched: unknown[] } {
+  const dispatched: unknown[] = [];
+  return {
+    dispatched,
+    name: "task",
+    description: TASK_DESCRIPTION,
+    invoke: (input: unknown) => {
+      dispatched.push(input);
+      return Promise.resolve("dispatched");
+    },
+  };
+}
+
+/**
+ * A chat model that replays a fixed script, so one turn can call a tool and the
+ * next can end the run. The fakes in `@langchain/core` cannot: their `_generate`
+ * always returns the first response, which turns a tool call into a loop.
+ */
+class ScriptedChatModel extends BaseChatModel {
+  /** Tools from the most recent bind, as the agent assembled them. */
+  bound: StructuredToolInterface[] = [];
+
+  #turn = 0;
+
+  constructor(private readonly script: AIMessage[]) {
+    super({});
+  }
+
+  _llmType(): string {
+    return "scripted";
+  }
+
+  _combineLLMOutput() {
+    return [];
+  }
+
+  bindTools(tools: StructuredToolInterface[]): this {
+    this.bound = tools;
+    return this;
+  }
+
+  _generate(): Promise<ChatResult> {
+    const message = this.script[Math.min(this.#turn++, this.script.length - 1)];
+    return Promise.resolve({ generations: [{ message, text: "" }] });
+  }
+}
+
+/** A ToolMessage's text, whether it was stored as a string or content blocks. */
+function contentText(message: ToolMessage | undefined): string {
+  const content = message?.content;
+  if (typeof content === "string") return content;
+  return (content ?? [])
+    .map((block) =>
+      typeof block === "object" && "text" in block ? block.text : "",
+    )
+    .join("");
+}
+
+/** Every ToolMessage the run produced, in order. */
+function toolMessages(result: unknown): ToolMessage[] {
+  const messages = (result as { messages?: unknown[] }).messages ?? [];
+  return messages.filter((message): message is ToolMessage =>
+    ToolMessage.isInstance(message),
+  );
+}
+
+describe("general-purpose subagent guard", () => {
+  test("strips general-purpose from the roster and the usage notes", () => {
+    const stripped = stripGeneralPurpose(TASK_DESCRIPTION);
+
+    expect(stripped).not.toContain("general-purpose");
+    expect(stripped).toContain("- page-author: Writes one assigned wiki page.");
+    expect(stripped).toContain("Available agent types");
+    expect(stripped).toContain("- Each invocation is stateless.");
+  });
+
+  test("reads the subagent name and caller from both call shapes", () => {
+    // ToolNode invokes with the tool call; the REPL bridge with the arguments.
+    expect(
+      readSubagentType({
+        name: "task",
+        args: { description: "d", subagent_type: "page-author" },
+        id: "call-1",
+        type: "tool_call",
+      }),
+    ).toEqual({ subagentType: "page-author", toolCallId: "call-1" });
+    expect(
+      readSubagentType({ description: "d", subagent_type: "page-author" }),
+    ).toEqual({ subagentType: "page-author", toolCallId: undefined });
+    expect(readSubagentType({ description: "d" })).toEqual({
+      subagentType: undefined,
+      toolCallId: undefined,
+    });
+    expect(readSubagentType("task")).toEqual({});
+  });
+
+  test("rejects a REPL dispatch of general-purpose rather than answering it", async () => {
+    const taskTool = stubTaskTool();
+    applyGeneralPurposeGuard(taskTool);
+
+    // `@langchain/quickjs` invokes with the arguments directly and hands the
+    // result to guest code, so a refusal has to reject: returned as a value it
+    // would read as the subagent's own output.
+    await expect(
+      taskTool.invoke({
+        description: "explore",
+        subagent_type: "general-purpose",
+      }),
+    ).rejects.toThrow(/"general-purpose" subagent is not available/u);
+    expect(taskTool.dispatched).toEqual([]);
+  });
+
+  test("answers a model tool call with an error message rather than throwing", async () => {
+    const taskTool = stubTaskTool();
+    applyGeneralPurposeGuard(taskTool);
+
+    // Throwing here would end the run: ToolNode rethrows anything raised under
+    // a wrapToolCall, which DeepAgents always installs.
+    const refusal = (await taskTool.invoke({
+      name: "task",
+      args: { description: "explore", subagent_type: "general-purpose" },
+      id: "call-1",
+      type: "tool_call",
+    })) as ToolMessage;
+
+    expect(ToolMessage.isInstance(refusal)).toBe(true);
+    expect(refusal.status).toBe("error");
+    expect(refusal.tool_call_id).toBe("call-1");
+    expect(contentText(refusal)).toContain(
+      '"general-purpose" subagent is not available',
+    );
+    expect(taskTool.dispatched).toEqual([]);
+  });
+
+  test("passes every other subagent through untouched", async () => {
+    const taskTool = stubTaskTool();
+    applyGeneralPurposeGuard(taskTool);
+
+    await expect(
+      taskTool.invoke({ description: "write", subagent_type: "page-author" }),
+    ).resolves.toBe("dispatched");
+    await expect(
+      taskTool.invoke({
+        name: "task",
+        args: { description: "write", subagent_type: "page-author" },
+        id: "call-1",
+        type: "tool_call",
+      }),
+    ).resolves.toBe("dispatched");
+    expect(taskTool.dispatched).toHaveLength(2);
+  });
+
+  test("guards the registered task tool of a real agent", async () => {
+    const model = new ScriptedChatModel([
+      new AIMessage({
+        content: "",
+        tool_calls: [
+          {
+            id: "call-1",
+            name: "task",
+            args: {
+              description: "explore the repo",
+              subagent_type: "general-purpose",
+            },
+          },
+        ],
+      }),
+      new AIMessage({ content: "done" }),
+    ]);
+    const agent = createDeepAgent({
+      model,
+      middleware: [createOpenWikiGeneralPurposeGuardMiddleware()],
+      subagents: [
+        {
+          name: "page-author",
+          description: "Writes one assigned wiki page.",
+          systemPrompt: "Write the page.",
+        },
+      ],
+    });
+
+    const result = await agent.invoke({ messages: [new HumanMessage("go")] });
+
+    // The model never sees it offered: the guard rewrote the description of the
+    // same instance the agent binds.
+    const boundTask = model.bound.find((tool) => tool.name === "task");
+    expect(boundTask?.description).toBeDefined();
+    expect(boundTask?.description).not.toContain("general-purpose");
+    expect(boundTask?.description).toContain("page-author");
+
+    // And the instance ToolNode executes is the guarded one, which is the whole
+    // reason the patch is applied in place rather than to a copy.
+    const refusal = toolMessages(result).find(
+      (message) => message.name === "task",
+    );
+    expect(refusal?.status).toBe("error");
+    expect(contentText(refusal)).toContain(
+      '"general-purpose" subagent is not available',
+    );
+  });
+
+  test("fails loudly when the task tool is absent", () => {
+    const middleware = createOpenWikiGeneralPurposeGuardMiddleware();
+    const wrapModelCall = middleware.wrapModelCall as (
+      request: unknown,
+      handler: (request: unknown) => unknown,
+    ) => unknown;
+
+    expect(() =>
+      wrapModelCall({ tools: [{ name: "read_file" }] }, (request) => request),
+    ).toThrow(/requires the subagent task tool/u);
+  });
+});


### PR DESCRIPTION
A repository init has a named subagent for every fan-out it wants. DeepAgents' auto-added `general-purpose` is none of them: it inherits the main agent's whole tool set — connector tools, Claims tools, and a filesystem middleware carrying the agent's own write permissions — behind a prompt that says only "research complex questions". That makes it the one dispatch target that can author a page with no brief, no edges, and none of the claim discipline every other authoring path enforces.

DeepAgents can drop it at construction, but only through a harness profile, and profiles resolve off the model instance via `getModelProvider` — which recognizes `ChatAnthropic`, `ChatOpenAI` and `ChatGoogleGenerativeAI` and nothing else. Against deepagents 1.12.0 that leaves it reachable for `gemini`, `openrouter` and `bedrock` while removing it for `anthropic` and the ChatOpenAI-backed providers, so the boundary would hold or not depending on `--provider`.

So `OpenWikiGeneralPurposeGuardMiddleware` enforces it on the `task` tool itself, patched in place because that instance is the one object both callers share — the REPL's `task()` global resolves the tool out of `request.tools` and invokes it directly, no `wrapToolCall` runs there, and LangChain rejects substituting a wrapper to keep ToolNode's execution identity. Middleware order is therefore irrelevant.

The refusal differs per caller. A model tool call gets an error `ToolMessage`: throwing ends the run, since ToolNode rethrows anything raised under a `wrapToolCall` past `handleToolErrors`, and a bad `subagentType` should cost a turn rather than a finished wiki. The REPL gets a rejection, because its `task()` returns a promise into guest code where a refusal string would read as the subagent's own output.

Scoped to repository init, which is where the named subagents are — an update or local-wiki run has `general-purpose` and nothing else, so refusing it there would leave `task()` with no target rather than a better one.

## Testing

`test/agent/general-purpose-guard.test.ts` covers the description rewrite, both call shapes, and both refusal forms, plus an end-to-end pass over a real `createDeepAgent` proving the guarded instance is the one bound to the model and executed by ToolNode. `test/agent/claims-agent-integration.test.ts` asserts the registration per command, since a missing guard fails silently. Full agent suite green (548 tests), both typechecks, lint, prettier.