### PR TITLE
fix: skip failed page workers without aborting updates

### DIFF
--- a/.changeset/some-shirts-prove.md
+++ b/.changeset/some-shirts-prove.md
@@ -1,0 +1,5 @@
+---
+"openwiki": patch
+---
+
+fix: skip failed page workers without aborting updates

--- a/src/agent/repository-runner.ts
+++ b/src/agent/repository-runner.ts
@@ -8,14 +8,17 @@ import { z } from "zod";
 import { RepositoryRunError } from "../generation/errors.js";
 import {
   beginRepositoryRun,
+  captureRepositoryPageSnapshot,
   finishRepositoryRun,
   nextRepositoryPage,
+  skipRepositoryPage,
   submitRepositoryPage,
   submitRepositoryPlan,
   type ActiveBeginView,
   type ActiveRepositoryRun,
   type BeginRepositoryRunResult,
   type NextRepositoryPageResult,
+  type RepositoryPageSnapshot,
 } from "../generation/repository-run.js";
 import type { RepositoryRunMode } from "../generation/run-state.js";
 import { OPENWIKI_PRODUCER_ACTOR } from "../version.js";
@@ -212,7 +215,12 @@ export async function runNativeRepositoryGeneration(
       );
     }
 
-    await runPendingPageAgents(run, options.model, options.onEvent, view);
+    const skippedPageSnapshots = await runPendingPageAgents(
+      run,
+      options.model,
+      options.onEvent,
+      view,
+    );
     options.onEvent?.({
       type: "repository_progress",
       stage: "finalizing",
@@ -221,7 +229,7 @@ export async function runNativeRepositoryGeneration(
     });
 
     try {
-      await finishRepositoryRun(run);
+      await finishRepositoryRun(run, { skippedPageSnapshots });
       return { skipped: false };
     } catch (error) {
       if (!isSourceDriftInvalidation(error)) {
@@ -366,10 +374,11 @@ async function runPendingPageAgents(
   model: BaseChatModel,
   onEvent: ((event: OpenWikiRunEvent) => void) | undefined,
   view: ActiveBeginView,
-): Promise<void> {
+): Promise<RepositoryPageSnapshot[]> {
+  const skipped: RepositoryPageSnapshot[] = [];
   while (true) {
     const next = await nextRepositoryPage(run);
-    if (next.status === "complete") return;
+    if (next.status === "complete") return skipped;
 
     const pages = run.state.plan?.pages ?? [];
     const pageIndex = pages.findIndex(({ id }) => id === next.job.id) + 1;
@@ -381,7 +390,8 @@ async function runPendingPageAgents(
       pageIndex,
       pageCount: pages.length,
     });
-    await runPageAgent(run, next.job, model, onEvent);
+    const skippedSnapshot = await runPageAgent(run, next.job, model, onEvent);
+    if (skippedSnapshot) skipped.push(skippedSnapshot);
   }
 }
 
@@ -398,7 +408,8 @@ async function runPageAgent(
   job: PendingPageJob,
   model: BaseChatModel,
   onEvent?: (event: OpenWikiRunEvent) => void,
-): Promise<void> {
+): Promise<RepositoryPageSnapshot | null> {
+  const snapshot = await captureRepositoryPageSnapshot(run, job.id);
   const ignore = await OpenWikiIgnore.load(run.root);
   const wikiBackend = new OpenWikiLocalShellBackend({
     docsOnly: true,
@@ -412,6 +423,7 @@ async function runPageAgent(
   });
 
   let submitted = false;
+  let fatalSubmissionFailure = false;
   const submitPageTool = new DynamicStructuredTool({
     name: "submit_page",
     description:
@@ -441,6 +453,7 @@ async function runPageAgent(
               ?.id,
           );
         }
+        fatalSubmissionFailure = true;
         throw error;
       }
     },
@@ -469,20 +482,41 @@ async function runPageAgent(
     ),
   });
 
-  await streamWorkerTools(
-    agent,
-    [
-      {
-        role: "user",
-        content: "Research and document the assigned page, then submit it.",
-      },
-    ],
-    onEvent,
-  );
-
-  if (!submitted) {
-    throw new Error(`${job.path} worker exited without submit_page.`);
+  try {
+    await streamWorkerTools(
+      agent,
+      [
+        {
+          role: "user",
+          content: "Research and document the assigned page, then submit it.",
+        },
+      ],
+      onEvent,
+    );
+  } catch (error) {
+    if (submitted) return null;
+    if (fatalSubmissionFailure) throw error;
+    await skipRepositoryPage(run, snapshot);
+    emitDeferredPageWarning(job.path, onEvent);
+    return snapshot;
   }
+
+  if (submitted) return null;
+
+  await skipRepositoryPage(run, snapshot);
+  emitDeferredPageWarning(job.path, onEvent);
+  return snapshot;
+}
+
+function emitDeferredPageWarning(
+  page: string,
+  onEvent?: (event: OpenWikiRunEvent) => void,
+): void {
+  onEvent?.({
+    type: "text",
+    source: "main",
+    text: `${page} was restored after its worker exited without submitting. It was skipped for this update and will be reconsidered on the next update.\n`,
+  });
 }
 
 /**

--- a/src/agent/utils.ts
+++ b/src/agent/utils.ts
@@ -205,12 +205,16 @@ export async function writeLastUpdateMetadata(
   outputMode: OpenWikiOutputMode = "repository",
   status: UpdateRunStatus = "complete",
   language?: string,
+  gitHeadOverride?: string,
 ): Promise<void> {
   const metadataFile = getMetadataFilePath(cwd, outputMode);
   const metadata: UpdateMetadata = {
     updatedAt: new Date().toISOString(),
     command,
-    gitHead: outputMode === "repository" ? await getGitHead(cwd) : undefined,
+    gitHead:
+      outputMode === "repository"
+        ? (gitHeadOverride ?? (await getGitHead(cwd)))
+        : undefined,
     model: modelId,
     status,
     ...(language ? { language } : {}),

--- a/src/claims/brains/code/runtime.ts
+++ b/src/claims/brains/code/runtime.ts
@@ -37,7 +37,7 @@ export interface ClaimsRuntime {
   /**
    * Persists Claims and synchronizes verification/page versions or rejects.
    */
-  finalize(at?: string): Promise<void>;
+  finalize(at?: string, excludedPages?: ReadonlySet<string>): Promise<void>;
 }
 
 /**
@@ -120,11 +120,18 @@ function buildClaimsRuntime(
     session,
     issueCount: issues.length,
     issues: [...issues],
-    finalize: async (at = new Date().toISOString()) => {
-      const result = await session.finalize(store, {
-        by: OPENWIKI_PRODUCER_ACTOR,
-        at,
-      });
+    finalize: async (
+      at = new Date().toISOString(),
+      excludedPages: ReadonlySet<string> = new Set(),
+    ) => {
+      const result = await session.finalize(
+        store,
+        {
+          by: OPENWIKI_PRODUCER_ACTOR,
+          at,
+        },
+        excludedPages,
+      );
       const warnings = [...result.warnings];
       warnings.push(
         ...(await finalizeVerificationProjection(

--- a/src/claims/brains/code/session.ts
+++ b/src/claims/brains/code/session.ts
@@ -288,6 +288,7 @@ export class ClaimSession {
   async finalize(
     store: ClaimsStore,
     verification: ClaimsVerificationEvent,
+    excludedPages: ReadonlySet<string> = new Set(),
   ): Promise<ClaimsFinalizeResult> {
     const resolver = cacheEvidenceResolver(this.resolver);
     const warnings: string[] = [];
@@ -303,6 +304,7 @@ export class ClaimSession {
     }> = [];
 
     for (const [page, state] of this.pages) {
+      if (excludedPages.has(page)) continue;
       await state.pendingMutation;
       if (state.deleted || !state.dirty) {
         continue;
@@ -331,6 +333,7 @@ export class ClaimSession {
     }
 
     for (const orphan of this.orphanPages) {
+      if (excludedPages.has(orphan)) continue;
       try {
         await store.deletePage(orphan);
       } catch (error) {
@@ -341,6 +344,7 @@ export class ClaimSession {
       }
     }
     for (const missingPage of missingPages) {
+      if (excludedPages.has(missingPage)) continue;
       try {
         await store.deletePage(missingPage);
       } catch (error) {
@@ -351,6 +355,7 @@ export class ClaimSession {
       }
     }
     for (const [page, state] of this.pages) {
+      if (excludedPages.has(page)) continue;
       if (state.deleted) {
         try {
           await store.deletePage(page);
@@ -384,6 +389,7 @@ export class ClaimSession {
     }
 
     for (const [page, state] of this.pages) {
+      if (excludedPages.has(page)) continue;
       if (state.deleted) continue;
       const eligible =
         state.persisted &&

--- a/src/generation/repository-run.ts
+++ b/src/generation/repository-run.ts
@@ -27,6 +27,7 @@ import { ClaimsStore } from "../claims/brains/code/store.js";
 import type {
   GroundingIssue,
   InspectedClaim,
+  PageClaims,
 } from "../claims/brains/code/types.js";
 import { ensureCodeModeRepoSetup } from "../ingestion/code-mode.js";
 import {
@@ -127,6 +128,16 @@ export interface ActiveRepositoryRun {
    * Strict process-local Claims runtime rebuilt from durable state.
    */
   claimsRuntime: ClaimsRuntime;
