### PR TITLE
fix: default Bedrock Claude runs to a 16,384-token output ceiling

### DIFF
--- a/.changeset/bedrock-default-max-output-tokens.md
+++ b/.changeset/bedrock-default-max-output-tokens.md
@@ -1,0 +1,12 @@
+---
+"openwiki": patch
+---
+
+fix: default Bedrock runs on modern Claude models to a 16,384-token output ceiling
+
+The Bedrock Converse API caps output at 4,096 tokens when a request sends no
+`inferenceConfig`, which truncated long pages mid-write and ended the run
+cleanly, looking like a page-count limit. Bedrock runs on modern Claude models
+now use the same 16,384-token ceiling as the direct Anthropic provider. Models
+without a known-wide output window keep the provider default, and
+`OPENWIKI_MAX_OUTPUT_TOKENS` still overrides both.

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -1215,10 +1215,17 @@ export function createModel(
   }
 
   if (provider === "bedrock") {
+    const bedrockMaxTokens = resolveBedrockMaxOutputTokens(
+      modelId,
+      configuredMaxOutputTokens,
+    );
+
     return new ChatBedrockConverse({
       model: modelId,
       region: resolveProviderRegion(provider),
-      ...maxTokensOptions,
+      ...(bedrockMaxTokens !== undefined
+        ? { maxTokens: bedrockMaxTokens }
+        : {}),
       ...streamIdleTimeoutOptions,
       ...retryOptions,
     });
@@ -1297,6 +1304,21 @@ const GEMINI_THOUGHT_SIGNATURE_OPTIONS = {
   outputVersion: "v0",
 } as const;
 
+// Matches the modern Claude families whose output window is wide enough for
+// OpenWiki's 16,384-token default. Deliberately excludes Claude 3.x
+// (`claude-3-5-sonnet-…`, `claude-3-haiku-…`), which expose a smaller ceiling,
+// and any custom or unrecognized ID.
+const MODERN_CLAUDE_MODEL_PATTERN =
+  /^claude-(?:haiku|sonnet|opus)-(?:4|5)(?:[-.@]|$)/u;
+
+// Bedrock qualifies foundation-model IDs with the vendor, e.g.
+// `anthropic.claude-sonnet-5-20260101-v1:0`.
+const BEDROCK_ANTHROPIC_VENDOR_PREFIX = "anthropic.";
+
+// Cross-region inference profiles prefix the vendor-qualified ID with a geo
+// code, e.g. `us.anthropic.claude-sonnet-5-20260101-v1:0`.
+const BEDROCK_INFERENCE_PROFILE_GEO_PATTERN = /^(?:us-gov|apac|us|eu)\./u;
+
 /**
  * Chooses the Anthropic request limit without imposing a modern limit on older
  * or custom Claude models that may expose a smaller output window.
@@ -1318,10 +1340,57 @@ function resolveAnthropicMaxOutputTokens(
     return configuredMaxOutputTokens;
   }
 
-  const normalizedModelId = stripPublisherPath(modelId);
+  return MODERN_CLAUDE_MODEL_PATTERN.test(stripPublisherPath(modelId))
+    ? DEFAULT_ANTHROPIC_MAX_OUTPUT_TOKENS
+    : undefined;
+}
 
-  return /^claude-(?:haiku|sonnet|opus)-(?:4|5)(?:[-.@]|$)/u.test(
-    normalizedModelId,
+/**
+ * Reduces a Bedrock model ID to its bare vendor-qualified form, e.g.
+ * `arn:aws:bedrock:us-east-1:1234:inference-profile/us.anthropic.claude-sonnet-5`
+ * -> `anthropic.claude-sonnet-5`. ARN and inference-profile forms address the
+ * same foundation model as the bare ID, so the output ceiling must not depend
+ * on which form the operator pasted. Bare IDs pass through unchanged.
+ */
+function normalizeBedrockModelId(modelId: string): string {
+  const segments = modelId.split("/");
+  const bareModelId = segments[segments.length - 1] ?? modelId;
+
+  return bareModelId.replace(BEDROCK_INFERENCE_PROFILE_GEO_PATTERN, "");
+}
+
+/**
+ * Chooses the Bedrock request limit, mirroring the direct Anthropic path so the
+ * same Claude model produces the same ceiling however it is reached.
+ *
+ * `ChatBedrockConverse` sends no `inferenceConfig` when nothing is configured,
+ * so the Converse API applies its own 4,096-token default and truncates long
+ * pages mid-`write_file`. Bedrock serves every vendor through this one client,
+ * though, and a ceiling above a model's own maximum is a `ValidationException` —
+ * so the default is raised only for the modern Anthropic families known to
+ * accept it, leaving every other model on the provider default it works with
+ * today. An explicit setting always wins.
+ *
+ * @param modelId - Bare, inference-profile, or ARN-qualified Bedrock model ID.
+ * @param configuredMaxOutputTokens - Explicit OpenWiki setting, when present.
+ * @returns The explicit limit, modern-Claude default, or `undefined`.
+ */
+function resolveBedrockMaxOutputTokens(
+  modelId: string,
+  configuredMaxOutputTokens: number | undefined,
+): number | undefined {
+  if (configuredMaxOutputTokens !== undefined) {
+    return configuredMaxOutputTokens;
+  }
+
+  const normalizedModelId = normalizeBedrockModelId(modelId);
+
+  if (!normalizedModelId.startsWith(BEDROCK_ANTHROPIC_VENDOR_PREFIX)) {
+    return undefined;
+  }
+
+  return MODERN_CLAUDE_MODEL_PATTERN.test(
+    normalizedModelId.slice(BEDROCK_ANTHROPIC_VENDOR_PREFIX.length),
   )
     ? DEFAULT_ANTHROPIC_MAX_OUTPUT_TOKENS
     : undefined;

--- a/test/agent/bedrock-model.test.ts
+++ b/test/agent/bedrock-model.test.ts
@@ -22,6 +22,7 @@ const ENV_KEYS = [
   "BEDROCK_AWS_ACCESS_KEY_ID",
   "BEDROCK_AWS_REGION",
   "BEDROCK_AWS_SECRET_ACCESS_KEY",
+  "OPENWIKI_MAX_OUTPUT_TOKENS",
 ] as const;
 
 const originalEnv = new Map(
@@ -63,10 +64,10 @@ describe("createModel Bedrock credentials", () => {
     expect(bedrockConstructorArgs[0]).not.toHaveProperty("credentials");
   });
 
-  test("preserves the provider default when no output token limit is set", () => {
+  test("preserves the provider default for models without a known ceiling", () => {
     process.env.AWS_REGION = "us-east-1";
 
-    createModel("bedrock", "anthropic.claude-sonnet-5", 4);
+    createModel("bedrock", "amazon.nova-pro-v1:0", 4);
 
     expect(bedrockConstructorArgs[0]).not.toHaveProperty("maxTokens");
     expect(bedrockConstructorArgs[0]).not.toHaveProperty("streamIdleTimeout");
@@ -117,5 +118,56 @@ describe("createModel Bedrock credentials", () => {
       region: "us-west-2",
     });
     expect(bedrockConstructorArgs[0]).not.toHaveProperty("credentials");
+  });
+});
+
+describe("createModel Bedrock output-token ceiling", () => {
+  beforeEach(() => {
+    process.env.AWS_REGION = "us-east-1";
+  });
+
+  // The Converse API applies its own 4096-token default when no
+  // inferenceConfig is sent, which truncates long pages mid-write_file.
+  test.each([
+    ["bare foundation-model ID", "anthropic.claude-sonnet-5-20260101-v1:0"],
+    ["cross-region inference profile", "us.anthropic.claude-sonnet-5"],
+    ["EU inference profile", "eu.anthropic.claude-opus-5"],
+    ["APAC inference profile", "apac.anthropic.claude-haiku-4-5"],
+    ["GovCloud inference profile", "us-gov.anthropic.claude-sonnet-5"],
+    [
+      "inference-profile ARN",
+      "arn:aws:bedrock:us-east-1:123456789012:inference-profile/us.anthropic.claude-sonnet-5-20260101-v1:0",
+    ],
+  ])("raises the modern Claude ceiling for a %s", (_label, modelId) => {
+    createModel("bedrock", modelId, 4);
+
+    expect(bedrockConstructorArgs[0]).toMatchObject({ maxTokens: 16_384 });
+  });
+
+  // A ceiling above a model's own maximum is a Bedrock ValidationException, so
+  // anything without a known-wide output window keeps the provider default.
+  test.each([
+    ["a non-Anthropic vendor", "meta.llama3-3-70b-instruct-v1:0"],
+    ["an older Claude family", "anthropic.claude-3-5-sonnet-20241022-v2:0"],
+    ["Claude 3 Haiku", "us.anthropic.claude-3-haiku-20240307-v1:0"],
+    ["a custom or unrecognized ID", "my-private-deployment"],
+  ])("leaves the provider default in place for %s", (_label, modelId) => {
+    createModel("bedrock", modelId, 4);
+
+    expect(bedrockConstructorArgs[0]).not.toHaveProperty("maxTokens");
+  });
+
+  test("lets an explicit run option win over the modern Claude default", () => {
+    createModel("bedrock", "us.anthropic.claude-sonnet-5", 4, 8192);
+
+    expect(bedrockConstructorArgs[0]).toMatchObject({ maxTokens: 8192 });
+  });
+
+  test("lets OPENWIKI_MAX_OUTPUT_TOKENS win for a model with no known ceiling", () => {
+    process.env.OPENWIKI_MAX_OUTPUT_TOKENS = "2048";
+
+    createModel("bedrock", "meta.llama3-3-70b-instruct-v1:0", 4);
+
+    expect(bedrockConstructorArgs[0]).toMatchObject({ maxTokens: 2048 });
   });
 });


### PR DESCRIPTION
## What and why

On the `bedrock` provider a default run sends no `inferenceConfig` at all, so the Converse API applies its own **4,096-token** output ceiling. A turn that hits the cap truncates mid-`write_file` and the agent graph ends cleanly (exit 0), which reads as a page-count or runtime limit rather than an output-token cap — `--init` on a medium repo writes ~4 short pages and stops mid-sentence.

`ChatBedrockConverse` attaches an `inferenceConfig` only when one of `maxTokens`/`temperature`/`topP`/`stop` is set. Since #459, OpenWiki does pass `maxTokens` on the Bedrock path — but only when `OPENWIKI_MAX_OUTPUT_TOKENS` or an explicit run option is configured. Out of the box nothing is, so nothing is sent. The direct Anthropic path has no such gap: `resolveAnthropicMaxOutputTokens` gives modern Claude families 16,384 by default. `us.anthropic.claude-sonnet-5` over Bedrock gets nothing.

This mirrors that helper on the Bedrock path, so the same Claude model gets the same ceiling however it is reached.

## Why the ceiling is model-derived rather than flat

Bedrock serves every vendor through this one client, and a ceiling above a model's own maximum is a `ValidationException`. So the default is raised only for the modern Anthropic families known to accept it — non-Anthropic vendors (Nova, Llama, Mistral), Claude 3.x (`claude-3-5-sonnet-…`, `claude-3-haiku-…`), and custom IDs keep the provider default they work with today. Bare, cross-region inference-profile (`us.`/`eu.`/`apac.`/`us-gov.`), and ARN-qualified IDs all normalize to the same decision, so the ceiling doesn't depend on which form the operator pasted.

Configuration is unchanged: `OPENWIKI_MAX_OUTPUT_TOKENS` (and an explicit run option) still overrides, including for models with no known ceiling. No new env var — the provider-neutral one from #459 already reaches this path.

## Relationship to #743

#743 targets the same issue. It was written against a pre-#459 tree — its base Bedrock constructor has neither `maxTokensOptions` nor `streamIdleTimeoutOptions` — and currently conflicts. Against today's `main` it would add `OPENWIKI_BEDROCK_MAX_TOKENS` as a third max-tokens env var alongside the provider-neutral one, reimplement `resolvePositiveIntegerSetting`, and apply a flat `16000` to every Bedrock model including those with a lower ceiling. This PR is an alternative built on current `main`; happy to defer if maintainers prefer that direction instead. Credit to @Christian-Sidak for getting to it first, and to @tshappee-veeva for the root-cause writeup in #722 — the `stopReason: max_tokens` / `outputTokens: 4096` proof is what makes this diagnosable at all.

## How I tested it

`test/agent/bedrock-model.test.ts` — 18 tests, all passing:

- **Raises to 16,384** for bare foundation-model IDs, `us.`/`eu.`/`apac.`/`us-gov.` inference profiles, and inference-profile ARNs
- **Leaves the provider default in place** for non-Anthropic vendors, Claude 3.5, Claude 3 Haiku, and unrecognized IDs
- **Explicit override wins** — both the run option and `OPENWIKI_MAX_OUTPUT_TOKENS`, the latter verified on a model with no known ceiling
- Updated the existing "preserves the provider default" test to a non-Anthropic model; it previously pinned `anthropic.claude-sonnet-5` to *no* `maxTokens`, which is the behavior this fixes
- Added `OPENWIKI_MAX_OUTPUT_TOKENS` to the suite's env isolation list

Full gate green: `pnpm run format`, `pnpm run lint`, `pnpm test` (220 files, 2951 tests). Changeset included (patch).

> Note, unrelated: `pnpm test` prints `stamp-build-channel failed: expected exactly one BUILD_CHANNEL assignment to stamp, found 0`. It reproduces on unmodified `main` and is not caused by this change — flagging it rather than fixing it here, per the one-PR-one-change rule.

Fixes #722
