### PR TITLE
fix: finalize repository generation once when source changes during a run

### DIFF
--- a/.changeset/calm-runs-finish.md
+++ b/.changeset/calm-runs-finish.md
@@ -1,0 +1,5 @@
+---
+"openwiki": patch
+---
+
+fix: finalize repository generation once when source changes during a run

--- a/src/agent/repository-runner.ts
+++ b/src/agent/repository-runner.ts
@@ -148,7 +148,7 @@ export interface NativeRepositoryGenerationOptions {
   force?: boolean;
 
   /**
-   * Actual user and connector context supplied to planning and replanning.
+   * Actual user and connector context supplied to planning.
    */
   planningContext?: string | null;
 
@@ -176,6 +176,11 @@ export interface NativeRepositoryGenerationResult {
    * Whether strict preflight proved that an update required no generation.
    */
   skipped: boolean;
+
+  /**
+   * Whether the repository changed after planning, leaving a later update due.
+   */
+  sourceChanged?: true;
 }
 
 /**
@@ -185,66 +190,57 @@ export interface NativeRepositoryGenerationResult {
  * worker state survives beyond the durable core.
  *
  * @param options - Repository, model, planning context, and event consumer.
- * @returns Whether the command completed through the strict no-op path.
+ * @returns No-op status and whether a later update remains due to source drift.
  */
 export async function runNativeRepositoryGeneration(
   options: NativeRepositoryGenerationOptions,
 ): Promise<NativeRepositoryGenerationResult> {
-  let begun = await beginNativeRepositoryRun(options);
-  let replanningAfterSourceDrift = false;
+  const begun = await beginNativeRepositoryRun(options);
+  if (!("run" in begun)) {
+    options.onEvent?.({ type: "repository_progress", stage: "noop" });
+    return { skipped: true };
+  }
 
-  while (true) {
-    if (!("run" in begun)) {
-      options.onEvent?.({ type: "repository_progress", stage: "noop" });
-      return { skipped: true };
-    }
-
-    const { run, view } = begun;
-    if (run.state.phase === "planning") {
-      options.onEvent?.({
-        type: "repository_progress",
-        stage: replanningAfterSourceDrift ? "replanning" : "planning",
-        resumed: view.resumed,
-      });
-      await runPlanningAgent(
-        run,
-        view,
-        options.model,
-        run.state.planningContext,
-        options.onEvent,
-      );
-    }
-
-    const skippedPageSnapshots = await runPendingPageAgents(
-      run,
-      options.model,
-      options.onEvent,
-      view,
-    );
+  const { run, view } = begun;
+  if (run.state.phase === "planning") {
     options.onEvent?.({
       type: "repository_progress",
-      stage: "finalizing",
+      stage: "planning",
       resumed: view.resumed,
-      pageCount: run.state.plan?.pages.length,
     });
-
-    try {
-      await finishRepositoryRun(run, { skippedPageSnapshots });
-      return { skipped: false };
-    } catch (error) {
-      if (!isSourceDriftInvalidation(error)) {
-        throw error;
-      }
-
-      options.onEvent?.({
-        type: "repository_progress",
-        stage: "replanning",
-        resumed: true,
-      });
-      replanningAfterSourceDrift = true;
-      begun = await beginNativeRepositoryRun(options);
-    }
+    await runPlanningAgent(
+      run,
+      view,
+      options.model,
+      run.state.planningContext,
+      options.onEvent,
+    );
   }
+
+  const skippedPageSnapshots = await runPendingPageAgents(
+    run,
+    options.model,
+    options.onEvent,
+    view,
+  );
+  options.onEvent?.({
+    type: "repository_progress",
+    stage: "finalizing",
+    resumed: view.resumed,
+    pageCount: run.state.plan?.pages.length,
+  });
+
+  const result = await finishRepositoryRun(run, { skippedPageSnapshots });
+  if (result.sourceChanged) {
+    options.onEvent?.({
+      type: "text",
+      source: "main",
+      text: "Repository source changed while OpenWiki was running. The wiki was finalized without advancing its source checkpoint; run openwiki --update to reconcile the changes.\n",
+    });
+  }
+  return result.sourceChanged
+    ? { skipped: false, sourceChanged: true }
+    : { skipped: false };
 }
 
 /**
@@ -585,22 +581,6 @@ export function parseWorkerToolEvent(chunk: unknown): OpenWikiRunEvent | null {
   }
 
   return null;
-}
-
-/**
- * Identifies the durable core's explicit whole-plan source-drift invalidation.
- *
- * @param error - Unknown finish failure.
- * @returns Whether the runner must rebuild runtime context and replan.
- */
-function isSourceDriftInvalidation(error: unknown): boolean {
-  return (
-    error instanceof RepositoryRunError &&
-    error.code === "conflict" &&
-    error.message.startsWith(
-      "Repository source changed during this OpenWiki run.",
-    )
-  );
 }
 
 /**

--- a/src/agent/utils.ts
+++ b/src/agent/utils.ts
@@ -197,6 +197,8 @@ export function shouldCheckUpdateNoop(options: OpenWikiRunOptions): boolean {
  * Records an init/update run so future updates can diff from this git head.
  * Interrupted runs are recorded with status "interrupted" so the update
  * no-op check knows the wiki may be partial and does not skip the retry.
+ * A `null` override deliberately omits the checkpoint when no successful
+ * repository baseline exists.
  */
 export async function writeLastUpdateMetadata(
   command: OpenWikiCommand,
@@ -205,16 +207,19 @@ export async function writeLastUpdateMetadata(
   outputMode: OpenWikiOutputMode = "repository",
   status: UpdateRunStatus = "complete",
   language?: string,
-  gitHeadOverride?: string,
+  gitHeadOverride?: string | null,
 ): Promise<void> {
   const metadataFile = getMetadataFilePath(cwd, outputMode);
+  const gitHead =
+    outputMode !== "repository"
+      ? undefined
+      : gitHeadOverride === null
+        ? undefined
+        : (gitHeadOverride ?? (await getGitHead(cwd)));
   const metadata: UpdateMetadata = {
     updatedAt: new Date().toISOString(),
     command,
-    gitHead:
-      outputMode === "repository"
-        ? (gitHeadOverride ?? (await getGitHead(cwd)))
-        : undefined,
+    gitHead,
     model: modelId,
     status,
     ...(language ? { language } : {}),

--- a/src/generation/repository-run.ts
+++ b/src/generation/repository-run.ts
@@ -390,6 +390,7 @@ export async function beginRepositoryRun(
       "repository",
       "interrupted",
       language,
+      context.lastUpdate?.gitHead ?? null,
     );
 
     // Critical: do NOT hold the old init backup until finish. Once the run state
@@ -822,7 +823,7 @@ export async function skipRepositoryPage(
     "repository",
     "interrupted",
     run.state.language,
-    run.state.baseGitHead,
+    run.state.baseGitHead ?? null,
   );
 
   const nextState: RepositoryRunState = {
@@ -1156,7 +1157,7 @@ function sameResourceSet(
 }
 
 /**
- * Deterministically finalizes a complete source-stable run.
+ * Deterministically finalizes a complete run and records any source drift.
  *
  * `.run.json` is removed last; every earlier failure leaves the run resumable.
  *
@@ -1168,9 +1169,7 @@ export async function finishRepositoryRun(
   options: {
     skippedPageSnapshots?: readonly RepositoryPageSnapshot[];
   } = {},
-): Promise<{ status: "complete" }> {
-  await requireStableSourceFingerprint(run);
-
+): Promise<{ status: "complete"; sourceChanged?: true }> {
   const plan = run.state.plan;
   if (!plan) {
     throw new RepositoryRunError(
@@ -1201,6 +1200,7 @@ export async function finishRepositoryRun(
     );
   }
   const skippedPages = new Set(skippedJobs.map(({ path }) => path));
+  const sourceChangedBeforeFinish = await hasRepositorySourceChanged(run);
 
   await applyAbandonedGeneratedPageDeletions(run, plan);
   await applyPlannedDeletions(run, plan.deletePages);
@@ -1223,10 +1223,9 @@ export async function finishRepositoryRun(
 
   await run.claimsRuntime.finalize(run.state.startedAt, skippedPages);
   await assertRepositoryClaimsDurable(run, skippedPages);
-  // Close the check/use race: source must remain unchanged across the entire
-  // deterministic finish window, not only at its start.
-  await requireStableSourceFingerprint(run);
-  if (skippedPages.size > 0) {
+  const sourceChanged =
+    sourceChangedBeforeFinish || (await hasRepositorySourceChanged(run));
+  if (skippedPages.size > 0 || sourceChanged) {
     await writeLastUpdateMetadata(
       run.state.mode,
       run.root,
@@ -1234,7 +1233,7 @@ export async function finishRepositoryRun(
       "repository",
       "interrupted",
       run.state.language,
-      run.state.baseGitHead,
+      run.state.baseGitHead ?? null,
     );
   } else {
     await persistRunMetadataIfChanged(
@@ -1251,32 +1250,22 @@ export async function finishRepositoryRun(
   // Delete this LAST. If anything above fails, begin() can reconstruct and retry.
   await removeRepositoryRunState(run.root);
 
-  return { status: "complete" };
+  return sourceChanged
+    ? { status: "complete", sourceChanged: true }
+    : { status: "complete" };
 }
 
 /**
- * Invalidates and persists the whole plan when repository source has drifted.
+ * Checks whether model-visible repository source changed after planning.
  *
- * @param run - Active run whose source fingerprint must still match.
+ * @param run - Active run carrying the source fingerprint used by its plan.
+ * @returns Whether the current repository differs from the planned source.
  */
-async function requireStableSourceFingerprint(
+async function hasRepositorySourceChanged(
   run: ActiveRepositoryRun,
-): Promise<void> {
+): Promise<boolean> {
   const current = await createRepositorySourceFingerprint(run.root, run.ignore);
-  if (current === run.state.sourceFingerprint) return;
-
-  const nextState: RepositoryRunState = {
-    ...run.state,
-    phase: "planning",
-    sourceFingerprint: current,
-  };
-  delete nextState.plan;
-  await writeRepositoryRunState(run.root, nextState);
-  run.state = nextState;
-  throw new RepositoryRunError(
-    "conflict",
-    "Repository source changed during this OpenWiki run. The old plan was invalidated; call begin and submit a replacement plan.",
-  );
+  return current !== run.state.sourceFingerprint;
 }
 
 /**

--- a/src/integrations/core/session-manager.ts
+++ b/src/integrations/core/session-manager.ts
@@ -244,7 +244,7 @@ export class HostSessionManager {
       {
         name: "openwiki_finish",
         description:
-          "Finish only after every PageJob is complete. Runs deterministic deletion, validation, indexing, provenance, Claims finalization, and complete metadata persistence.",
+          "Finish only after every PageJob is complete. Runs deterministic deletion, validation, indexing, provenance, Claims finalization, and run metadata persistence.",
         schema: RunInput,
         handle: async (input) => this.finish(RunInput.parse(input)),
       },

--- a/test/agent/repository-runner.test.ts
+++ b/test/agent/repository-runner.test.ts
@@ -356,17 +356,10 @@ vi.mock("../../src/generation/repository-run.js", () => ({
       remaining: 0,
     });
   },
-  async finishRepositoryRun(run: HarnessRun) {
+  finishRepositoryRun() {
     harness.finishCalls += 1;
     if (harness.driftOnce && harness.finishCalls === 1) {
-      run.state.phase = "planning";
-      delete run.state.plan;
-      const { RepositoryRunError } =
-        await import("../../src/generation/errors.js");
-      throw new RepositoryRunError(
-        "conflict",
-        "Repository source changed during this OpenWiki run. The old plan was invalidated; call begin and submit a replacement plan.",
-      );
+      return { status: "complete", sourceChanged: true };
     }
     return { status: "complete" };
   },
@@ -580,22 +573,15 @@ describe("runNativeRepositoryGeneration", () => {
     );
   });
 
-  test("re-begins and replans after finish-time source drift", async () => {
+  test("finalizes once and warns after finish-time source drift", async () => {
     harness.driftOnce = true;
     harness.planPaths = ["/openwiki/quickstart.md"];
 
     const events = await runHarness();
 
-    expect(harness.beginCalls).toBe(2);
-    expect(harness.finishCalls).toBe(2);
-    expect(harness.agentOptions).toHaveLength(4);
-    expect(events).toContainEqual(
-      expect.objectContaining({
-        type: "repository_progress",
-        stage: "replanning",
-        resumed: true,
-      }),
-    );
+    expect(harness.beginCalls).toBe(1);
+    expect(harness.finishCalls).toBe(1);
+    expect(harness.agentOptions).toHaveLength(2);
     expect(
       events.filter(
         (event) =>
@@ -603,11 +589,12 @@ describe("runNativeRepositoryGeneration", () => {
       ),
     ).toHaveLength(1);
     expect(
-      events.filter(
+      events.some(
         (event) =>
-          event.type === "repository_progress" && event.stage === "replanning",
+          event.type === "text" &&
+          event.text.includes("finalized without advancing"),
       ),
-    ).toHaveLength(2);
+    ).toBe(true);
   });
 
   test("restores and leaves a page pending when its worker does not submit", async () => {

--- a/test/generation/repository-run.test.ts
+++ b/test/generation/repository-run.test.ts
@@ -912,10 +912,10 @@ describe("finishRepositoryRun", () => {
     }
   });
 
-  test("invalidates the whole plan on drift and removes only abandoned new pages", async () => {
+  test("finalizes completed work once without advancing a drifted source", async () => {
     const root = await createRepository(["pre-existing.md"]);
-    const runA = await beginForcedUpdate(root, "Plan A context");
-    await submitRepositoryPlan(runA, {
+    const run = await beginForcedUpdate(root, "Plan A context");
+    await submitRepositoryPlan(run, {
       pages: [
         {
           path: "/openwiki/new-page.md",
@@ -924,63 +924,56 @@ describe("finishRepositoryRun", () => {
         },
       ],
     });
-    await runA.backend.write("/openwiki/new-page.md", validPage("New Page"));
+    await completeCurrentPage(run, "New Page");
     await writeFile(
       path.join(root, "README.md"),
       "# Repository\nSource changed.\n",
       "utf8",
     );
 
-    await expect(finishRepositoryRun(runA)).rejects.toMatchObject({
-      code: "conflict",
+    await expect(finishRepositoryRun(run)).resolves.toEqual({
+      status: "complete",
+      sourceChanged: true,
     });
-    expect(runA.state.phase).toBe("planning");
-    expect(runA.state.plan).toBeUndefined();
-    expect((await readRepositoryRunState(root))?.plan).toBeUndefined();
-
-    const resumedResult = await beginRepositoryRun({
-      root,
-      mode: "update",
-      planningContext: "Plan B context",
-      actor: ACTOR,
-    });
-    const runB = requireActiveRun(resumedResult);
-    expect(runB.state.runId).toBe(runA.state.runId);
-    expect(runB.state.planningContext).toBe("Plan B context");
-    await submitRepositoryPlan(runB, { pages: [] });
-    await finishRepositoryRun(runB);
+    expect(await readRepositoryRunState(root)).toBeNull();
 
     await expect(
       readFile(path.join(root, "openwiki", "new-page.md"), "utf8"),
-    ).rejects.toMatchObject({ code: "ENOENT" });
+    ).resolves.toContain("# New Page");
     await expect(
       readFile(path.join(root, "openwiki", "pre-existing.md"), "utf8"),
     ).resolves.toContain("# pre-existing");
+    await expect(
+      readFile(path.join(root, "openwiki", ".last-update.json"), "utf8").then(
+        JSON.parse,
+      ),
+    ).resolves.toMatchObject({
+      gitHead: run.state.baseGitHead,
+      status: "interrupted",
+    });
   });
 
-  test("does not mutate active state when durable drift invalidation fails", async () => {
+  test("keeps finalized work resumable when drift metadata persistence fails", async () => {
     const root = await createRepository();
     const run = await beginForcedUpdate(root);
     await submitRepositoryPlan(run, { pages: [] });
-    const originalState = run.state;
     await writeFile(
       path.join(root, "README.md"),
       "# Repository\nSource changed.\n",
       "utf8",
     );
-    failureHarness.stateWrites = 1;
+    failureHarness.metadataWrites = 1;
 
     await expect(finishRepositoryRun(run)).rejects.toThrow(
-      "injected run-state write failure",
+      "injected metadata failure",
     );
-    expect(run.state).toBe(originalState);
     expect((await readRepositoryRunState(root))?.plan).toBeDefined();
 
-    await expect(finishRepositoryRun(run)).rejects.toMatchObject({
-      code: "conflict",
+    await expect(finishRepositoryRun(run)).resolves.toEqual({
+      status: "complete",
+      sourceChanged: true,
     });
-    expect(run.state.phase).toBe("planning");
-    expect(run.state.plan).toBeUndefined();
+    expect(await readRepositoryRunState(root)).toBeNull();
   });
 
   test("rechecks source after deterministic finalization before completion", async () => {
@@ -997,19 +990,53 @@ describe("finishRepositoryRun", () => {
       );
     });
 
-    await expect(finishRepositoryRun(run)).rejects.toMatchObject({
-      code: "conflict",
+    await expect(finishRepositoryRun(run)).resolves.toEqual({
+      status: "complete",
+      sourceChanged: true,
     });
-    expect(run.state.phase).toBe("planning");
-    expect(run.state.plan).toBeUndefined();
-    await expect(readRepositoryRunState(root)).resolves.toMatchObject({
-      phase: "planning",
-    });
+    expect(await readRepositoryRunState(root)).toBeNull();
     await expect(
       readFile(path.join(root, "openwiki", ".last-update.json"), "utf8").then(
         JSON.parse,
       ),
-    ).resolves.toMatchObject({ status: "interrupted" });
+    ).resolves.toMatchObject({
+      gitHead: run.state.baseGitHead,
+      status: "interrupted",
+    });
+  });
+
+  test("omits the checkpoint when a drifted init has no successful baseline", async () => {
+    const root = await createRepository();
+    await rm(path.join(root, "openwiki", ".last-update.json"));
+    const run = requireActiveRun(
+      await beginRepositoryRun({ root, mode: "init", actor: ACTOR }),
+    );
+    await submitRepositoryPlan(run, {
+      pages: [
+        {
+          path: "/openwiki/quickstart.md",
+          title: "Quickstart",
+          purpose: "Document the repository entry point.",
+        },
+      ],
+    });
+    await completeCurrentPage(run, "Quickstart");
+    await writeFile(
+      path.join(root, "README.md"),
+      "# Repository\nSource changed during init.\n",
+      "utf8",
+    );
+
+    await expect(finishRepositoryRun(run)).resolves.toEqual({
+      status: "complete",
+      sourceChanged: true,
+    });
+
+    const metadata = JSON.parse(
+      await readFile(path.join(root, "openwiki", ".last-update.json"), "utf8"),
+    ) as Record<string, unknown>;
+    expect(metadata).toMatchObject({ status: "interrupted" });
+    expect(metadata).not.toHaveProperty("gitHead");
   });
 
   test("applies explicit existing-page deletions with Claims cleanup", async () => {


### PR DESCRIPTION
## Summary

- Prevent init/update from restarting when repository source changes during generation.
- Finalize completed work once and warn that a follow-up update is needed.
- Mark the run interrupted without advancing the last successful source checkpoint.
- Add regression coverage for update and fresh-init drift behavior.