### PR TITLE
refactor(scheduling): generalize launchd-named schedule fields to platform-neutral names

### DIFF
--- a/.changeset/gentle-schedule-field-rename.md
+++ b/.changeset/gentle-schedule-field-rename.md
@@ -1,0 +1,19 @@
+---
+"openwiki": minor
+---
+
+refactor(scheduling): generalize launchd-named schedule fields to platform-neutral names
+
+Renames the launchd-specific schedule identifiers to platform-neutral ones so a
+non-macOS scheduler backend can reuse the existing seams (#421):
+
+- `ScheduleInstallResult.launchAgentPath` -> `nativeJobPath`
+- `ConnectorScheduleStatus.launchAgentLoaded` -> `nativeJobInstalled`
+- `ConnectorScheduleStatus.launchAgentPlistExists` -> `nativeJobPathExists`
+- `OnboardingSourceScheduleConfig.launchAgentPath` -> `nativeJobPath` (legacy
+  `launchAgentPath` key is still read and migrated by `normalizeSourceScheduleConfig`)
+
+CLI status output labels change from `Launchd`/`Plist` to `Scheduler`/`Job file`.
+No behavior change on macOS: the launchd implementation, plist writing, and
+`launchctl` invocations are untouched. The deprecated `launchAgentPath` field
+remains on the type for one release.

--- a/src/cli/commands.ts
+++ b/src/cli/commands.ts
@@ -1140,7 +1140,8 @@ export const helpContent: HelpContent = {
     },
     {
       label: "openwiki cron list",
-      description: "List saved connector schedules and local launchd status.",
+      description:
+        "List saved connector schedules and native scheduler status.",
     },
     {
       label: "openwiki cron pause all",

--- a/src/cli/schedule-format.ts
+++ b/src/cli/schedule-format.ts
@@ -112,20 +112,20 @@ export function formatPowerScheduleStatus(
 export function formatScheduleStatus(
   schedule: ConnectorScheduleStatus,
 ): string {
-  const launchdStatus =
+  const nativeJobStatus =
     schedule.pausedAt !== undefined
       ? "paused"
-      : schedule.launchAgentPath === undefined
+      : schedule.nativeJobPath === undefined
         ? "not installed"
-        : schedule.launchAgentLoaded
+        : schedule.nativeJobInstalled
           ? "loaded"
-          : schedule.launchAgentPlistExists
-            ? "plist exists, not loaded"
-            : "plist missing";
+          : schedule.nativeJobPathExists
+            ? "job file exists, not loaded"
+            : "job file missing";
   const rows = [
     ["Schedule", schedule.description],
     ["Cron", schedule.expression],
-    ["Launchd", launchdStatus],
+    ["Scheduler", nativeJobStatus],
     ["Updated", schedule.updatedAt],
   ];
 
@@ -133,8 +133,8 @@ export function formatScheduleStatus(
     rows.push(["Paused", schedule.pausedAt]);
   }
 
-  if (schedule.launchAgentPath) {
-    rows.push(["Plist", schedule.launchAgentPath]);
+  if (schedule.nativeJobPath) {
+    rows.push(["Job file", schedule.nativeJobPath]);
   }
 
   if (schedule.warning) {

--- a/src/scheduling/schedules.ts
+++ b/src/scheduling/schedules.ts
@@ -32,7 +32,7 @@ export type CronValidationResult =
 export type ScheduleInstallResult = {
   description: string;
   expression: string;
-  launchAgentPath?: string;
+  nativeJobPath?: string;
   warning?: string;
 };
 
@@ -41,9 +41,9 @@ export type ConnectorScheduleStatus = {
   description: string;
   displayName?: string;
   expression: string;
-  launchAgentLoaded: boolean;
-  launchAgentPath?: string;
-  launchAgentPlistExists: boolean;
+  nativeJobInstalled: boolean;
+  nativeJobPath?: string;
+  nativeJobPathExists: boolean;
   pausedAt?: string;
   sourceInstanceId: string;
   updatedAt: string;
@@ -198,7 +198,7 @@ export async function installConnectorSchedule({
   return {
     description: validation.description,
     expression: validation.expression,
-    launchAgentPath: plistPath,
+    nativeJobPath: plistPath,
   };
 }
 
@@ -210,18 +210,18 @@ export async function listConnectorSchedules(
     return [];
   }
 
-  const launchAgentPath = schedule.launchAgentPath;
+  const nativeJobPath = schedule.nativeJobPath;
   return [
     {
       description: schedule.description,
       displayName: "All ingestion",
       expression: schedule.expression,
-      launchAgentLoaded: schedule.pausedAt
+      nativeJobInstalled: schedule.pausedAt
         ? false
         : await isLaunchAgentLoaded(),
-      launchAgentPath,
-      launchAgentPlistExists: launchAgentPath
-        ? await pathExists(launchAgentPath)
+      nativeJobPath,
+      nativeJobPathExists: nativeJobPath
+        ? await pathExists(nativeJobPath)
         : false,
       pausedAt: schedule.pausedAt,
       sourceInstanceId: "all",
@@ -303,7 +303,7 @@ export async function resumeConnectorSchedules({
     ingestionSchedule: {
       description: result.description,
       expression: result.expression,
-      launchAgentPath: result.launchAgentPath,
+      nativeJobPath: result.nativeJobPath,
       updatedAt: new Date().toISOString(),
       warning: result.warning,
     },

--- a/src/setup/credentials/use-init-setup.ts
+++ b/src/setup/credentials/use-init-setup.ts
@@ -2475,7 +2475,7 @@ export function useInitSetup({
         ingestionSchedule: {
           description: result.description,
           expression: result.expression,
-          launchAgentPath: result.launchAgentPath,
+          nativeJobPath: result.nativeJobPath,
           updatedAt: new Date().toISOString(),
           warning: result.warning,
         },

--- a/src/setup/onboarding.ts
+++ b/src/setup/onboarding.ts
@@ -21,7 +21,14 @@ export const REPOSITORY_INSTRUCTIONS_FILE = "INSTRUCTIONS.md";
 export type OnboardingSourceScheduleConfig = {
   description: string;
   expression: string;
+  /**
+   * Path of the installed native scheduler job (launchd plist on macOS).
+   *
+   * @deprecated legacy key spelling retained for reading old configs; new
+   * writes use {@link nativeJobPath}.
+   */
   launchAgentPath?: string;
+  nativeJobPath?: string;
   pausedAt?: string;
   updatedAt: string;
   warning?: string;
@@ -390,10 +397,14 @@ function normalizeSourceScheduleConfig(
   return {
     description: typeof value.description === "string" ? value.description : "",
     expression: typeof value.expression === "string" ? value.expression : "",
-    launchAgentPath:
-      typeof value.launchAgentPath === "string"
-        ? value.launchAgentPath
-        : undefined,
+    // `launchAgentPath` is the legacy key spelling; migrate it so configs
+    // written by older versions keep resolving their installed job.
+    nativeJobPath:
+      typeof value.nativeJobPath === "string"
+        ? value.nativeJobPath
+        : typeof value.launchAgentPath === "string"
+          ? value.launchAgentPath
+          : undefined,
     pausedAt: typeof value.pausedAt === "string" ? value.pausedAt : undefined,
     updatedAt:
       typeof value.updatedAt === "string"

--- a/test/cli/schedule-format.test.ts
+++ b/test/cli/schedule-format.test.ts
@@ -38,8 +38,8 @@ function connectorStatus(
   return {
     description: "Daily refresh",
     expression: "0 9 * * *",
-    launchAgentLoaded: false,
-    launchAgentPlistExists: false,
+    nativeJobInstalled: false,
+    nativeJobPathExists: false,
     sourceInstanceId: "src-1",
     updatedAt: "2026-01-01T00:00:00Z",
     ...overrides,
@@ -158,19 +158,19 @@ describe("formatPowerScheduleStatus", () => {
 });
 
 describe("formatScheduleStatus", () => {
-  test("reports not installed when there is no launch agent path", () => {
+  test("reports not installed when there is no native job path", () => {
     const result = formatScheduleStatus(connectorStatus());
 
-    expect(result).toContain("Launchd");
+    expect(result).toContain("Scheduler");
     expect(result).toContain("not installed");
   });
 
-  test("reports loaded when the launch agent is loaded", () => {
+  test("reports loaded when the native job is loaded", () => {
     const result = formatScheduleStatus(
       connectorStatus({
-        launchAgentLoaded: true,
-        launchAgentPath: "/tmp/agent.plist",
-        launchAgentPlistExists: true,
+        nativeJobInstalled: true,
+        nativeJobPath: "/tmp/agent.plist",
+        nativeJobPathExists: true,
       }),
     );
 

--- a/test/scheduling/schedule-operations.test.ts
+++ b/test/scheduling/schedule-operations.test.ts
@@ -101,7 +101,7 @@ describe("installConnectorSchedule", () => {
     });
 
     expect(result.expression).toBe("*/15 2 * * *");
-    expect(result.launchAgentPath).toBeUndefined();
+    expect(result.nativeJobPath).toBeUndefined();
     expect(result.warning).toMatch(/too complex/i);
     expect(result.description.length).toBeGreaterThan(0);
   });
@@ -116,7 +116,7 @@ describe("installConnectorSchedule", () => {
     });
 
     expect(result.expression).toBe("0 2 * * *");
-    expect(result.launchAgentPath).toBeUndefined();
+    expect(result.nativeJobPath).toBeUndefined();
     expect(result.warning).toMatch(/macOS-only/i);
   });
 });
@@ -260,16 +260,16 @@ describe("listConnectorSchedules", () => {
     expect(status).toMatchObject({
       displayName: "All ingestion",
       expression: "0 2 * * *",
-      launchAgentLoaded: false,
-      launchAgentPlistExists: false,
+      nativeJobInstalled: false,
+      nativeJobPathExists: false,
       pausedAt: "2026-01-02T00:00:00.000Z",
       sourceInstanceId: "all",
       warning: "some warning",
     });
-    expect(status.launchAgentPath).toBeUndefined();
+    expect(status.nativeJobPath).toBeUndefined();
   });
 
-  test("checks plist existence on disk and treats non-Darwin as never loaded", async () => {
+  test("checks job file existence on disk and treats non-Darwin as never loaded", async () => {
     stubPlatform("linux");
 
     const dir = await mkdtemp(path.join(os.tmpdir(), "openwiki-sched-"));
@@ -278,17 +278,17 @@ describe("listConnectorSchedules", () => {
     await writeFile(plistPath, "<plist/>", "utf8");
 
     const present = await listConnectorSchedules(
-      configWithSchedule("0 2 * * *", { launchAgentPath: plistPath }),
+      configWithSchedule("0 2 * * *", { nativeJobPath: plistPath }),
     );
-    expect(present[0].launchAgentLoaded).toBe(false);
-    expect(present[0].launchAgentPlistExists).toBe(true);
+    expect(present[0].nativeJobInstalled).toBe(false);
+    expect(present[0].nativeJobPathExists).toBe(true);
 
     const absent = await listConnectorSchedules(
       configWithSchedule("0 2 * * *", {
-        launchAgentPath: path.join(dir, "missing.plist"),
+        nativeJobPath: path.join(dir, "missing.plist"),
       }),
     );
-    expect(absent[0].launchAgentPlistExists).toBe(false);
+    expect(absent[0].nativeJobPathExists).toBe(false);
   });
 });
 

--- a/test/scheduling/schedules-launchd.test.ts
+++ b/test/scheduling/schedules-launchd.test.ts
@@ -217,7 +217,7 @@ describe("installConnectorSchedule (darwin native install)", () => {
       cwd,
     });
 
-    expect(result.launchAgentPath).toBe(PLIST_PATH);
+    expect(result.nativeJobPath).toBe(PLIST_PATH);
     expect(result.warning).toBeUndefined();
 
     const plist = await readFile(PLIST_PATH, "utf8");
@@ -322,7 +322,7 @@ describe("isLaunchAgentLoaded via listConnectorSchedules (darwin)", () => {
       configWithSchedule("0 2 * * *"),
     );
 
-    expect(status.launchAgentLoaded).toBe(true);
+    expect(status.nativeJobInstalled).toBe(true);
     const call = findCall("launchctl", "print");
     expect(call?.[1]).toEqual(["print", `${LAUNCHD_DOMAIN}/${LABEL}`]);
     expectSafeArgv(call as unknown[], "launchctl");
@@ -337,7 +337,7 @@ describe("isLaunchAgentLoaded via listConnectorSchedules (darwin)", () => {
       configWithSchedule("0 2 * * *"),
     );
 
-    expect(status.launchAgentLoaded).toBe(false);
+    expect(status.nativeJobInstalled).toBe(false);
   });
 });
 
@@ -412,7 +412,7 @@ describe("resumeConnectorSchedules (darwin reinstall + power reconcile)", () => 
 
     expect(result.connectorIds).toEqual(["all"]);
     expect(result.config.ingestionSchedule?.pausedAt).toBeUndefined();
-    expect(result.config.ingestionSchedule?.launchAgentPath).toBe(PLIST_PATH);
+    expect(result.config.ingestionSchedule?.nativeJobPath).toBe(PLIST_PATH);
     // An active ingestion schedule plus saved pmset drives reconciliation down
     // the install-power-window branch, re-enabling the wake schedule.
     expect(result.powerSchedule?.enabled).toBe(true);

--- a/test/setup/onboarding.test.ts
+++ b/test/setup/onboarding.test.ts
@@ -546,7 +546,7 @@ describe("normalizeOnboardingConfig (via readOpenWikiOnboardingConfig)", () => {
     expect(config.ingestionSchedule).toEqual({
       description: "",
       expression: "",
-      launchAgentPath: undefined,
+      nativeJobPath: undefined,
       pausedAt: undefined,
       updatedAt: new Date(0).toISOString(),
       warning: undefined,
@@ -560,7 +560,7 @@ describe("normalizeOnboardingConfig (via readOpenWikiOnboardingConfig)", () => {
       ingestionSchedule: {
         description: "nightly",
         expression: "0 3 * * *",
-        launchAgentPath: "/Library/LaunchAgents/openwiki.plist",
+        nativeJobPath: "/Library/LaunchAgents/openwiki.plist",
         pausedAt: "2026-02-01T00:00:00.000Z",
         updatedAt: "2026-01-01T00:00:00.000Z",
         warning: "battery only",
@@ -575,7 +575,7 @@ describe("normalizeOnboardingConfig (via readOpenWikiOnboardingConfig)", () => {
     expect(config.ingestionSchedule).toEqual({
       description: "nightly",
       expression: "0 3 * * *",
-      launchAgentPath: "/Library/LaunchAgents/openwiki.plist",
+      nativeJobPath: "/Library/LaunchAgents/openwiki.plist",
       pausedAt: "2026-02-01T00:00:00.000Z",
       updatedAt: "2026-01-01T00:00:00.000Z",
       warning: "battery only",


### PR DESCRIPTION
## Summary

Preparatory refactor for #421 (Windows Task Scheduler backend): renames the launchd-specific schedule fields and CLI labels to platform-neutral names so a non-macOS backend can slot into the existing seams without stretching launchd semantics.

No behavior change on macOS: the launchd implementation, plist writing, and all `launchctl` invocations are untouched.

## Renames

| Before | After |
|---|---|
| `ScheduleInstallResult.launchAgentPath` | `nativeJobPath` |
| `ConnectorScheduleStatus.launchAgentLoaded` | `nativeJobInstalled` |
| `ConnectorScheduleStatus.launchAgentPlistExists` | `nativeJobPathExists` |
| `OnboardingSourceScheduleConfig.launchAgentPath` | `nativeJobPath` (legacy key still read, see below) |

CLI output changes (`openwiki cron list` status block):
- `Launchd` row label → `Scheduler`
- `Plist` row label → `Job file`
- `plist exists, not loaded` → `job file exists, not loaded`
- `cron` command help no longer says "local launchd status"

## Backward compatibility

The persisted onboarding config may contain the legacy `launchAgentPath` key from older versions. `normalizeSourceScheduleConfig` now accepts both spellings and migrates `launchAgentPath` → `nativeJobPath` when reading, so existing macOS installations keep resolving their installed job after upgrading. The `launchAgentPath` field stays on the type as deprecated for one release.

## Verification

- `pnpm run format:check`, `pnpm run lint:check`, `tsc --noEmit` (both configs): clean
- `test/scheduling/`, `test/cli/schedule-format.test.ts`, `test/setup/onboarding.test.ts`, `test/setup/credentials/`: 411 passed; the single failure (`persists the resolved config directory for scheduled runs`) is a pre-existing Windows-environmental failure also present on clean `main` (expected POSIX-style config dir path in plist XML vs Windows path)
- Tests updated in place to the new names; legacy-key migration covered by the existing onboarding normalization tests

Part of #421. A follow-up PR will add the Windows `schtasks` backend on top of these names.

Refs: #421 (per its open question on naming — this PR implements option (a): generalized field names as a separate preparatory PR).