### PR TITLE
test: stop the stamp drift test printing its expected failure

### DIFF
--- a/test/stamp-build-channel.test.ts
+++ b/test/stamp-build-channel.test.ts
@@ -47,6 +47,12 @@ afterEach(async () => {
 /**
  * Runs the stamp script against the temp target with `channel` as the env value
  * (omitted entirely when undefined), then returns the rewritten file contents.
+ *
+ * stderr is captured rather than forwarded: `execFileSync` pipes a child's
+ * stderr to the parent's by default, which would print the drift-detection
+ * test's *expected* failure into the suite output and read as a real problem.
+ * Capturing it also appends the child's stderr to the thrown error's message,
+ * so the failure case can assert on the diagnostic the release would show.
  */
 function stamp(channel: string | undefined): void {
   const env = { ...process.env };
@@ -55,7 +61,11 @@ function stamp(channel: string | undefined): void {
   } else {
     env.OPENWIKI_BUILD_CHANNEL = channel;
   }
-  execFileSync(process.execPath, [SCRIPT, target], { env, encoding: "utf8" });
+  execFileSync(process.execPath, [SCRIPT, target], {
+    env,
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"],
+  });
 }
 
 describe("stamp-build-channel", () => {
@@ -92,7 +102,12 @@ describe("stamp-build-channel", () => {
   test("a source missing the assignment fails loudly and is left unchanged", async () => {
     await writeFile(target, "const something = 1;\n", "utf8");
 
-    expect(() => stamp("official")).toThrow();
+    // A drifted gates.ts must abort the release with an actionable reason, not
+    // publish an unstamped build, so assert the diagnostic and not just the
+    // non-zero exit.
+    expect(() => stamp("official")).toThrow(
+      /expected exactly one BUILD_CHANNEL assignment to stamp, found 0/u,
+    );
 
     const result = await readFile(target, "utf8");
     expect(result).toBe("const something = 1;\n");


### PR DESCRIPTION
## What and why

Every `pnpm test` run prints:

```
stamp-build-channel failed: expected exactly one BUILD_CHANNEL assignment to stamp, found 0
```

Nothing is actually wrong. `test/stamp-build-channel.test.ts` runs the real `scripts/stamp-build-channel.cjs` against a source missing the `BUILD_CHANNEL` assignment, to prove a drifted `gates.ts` aborts the release instead of silently publishing an unstamped build. The script's `catch` writes that diagnostic to stderr and exits non-zero — exactly as intended — and `execFileSync` forwards a child's stderr to the parent's unless `stdio` says otherwise, so the expected failure lands in the suite output.

The test passes, so this is cosmetic. It's still worth fixing: a scary line in an otherwise green run reads as a real build problem, and the habit of ignoring it is how a genuine stderr warning gets missed later.

## The change

Capture the child's stderr (`stdio: ["ignore", "pipe", "pipe"]`) instead of forwarding it. Node then appends the child's stderr to the thrown error's `message`, so the drift case can assert on the diagnostic rather than just the non-zero exit:

```ts
expect(() => stamp("official")).toThrow(
  /expected exactly one BUILD_CHANNEL assignment to stamp, found 0/u,
);
```

That is a slightly stronger test than before — it now pins the actionable reason the release would surface, not merely that *something* failed.

## Scope

Test-only, one concern. No changeset: it does not affect the published package. The stamping behavior, `scripts/stamp-build-channel.cjs`, and `src/telemetry/gates.ts` are all untouched.

## How I tested it

- `npx vitest run test/stamp-build-channel.test.ts` — 4 passed, no stderr line
- `pnpm test` — 220 files, 2939 tests passing, and the `stamp-build-channel failed` line no longer appears anywhere in the output
- `pnpm run format` and `pnpm run lint` clean

Verified the line was pre-existing by stashing and re-running on unmodified `main`.
