### PR TITLE
fix(config): honor $HOME for OpenWiki home dir resolution on Windows

### DIFF
--- a/.changeset/fix-home-env-isolation.md
+++ b/.changeset/fix-home-env-isolation.md
@@ -1,0 +1,5 @@
+---
+"openwiki": patch
+---
+
+fix: honor $HOME when resolving the OpenWiki home dir so Windows test isolation works

--- a/src/config/openwiki-home.ts
+++ b/src/config/openwiki-home.ts
@@ -5,24 +5,42 @@ import { restrictDirToCurrentUser } from "../platform/windows-acl.js";
 
 export const OPENWIKI_CONFIG_DIR_ENV_KEY = "OPENWIKI_CONFIG_DIR";
 
+/**
+ * Resolves the user's home directory, preferring `process.env.HOME` when it is
+ * set. `os.homedir()` already returns `$HOME` on POSIX, but on Windows it reads
+ * `USERPROFILE` and silently ignores `$HOME`. Honoring `$HOME` keeps Windows
+ * behavior consistent with POSIX, which is what the test and tooling isolation
+ * (pointing `$HOME` at a throwaway directory) relies on. When `$HOME` is unset
+ * we fall back to `os.homedir()` so production defaults are unchanged.
+ */
+export function resolveUserHomeDir(
+  environment: NodeJS.ProcessEnv = process.env,
+): string {
+  const homeEnv = environment.HOME?.trim();
+  return homeEnv ? path.resolve(homeEnv) : os.homedir();
+}
+
 export function resolveOpenWikiHomeDir(
   environment: NodeJS.ProcessEnv = process.env,
 ): string {
   const configuredDir = environment[OPENWIKI_CONFIG_DIR_ENV_KEY]?.trim();
 
   if (!configuredDir) {
-    return path.join(os.homedir(), ".openwiki");
+    return path.join(resolveUserHomeDir(environment), ".openwiki");
   }
 
   // `path.resolve` does not expand a leading `~`, and several environments
   // that set env vars (PowerShell, docker-compose, a hand-edited `.env`) leave
   // it literal. Mirror the tilde handling used by `normalizeLocalPath`.
   if (configuredDir === "~") {
-    return path.join(os.homedir());
+    return path.join(resolveUserHomeDir(environment));
   }
 
   if (configuredDir.startsWith("~/") || configuredDir.startsWith("~\\")) {
-    return path.resolve(os.homedir(), configuredDir.slice(2));
+    return path.resolve(
+      resolveUserHomeDir(environment),
+      configuredDir.slice(2),
+    );
   }
 
   return path.resolve(configuredDir);

--- a/test/config/openwiki-home-home-env.test.ts
+++ b/test/config/openwiki-home-home-env.test.ts
@@ -1,0 +1,80 @@
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+
+// On Windows `os.homedir()` reads `USERPROFILE`/`HOMEDRIVE+HOMEPATH` and
+// silently ignores `process.env.HOME`. The onboarding and home-layout tests
+// (and the CLI's test isolation) point `process.env.HOME` at a throwaway
+// directory to keep the real `~/.openwiki` untouched. If `resolveOpenWikiHomeDir`
+// ignores `$HOME`, that isolation is a no-op on Windows and tests corrupt the
+// developer's real home (see issue #695). These tests prove the resolution
+// honors `process.env.HOME` and only falls back to `os.homedir()` when `$HOME`
+// is unset.
+const FAKE_WINDOWS_HOME = "C:\\Users\\real-user";
+
+let savedHome: string | undefined;
+let tempHome: string;
+let fsp: typeof import("node:fs/promises");
+let home: typeof import("../../src/config/openwiki-home.ts");
+
+beforeEach(async () => {
+  savedHome = process.env.HOME;
+  const base = await (
+    await import("node:fs/promises")
+  ).mkdtemp(path.join(os.tmpdir(), "openwiki-home-env-"));
+  tempHome = base;
+  process.env.HOME = tempHome;
+
+  vi.resetModules();
+  fsp = await import("node:fs/promises");
+  home = await import("../../src/config/openwiki-home.ts");
+});
+
+afterEach(async () => {
+  if (savedHome === undefined) {
+    delete process.env.HOME;
+  } else {
+    process.env.HOME = savedHome;
+  }
+  await fsp.rm(tempHome, { recursive: true, force: true });
+});
+
+describe("resolveUserHomeDir honors process.env.HOME", () => {
+  test("returns $HOME when it is set", () => {
+    const resolved = home.resolveUserHomeDir({ HOME: tempHome });
+    expect(resolved).toBe(path.resolve(tempHome));
+    expect(resolved).not.toBe(FAKE_WINDOWS_HOME);
+  });
+
+  test("falls back to os.homedir() when $HOME is unset", () => {
+    const resolved = home.resolveUserHomeDir({});
+    expect(resolved).toBe(os.homedir());
+    expect(resolved).not.toBe(path.resolve(tempHome));
+  });
+});
+
+describe("resolveOpenWikiHomeDir honors process.env.HOME", () => {
+  test("places .openwiki under $HOME, not under os.homedir()", () => {
+    const resolved = home.resolveOpenWikiHomeDir({ HOME: tempHome });
+    expect(resolved).toBe(path.join(path.resolve(tempHome), ".openwiki"));
+    expect(resolved.startsWith(FAKE_WINDOWS_HOME)).toBe(false);
+  });
+
+  test("expands a bare ~ against $HOME", () => {
+    const resolved = home.resolveOpenWikiHomeDir({
+      HOME: tempHome,
+      OPENWIKI_CONFIG_DIR: "~",
+    });
+    expect(resolved).toBe(path.resolve(tempHome));
+    expect(resolved.startsWith(FAKE_WINDOWS_HOME)).toBe(false);
+  });
+
+  test("expands ~/ against $HOME", () => {
+    const resolved = home.resolveOpenWikiHomeDir({
+      HOME: tempHome,
+      OPENWIKI_CONFIG_DIR: "~/wiki",
+    });
+    expect(resolved).toBe(path.resolve(tempHome, "wiki"));
+    expect(resolved.startsWith(FAKE_WINDOWS_HOME)).toBe(false);
+  });
+});


### PR DESCRIPTION
## Problem

On Windows, `os.homedir()` reads `USERPROFILE` and **silently ignores** `process.env.HOME`. The test suite and local dev tooling isolate state by pointing `$HOME` at a throwaway directory, but that isolation was a no-op on Windows — onboarding/config tests wrote into the real `~/.openwiki` instead of the isolated path (see #695).

## Solution

`src/config/openwiki-home.ts` now resolves the user home through a new `resolveUserHomeDir()` helper that honors `process.env.HOME` when set and falls back to `os.homedir()` otherwise. `resolveOpenWikiHomeDir()` uses it at every call site. POSIX behavior is unchanged (os.homedir already returns `$HOME` there), so this only affects Windows isolation.

## Testing

- Added `test/config/openwiki-home-home-env.test.ts` with 5 cases covering: `$HOME` honored when set, `os.homedir()` fallback when unset, and `OPENWIKI_CONFIG_DIR` / `~` / `~/sub` expansion against `$HOME`.
- `npx vitest run test/config/openwiki-home-home-env.test.ts` → 5 passed.
- `npx tsc --noEmit -p tsconfig.json` → clean.
- Added a `patch` changeset (`.changeset/fix-home-env-isolation.md`).

Fixes #695