### PR TITLE
fix: allow init and update runs to snapshot pages that do not exist yet

### DIFF
--- a/.changeset/fresh-pages-snapshot.md
+++ b/.changeset/fresh-pages-snapshot.md
@@ -1,0 +1,5 @@
+---
+"openwiki": patch
+---
+
+fix: allow init and update runs to snapshot pages that do not exist yet

--- a/src/generation/repository-run.ts
+++ b/src/generation/repository-run.ts
@@ -743,25 +743,31 @@ export async function captureRepositoryPageSnapshot(
     );
   }
 
-  const read = await run.backend.readRaw(current.path);
-  if (read.error && read.error !== "file_not_found") {
-    throw new RepositoryRunError(
-      "invalid_state",
-      `Could not snapshot ${current.path}: ${read.error}`,
-    );
-  }
-  const content = read.data?.content;
-  if (content !== undefined && typeof content !== "string") {
-    throw new RepositoryRunError(
-      "invalid_state",
-      `Could not snapshot non-text Markdown page ${current.path}.`,
-    );
+  let markdown: string | null = null;
+  try {
+    const read = await run.backend.readRaw(current.path);
+    if (read.error && read.error !== "file_not_found") {
+      throw new RepositoryRunError(
+        "invalid_state",
+        `Could not snapshot ${current.path}: ${read.error}`,
+      );
+    }
+    const content = read.data?.content;
+    if (content !== undefined && typeof content !== "string") {
+      throw new RepositoryRunError(
+        "invalid_state",
+        `Could not snapshot non-text Markdown page ${current.path}.`,
+      );
+    }
+    markdown = content ?? null;
+  } catch (error) {
+    if (!isFileNotFoundError(error)) throw error;
   }
 
   return {
     jobId: current.id,
     path: current.path,
-    markdown: content ?? null,
+    markdown,
     claims: await new ClaimsStore(run.root).loadPage(current.path),
   };
 }

--- a/test/generation/repository-run.test.ts
+++ b/test/generation/repository-run.test.ts
@@ -305,6 +305,50 @@ test("restores the exact pending Markdown and Claims snapshot", async () => {
   });
 });
 
+test.each([
+  { mode: "init" as const, page: "/openwiki/quickstart.md" },
+  { mode: "update" as const, page: "/openwiki/new-page.md" },
+])(
+  "treats an absent $mode page as a restorable snapshot",
+  async ({ mode, page }) => {
+    const root = await createRepository();
+    const run =
+      mode === "init"
+        ? requireActiveRun(
+            await beginRepositoryRun({ root, mode: "init", actor: ACTOR }),
+          )
+        : await beginForcedUpdate(root);
+    await submitRepositoryPlan(run, {
+      pages: [
+        {
+          path: page,
+          title: "New Page",
+          purpose: "Document a newly planned page.",
+        },
+      ],
+    });
+    const next = await nextRepositoryPage(run);
+    if (next.status !== "pending") throw new Error("Expected pending page.");
+
+    const snapshot = await captureRepositoryPageSnapshot(run, next.job.id);
+
+    expect(snapshot).toMatchObject({
+      path: page,
+      markdown: null,
+      claims: null,
+    });
+    const write = await run.backend.write(page, validPage("Partial"));
+    if (write.error) throw new Error(write.error);
+
+    await skipRepositoryPage(run, snapshot);
+
+    await expect(
+      readFile(path.join(root, page.replace(/^\//u, "")), "utf8"),
+    ).rejects.toMatchObject({ code: "ENOENT" });
+    expect(run.state.plan?.pages[0]?.status).toBe("skipped");
+  },
+);
+
 beforeEach(() => {
   failureHarness.metadataWrites = 0;
   failureHarness.stateWrites = 0;


### PR DESCRIPTION
## Summary

- Allow init and update runs to snapshot pages that do not exist yet.
- Treat missing new pages as an empty snapshot while preserving fatal behavior for other read errors.
- Add regression coverage for init, update, and rollback of partially created pages.
