### PR TITLE
fix: dedupe managed agent files by resolved path

### DIFF
--- a/.changeset/symlinked-claude-md-managed-block.md
+++ b/.changeset/symlinked-claude-md-managed-block.md
@@ -1,0 +1,5 @@
+---
+"openwiki": patch
+---
+
+fix: stop corrupting the managed block when CLAUDE.md is a symlink to AGENTS.md

--- a/src/ingestion/code-mode.ts
+++ b/src/ingestion/code-mode.ts
@@ -1,4 +1,4 @@
-import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { mkdir, readFile, realpath, writeFile } from "node:fs/promises";
 import path from "node:path";
 import {
   getProviderAuthMethod,
@@ -195,10 +195,12 @@ async function writeCodeModeAgentSnippets(cwd: string): Promise<void> {
     "AGENTS.md": agentsSnippet,
     "CLAUDE.md": claudeSnippet,
   };
+  const targetFiles = await resolveDistinctAgentFiles(cwd);
+
   // Prepare and validate both files before writing either one. If one file has
   // malformed markers, setup fails without partially refreshing its sibling.
   const updates = await Promise.all(
-    CODE_MODE_AGENT_FILES.map((fileName) =>
+    targetFiles.map((fileName) =>
       prepareCodeModeAgentSnippet(
         path.join(cwd, fileName),
         snippetByFile[fileName] ?? agentsSnippet,
@@ -211,6 +213,49 @@ async function writeCodeModeAgentSnippets(cwd: string): Promise<void> {
       writeFile(agentsPath, nextContent, "utf8"),
     ),
   );
+}
+
+/**
+ * The managed agent files to write, with names that resolve to the same file
+ * collapsed to the first one.
+ *
+ * Two entries in {@link CODE_MODE_AGENT_FILES} can name a single file: repos
+ * that keep one canonical guide often symlink `CLAUDE.md` to `AGENTS.md`. Each
+ * entry gets a *different* snippet, and every update is prepared from the
+ * pre-write content before any of them is written, so writing both would race
+ * two payloads onto one inode and leave a mangled block behind. That block then
+ * has duplicated markers, which makes the next run reject the file outright.
+ *
+ * Order is preserved and the first name wins, so `AGENTS.md` keeps the full
+ * snippet and the `CLAUDE.md` pointer is skipped rather than the reverse: the
+ * symlink already gives that host the canonical instructions.
+ *
+ * A name that does not resolve is kept as its own target — it will be created
+ * at exactly that path, so the unresolved path is already its identity.
+ */
+async function resolveDistinctAgentFiles(cwd: string): Promise<string[]> {
+  const distinctFiles: string[] = [];
+  const seenRealPaths = new Set<string>();
+
+  for (const fileName of CODE_MODE_AGENT_FILES) {
+    const filePath = path.join(cwd, fileName);
+    let resolvedPath = filePath;
+    try {
+      resolvedPath = await realpath(filePath);
+    } catch (error) {
+      if (!isFileNotFoundError(error)) {
+        throw error;
+      }
+    }
+
+    if (seenRealPaths.has(resolvedPath)) {
+      continue;
+    }
+    seenRealPaths.add(resolvedPath);
+    distinctFiles.push(fileName);
+  }
+
+  return distinctFiles;
 }
 
 async function prepareCodeModeAgentSnippet(

--- a/test/ingestion/code-mode.test.ts
+++ b/test/ingestion/code-mode.test.ts
@@ -1,4 +1,11 @@
-import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import {
+  mkdir,
+  mkdtemp,
+  readFile,
+  rm,
+  symlink,
+  writeFile,
+} from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, test } from "vitest";
@@ -119,6 +126,47 @@ Trailing notes that must survive.
     const second = await readIfPresent(path.join(repo, "CLAUDE.md"));
 
     expect(second).toEqual(first);
+  });
+
+  test("keeps a CLAUDE.md symlinked to AGENTS.md intact and well-formed", async () => {
+    const repo = await createTempRepo();
+    const agentsPath = path.join(repo, "AGENTS.md");
+    const claudePath = path.join(repo, "CLAUDE.md");
+    const policy = "DO NOT DELETE: hand-written project policy";
+    await writeFile(
+      agentsPath,
+      `# Project instructions\n\n${policy}\n`,
+      "utf8",
+    );
+    // One canonical guide, read under both names.
+    await symlink("AGENTS.md", claudePath);
+
+    await ensureCodeModeRepoSetup(repo);
+
+    const content = await readIfPresent(agentsPath);
+    expect(content).toContain(policy);
+    // Writing both snippets through the symlink would race two payloads onto
+    // one file and duplicate the markers.
+    expect(content?.split(SNIPPET_START).length).toBe(2);
+    expect(content?.split(SNIPPET_END).length).toBe(2);
+    // AGENTS.md keeps the full snippet rather than CLAUDE.md's pointer.
+    expect(content).not.toContain("See [AGENTS.md](AGENTS.md)");
+    expect(await readIfPresent(claudePath)).toBe(content);
+  });
+
+  test("stays idempotent across runs when CLAUDE.md is a symlink to AGENTS.md", async () => {
+    const repo = await createTempRepo();
+    const agentsPath = path.join(repo, "AGENTS.md");
+    await writeFile(agentsPath, "# Project instructions\n", "utf8");
+    await symlink("AGENTS.md", path.join(repo, "CLAUDE.md"));
+
+    await ensureCodeModeRepoSetup(repo);
+    const first = await readIfPresent(agentsPath);
+    // A corrupted first pass leaves duplicated markers, which makes the second
+    // pass reject the file instead of refreshing it.
+    await ensureCodeModeRepoSetup(repo);
+
+    expect(await readIfPresent(agentsPath)).toEqual(first);
   });
 
   for (const [name, existing] of [


### PR DESCRIPTION
Fixes #725.

## What

`writeCodeModeAgentSnippets` treats the two entries of `CODE_MODE_AGENT_FILES` as two files. When `CLAUDE.md` is a symlink to `AGENTS.md` they are one file, and the two different snippets race onto a single inode:

```js
const updates = await Promise.all(   // both prepared from the same pre-write content
  CODE_MODE_AGENT_FILES.map((fileName) => prepareCodeModeAgentSnippet(...)));

await Promise.all(                   // both written, concurrently
  updates.map(({ agentsPath, nextContent }) => writeFile(agentsPath, nextContent, "utf8")));
```

This collapses the target list by resolved path before any update is prepared, keeping the first name so `AGENTS.md` wins and the `CLAUDE.md` pointer is skipped — the symlink already gives that host the canonical instructions. A name that does not resolve stays its own target, since it will be created at exactly that path; anything other than `ENOENT` still propagates.

## Why

Symlinking `CLAUDE.md` to `AGENTS.md` is a common way to keep one canonical guide. Today every run in such a repo leaves a block with the pointer text inside it, an orphaned snippet tail, and a duplicated `OPENWIKI:END`.

That is not only cosmetic. `prepareCodeModeAgentSnippet` rejects malformed or duplicated markers, so the **next** run fails outright on a file the previous run corrupted:

```
Cannot update AGENTS.md because its OpenWiki managed markers are malformed or
duplicated. … the file was left unchanged.
```

Setup then stays broken until someone repairs the markers by hand. #725 has the full reproduction and the resulting file.

## How it was tested

Two tests added to `test/ingestion/code-mode.test.ts`, both verified failing on `main` before the fix and passing after:

- *keeps a CLAUDE.md symlinked to AGENTS.md intact and well-formed* — asserts one marker pair, the preserved hand-written policy, no pointer text in `AGENTS.md`, and both names reading identical content. Fails before the fix with `expected 3 to be 2` on the `OPENWIKI:END` count.
- *stays idempotent across runs when CLAUDE.md is a symlink to AGENTS.md* — runs setup twice and compares. Fails before the fix with the malformed-markers error, which is the follow-on breakage above.

`pnpm run format`, `pnpm run lint`, and `pnpm test` all pass: 2908 tests (2906 on `main` plus these 2), 219 files.

One caveat, reported rather than hidden: on the first full run `test/cli/components/chat.test.tsx` failed once on the reasoning-effort assertion. It passes in isolation on both this branch and clean `main`, and passes on a re-run of the full suite here; a clean-`main` full run is also green. It looks like a timing flake in that Ink rendering test, unrelated to this change, but flagging it in case it is known.

## Scope

One change: the duplicate-target bug, its regression tests, and a patch changeset. No behavior change for repos where `AGENTS.md` and `CLAUDE.md` are distinct files — they still receive their existing separate snippets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)