+}
+
+/**
+ * Page-local durable state captured before a bounded worker starts.
+ */
+export interface RepositoryPageSnapshot {
+  jobId: string;
+  path: string;
+  markdown: string | null;
+  claims: PageClaims | null;
 }
 
 /**
@@ -456,12 +467,26 @@ async function resumeRepositoryRun(
     ignore,
   );
   const sourceChanged = currentFingerprint !== state.sourceFingerprint;
+  const resetSkippedPages =
+    state.plan?.pages.some(({ status }) => status === "skipped") ?? false;
   const nextState: RepositoryRunState = {
     ...state,
     actor: {
       ...state.actor,
       metadataModel: input.actor.metadataModel,
     },
+    ...(state.plan && resetSkippedPages
+      ? {
+          plan: {
+            ...state.plan,
+            pages: state.plan.pages.map((page) =>
+              page.status === "skipped"
+                ? { ...page, status: "pending" as const }
+                : page,
+            ),
+          },
+        }
+      : {}),
   };
   if (sourceChanged) {
     nextState.phase = "planning";
@@ -476,6 +501,7 @@ async function resumeRepositoryRun(
   }
   if (
     sourceChanged ||
+    resetSkippedPages ||
     state.actor.metadataModel !== input.actor.metadataModel ||
     nextState.planningContext !== state.planningContext
   ) {
@@ -698,6 +724,133 @@ export async function nextRepositoryPage(
       existingClaims: run.claimsRuntime.session.inspectClaims(job.path),
     },
   };
+}
+
+/**
+ * Captures the current pending page and Claims sidecar before model-owned work.
+ */
+export async function captureRepositoryPageSnapshot(
+  run: ActiveRepositoryRun,
+  jobId: string,
+): Promise<RepositoryPageSnapshot> {
+  const current = run.state.plan?.pages.find(
+    ({ status }) => status === "pending",
+  );
+  if (!current || current.id !== jobId) {
+    throw new RepositoryRunError(
+      "invalid_state",
+      "Only the current pending OpenWiki page job may be snapshotted.",
+    );
+  }
+
+  const read = await run.backend.readRaw(current.path);
+  if (read.error && read.error !== "file_not_found") {
+    throw new RepositoryRunError(
+      "invalid_state",
+      `Could not snapshot ${current.path}: ${read.error}`,
+    );
+  }
+  const content = read.data?.content;
+  if (content !== undefined && typeof content !== "string") {
+    throw new RepositoryRunError(
+      "invalid_state",
+      `Could not snapshot non-text Markdown page ${current.path}.`,
+    );
+  }
+
+  return {
+    jobId: current.id,
+    path: current.path,
+    markdown: content ?? null,
+    claims: await new ClaimsStore(run.root).loadPage(current.path),
+  };
+}
+
+/**
+ * Rolls a failed page worker back without advancing its pending checkpoint.
+ */
+export async function skipRepositoryPage(
+  run: ActiveRepositoryRun,
+  snapshot: RepositoryPageSnapshot,
+): Promise<void> {
+  const plan = run.state.plan;
+  const current = plan?.pages.find(({ status }) => status === "pending");
+  if (
+    !plan ||
+    !current ||
+    current.id !== snapshot.jobId ||
+    current.path !== snapshot.path
+  ) {
+    throw new RepositoryRunError(
+      "invalid_state",
+      "The failed page worker no longer owns the current pending job.",
+    );
+  }
+
+  await restoreRepositoryPageMarkdown(run, snapshot);
+
+  const store = new ClaimsStore(run.root);
+  if (snapshot.claims) {
+    await store.writePage(snapshot.path, snapshot.claims);
+  } else {
+    await store.deletePage(snapshot.path);
+  }
+
+  const claimsRuntime = await prepareClaimsRuntime(
+    run.state.mode,
+    "repository",
+    run.root,
+    run.ignore,
+    () => undefined,
+    { resumeInit: run.state.mode === "init" },
+  );
+  if (!claimsRuntime) {
+    throw new Error("Repository Claims runtime was not restored.");
+  }
+  run.claimsRuntime = claimsRuntime;
+
+  await writeLastUpdateMetadata(
+    run.state.mode,
+    run.root,
+    run.state.actor.metadataModel,
+    "repository",
+    "interrupted",
+    run.state.language,
+    run.state.baseGitHead,
+  );
+
+  const nextState: RepositoryRunState = {
+    ...run.state,
+    plan: {
+      ...plan,
+      pages: plan.pages.map((page) =>
+        page.id === snapshot.jobId
+          ? { ...page, status: "skipped" as const }
+          : page,
+      ),
+    },
+  };
+  await writeRepositoryRunState(run.root, nextState);
+  run.state = nextState;
+}
+
+async function restoreRepositoryPageMarkdown(
+  run: ActiveRepositoryRun,
+  snapshot: RepositoryPageSnapshot,
+): Promise<void> {
+  const result =
+    snapshot.markdown === null
+      ? await run.backend.delete(snapshot.path)
+      : await run.backend.write(snapshot.path, snapshot.markdown);
+  if (
+    result.error &&
+    !(snapshot.markdown === null && result.error === "file_not_found")
+  ) {
+    throw new RepositoryRunError(
+      "invalid_state",
+      `Could not restore ${snapshot.path}: ${result.error}`,
+    );
+  }
 }
 
 /**
@@ -932,6 +1085,7 @@ function isVerificationEvent(
  */
 async function assertRepositoryClaimsDurable(
   run: ActiveRepositoryRun,
+  excludedPages: ReadonlySet<string> = new Set(),
 ): Promise<void> {
   const store = new ClaimsStore(run.root);
   const currentPages = new Set(await store.discoverPages());
@@ -952,6 +1106,7 @@ async function assertRepositoryClaimsDurable(
   for (const page of run.claimsRuntime.session
     .getEvidenceResourcesByPage()
     .keys()) {
+    if (excludedPages.has(page)) continue;
     if (run.claimsRuntime.session.inspectClaims(page).length === 0) continue;
     if (!currentPages.has(page)) {
       throw new RepositoryRunError(
@@ -1004,6 +1159,9 @@ function sameResourceSet(
  */
 export async function finishRepositoryRun(
   run: ActiveRepositoryRun,
+  options: {
+    skippedPageSnapshots?: readonly RepositoryPageSnapshot[];
+  } = {},
 ): Promise<{ status: "complete" }> {
   await requireStableSourceFingerprint(run);
 
@@ -1014,13 +1172,29 @@ export async function finishRepositoryRun(
       "OpenWiki cannot finish before a plan is submitted.",
     );
   }
-  const pending = plan.pages.filter(({ status }) => status !== "complete");
+  const pending = plan.pages.filter(({ status }) => status === "pending");
   if (pending.length > 0) {
     throw new RepositoryRunError(
       "invalid_state",
       `OpenWiki cannot finish with ${pending.length} pending page job(s).`,
     );
   }
+
+  const skippedJobs = plan.pages.filter(({ status }) => status === "skipped");
+  const snapshots = options.skippedPageSnapshots ?? [];
+  const snapshotsByJobId = new Map(
+    snapshots.map((snapshot) => [snapshot.jobId, snapshot]),
+  );
+  if (
+    skippedJobs.length !== snapshots.length ||
+    skippedJobs.some((job) => snapshotsByJobId.get(job.id)?.path !== job.path)
+  ) {
+    throw new RepositoryRunError(
+      "invalid_state",
+      "Every skipped OpenWiki page job requires its original page snapshot before finish.",
+    );
+  }
+  const skippedPages = new Set(skippedJobs.map(({ path }) => path));
 
   await applyAbandonedGeneratedPageDeletions(run, plan);
   await applyPlannedDeletions(run, plan.deletePages);
@@ -1037,20 +1211,36 @@ export async function finishRepositoryRun(
     claimSources: run.claimsRuntime.session.getEvidenceResourcesByPage(),
   });
 
-  await run.claimsRuntime.finalize(run.state.startedAt);
-  await assertRepositoryClaimsDurable(run);
+  for (const snapshot of snapshots) {
+    await restoreRepositoryPageMarkdown(run, snapshot);
+  }
+
+  await run.claimsRuntime.finalize(run.state.startedAt, skippedPages);
+  await assertRepositoryClaimsDurable(run, skippedPages);
   // Close the check/use race: source must remain unchanged across the entire
   // deterministic finish window, not only at its start.
   await requireStableSourceFingerprint(run);
-  await persistRunMetadataIfChanged(
-    run.state.mode,
-    run.root,
-    run.state.actor.metadataModel,
-    "repository",
-    run.state.beforeContentSnapshot,
-    "complete",
-    run.state.language,
-  );
+  if (skippedPages.size > 0) {
+    await writeLastUpdateMetadata(
+      run.state.mode,
+      run.root,
+      run.state.actor.metadataModel,
+      "repository",
+      "interrupted",
+      run.state.language,
+      run.state.baseGitHead,
+    );
+  } else {
+    await persistRunMetadataIfChanged(
+      run.state.mode,
+      run.root,
+      run.state.actor.metadataModel,
+      "repository",
+      run.state.beforeContentSnapshot,
+      "complete",
+      run.state.language,
+    );
+  }
 
   // Delete this LAST. If anything above fails, begin() can reconstruct and retry.
   await removeRepositoryRunState(run.root);

--- a/src/generation/run-state.ts
+++ b/src/generation/run-state.ts
@@ -31,7 +31,7 @@ export type RepositoryRunPhase = "planning" | "generating";
 /**
  * Persisted completion state for one ordered page job.
  */
-export type PageJobStatus = "pending" | "complete";
+export type PageJobStatus = "pending" | "skipped" | "complete";
 
 /**
  * Stable producer and metadata identities retained across resume.
@@ -243,7 +243,7 @@ const PageJobSchema = z
     seedPaths: z.array(z.string()),
     relatedPages: z.array(z.string()),
     instructions: z.array(z.string().trim().min(1)),
-    status: z.enum(["pending", "complete"]),
+    status: z.enum(["pending", "skipped", "complete"]),
   })
   .strict();
 

--- a/test/agent/repository-runner.test.ts
+++ b/test/agent/repository-runner.test.ts
@@ -9,7 +9,7 @@ type HarnessPage = {
   seedPaths: string[];
   relatedPages: string[];
   instructions: string[];
-  status: "pending" | "complete";
+  status: "pending" | "skipped" | "complete";
 };
 
 type HarnessPlan = {
@@ -78,6 +78,8 @@ const harness = vi.hoisted(() => ({
   planToolResults: [] as unknown[],
   planPaths: ["/openwiki/quickstart.md", "/openwiki/architecture.md"],
   resumed: false,
+  restoreCalls: 0,
+  workerExitsWithoutSubmit: false,
 }));
 
 vi.mock("deepagents", async (importOriginal) => {
@@ -210,7 +212,13 @@ vi.mock("deepagents", async (importOriginal) => {
                       },
                     ],
                   };
-            await completionTool.invoke(input);
+            const exitWithoutSubmit =
+              toolName === "submit_page" && harness.workerExitsWithoutSubmit;
+            if (exitWithoutSubmit) {
+              harness.workerExitsWithoutSubmit = false;
+            } else {
+              await completionTool.invoke(input);
+            }
           },
         }),
       );
@@ -220,6 +228,21 @@ vi.mock("deepagents", async (importOriginal) => {
 });
 
 vi.mock("../../src/generation/repository-run.js", () => ({
+  captureRepositoryPageSnapshot(_run: HarnessRun, jobId: string) {
+    return Promise.resolve({
+      jobId,
+      path: "/openwiki/snapshot.md",
+      markdown: "original\n",
+      claims: null,
+    });
+  },
+  skipRepositoryPage(run: HarnessRun, snapshot: { jobId: string }) {
+    harness.restoreCalls += 1;
+    const job = run.state.plan?.pages.find(({ id }) => id === snapshot.jobId);
+    if (!job) throw new Error("Expected skipped harness page job.");
+    job.status = "skipped";
+    return Promise.resolve();
+  },
   beginRepositoryRun() {
     harness.beginCalls += 1;
     if (harness.noop) {
@@ -390,6 +413,8 @@ beforeEach(() => {
   harness.planToolResults = [];
   harness.planPaths = ["/openwiki/quickstart.md", "/openwiki/architecture.md"];
   harness.resumed = false;
+  harness.restoreCalls = 0;
+  harness.workerExitsWithoutSubmit = false;
 });
 
 describe("runNativeRepositoryGeneration", () => {
@@ -583,6 +608,26 @@ describe("runNativeRepositoryGeneration", () => {
           event.type === "repository_progress" && event.stage === "replanning",
       ),
     ).toHaveLength(2);
+  });
+
+  test("restores and leaves a page pending when its worker does not submit", async () => {
+    harness.workerExitsWithoutSubmit = true;
+    harness.planPaths = ["/openwiki/testing.md", "/openwiki/later.md"];
+
+    const events = await runHarness();
+
+    expect(harness.restoreCalls).toBe(1);
+    expect(harness.finishCalls).toBe(1);
+    expect(harness.currentRun?.state.plan?.pages[0]?.status).toBe("skipped");
+    expect(harness.currentRun?.state.plan?.pages[1]?.status).toBe("complete");
+    expect(harness.agentOptions).toHaveLength(3);
+    expect(
+      events.some(
+        (event) =>
+          event.type === "text" &&
+          event.text.includes("reconsidered on the next update"),
+      ),
+    ).toBe(true);
   });
 
   test("reports strict no-op without constructing a worker", async () => {

--- a/test/generation/repository-run.test.ts
+++ b/test/generation/repository-run.test.ts
@@ -64,8 +64,10 @@ import {
 import { OPENWIKI_PRODUCER_ACTOR } from "../../src/version.ts";
 import {
   beginRepositoryRun,
+  captureRepositoryPageSnapshot,
   finishRepositoryRun,
   nextRepositoryPage,
+  skipRepositoryPage,
   submitRepositoryPage,
   submitRepositoryPlan,
   type ActiveRepositoryRun,
@@ -235,6 +237,74 @@ async function completeCurrentPage(
   });
 }
 
+test("restores the exact pending Markdown and Claims snapshot", async () => {
+  const root = await createRepository(["testing.md"]);
+  const page = "/openwiki/testing.md";
+  const successfulMetadata = JSON.parse(
+    await readFile(path.join(root, "openwiki/.last-update.json"), "utf8"),
+  ) as { gitHead: string };
+  await writeFile(
+    path.join(root, "README.md"),
+    "# Changed repository\n",
+    "utf8",
+  );
+  await git(root, ["add", "README.md"]);
+  await git(root, ["commit", "--quiet", "-m", "change source"]);
+  const store = new ClaimsStore(root);
+  const originalClaims = {
+    schemaVersion: 1 as const,
+    pageVersion: await store.hashPage(page),
+    claims: [],
+  };
+  await store.writePage(page, originalClaims);
+
+  const run = await beginForcedUpdate(root);
+  await submitRepositoryPlan(run, {
+    pages: [
+      {
+        path: page,
+        title: "Testing",
+        purpose: "Update testing documentation.",
+      },
+    ],
+  });
+  const next = await nextRepositoryPage(run);
+  if (next.status !== "pending") throw new Error("Expected pending page.");
+  const snapshot = await captureRepositoryPageSnapshot(run, next.job.id);
+
+  await run.backend.write(page, validPage("Changed"));
+  await store.writePage(page, {
+    schemaVersion: 1,
+    pageVersion: await store.hashPage(page),
+    claims: [],
+  });
+
+  await skipRepositoryPage(run, snapshot);
+
+  expect(await readFile(path.join(root, "openwiki/testing.md"), "utf8")).toBe(
+    validPage("testing"),
+  );
+  expect(await store.loadPage(page)).toEqual(originalClaims);
+  expect(run.state.plan?.pages[0]?.status).toBe("skipped");
+  expect((await nextRepositoryPage(run)).status).toBe("complete");
+
+  await finishRepositoryRun(run, { skippedPageSnapshots: [snapshot] });
+
+  expect(await readFile(path.join(root, "openwiki/testing.md"), "utf8")).toBe(
+    validPage("testing"),
+  );
+  expect(await store.loadPage(page)).toEqual(originalClaims);
+  expect(await readRepositoryRunState(root)).toBeNull();
+  expect(
+    JSON.parse(
+      await readFile(path.join(root, "openwiki/.last-update.json"), "utf8"),
+    ),
+  ).toMatchObject({
+    gitHead: successfulMetadata.gitHead,
+    status: "interrupted",
+  });
+});
+
 beforeEach(() => {
   failureHarness.metadataWrites = 0;
   failureHarness.stateWrites = 0;
@@ -397,6 +467,40 @@ describe("beginRepositoryRun", () => {
 });
 
 describe("repository page queue", () => {
+  test("resets an interrupted skipped job to pending on resume", async () => {
+    const root = await createRepository(["second.md"]);
+    const initial = await beginForcedUpdate(root);
+    await submitRepositoryPlan(initial, {
+      pages: [
+        {
+          path: "/openwiki/second.md",
+          title: "Second",
+          purpose: "Refresh the secondary guide.",
+        },
+        {
+          path: "/openwiki/quickstart.md",
+          title: "Quickstart",
+          purpose: "Refresh the repository entry point.",
+        },
+      ],
+    });
+    const next = await nextRepositoryPage(initial);
+    if (next.status !== "pending") throw new Error("Expected pending page.");
+    const snapshot = await captureRepositoryPageSnapshot(initial, next.job.id);
+    await initial.backend.write(next.job.path, validPage("Partial"));
+    await skipRepositoryPage(initial, snapshot);
+
+    const resumed = requireActiveRun(
+      await beginRepositoryRun({ root, mode: "update", actor: ACTOR }),
+    );
+
+    expect(resumed.state.plan?.pages[0]?.status).toBe("pending");
+    await expect(nextRepositoryPage(resumed)).resolves.toMatchObject({
+      status: "pending",
+      job: { id: next.job.id, path: next.job.path },
+    });
+  });
+
   test("keeps in-memory state unchanged until plan persistence succeeds", async () => {
     const root = await createRepository();
     const run = await beginForcedUpdate(root);


### PR DESCRIPTION
## Summary

- Restore the original Markdown and Claims when a page worker fails to submit.
- Continue processing remaining pages and run global finalization.
- Exclude skipped pages from finalization changes.
- Preserve the previous successful Git checkpoint so skipped work is reconsidered on the next update.
- Keep rollback and infrastructure failures fatal.

## Testing

- Added rollback, continuation, finalization, and resume coverage.
- pnpm test — 2,930 passed.
- Typecheck, lint, and formatting checks pass.