### PR TITLE
fix: prevent invalid optional OKF metadata from aborting wiki generation by repairing or removing it deterministically

### DIFF
--- a/.changeset/neat-yaks-reply.md
+++ b/.changeset/neat-yaks-reply.md
@@ -1,0 +1,5 @@
+---
+"openwiki": patch
+---
+
+fix: prevent invalid optional OKF metadata from aborting wiki generation by repairing or removing it deterministically

--- a/src/agent/okf-middleware.ts
+++ b/src/agent/okf-middleware.ts
@@ -4,7 +4,7 @@ import { createMiddleware } from "langchain";
 import path from "node:path";
 import type { ClaimEvidenceResources } from "../okf/claim-sources.js";
 import {
-  validatePersistedFile,
+  repairPersistedFile,
   type FrontmatterIssue,
 } from "../okf/frontmatter.js";
 import {
@@ -96,6 +96,7 @@ export function createOpenWikiIndexMiddleware(
         backend,
         outputMode,
         request.toolCall.name,
+        conceptType,
       );
     },
     afterAgent: async () => {
@@ -121,13 +122,15 @@ export function createOpenWikiIndexMiddleware(
 }
 
 /**
- * Appends an actionable warning when a wiki write leaves invalid front matter.
+ * Deterministically repairs invalid OKF metadata after a wiki write. A warning
+ * is appended only when the repaired bytes cannot be persisted or re-read.
  */
 export async function addFrontmatterWarning<Result>(
   result: Result,
   backend: BackendProtocolV2,
   outputMode: OpenWikiOutputMode,
   toolName: string,
+  conceptType: string = ENGLISH_CONCEPT_TYPE,
 ): Promise<Result> {
   if (!WRITE_TOOLS.has(toolName)) return result;
 
@@ -143,10 +146,10 @@ export async function addFrontmatterWarning<Result>(
     );
   if (!mutation) return result;
 
-  const validation = await validatePersistedFile(backend, mutation.path);
-  if (validation.valid) return result;
+  const repair = await repairPersistedFile(backend, mutation.path, conceptType);
+  if (repair.validation.valid) return result;
 
-  const warning = formatWarning(mutation.path, validation.issues);
+  const warning = formatWarning(mutation.path, repair.validation.issues);
   mutation.message.content =
     typeof mutation.message.content === "string"
       ? `${mutation.message.content}\n\n${warning}`
@@ -196,7 +199,7 @@ function formatWarning(path: string, issues: FrontmatterIssue[]): string {
         `- [${code}]${line ? ` line ${line}:` : ""} ${message}`,
     )
     .join("\n");
-  return `WARNING: YAML front matter was NOT formatted properly in \`${path}\`.\n${details}\nYou MUST correct this file's YAML front matter before continuing.`;
+  return `WARNING: OpenWiki could not persist deterministic YAML front matter repair in \`${path}\`.\n${details}\nRewrite this file before continuing.`;
 }
 
 /**

--- a/src/generation/repository-run.ts
+++ b/src/generation/repository-run.ts
@@ -31,7 +31,7 @@ import type {
 import { ensureCodeModeRepoSetup } from "../ingestion/code-mode.js";
 import {
   parseFrontmatterFields,
-  validatePersistedFile,
+  repairPersistedFile,
 } from "../okf/frontmatter.js";
 import {
   resolveConceptTypeLabel,
@@ -761,9 +761,13 @@ export async function submitRepositoryPage(
     );
   }
 
-  const frontmatter = await validatePersistedFile(run.backend, current.path);
-  if (!frontmatter.valid) {
-    const details = frontmatter.issues
+  const frontmatter = await repairPersistedFile(
+    run.backend,
+    current.path,
+    resolveConceptTypeLabel(run.state.language),
+  );
+  if (!frontmatter.validation.valid) {
+    const details = frontmatter.validation.issues
       .map(
         ({ code, line, message }) =>
           `[${code}]${line ? ` line ${line}:` : ""} ${message}`,
@@ -771,7 +775,7 @@ export async function submitRepositoryPage(
       .join("; ");
     throw new RepositoryRunError(
       "invalid_input",
-      `Fix invalid front matter in ${current.path} before submission: ${details}`,
+      `Could not deterministically repair front matter in ${current.path}: ${details}`,
     );
   }
 

--- a/src/okf/claim-sources.ts
+++ b/src/okf/claim-sources.ts
@@ -6,7 +6,11 @@ import {
   formatRepositoryEvidenceResource,
   parseRepositoryEvidenceResource,
 } from "../claims/evidence/repository/resource.js";
-import { parseFrontmatterFields, setOkfSources } from "./frontmatter.js";
+import {
+  parseFrontmatterFields,
+  repairOkfFrontmatter,
+  setOkfSources,
+} from "./frontmatter.js";
 import { listWikiConceptPaths } from "./index-sync.js";
 
 /**
@@ -44,17 +48,19 @@ export async function synchronizeClaimSources(
   for (const page of pages) {
     if (!concepts.has(page)) continue;
     const content = await readRequiredContent(backend, page);
-    const currentSources = readSourceEntries(content);
+    const repaired = repairOkfFrontmatter(content, page).content;
+    const currentSources = readSourceEntries(repaired);
     const nextSources = mergeClaimSources(
       currentSources,
       resourcesByPage.get(page) ?? [],
     );
-    if (isDeepStrictEqual(currentSources, nextSources)) continue;
+    const projected = isDeepStrictEqual(currentSources, nextSources)
+      ? repaired
+      : repairOkfFrontmatter(setOkfSources(repaired, nextSources), page)
+          .content;
+    if (projected === content) continue;
 
-    const result = await backend.write(
-      page,
-      setOkfSources(content, nextSources),
-    );
+    const result = await backend.write(page, projected);
     if (result.error) {
       throw new Error(
         `Unable to synchronize OKF sources for ${page}: ${result.error}`,

--- a/src/okf/claims-verification.ts
+++ b/src/okf/claims-verification.ts
@@ -1,6 +1,10 @@
 import { isDeepStrictEqual } from "node:util";
 import type { ClaimsVerificationEvent } from "../claims/brains/code/types.js";
-import { parseFrontmatterFields, setOkfVerified } from "./frontmatter.js";
+import {
+  parseFrontmatterFields,
+  repairOkfFrontmatter,
+  setOkfVerified,
+} from "./frontmatter.js";
 
 /**
  * Minimal generated-page storage required by the verification projector.
@@ -36,15 +40,16 @@ export async function synchronizeClaimsVerification(
 
   for (const page of await store.discoverPages()) {
     const content = await store.readMarkdown(page);
-    const current = readVerificationEvents(content);
+    const repaired = repairOkfFrontmatter(content, page).content;
+    const current = readVerificationEvents(repaired);
     const retained = current.filter((event) => !isOpenWikiActor(event.by));
     const active = verificationByPage.get(page);
     const next = active ? [...retained, { ...active }] : retained;
 
-    if (isDeepStrictEqual(current, next) && isCanonicalList(content)) continue;
-    if (current.length === 0 && next.length === 0) continue;
-
-    const projected = setOkfVerified(content, next);
+    const projected =
+      isDeepStrictEqual(current, next) && isCanonicalList(repaired)
+        ? repaired
+        : repairOkfFrontmatter(setOkfVerified(repaired, next), page).content;
     if (projected === content) continue;
     await store.writeMarkdown(page, projected);
     changes.set(page, content);

--- a/src/okf/frontmatter.ts
+++ b/src/okf/frontmatter.ts
@@ -14,6 +14,12 @@ const OKF_STRING_FIELDS = [
   "timestamp",
 ];
 
+const OKF_OPTIONAL_STRING_FIELDS = [
+  "description",
+  "resource",
+  "timestamp",
+] as const;
+
 /**
  * Lifecycle states defined by OKF v0.2 §5.4; an absent `status` means stable.
  */
@@ -39,28 +45,6 @@ export const OPENWIKI_GENERATED_FIELD = "openwiki_generated";
  */
 export const OPENWIKI_TRANSLATION_PENDING_FIELD =
   "openwiki_translation_pending";
-
-/**
- * Extension fields that must survive a deterministic front-matter regeneration.
- *
- * When a page fails OKF validation its front matter is rebuilt from a minimal
- * derived block, which would otherwise drop every extension field. Fields listed
- * here are carried across that rebuild so control markers are not lost when a
- * page happens to be both non-conformant and, say, pending translation.
- */
-const PRESERVED_EXTENSION_FIELDS = [OPENWIKI_TRANSLATION_PENDING_FIELD];
-
-/**
- * OKF v0.2 provenance/trust/lifecycle families (SPEC §5) that must survive the
- * deterministic type-less rebuild. Unlike {@link PRESERVED_EXTENSION_FIELDS}
- * these hold structured mappings or lists rather than scalar strings, so they
- * are carried across verbatim as complete raw fields rather than re-quoted.
- *
- * `generated` and Claims-derived `sources` are code-owned. Listing them here
- * keeps deterministic provenance from being discarded when a page also
- * happens to trip the type-less repair path.
- */
-const PRESERVED_STRUCTURED_FIELDS = ["generated", "verified", "sources"];
 
 /**
  * Matches a leading YAML front-matter block and captures its inner text.
@@ -109,6 +93,24 @@ export interface FrontmatterIssue {
  */
 export type FrontmatterValidation =
   { valid: true } | { valid: false; issues: FrontmatterIssue[] };
+
+/** Result of deterministically repairing one Markdown concept in memory. */
+export interface FrontmatterRepair {
+  /** Whether the returned Markdown differs from the input. */
+  changed: boolean;
+
+  /** Repaired Markdown, including the original authored body. */
+  content: string;
+}
+
+/** Result of repairing and re-validating one persisted Markdown concept. */
+export interface PersistedFrontmatterRepair {
+  /** Whether a repaired version was written. */
+  changed: boolean;
+
+  /** Validation of the final bytes that could be read from storage. */
+  validation: FrontmatterValidation;
+}
 
 /**
  * Parses and validates OKF front matter while tolerating producer extensions.
@@ -323,7 +325,15 @@ export async function validatePersistedFile(
   backend: BackendProtocolV2,
   filePath: string,
 ): Promise<FrontmatterValidation> {
-  const read = await backend.readRaw(filePath);
+  let read;
+  try {
+    read = await backend.readRaw(filePath);
+  } catch (error) {
+    return invalid(
+      "file_read_failed",
+      `Could not read the final Markdown text: ${errorMessage(error)}.`,
+    );
+  }
   const content = read.data?.content;
   if (read.error || content === undefined || content instanceof Uint8Array) {
     return invalid(
@@ -334,6 +344,73 @@ export async function validatePersistedFile(
   return validateOkfFrontmatter(
     Array.isArray(content) ? content.join("\n") : content,
   );
+}
+
+/**
+ * Repairs recognized OKF metadata, persists it only when necessary, and proves
+ * the final stored bytes. Read and write failures are returned as structured
+ * validation issues because callers choose whether storage is a fatal boundary.
+ */
+export async function repairPersistedFile(
+  backend: BackendProtocolV2,
+  filePath: string,
+  conceptType: string = "Reference",
+): Promise<PersistedFrontmatterRepair> {
+  let read;
+  try {
+    read = await backend.readRaw(filePath);
+  } catch (error) {
+    return {
+      changed: false,
+      validation: invalid(
+        "file_read_failed",
+        `Could not read the final Markdown text: ${errorMessage(error)}.`,
+      ),
+    };
+  }
+  const stored = read.data?.content;
+  if (read.error || stored === undefined || stored instanceof Uint8Array) {
+    return {
+      changed: false,
+      validation: invalid(
+        "file_read_failed",
+        `Could not read the final Markdown text: ${read.error ?? "no text data"}.`,
+      ),
+    };
+  }
+
+  const content = Array.isArray(stored) ? stored.join("\n") : stored;
+  const repaired = repairOkfFrontmatter(content, filePath, conceptType);
+  if (!repaired.changed) {
+    return { changed: false, validation: validateOkfFrontmatter(content) };
+  }
+
+  let write;
+  try {
+    write = await backend.write(filePath, repaired.content);
+  } catch (error) {
+    return {
+      changed: false,
+      validation: invalid(
+        "file_write_failed",
+        `Could not persist repaired Markdown text: ${errorMessage(error)}.`,
+      ),
+    };
+  }
+  if (write.error) {
+    return {
+      changed: false,
+      validation: invalid(
+        "file_write_failed",
+        `Could not persist repaired Markdown text: ${write.error}.`,
+      ),
+    };
+  }
+
+  return {
+    changed: true,
+    validation: await validatePersistedFile(backend, filePath),
+  };
 }
 
 /**
@@ -432,19 +509,7 @@ export function setFrontmatterField(
   value: string,
 ): string {
   const line = `${key}: ${JSON.stringify(value)}`;
-  const { block, body } = splitFrontmatter(content);
-  if (block === undefined) {
-    return `---\n${line}\n---\n\n${content}`;
-  }
-
-  const lines = block.split("\n");
-  const index = lines.findIndex((current) => isFieldLine(current, key));
-  if (index === -1) {
-    lines.push(line);
-  } else {
-    lines[index] = line;
-  }
-  return `---\n${lines.join("\n")}\n---\n${body}`;
+  return replaceFrontmatterFieldBlock(content, key, [line]);
 }
 
 /**
@@ -471,19 +536,7 @@ export function setGeneratedEvent(
       ? `by: ${JSON.stringify(by)}`
       : `by: ${JSON.stringify(by)}, at: ${JSON.stringify(at)}`;
   const line = `generated: {${members}}`;
-  const { block, body } = splitFrontmatter(content);
-  if (block === undefined) {
-    return `---\n${line}\n---\n\n${content}`;
-  }
-
-  const lines = block.split("\n");
-  const index = lines.findIndex((current) => isFieldLine(current, "generated"));
-  if (index === -1) {
-    lines.push(line);
-  } else {
-    lines[index] = line;
-  }
-  return `---\n${lines.join("\n")}\n---\n${body}`;
+  return replaceFrontmatterFieldBlock(content, "generated", [line]);
 }
 
 /**
@@ -548,40 +601,7 @@ export function setOkfVerified(
  * the field was the block's only line, the now-empty block is dropped entirely.
  */
 export function removeFrontmatterField(content: string, key: string): string {
-  const { block, body } = splitFrontmatter(content);
-  if (block === undefined) return content;
-
-  const kept = block.split("\n").filter((line) => !isFieldLine(line, key));
-  if (kept.length === block.split("\n").length) return content;
-  if (kept.length === 0) return body.replace(/^\r?\n/u, "");
-  return `---\n${kept.join("\n")}\n---\n${body}`;
-}
-
-/**
- * Returns the complete raw front-matter field declaring the given top-level
- * key, including indented continuation lines, or undefined when absent. Used
- * to carry structured provenance across a deterministic rebuild without
- * parsing and re-rendering it.
- */
-function rawFrontmatterField(content: string, key: string): string | undefined {
-  const { block } = splitFrontmatter(content);
-  if (block === undefined) return undefined;
-  const lines = block.split("\n");
-  const start = lines.findIndex((line) => isFieldLine(line, key));
-  if (start === -1) return undefined;
-  const end = findFrontmatterFieldEnd(lines, start);
-  return lines.slice(start, end).join("\n");
-}
-
-/**
- * Appends a complete raw front-matter field verbatim, preserving every existing
- * line. A page with no block is returned unchanged, since the rebuild path
- * always constructs one before calling this.
- */
-function appendFrontmatterField(content: string, rawField: string): string {
-  const { block, body } = splitFrontmatter(content);
-  if (block === undefined) return content;
-  return `---\n${block}\n${rawField}\n---\n${body}`;
+  return replaceFrontmatterFieldBlock(content, key, []);
 }
 
 /**
@@ -610,6 +630,18 @@ function replaceFrontmatterFieldBlock(
   const next = [...lines.slice(0, start), ...replacement, ...lines.slice(end)];
   if (next.length === 0) return body.replace(/^\r?\n/u, "");
   return `---\n${next.join("\n")}\n---\n${body}`;
+}
+
+/** Renders and replaces one complete structured YAML field. */
+function setFrontmatterValue(
+  content: string,
+  key: string,
+  value: unknown,
+): string {
+  const replacement = stringify({ [key]: value }, { lineWidth: 0 })
+    .trimEnd()
+    .split("\n");
+  return replaceFrontmatterFieldBlock(content, key, replacement);
 }
 
 /**
@@ -692,14 +724,10 @@ export function renderFrontmatter(
 /**
  * Guarantees a page has valid OKF front matter without destroying good data.
  *
- * Rule: if the front matter parses and has a non-empty `type`, the page is left
- * unchanged. Otherwise (no front matter, unparseable YAML, or a missing `type`)
- * its front matter is replaced with a minimal block derived from the body and
- * tagged `openwiki_generated` for later agent review.
- *
- * Pages that already have a `type` are kept even when optional fields like
- * `title` are junk, so an author's `type` and custom fields are never
- * overwritten; the index generator already ignores unusable optional fields.
+ * Valid pages are left byte-for-byte unchanged. Invalid recognized fields are
+ * repaired or removed conservatively; an unusable YAML block falls back to a
+ * minimal derived block tagged `openwiki_generated` for later agent review.
+ * Producer extensions survive whenever the original YAML mapping is parseable.
  * Never throws. Returns the new content and whether it changed.
  *
  * `conceptType` is the localized fallback used for a repaired page's `type`; it
@@ -710,37 +738,117 @@ export function normalizeConceptContent(
   filePath: string,
   conceptType: string = "Reference",
 ): { changed: boolean; content: string } {
-  if (hasUsableConceptType(content)) {
-    return { changed: false, content };
-  }
-  const { body } = splitFrontmatter(content);
-  const derived = deriveMinimalFrontmatter(body, filePath, conceptType);
-  const front = renderFrontmatter(derived, { generated: true });
-  let rebuilt = `${front}${body.replace(/^\s+/u, "")}`;
-  for (const field of PRESERVED_EXTENSION_FIELDS) {
-    const value = readFrontmatterField(content, field);
-    if (value !== undefined) {
-      rebuilt = setFrontmatterField(rebuilt, field, value);
-    }
-  }
-  for (const field of PRESERVED_STRUCTURED_FIELDS) {
-    const rawField = rawFrontmatterField(content, field);
-    if (rawField !== undefined) {
-      rebuilt = appendFrontmatterField(rebuilt, rawField);
-    }
-  }
-  return { changed: true, content: rebuilt };
+  return repairOkfFrontmatter(content, filePath, conceptType);
 }
 
 /**
- * Reports whether a page already declares a usable OKF `type`, meaning its
- * front matter parses and `type` is a non-empty string.
+ * Deterministically repairs every recognized OKF field while preserving the
+ * authored Markdown body and producer extension fields whenever the YAML map
+ * remains parseable.
+ *
+ * Invalid optional scalar fields are removed, except `title`, which is derived
+ * from the first H1 or filename. Invalid list families retain only conformant
+ * entries. Trust assertions that cannot be proven conformant are removed rather
+ * than rewritten into a false assertion. Missing or invalid `type` receives the
+ * localized fallback and marks the metadata as derived.
+ *
+ * If the YAML mapping itself is unusable, or a raw representation cannot be
+ * repaired safely, the deterministic last resort is a minimal valid block. In
+ * all cases the returned content passes {@link validateOkfFrontmatter}.
  */
-function hasUsableConceptType(content: string): boolean {
+export function repairOkfFrontmatter(
+  content: string,
+  filePath: string,
+  conceptType: string = "Reference",
+): FrontmatterRepair {
+  if (validateOkfFrontmatter(content).valid) {
+    return { changed: false, content };
+  }
+
   const fields = parseFrontmatterFields(content);
-  return (
-    fields !== undefined &&
-    typeof fields.type === "string" &&
-    fields.type.trim() !== ""
-  );
+  const { body } = splitFrontmatter(content);
+  const fallbackType = isNonEmptyString(conceptType)
+    ? conceptType
+    : "Reference";
+  const derived = deriveMinimalFrontmatter(body, filePath, fallbackType);
+  if (!fields) return rebuildMinimalConcept(content, body, derived);
+
+  let repaired = content;
+  const typeWasDerived = !isNonEmptyString(fields.type);
+  if (typeWasDerived) {
+    repaired = setFrontmatterField(repaired, "type", derived.type);
+    repaired = setFrontmatterValue(repaired, OPENWIKI_GENERATED_FIELD, true);
+  }
+  if (
+    (typeWasDerived && !Object.hasOwn(fields, "title")) ||
+    (Object.hasOwn(fields, "title") && !isNonEmptyString(fields.title))
+  ) {
+    repaired = setFrontmatterField(repaired, "title", derived.title);
+  }
+  for (const field of OKF_OPTIONAL_STRING_FIELDS) {
+    if (Object.hasOwn(fields, field) && !isNonEmptyString(fields[field])) {
+      repaired = removeFrontmatterField(repaired, field);
+    }
+  }
+
+  if (Object.hasOwn(fields, "tags")) {
+    const tags = Array.isArray(fields.tags)
+      ? fields.tags.filter(isNonEmptyString)
+      : [];
+    repaired =
+      tags.length > 0
+        ? setFrontmatterValue(repaired, "tags", tags)
+        : removeFrontmatterField(repaired, "tags");
+  }
+  if (Object.hasOwn(fields, "generated") && !isActorEvent(fields.generated)) {
+    repaired = removeFrontmatterField(repaired, "generated");
+  }
+  if (Object.hasOwn(fields, "verified")) {
+    const candidates = Array.isArray(fields.verified)
+      ? fields.verified
+      : [fields.verified];
+    const events = candidates.filter(
+      (event): event is Record<string, unknown> =>
+        isRecord(event) && isActorEvent(event),
+    );
+    repaired = setOkfVerified(repaired, events);
+  }
+  if (Object.hasOwn(fields, "sources")) {
+    const sources = Array.isArray(fields.sources)
+      ? fields.sources.filter(
+          (source): source is Record<string, unknown> =>
+            isRecord(source) && isNonEmptyString(source.resource),
+        )
+      : [];
+    repaired = setOkfSources(repaired, sources);
+  }
+  if (
+    Object.hasOwn(fields, "status") &&
+    (typeof fields.status !== "string" ||
+      !OKF_STATUS_VALUES.includes(fields.status))
+  ) {
+    repaired = removeFrontmatterField(repaired, "status");
+  }
+  if (
+    Object.hasOwn(fields, "stale_after") &&
+    (typeof fields.stale_after !== "string" ||
+      !isIsoDateTimeWithOffset(fields.stale_after))
+  ) {
+    repaired = removeFrontmatterField(repaired, "stale_after");
+  }
+
+  if (validateOkfFrontmatter(repaired).valid) {
+    return { changed: repaired !== content, content: repaired };
+  }
+  return rebuildMinimalConcept(content, body, derived);
+}
+
+/** Replaces unusable YAML with the smallest truthful valid OKF block. */
+function rebuildMinimalConcept(
+  original: string,
+  body: string,
+  derived: DerivedFrontmatter,
+): FrontmatterRepair {
+  const rebuilt = `${renderFrontmatter(derived, { generated: true })}${body}`;
+  return { changed: rebuilt !== original, content: rebuilt };
 }

--- a/src/okf/generated-provenance.ts
+++ b/src/okf/generated-provenance.ts
@@ -3,6 +3,7 @@ import type { BackendProtocolV2 } from "deepagents";
 import type { OpenWikiOutputMode } from "../agent/types.js";
 import {
   parseFrontmatterFields,
+  repairOkfFrontmatter,
   removeFrontmatterField,
   setGeneratedEvent,
   splitFrontmatter,
@@ -173,24 +174,32 @@ export async function finalizeGeneratedProvenance(
   }
 
   for (const page of await listWikiConceptPaths(backend, outputMode)) {
-    const content = await readRequiredContent(backend, page);
+    let content: string;
+    try {
+      content = await readRequiredContent(backend, page);
+    } catch {
+      // Generated provenance is optional trust metadata. If a page cannot be
+      // read during this best-effort pass, preserve the rest of the finalized
+      // wiki instead of failing the complete run.
+      continue;
+    }
     const initial = initialConcepts.get(page);
     const bodyChanged =
       initial === undefined || initial.bodyHash !== hashConceptBody(content);
-    const reconciled = bodyChanged
+    const candidate = bodyChanged
       ? removeFrontmatterField(
           setGeneratedEvent(content, producerActor, now),
           "timestamp",
         )
       : restoreGeneratedEvent(content, initial.generated);
+    const reconciled = repairOkfFrontmatter(candidate, page).content;
 
     if (reconciled !== content) {
       const result = await backend.write(page, reconciled);
-      if (result.error) {
-        throw new Error(
-          `Unable to finalize generated provenance for ${page}: ${result.error}`,
-        );
-      }
+      // A provenance write is useful but not essential page content. The
+      // deterministic fallback is the already-persisted unstamped/stale page;
+      // later finalizers can still synchronize Claims against those bytes.
+      if (result.error) continue;
     }
   }
 }

--- a/test/agent/frontmatter-validator.test.ts
+++ b/test/agent/frontmatter-validator.test.ts
@@ -1,5 +1,4 @@
 import { ToolMessage } from "@langchain/core/messages";
-import type { BackendProtocolV2 } from "deepagents";
 import { describe, expect, test, vi } from "vitest";
 import { MUTATION_PATH_METADATA_KEY } from "../../src/agent/docs-only-backend.ts";
 import { addFrontmatterWarning } from "../../src/agent/okf-middleware.ts";
@@ -9,8 +8,10 @@ function markdown(frontmatter: string): string {
   return `---\n${frontmatter}\n---\n\n# Page\n`;
 }
 
-function backendWith(content: string) {
+function backendWith(initialContent: string) {
+  let content = initialContent;
   return {
+    current: () => content,
     readRaw: vi.fn(() => ({
       data: {
         content,
@@ -19,7 +20,11 @@ function backendWith(content: string) {
         modified_at: "2026-07-13T00:00:00.000Z",
       },
     })),
-  } satisfies Pick<BackendProtocolV2, "readRaw">;
+    write: vi.fn((_path: string, next: string) => {
+      content = next;
+      return {};
+    }),
+  };
 }
 
 function mutationMessage(path = "/openwiki/page.md") {
@@ -243,20 +248,27 @@ describe("validateOkfFrontmatter", () => {
 });
 
 describe("addFrontmatterWarning", () => {
-  test("appends actionable validation details after an invalid wiki write", async () => {
+  test("repairs invalid wiki metadata without asking the model to retry", async () => {
     const message = mutationMessage();
-    await addFrontmatterWarning(
-      message,
-      backendWith("# Missing front matter"),
-      "repository",
-      "write_file",
-    );
+    const backend = backendWith("# Missing front matter");
+    await addFrontmatterWarning(message, backend, "repository", "write_file");
+
+    expect(message.content).toBe("Successfully wrote file.");
+    expect(validateOkfFrontmatter(backend.current())).toEqual({ valid: true });
+    expect(backend.current()).toContain("# Missing front matter");
+  });
+
+  test("warns when deterministic repair cannot be persisted", async () => {
+    const message = mutationMessage();
+    const backend = backendWith("# Missing front matter");
+    vi.mocked(backend.write).mockResolvedValue({ error: "disk full" });
+
+    await addFrontmatterWarning(message, backend, "repository", "write_file");
 
     expect(message.content).toContain(
-      "YAML front matter was NOT formatted properly",
+      "could not persist deterministic YAML front matter repair",
     );
-    expect(message.content).toContain("[missing_opening_delimiter] line 1");
-    expect(message.content).toContain("MUST correct this file");
+    expect(message.content).toContain("[file_write_failed]");
   });
 
   test("leaves valid files and unrelated tool calls unchanged", async () => {
@@ -304,13 +316,10 @@ describe("addFrontmatterWarning", () => {
   test("edits tool messages nested in Command results", async () => {
     const message = mutationMessage();
     const command = { update: { messages: [message] } };
-    await addFrontmatterWarning(
-      command,
-      backendWith(markdown("title: Missing type")),
-      "repository",
-      "edit_file",
-    );
+    const backend = backendWith(markdown("title: Missing type"));
+    await addFrontmatterWarning(command, backend, "repository", "edit_file");
 
-    expect(message.content).toContain("[missing_type]");
+    expect(message.content).toBe("Successfully wrote file.");
+    expect(validateOkfFrontmatter(backend.current())).toEqual({ valid: true });
   });
 });

--- a/test/agent/index-middleware.test.ts
+++ b/test/agent/index-middleware.test.ts
@@ -330,7 +330,7 @@ describe("synchronizeWikiIndexes", () => {
     ["[one, two]", "{ text: nested }"],
     ["{ text: nested }", ""],
   ])(
-    "falls back when optional title and description are not usable strings: %s / %s",
+    "repairs optional title and description when they are not usable strings: %s / %s",
     async (title, description) => {
       const { backend, rootDir } = await setup();
       await backend.write(
@@ -344,7 +344,7 @@ describe("synchronizeWikiIndexes", () => {
         path.join(rootDir, "openwiki/index.md"),
         "utf8",
       );
-      expect(index).toContain("- [page](page.md)\n");
+      expect(index).toContain("- [Page](page.md)\n");
       expect(index).not.toContain(" - ");
     },
   );
@@ -876,7 +876,7 @@ describe("createOpenWikiIndexMiddleware generated finalization", () => {
     expect(page).not.toContain("generated:");
   });
 
-  test("fails finalization when the generated event cannot be persisted", async () => {
+  test("keeps authored content when generated provenance cannot be persisted", async () => {
     const { backend, rootDir } = await setup();
     const middleware = createOpenWikiIndexMiddleware(
       backend,
@@ -900,15 +900,13 @@ describe("createOpenWikiIndexMiddleware generated finalization", () => {
       });
 
     try {
-      await expect(runAfterAgent(middleware)).rejects.toThrow(
-        "Unable to finalize generated provenance for /openwiki/page.md: disk full",
-      );
+      await expect(runAfterAgent(middleware)).resolves.toBeUndefined();
     } finally {
       writeSpy.mockRestore();
     }
 
-    // The model-authored content survives, but the run cannot claim successful
-    // finalization while its code-owned provenance is absent.
+    // Provenance degrades to absent while the useful model-authored page and
+    // the rest of the run survive.
     const page = await readFile(path.join(rootDir, "openwiki/page.md"), "utf8");
     expect(page).toBe(body);
     expect(page).not.toContain("generated:");

--- a/test/agent/wiki-finalizer.test.ts
+++ b/test/agent/wiki-finalizer.test.ts
@@ -232,4 +232,39 @@ describe("finalizeWikiArtifacts", () => {
     expect(page).not.toContain("host-agent/codex");
     expect(page).not.toContain(RUN_TIMESTAMP);
   });
+
+  test("replaces multiline generated metadata without invalidating the page", async () => {
+    const { backend, rootDir } = await setupWiki();
+    await backend.write(
+      "/openwiki/existing.md",
+      '---\ntype: Guide\ngenerated:\n  by: openwiki/0.3.2\n  at: "2026-08-18T10:00:00.000Z"\n---\n\n# Existing\n\nOld body.\n',
+    );
+    const prepared = await prepareWikiForAuthoring({
+      backend,
+      outputMode: "repository",
+    });
+    await backend.write(
+      "/openwiki/existing.md",
+      '---\ntype: Guide\ngenerated:\n  by: openwiki/0.3.2\n  at: "2026-08-18T10:00:00.000Z"\n---\n\n# Existing\n\nNew body.\n',
+    );
+
+    await expect(
+      finalizeWikiArtifacts({
+        backend,
+        outputMode: "repository",
+        prepared,
+        at: RUN_TIMESTAMP,
+        producerActor: "host-agent/codex",
+      }),
+    ).resolves.toBeUndefined();
+
+    const page = await readFile(
+      path.join(rootDir, "openwiki/existing.md"),
+      "utf8",
+    );
+    expect(page).toContain(
+      `generated: {by: "host-agent/codex", at: "${RUN_TIMESTAMP}"}`,
+    );
+    expect(page).not.toContain("\n  by: openwiki/0.3.2");
+  });
 });

--- a/test/generation/repository-run.test.ts
+++ b/test/generation/repository-run.test.ts
@@ -57,7 +57,10 @@ vi.mock("../../src/generation/run-state.js", async (importOriginal) => {
 import { ensureCodeModeRepoSetup } from "../../src/ingestion/code-mode.ts";
 import { ClaimsPersistenceError } from "../../src/claims/core/errors.ts";
 import { ClaimsStore } from "../../src/claims/brains/code/store.ts";
-import { parseFrontmatterFields } from "../../src/okf/frontmatter.ts";
+import {
+  parseFrontmatterFields,
+  validateOkfFrontmatter,
+} from "../../src/okf/frontmatter.ts";
 import { OPENWIKI_PRODUCER_ACTOR } from "../../src/version.ts";
 import {
   beginRepositoryRun,
@@ -543,7 +546,7 @@ describe("repository page queue", () => {
     ).resolves.toMatchObject({ status: "complete", remaining: 0 });
   });
 
-  test("rejects out-of-order submission and invalid final frontmatter", async () => {
+  test("rejects out-of-order submission but repairs invalid frontmatter", async () => {
     const root = await createRepository(["second.md"]);
     const run = await beginForcedUpdate(root);
     await submitRepositoryPlan(run, {
@@ -568,9 +571,22 @@ describe("repository page queue", () => {
 
     await run.backend.write(jobs[0].path, "# Missing frontmatter\n");
     await expect(
-      submitRepositoryPage(run, { jobId: jobs[0].id, claims: [] }),
-    ).rejects.toThrow("Fix invalid front matter");
-    expect(run.state.plan?.pages[0]?.status).toBe("pending");
+      submitRepositoryPage(run, {
+        jobId: jobs[0].id,
+        claims: [
+          {
+            statement: "The repository has a README.",
+            evidence: [{ resource: "repo://README.md" }],
+          },
+        ],
+      }),
+    ).resolves.toMatchObject({ status: "complete" });
+    const repaired = await readFile(
+      path.join(root, jobs[0].path.replace(/^\//u, "")),
+      "utf8",
+    );
+    expect(validateOkfFrontmatter(repaired)).toEqual({ valid: true });
+    expect(repaired).toContain("# Missing frontmatter");
   });
 });
 
@@ -634,6 +650,106 @@ describe("finishRepositoryRun", () => {
         JSON.parse,
       ),
     ).resolves.toMatchObject({ status: "complete", model: "test-model" });
+  });
+
+  test("finishes with multiline generated metadata instead of corrupting verification", async () => {
+    const root = await createRepository();
+    const run = await beginForcedUpdate(root);
+    await submitRepositoryPlan(run, {
+      pages: [
+        {
+          path: "/openwiki/quickstart.md",
+          title: "Quickstart",
+          purpose: "Refresh quickstart.",
+        },
+      ],
+    });
+    const next = await nextRepositoryPage(run);
+    if (next.status !== "pending") throw new Error("Expected page job.");
+    await run.backend.write(
+      next.job.path,
+      '---\ntype: Guide\ntitle: Quickstart\ngenerated:\n  by: openwiki/0.4.0\n  at: "2026-08-23T12:00:00.000Z"\n---\n\n# Quickstart\n\nUpdated.\n',
+    );
+    await submitRepositoryPage(run, {
+      jobId: next.job.id,
+      claims: [
+        {
+          statement: "The repository has a README.",
+          evidence: [{ resource: "repo://README.md" }],
+        },
+      ],
+    });
+
+    await expect(finishRepositoryRun(run)).resolves.toEqual({
+      status: "complete",
+    });
+
+    const content = await readFile(
+      path.join(root, "openwiki", "quickstart.md"),
+      "utf8",
+    );
+    expect(parseFrontmatterFields(content)).toMatchObject({
+      generated: { by: ACTOR.producerActor, at: STARTED_AT },
+      verified: [{ by: OPENWIKI_PRODUCER_ACTOR, at: STARTED_AT }],
+    });
+  });
+
+  test("finishes after deterministically degrading every invalid optional OKF family", async () => {
+    const root = await createRepository();
+    const run = await beginForcedUpdate(root);
+    await submitRepositoryPlan(run, {
+      pages: [
+        {
+          path: "/openwiki/quickstart.md",
+          title: "Quickstart",
+          purpose: "Refresh quickstart.",
+        },
+      ],
+    });
+    const next = await nextRepositoryPage(run);
+    if (next.status !== "pending") throw new Error("Expected page job.");
+    await run.backend.write(
+      next.job.path,
+      "---\ntype: Guide\ntitle: 9\ndescription: []\nresource: {}\ntimestamp: []\ntags: [docs, 7]\ngenerated: someday\nverified: [{at: someday}]\nsources: [{id: missing-resource}]\nstatus: reviewed\nstale_after: later\nproducer_extension: keep\n---\n\n# Quickstart\n\nUpdated.\n",
+    );
+    await submitRepositoryPage(run, {
+      jobId: next.job.id,
+      claims: [
+        {
+          statement: "The repository has a README.",
+          evidence: [{ resource: "repo://README.md" }],
+        },
+      ],
+    });
+
+    await expect(finishRepositoryRun(run)).resolves.toEqual({
+      status: "complete",
+    });
+
+    const content = await readFile(
+      path.join(root, "openwiki", "quickstart.md"),
+      "utf8",
+    );
+    const fields = parseFrontmatterFields(content);
+    expect(validateOkfFrontmatter(content)).toEqual({ valid: true });
+    expect(fields).toMatchObject({
+      generated: { by: ACTOR.producerActor, at: STARTED_AT },
+      producer_extension: "keep",
+      sources: [expect.objectContaining({ resource: "repo://README.md" })],
+      tags: ["docs"],
+      title: "Quickstart",
+      type: "Guide",
+      verified: [{ by: OPENWIKI_PRODUCER_ACTOR, at: STARTED_AT }],
+    });
+    for (const field of [
+      "description",
+      "resource",
+      "timestamp",
+      "status",
+      "stale_after",
+    ]) {
+      expect(fields).not.toHaveProperty(field);
+    }
   });
 
   test("invalidates the whole plan on drift and removes only abandoned new pages", async () => {

--- a/test/okf/frontmatter.test.ts
+++ b/test/okf/frontmatter.test.ts
@@ -6,6 +6,8 @@ import {
   parseFrontmatterFields,
   readFrontmatterField,
   removeFrontmatterField,
+  repairOkfFrontmatter,
+  repairPersistedFile,
   renderFrontmatter,
   setFrontmatterField,
   setGeneratedEvent,
@@ -44,16 +46,20 @@ describe("normalizeConceptContent", () => {
     expect(result.content).toBe(content);
   });
 
-  test("keeps a page that has a usable type even when optional fields are junk", () => {
-    // A valid `type` plus a non-string title is tolerated, not clobbered (#376).
+  test("repairs optional fields while preserving producer extensions", () => {
     const content =
       "---\ntype: Domain\ntitle: 123\ndescription: [one, two]\ncustom_ext: keep-me\n---\n\n# Orders\n";
     const result = normalizeConceptContent(content, PATH);
 
-    expect(result.changed).toBe(false);
-    expect(result.content).toBe(content);
-    // the producer extension field is preserved because nothing was rewritten
+    expect(result.changed).toBe(true);
+    expect(parseFrontmatterFields(result.content)).toMatchObject({
+      custom_ext: "keep-me",
+      title: "Orders",
+      type: "Domain",
+    });
+    expect(result.content).not.toContain("description:");
     expect(result.content).toContain("custom_ext: keep-me");
+    expect(validateOkfFrontmatter(result.content)).toEqual({ valid: true });
   });
 
   test("regenerates a page whose front matter has no type", () => {
@@ -165,6 +171,102 @@ describe("normalizeConceptContent", () => {
   });
 });
 
+describe("repairOkfFrontmatter", () => {
+  test.each([
+    {
+      field: "type",
+      yaml: "type: [Reference]",
+      expected: {
+        openwiki_generated: true,
+        title: "Page",
+        type: "Referenca",
+      },
+    },
+    {
+      field: "title",
+      yaml: "type: Guide\ntitle: 42",
+      expected: { title: "Page", type: "Guide" },
+    },
+    {
+      field: "description",
+      yaml: "type: Guide\ndescription: [invalid]",
+      absent: "description",
+    },
+    {
+      field: "resource",
+      yaml: "type: Guide\nresource: {invalid: true}",
+      absent: "resource",
+    },
+    {
+      field: "timestamp",
+      yaml: "type: Guide\ntimestamp: []",
+      absent: "timestamp",
+    },
+    {
+      field: "tags",
+      yaml: 'type: Guide\ntags: [docs, 7, "", api]',
+      expected: { tags: ["docs", "api"] },
+    },
+    {
+      field: "generated",
+      yaml: "type: Guide\ngenerated: {at: 2026-08-20T00:00:00Z}",
+      absent: "generated",
+    },
+    {
+      field: "verified",
+      yaml: "type: Guide\nverified:\n  - {by: human:reviewer, at: 2026-08-20T00:00:00Z}\n  - {by: human:broken, at: someday}",
+      expected: {
+        verified: [{ by: "human:reviewer", at: "2026-08-20T00:00:00Z" }],
+      },
+    },
+    {
+      field: "sources",
+      yaml: "type: Guide\nsources:\n  - {id: good, resource: repo://README.md}\n  - {id: missing-resource}",
+      expected: {
+        sources: [{ id: "good", resource: "repo://README.md" }],
+      },
+    },
+    {
+      field: "status",
+      yaml: "type: Guide\nstatus: reviewed",
+      absent: "status",
+    },
+    {
+      field: "stale_after",
+      yaml: "type: Guide\nstale_after: someday",
+      absent: "stale_after",
+    },
+  ])("deterministically degrades invalid $field metadata", (fixture) => {
+    const content = `---\n${fixture.yaml}\nproducer_extension: keep\n---\n\n# Page\n\nAuthored body.\n`;
+    const repaired = repairOkfFrontmatter(content, PATH, "Referenca");
+    const fields = parseFrontmatterFields(repaired.content);
+
+    expect(repaired.changed).toBe(true);
+    expect(fields).toMatchObject({
+      producer_extension: "keep",
+      ...(fixture.expected ?? {}),
+    });
+    if (fixture.absent) expect(fields).not.toHaveProperty(fixture.absent);
+    expect(repaired.content).toContain("# Page\n\nAuthored body.\n");
+    expect(validateOkfFrontmatter(repaired.content)).toEqual({ valid: true });
+  });
+
+  test("falls back to minimal valid metadata for an unusable YAML mapping", () => {
+    const repaired = repairOkfFrontmatter(
+      "---\ntype: Guide\ntype: Domain\n---\n\n# Page\n\nBody.\n",
+      PATH,
+    );
+
+    expect(parseFrontmatterFields(repaired.content)).toEqual({
+      openwiki_generated: true,
+      title: "Page",
+      type: "Reference",
+    });
+    expect(repaired.content).toContain("# Page\n\nBody.\n");
+    expect(validateOkfFrontmatter(repaired.content)).toEqual({ valid: true });
+  });
+});
+
 describe("setOkfSources", () => {
   test("adds a structured sources list without rewriting sibling fields", () => {
     const result = setOkfSources(
@@ -247,6 +349,19 @@ describe("setGeneratedEvent", () => {
     ).toBe(
       '---\ntype: Reference\ngenerated: {by: "openwiki/0.3.1", at: "2026-08-18T09:00:00.000Z"}\ntitle: Page\n---\n\n# Page\n',
     );
+  });
+
+  test("replaces a multiline generated mapping as one complete field", () => {
+    const stamped = setGeneratedEvent(
+      '---\ntype: Reference\ngenerated:\n  by: openwiki/0.3.0\n  at: "2026-08-17T09:00:00.000Z"\ntitle: Page\n---\n\n# Page\n',
+      "openwiki/0.3.1",
+      "2026-08-18T09:00:00.000Z",
+    );
+
+    expect(stamped).toBe(
+      '---\ntype: Reference\ngenerated: {by: "openwiki/0.3.1", at: "2026-08-18T09:00:00.000Z"}\ntitle: Page\n---\n\n# Page\n',
+    );
+    expect(validateOkfFrontmatter(stamped)).toEqual({ valid: true });
   });
 
   test("emits a bare {by} event when no time is supplied", () => {
@@ -339,6 +454,15 @@ describe("removeFrontmatterField", () => {
     expect(
       removeFrontmatterField(content, "openwiki_translation_pending"),
     ).toBe(content);
+  });
+
+  test("removes a complete multiline mapping", () => {
+    expect(
+      removeFrontmatterField(
+        '---\ntype: Reference\ngenerated:\n  by: openwiki/0.3.0\n  at: "2026-08-17T09:00:00.000Z"\ntitle: Page\n---\n\n# Page\n',
+        "generated",
+      ),
+    ).toBe("---\ntype: Reference\ntitle: Page\n---\n\n# Page\n");
   });
 
   test("returns the content unchanged when there is no block", () => {
@@ -519,6 +643,33 @@ describe("validatePersistedFile", () => {
         valid: false,
       });
     }
+  });
+});
+
+describe("repairPersistedFile", () => {
+  test("writes and re-validates a deterministic repair", async () => {
+    let content =
+      "---\ntype: Guide\nstatus: reviewed\n---\n\n# Page\n\nBody.\n";
+    const backend = {
+      readRaw: vi.fn(() => ({
+        data: {
+          content,
+          mimeType: "text/markdown",
+          created_at: "2026-07-13T00:00:00.000Z",
+          modified_at: "2026-07-13T00:00:00.000Z",
+        },
+      })),
+      write: vi.fn((_path: string, next: string) => {
+        content = next;
+        return {};
+      }),
+    } as unknown as BackendProtocolV2;
+
+    await expect(
+      repairPersistedFile(backend, "/openwiki/page.md"),
+    ).resolves.toEqual({ changed: true, validation: { valid: true } });
+    expect(content).not.toContain("status:");
+    expect(content).toContain("# Page\n\nBody.\n");
   });
 });
 


### PR DESCRIPTION
## Summary

Prevent invalid optional OKF metadata from crashing wiki generation. Frontmatter is now deterministically repaired or safely removed while preserving authored Markdown and valid metadata.