### PR TITLE
fix(cli): preserve zero-based ordered list markers

### DIFF
--- a/.changeset/zero-lists-order.md
+++ b/.changeset/zero-lists-order.md
@@ -1,0 +1,5 @@
+---
+"openwiki": patch
+---
+
+fix: preserve zero-based ordered list markers in terminal Markdown output

--- a/src/cli/components/markdown.tsx
+++ b/src/cli/components/markdown.tsx
@@ -67,7 +67,7 @@ export function MarkdownBlock({
           <Text key={`${index}-${itemIndex}`} wrap="wrap">
             <Text color="gray">
               {(token as Tokens.List).ordered
-                ? `${Number((token as Tokens.List).start || 1) + itemIndex}. `
+                ? `${Number((token as Tokens.List).start ?? 1) + itemIndex}. `
                 : "- "}
             </Text>
             <InlineMarkdown tokens={getTokenChildren(item)} />

--- a/test/cli/components/markdown.test.tsx
+++ b/test/cli/components/markdown.test.tsx
@@ -42,6 +42,16 @@ describe("MarkdownText", () => {
     expect(frame).toContain("2. second");
   });
 
+  test("preserves an ordered list that starts at zero", () => {
+    const { lastFrame } = render(
+      <MarkdownText markdown={"0. first\n1. second"} />,
+    );
+
+    const frame = plain(lastFrame());
+    expect(frame).toContain("0. first");
+    expect(frame).toContain("1. second");
+  });
+
   test("strips raw HTML tags so no markup reaches the terminal", () => {
     const { lastFrame } = render(
       <MarkdownText markdown={"before <script>alert(1)</script> after"} />,


### PR DESCRIPTION
## Summary

- preserve the explicit `0` start value emitted by `marked` for zero-based ordered lists
- add a focused terminal-rendering regression test
- include a patch changeset for the CLI behavior fix

## Reproduction

Before this change, rendering `0. first\n1. second` produced `1. first\n2. second` because the renderer used a truthy fallback for the list start value.

## Testing

- `pnpm exec vitest run test/cli/components/markdown.test.tsx` (18 passed)
- `pnpm exec eslint src/cli/components/markdown.tsx test/cli/components/markdown.test.tsx`
- `pnpm exec prettier --check src/cli/components/markdown.tsx test/cli/components/markdown.test.tsx .changeset/zero-lists-order.md`
- `git diff --check`
