### PR TITLE
fix: stabilize generated wiki formatting and claims hashes

### DIFF
--- a/.changeset/calm-wikis-format.md
+++ b/.changeset/calm-wikis-format.md
@@ -1,0 +1,5 @@
+---
+"openwiki": patch
+---
+
+fix: stabilize generated wiki formatting and claims hashes

--- a/.prettierignore
+++ b/.prettierignore
@@ -3,3 +3,4 @@ dist
 node_modules
 *.tgz
 pnpm-lock.yaml
+/openwiki/

--- a/src/okf/frontmatter.ts
+++ b/src/okf/frontmatter.ts
@@ -514,8 +514,8 @@ export function setFrontmatterField(
 
 /**
  * Stamps the code-owned OKF `generated` provenance event on a page (SPEC §5.1),
- * setting or replacing a `generated: {by, at}` flow mapping and preserving every
- * other front-matter line byte-for-byte.
+ * setting or replacing a `generated: { by, at }` flow mapping and preserving
+ * every other front-matter line byte-for-byte.
  *
  * `generated` is a mapping, not a scalar, so it cannot go through
  * {@link setFrontmatterField}. The value is emitted as a single-line flow
@@ -535,7 +535,7 @@ export function setGeneratedEvent(
     at === undefined
       ? `by: ${JSON.stringify(by)}`
       : `by: ${JSON.stringify(by)}, at: ${JSON.stringify(at)}`;
-  const line = `generated: {${members}}`;
+  const line = `generated: { ${members} }`;
   return replaceFrontmatterFieldBlock(content, "generated", [line]);
 }
 

--- a/src/okf/generated-provenance.ts
+++ b/src/okf/generated-provenance.ts
@@ -187,9 +187,11 @@ export async function finalizeGeneratedProvenance(
     const bodyChanged =
       initial === undefined || initial.bodyHash !== hashConceptBody(content);
     const candidate = bodyChanged
-      ? removeFrontmatterField(
-          setGeneratedEvent(content, producerActor, now),
-          "timestamp",
+      ? canonicalizeChangedConcept(
+          removeFrontmatterField(
+            setGeneratedEvent(content, producerActor, now),
+            "timestamp",
+          ),
         )
       : restoreGeneratedEvent(content, initial.generated);
     const reconciled = repairOkfFrontmatter(candidate, page).content;
@@ -202,6 +204,21 @@ export async function finalizeGeneratedProvenance(
       if (result.error) continue;
     }
   }
+}
+
+/**
+ * Applies OpenWiki's minimal byte-level format to a concept changed this run.
+ *
+ * Only terminal line endings are canonicalized. Prose wrapping, indentation,
+ * tables, and every other producer-authored Markdown choice remain untouched.
+ * Existing no-op pages never pass through this function, preserving their
+ * bytes exactly.
+ *
+ * @param content - Changed or newly created concept content.
+ * @returns Content ending in exactly one LF line ending.
+ */
+function canonicalizeChangedConcept(content: string): string {
+  return `${content.replace(/[\r\n]*$/u, "")}\n`;
 }
 
 /**
@@ -271,9 +288,22 @@ function restoreGeneratedEvent(
   content: string,
   generated?: GeneratedEvent,
 ): string {
+  if (generated && sameGeneratedEvent(readGeneratedEvent(content), generated)) {
+    return content;
+  }
   return generated
     ? setGeneratedEvent(content, generated.by, generated.at)
     : removeFrontmatterField(content, "generated");
+}
+
+/**
+ * Compares two valid producer events by meaning rather than YAML formatting.
+ */
+function sameGeneratedEvent(
+  left: GeneratedEvent | undefined,
+  right: GeneratedEvent,
+): boolean {
+  return left?.by === right.by && left.at === right.at;
 }
 
 /**

--- a/test/agent/index-middleware.test.ts
+++ b/test/agent/index-middleware.test.ts
@@ -698,7 +698,7 @@ describe("createOpenWikiIndexMiddleware generated finalization", () => {
 
     const page = await readFile(path.join(rootDir, "openwiki/page.md"), "utf8");
     expect(page).toContain(
-      `generated: {by: "openwiki/${OPENWIKI_VERSION}", at: "${NOW}"}`,
+      `generated: { by: "openwiki/${OPENWIKI_VERSION}", at: "${NOW}" }`,
     );
   });
 
@@ -728,7 +728,7 @@ describe("createOpenWikiIndexMiddleware generated finalization", () => {
 
     const page = await readFile(path.join(rootDir, "openwiki/page.md"), "utf8");
     expect(page).toContain(
-      `generated: {by: "openwiki/${OPENWIKI_VERSION}", at: "${LATER}"}`,
+      `generated: { by: "openwiki/${OPENWIKI_VERSION}", at: "${LATER}" }`,
     );
     expect(page).not.toContain("timestamp:");
     // Exactly one generated event, not a duplicated field.

--- a/test/agent/wiki-finalizer.test.ts
+++ b/test/agent/wiki-finalizer.test.ts
@@ -187,7 +187,7 @@ describe("finalizeWikiArtifacts", () => {
     expect(page).toContain("```text");
     expect(page).toContain("openwiki: broken internal link [./missing.md]");
     expect(page).toContain(
-      `generated: {by: "host-agent/test", at: "${RUN_TIMESTAMP}"}`,
+      `generated: { by: "host-agent/test", at: "${RUN_TIMESTAMP}" }`,
     );
     expect(index).toContain("[Quickstart](quickstart.md) - Start here.");
   });
@@ -263,8 +263,76 @@ describe("finalizeWikiArtifacts", () => {
       "utf8",
     );
     expect(page).toContain(
-      `generated: {by: "host-agent/codex", at: "${RUN_TIMESTAMP}"}`,
+      `generated: { by: "host-agent/codex", at: "${RUN_TIMESTAMP}" }`,
     );
     expect(page).not.toContain("\n  by: openwiki/0.3.2");
+  });
+
+  test("preserves a semantically unchanged generated event byte-for-byte", async () => {
+    const { backend, rootDir } = await setupWiki();
+    const previousTimestamp = "2026-08-18T10:00:00.000Z";
+    const original = [
+      "---",
+      "type: Guide",
+      "generated:",
+      "  by: openwiki/0.3.2",
+      `  at: ${previousTimestamp}`,
+      "---",
+      "",
+      "# Existing",
+      "",
+      "Unchanged body.",
+      "",
+    ].join("\n");
+    await backend.write("/openwiki/existing.md", original);
+    const prepared = await prepareWikiForAuthoring({
+      backend,
+      outputMode: "repository",
+    });
+
+    await finalizeWikiArtifacts({
+      backend,
+      outputMode: "repository",
+      prepared,
+      at: RUN_TIMESTAMP,
+      producerActor: "host-agent/codex",
+    });
+
+    await expect(
+      readFile(path.join(rootDir, "openwiki/existing.md"), "utf8"),
+    ).resolves.toBe(original);
+  });
+
+  test("canonicalizes changed concepts once and remains idempotent", async () => {
+    const { backend, rootDir } = await setupWiki();
+    const prepared = await prepareWikiForAuthoring({
+      backend,
+      outputMode: "repository",
+    });
+    await backend.write(
+      "/openwiki/new.md",
+      "---\ntype: Guide\n---\n\n# New\n\nBody.\n\n\n",
+    );
+
+    const options = {
+      backend,
+      outputMode: "repository" as const,
+      prepared,
+      at: RUN_TIMESTAMP,
+      producerActor: "host-agent/codex",
+    };
+    await finalizeWikiArtifacts(options);
+    const first = await readFile(path.join(rootDir, "openwiki/new.md"), "utf8");
+    await finalizeWikiArtifacts(options);
+    const second = await readFile(
+      path.join(rootDir, "openwiki/new.md"),
+      "utf8",
+    );
+
+    expect(first).toContain(
+      `generated: { by: "host-agent/codex", at: "${RUN_TIMESTAMP}" }`,
+    );
+    expect(first).toMatch(/[^\n]\n$/u);
+    expect(second).toBe(first);
   });
 });

--- a/test/generation/repository-run.test.ts
+++ b/test/generation/repository-run.test.ts
@@ -207,16 +207,22 @@ async function beginForcedUpdate(
  *
  * @param run - Active run with a persisted one-page plan.
  * @param title - Final page title.
+ * @param terminalNewline - Whether the authored page includes a final newline.
  */
 async function completeCurrentPage(
   run: ActiveRepositoryRun,
   title: string,
+  terminalNewline = true,
 ): Promise<void> {
   const next = await nextRepositoryPage(run);
   if (next.status !== "pending") {
     throw new Error("Expected a pending page job.");
   }
-  const write = await run.backend.write(next.job.path, validPage(title));
+  const content = validPage(title);
+  const write = await run.backend.write(
+    next.job.path,
+    terminalNewline ? content : content.replace(/\n$/u, ""),
+  );
   if (write.error) throw new Error(write.error);
   await submitRepositoryPage(run, {
     jobId: next.job.id,
@@ -591,7 +597,7 @@ describe("repository page queue", () => {
 });
 
 describe("finishRepositoryRun", () => {
-  test("completes init with final Claims, sources, versions, and metadata durable", async () => {
+  test("completes init with canonical bytes and final Claims durable", async () => {
     const root = await createRepository(["old.md"]);
     const result = await beginRepositoryRun({
       root,
@@ -612,7 +618,7 @@ describe("finishRepositoryRun", () => {
         },
       ],
     });
-    await completeCurrentPage(run, "Quickstart");
+    await completeCurrentPage(run, "Quickstart", false);
 
     await expect(finishRepositoryRun(run)).resolves.toEqual({
       status: "complete",
@@ -623,6 +629,14 @@ describe("finishRepositoryRun", () => {
       readFile(path.join(root, "openwiki", "old.md"), "utf8"),
     ).rejects.toMatchObject({ code: "ENOENT" });
     const store = new ClaimsStore(root);
+    const markdown = await readFile(
+      path.join(root, "openwiki", "quickstart.md"),
+      "utf8",
+    );
+    expect(markdown).toMatch(/[^\n]\n$/u);
+    expect(markdown).toContain(
+      `generated: { by: "${ACTOR.producerActor}", at: "${STARTED_AT}" }`,
+    );
     const sidecar = await store.loadPage("/openwiki/quickstart.md");
     expect(sidecar?.pageVersion).toBe(
       await store.hashPage("/openwiki/quickstart.md"),
@@ -631,9 +645,7 @@ describe("finishRepositoryRun", () => {
       by: OPENWIKI_PRODUCER_ACTOR,
       at: STARTED_AT,
     });
-    const fields = parseFrontmatterFields(
-      await readFile(path.join(root, "openwiki", "quickstart.md"), "utf8"),
-    );
+    const fields = parseFrontmatterFields(markdown);
     expect(fields?.verified).toContainEqual({
       by: OPENWIKI_PRODUCER_ACTOR,
       at: STARTED_AT,

--- a/test/okf/frontmatter.test.ts
+++ b/test/okf/frontmatter.test.ts
@@ -335,7 +335,7 @@ describe("setGeneratedEvent", () => {
         "2026-08-18T09:00:00.000Z",
       ),
     ).toBe(
-      '---\ntype: Reference\ntitle: Page\ngenerated: {by: "openwiki/0.3.1", at: "2026-08-18T09:00:00.000Z"}\n---\n\n# Page\n',
+      '---\ntype: Reference\ntitle: Page\ngenerated: { by: "openwiki/0.3.1", at: "2026-08-18T09:00:00.000Z" }\n---\n\n# Page\n',
     );
   });
 
@@ -347,7 +347,7 @@ describe("setGeneratedEvent", () => {
         "2026-08-18T09:00:00.000Z",
       ),
     ).toBe(
-      '---\ntype: Reference\ngenerated: {by: "openwiki/0.3.1", at: "2026-08-18T09:00:00.000Z"}\ntitle: Page\n---\n\n# Page\n',
+      '---\ntype: Reference\ngenerated: { by: "openwiki/0.3.1", at: "2026-08-18T09:00:00.000Z" }\ntitle: Page\n---\n\n# Page\n',
     );
   });
 
@@ -359,7 +359,7 @@ describe("setGeneratedEvent", () => {
     );
 
     expect(stamped).toBe(
-      '---\ntype: Reference\ngenerated: {by: "openwiki/0.3.1", at: "2026-08-18T09:00:00.000Z"}\ntitle: Page\n---\n\n# Page\n',
+      '---\ntype: Reference\ngenerated: { by: "openwiki/0.3.1", at: "2026-08-18T09:00:00.000Z" }\ntitle: Page\n---\n\n# Page\n',
     );
     expect(validateOkfFrontmatter(stamped)).toEqual({ valid: true });
   });
@@ -371,7 +371,7 @@ describe("setGeneratedEvent", () => {
         "openwiki/0.3.1",
       ),
     ).toBe(
-      '---\ntype: Reference\ngenerated: {by: "openwiki/0.3.1"}\n---\n\n# Page\n',
+      '---\ntype: Reference\ngenerated: { by: "openwiki/0.3.1" }\n---\n\n# Page\n',
     );
   });
 
@@ -383,7 +383,7 @@ describe("setGeneratedEvent", () => {
         "2026-08-18T09:00:00.000Z",
       ),
     ).toBe(
-      '---\ngenerated: {by: "openwiki/0.3.1", at: "2026-08-18T09:00:00.000Z"}\n---\n\n# Page\nBody.\n',
+      '---\ngenerated: { by: "openwiki/0.3.1", at: "2026-08-18T09:00:00.000Z" }\n---\n\n# Page\nBody.\n',
     );
   });
 


### PR DESCRIPTION
## Summary

- Canonicalize generated provenance formatting.
- Ensure changed pages end with one newline before Claims hashing.
- Preserve unchanged pages byte-for-byte.
- Exclude generated openwiki/ pages from Prettier to prevent hash drift.