### PR TITLE
fix(cli): preserve sibling home paths in labels

### DIFF
--- a/.changeset/clean-paths-appear.md
+++ b/.changeset/clean-paths-appear.md
@@ -1,0 +1,5 @@
+---
+"openwiki": patch
+---
+
+Keep CLI working-directory labels unchanged for paths that only share the home directory prefix.

--- a/src/cli/format.ts
+++ b/src/cli/format.ts
@@ -1,3 +1,5 @@
+import path from "node:path";
+
 import {
   getDefaultModelId,
   OPENWIKI_MODEL_ID_ENV_KEY,
@@ -32,8 +34,20 @@ export function formatCount(
 export function formatCwd(cwd: string): string {
   const home = process.env.HOME;
 
-  if (home && cwd.startsWith(home)) {
-    return `~${cwd.slice(home.length)}`;
+  if (home) {
+    const relative = path.relative(home, cwd);
+
+    if (relative === "") {
+      return "~";
+    }
+
+    if (
+      relative !== ".." &&
+      !relative.startsWith(`..${path.sep}`) &&
+      !path.isAbsolute(relative)
+    ) {
+      return `~${path.sep}${relative}`;
+    }
   }
 
   return cwd;

--- a/test/cli/format.test.ts
+++ b/test/cli/format.test.ts
@@ -46,6 +46,7 @@ describe("formatCwd", () => {
   test("abbreviates a path under the home directory", () => {
     process.env.HOME = "/Users/example";
 
+    expect(formatCwd("/Users/example")).toBe("~");
     expect(formatCwd("/Users/example/dev/openwiki")).toBe("~/dev/openwiki");
   });
 
@@ -53,6 +54,14 @@ describe("formatCwd", () => {
     process.env.HOME = "/Users/example";
 
     expect(formatCwd("/var/log")).toBe("/var/log");
+  });
+
+  test("leaves sibling paths sharing the home prefix unchanged", () => {
+    process.env.HOME = "/Users/example";
+
+    expect(formatCwd("/Users/example-backup/openwiki")).toBe(
+      "/Users/example-backup/openwiki",
+    );
   });
 
   test("returns the path unchanged when HOME is unset", () => {


### PR DESCRIPTION
## Summary

- treat the configured home directory as a path boundary instead of a string prefix when formatting the CLI working-directory label
- keep sibling paths such as `/Users/example-backup` unchanged when `HOME=/Users/example`
- preserve the existing `~` and `~/...` output for the home directory and its descendants
- add a patch changeset

## Why

`formatCwd` currently checks `cwd.startsWith(HOME)`. A path that merely shares the same text prefix is therefore displayed as if it were inside the home directory; for example, `/Users/example-backup/openwiki` becomes `~-backup/openwiki`.

Using `path.relative` distinguishes real descendants from siblings and also handles platform-specific separators and cross-drive paths.

## Testing

- `pnpm exec vitest run test/cli/format.test.ts` — 10 passed
- `pnpm exec prettier --check src/cli/format.ts test/cli/format.test.ts .changeset/clean-paths-appear.md`
- `pnpm exec eslint src/cli/format.ts test/cli/format.test.ts`
- `pnpm run typecheck`
- `git diff --check`

No dedicated issue; this is a small, self-contained display bug found during a focused CLI audit.

AI-assisted tooling was used during investigation and implementation. I reviewed the final diff and ran the validation listed above.
