### PR TITLE
fix: prevent corruption when agent files share a target

### DIFF
--- a/.changeset/calm-files-share.md
+++ b/.changeset/calm-files-share.md
@@ -1,0 +1,5 @@
+---
+"openwiki": patch
+---
+
+Prevent code-mode setup from corrupting agent instructions when managed paths resolve to the same file.

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -146,7 +146,11 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Run Windows portability tests
-        run: pnpm exec vitest run test/agent/skills.test.ts test/config/env-behavior.test.ts test/agent/repository-source-fingerprint.test.ts
+        run: >-
+          pnpm exec vitest run test/agent/skills.test.ts
+          test/config/env-behavior.test.ts
+          test/agent/repository-source-fingerprint.test.ts
+          test/ingestion/code-mode.test.ts
 
   audit:
     name: Audit

--- a/src/ingestion/code-mode.ts
+++ b/src/ingestion/code-mode.ts
@@ -1,4 +1,11 @@
-import { mkdir, readFile, stat, writeFile } from "node:fs/promises";
+import {
+  lstat,
+  mkdir,
+  readFile,
+  readlink,
+  realpath,
+  writeFile,
+} from "node:fs/promises";
 import path from "node:path";
 import {
   getProviderAuthMethod,
@@ -191,27 +198,39 @@ async function readLastUpdatedAt(
 
 async function writeCodeModeAgentSnippets(cwd: string): Promise<void> {
   const agentsSnippet = createCodeModeAgentsSnippet();
-  // Some repositories make CLAUDE.md a link to AGENTS.md. There the import
-  // would point the file at itself, so the block carries the instructions
-  // instead of referring to them.
-  const claudeSnippet = (await resolvesToSameFile(
-    path.join(cwd, "AGENTS.md"),
-    path.join(cwd, "CLAUDE.md"),
-  ))
-    ? agentsSnippet
-    : createCodeModeClaudeSnippet();
   const snippetByFile: Record<string, string> = {
     "AGENTS.md": agentsSnippet,
-    "CLAUDE.md": claudeSnippet,
+    "CLAUDE.md": createCodeModeClaudeSnippet(),
   };
-  // Prepare and validate both files before writing either one. If one file has
-  // malformed markers, setup fails without partially refreshing its sibling.
+  const targets = await Promise.all(
+    CODE_MODE_AGENT_FILES.map(async (fileName) => {
+      const agentsPath = path.join(cwd, fileName);
+      return {
+        agentsPath,
+        fileIdentity: await resolveCodeModeAgentFileIdentity(agentsPath),
+        snippet: snippetByFile[fileName] ?? agentsSnippet,
+      };
+    }),
+  );
+
+  // AGENTS.md comes first intentionally. When another managed path resolves to
+  // the same file, the shared target receives the full instructions once rather
+  // than an import that would point back to itself.
+  const seenFileIdentities = new Set<string>();
+  const uniqueTargets = targets.filter(({ fileIdentity }) => {
+    if (seenFileIdentities.has(fileIdentity)) {
+      return false;
+    }
+    seenFileIdentities.add(fileIdentity);
+    return true;
+  });
+
+  // Prepare and validate every distinct file before writing any of them. If one
+  // file has malformed markers, setup fails without partially refreshing its
+  // sibling.
   const updates = await Promise.all(
-    CODE_MODE_AGENT_FILES.map((fileName) =>
-      prepareCodeModeAgentSnippet(
-        path.join(cwd, fileName),
-        snippetByFile[fileName] ?? agentsSnippet,
-      ),
+    uniqueTargets.map(({ agentsPath, snippet }) =>
+      prepareCodeModeAgentSnippet(agentsPath, snippet),
     ),
   );
 
@@ -222,6 +241,57 @@ async function writeCodeModeAgentSnippets(cwd: string): Promise<void> {
         : writeFile(agentsPath, nextContent, "utf8"),
     ),
   );
+}
+
+/**
+ * Resolve the physical identity of a managed agent file, including a symbolic
+ * link whose final target has not been created yet.
+ */
+async function resolveCodeModeAgentFileIdentity(
+  agentsPath: string,
+  visitedPaths = new Set<string>(),
+): Promise<string> {
+  const absolutePath = path.resolve(agentsPath);
+
+  try {
+    const fileStats = await lstat(absolutePath, { bigint: true });
+    if (fileStats.isSymbolicLink()) {
+      if (visitedPaths.has(absolutePath)) {
+        throw new Error(
+          `Cannot update ${path.basename(agentsPath)} because its symbolic link chain contains a cycle.`,
+        );
+      }
+      visitedPaths.add(absolutePath);
+      const target = await readlink(absolutePath);
+      return resolveCodeModeAgentFileIdentity(
+        path.resolve(path.dirname(absolutePath), target),
+        visitedPaths,
+      );
+    }
+
+    // Device and inode identify regular paths and hard links. Some filesystems
+    // report no useful inode, so use the canonical path as a safe fallback.
+    return fileStats.ino === 0n
+      ? `path:${await realpath(absolutePath)}`
+      : `inode:${fileStats.dev}:${fileStats.ino}`;
+  } catch (error) {
+    if (!isFileNotFoundError(error)) {
+      throw error;
+    }
+
+    // A missing target has no inode yet. Its canonical parent still lets a
+    // dangling link and the path it names share one stable identity.
+    let canonicalParent: string;
+    try {
+      canonicalParent = await realpath(path.dirname(absolutePath));
+    } catch (parentError) {
+      if (!isFileNotFoundError(parentError)) {
+        throw parentError;
+      }
+      canonicalParent = path.resolve(path.dirname(absolutePath));
+    }
+    return `path:${path.join(canonicalParent, path.basename(absolutePath))}`;
+  }
 }
 
 async function prepareCodeModeAgentSnippet(
@@ -454,21 +524,4 @@ function createCodeModeClaudeSnippet(): string {
 @AGENTS.md
 
 ${OPENWIKI_AGENTS_SNIPPET_END}`;
-}
-
-/**
- * Whether two paths are the same file on disk, following symlinks. Inode 0 is
- * treated as unknown because some Windows filesystems report it for every
- * file, which would otherwise make unrelated paths compare equal.
- */
-async function resolvesToSameFile(
-  first: string,
-  second: string,
-): Promise<boolean> {
-  try {
-    const [a, b] = await Promise.all([stat(first), stat(second)]);
-    return a.ino !== 0 && a.ino === b.ino && a.dev === b.dev;
-  } catch {
-    return false;
-  }
 }

--- a/test/ingestion/code-mode.test.ts
+++ b/test/ingestion/code-mode.test.ts
@@ -1,7 +1,10 @@
 import {
+  lstat,
+  link,
   mkdir,
   mkdtemp,
   readFile,
+  readlink,
   rm,
   symlink,
   writeFile,
@@ -170,11 +173,71 @@ describe("ensureCodeModeRepoSetup agent files", () => {
     await symlink("AGENTS.md", path.join(repo, "CLAUDE.md"));
 
     await ensureCodeModeRepoSetup(repo);
+    await ensureCodeModeRepoSetup(repo);
 
-    const content = await readIfPresent(path.join(repo, "CLAUDE.md"));
+    const claudePath = path.join(repo, "CLAUDE.md");
+    const content = await readIfPresent(claudePath);
     // Importing AGENTS.md here would point the file at itself.
     expect(content).not.toContain("@AGENTS.md");
     expect(content).toContain("generated `openwiki/` evidence index");
+    expect(content?.match(new RegExp(SNIPPET_START, "g"))).toHaveLength(1);
+    expect(content?.match(new RegExp(SNIPPET_END, "g"))).toHaveLength(1);
+    expect((await lstat(claudePath)).isSymbolicLink()).toBe(true);
+    expect(await readlink(claudePath)).toBe("AGENTS.md");
+  });
+
+  test("deduplicates a dangling CLAUDE.md link before creating AGENTS.md", async () => {
+    for (let attempt = 0; attempt < 20; attempt += 1) {
+      const repo = await createTempRepo();
+      const agentsPath = path.join(repo, "AGENTS.md");
+      const claudePath = path.join(repo, "CLAUDE.md");
+      await symlink("AGENTS.md", claudePath);
+
+      await ensureCodeModeRepoSetup(repo);
+      await ensureCodeModeRepoSetup(repo);
+
+      const content = await readFile(agentsPath, "utf8");
+      expect(content).toContain("generated `openwiki/` evidence index");
+      expect(content).not.toContain("@AGENTS.md");
+      expect(content.match(new RegExp(SNIPPET_START, "g"))).toHaveLength(1);
+      expect(content.match(new RegExp(SNIPPET_END, "g"))).toHaveLength(1);
+      expect(await readFile(claudePath, "utf8")).toBe(content);
+    }
+  });
+
+  test("writes hard-linked agent files once", async () => {
+    const repo = await createTempRepo();
+    const agentsPath = path.join(repo, "AGENTS.md");
+    const claudePath = path.join(repo, "CLAUDE.md");
+    await writeFile(agentsPath, "# Shared instructions\n", "utf8");
+    await link(agentsPath, claudePath);
+
+    await ensureCodeModeRepoSetup(repo);
+    await ensureCodeModeRepoSetup(repo);
+
+    const content = await readFile(agentsPath, "utf8");
+    expect(await readFile(claudePath, "utf8")).toBe(content);
+    expect(content).toContain("generated `openwiki/` evidence index");
+    expect(content).not.toContain("@AGENTS.md");
+    expect(content.match(new RegExp(SNIPPET_START, "g"))).toHaveLength(1);
+    expect(content.match(new RegExp(SNIPPET_END, "g"))).toHaveLength(1);
+  });
+
+  test("rejects a symbolic link cycle without replacing either link", async () => {
+    const repo = await createTempRepo();
+    const agentsPath = path.join(repo, "AGENTS.md");
+    const claudePath = path.join(repo, "CLAUDE.md");
+    await symlink("CLAUDE.md", agentsPath);
+    await symlink("AGENTS.md", claudePath);
+
+    await expect(ensureCodeModeRepoSetup(repo)).rejects.toThrow(
+      /symbolic link chain contains a cycle/u,
+    );
+
+    expect((await lstat(agentsPath)).isSymbolicLink()).toBe(true);
+    expect((await lstat(claudePath)).isSymbolicLink()).toBe(true);
+    expect(await readlink(agentsPath)).toBe("CLAUDE.md");
+    expect(await readlink(claudePath)).toBe("AGENTS.md");
   });
 
   test("preserves CLAUDE.md when it only imports AGENTS.md", async () => {


### PR DESCRIPTION
Follow-up to #719 after #777. Fixes #725.

The original report was about an existing `CLAUDE.md -> AGENTS.md` link. #777 now detects that case and also makes a distinct `CLAUDE.md` use the correct `@AGENTS.md` import.

There is still one bootstrap path where the two managed names are not recognized as the same target:

```text
CLAUDE.md -> AGENTS.md
AGENTS.md does not exist yet
```

`stat` cannot compare the files in that state. Setup therefore prepares the full `AGENTS.md` block and the shorter `CLAUDE.md` import from the same empty target, then writes both through the two paths concurrently.

This update resolves each managed path to a physical identity before preparing content. It follows symbolic links through a missing final target, uses device and inode for existing files and hard links, and prepares and writes each distinct target once. `AGENTS.md` remains first in the existing ordered list, so a shared target receives the full instructions. Distinct files keep the `@AGENTS.md` behavior from #777.

The same resolution also rejects a symbolic-link cycle without replacing either link. Existing validation still happens for every distinct file before any write.

### Before and after

I reran the dangling-link scenario on current `main` at `cf0700f` with Node 24.20.0 and real temporary files. On 100 fresh repositories, 75 were rejected on the second setup because the first left duplicated or malformed markers. The exact count varies with filesystem timing, which is consistent with the race.

With this update, 100 of 100 repositories completed both setup calls with one ordered marker pair, identical content through both paths and the symlink preserved.

### Tests

The focused suite now covers the dangling first-run case across repeated fresh repositories, the existing symlink behavior from #777, hard links, cycle rejection, distinct files, idempotence and malformed-marker safety. Following @vieko's suggestion, the existing code-mode suite is also included in the Windows portability job.

- Node 22.21.0: 30 focused tests passed
- Node 24.20.0: 30 focused tests passed
- Full suite: 225 files passed and 2 skipped. 3,069 tests passed and 3 skipped
- `pnpm run format:check`, `pnpm run lint:check`, `pnpm exec changeset status` and `git diff --check` passed

I have not reproduced the Windows environment locally. The added Windows CI coverage is intended to verify the same filesystem tests there before merge.

AI assisted with analysis and acted as a copilot.
