### PR TITLE
docs: correct the built cli entrypoint path in DEVELOPMENT.md

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -42,12 +42,12 @@ openwiki "Please focus on API documentation"
 ```
 
 The target repo is still the current working directory. The global link only
-avoids typing the path to `dist/cli.js`.
+avoids typing the path to `dist/cli/cli.js`.
 
 If you do not want to configure pnpm globals, use a shell alias instead:
 
 ```sh
-alias openwiki='node /path/to/openwiki/dist/cli.js'
+alias openwiki='node /path/to/openwiki/dist/cli/cli.js'
 ```
 
 That alias can go in `~/.zshrc` if you want it to persist.
@@ -58,7 +58,7 @@ After changing OpenWiki source code, rebuild from this package directory:
 pnpm run build
 ```
 
-The existing global link will keep using the rebuilt `dist/cli.js`.
+The existing global link will keep using the rebuilt `dist/cli/cli.js`.
 
 Real runs can write:
 


### PR DESCRIPTION
## What changed

`DEVELOPMENT.md` pointed local development at `dist/cli.js`, but the build emits
the CLI at `dist/cli/cli.js`. This corrects the three references in the
"Run Against Another Local Repo" section.

## Why

The documented shell alias is copy-pasted verbatim, and with the old path it
fails immediately:

```sh
alias openwiki='node /path/to/openwiki/dist/cli.js'
# Error: Cannot find module '/path/to/openwiki/dist/cli.js'
```

`dist/cli.js` has never existed for this layout. `tsconfig.json` compiles
`rootDir: "src"` into `outDir: "dist"`, so `src/cli/cli.tsx` lands at
`dist/cli/cli.js` — which is exactly what the package itself references:

- `package.json` → `"bin": { "openwiki": "./dist/cli/cli.js" }`
- `package.json` → `"postbuild": "node -e \"require('fs').chmodSync('dist/cli/cli.js', 0o755)\""`
- `package.json` → `"start": "node dist/cli/cli.js"`
- `CONTRIBUTING.md` already documents `dist/cli/cli.js`

So the alias fallback (for contributors who do not want to configure pnpm
globals) was the only documented path that did not work.

## Testing

Docs-only change, verified against a real build:

```sh
pnpm run build
ls dist/cli/cli.js   # -rwxr-xr-x ... dist/cli/cli.js
ls dist/cli.js       # No such file or directory
```

`prettier --check` passes on the changed file.

No changeset: `DEVELOPMENT.md` is not part of the published package
(`package.json` `files` ships `dist`, `integrations`, `skills`, `README.md`,
`LICENSE`), so this has no user-visible effect on the `openwiki` package.

Scope is a single concern per `CONTRIBUTING.md` — only the entrypoint path is
touched, with no unrelated edits bundled in.
