### PR TITLE
feat(scheduling): add Windows Task Scheduler backend (#421)

### DIFF
--- a/.changeset/witty-schtasks-backend.md
+++ b/.changeset/witty-schtasks-backend.md
@@ -1,0 +1,23 @@
+---
+"openwiki": minor
+---
+
+feat(scheduling): add Windows Task Scheduler backend
+
+Adds a native Windows scheduler surface (#421) that slots into the
+platform-neutral seams introduced by #758:
+
+- `parseSchtasksTriggerArgs()` — pure cron → `schtasks` trigger translation
+  (daily/weekly/monthly; rejects ranges, steps, lists, and cron semantics
+  `schtasks` can't AND, e.g. day-of-month + weekday together)
+- `installConnectorSchedule` on `win32` writes an `ingestion.schedule.cmd`
+  shim (cd into the repo, run `ingest all --scheduled`) and registers it via
+  `schtasks /Create`
+- `listConnectorSchedules` reports install state from `schtasks /Query`
+- `pauseConnectorSchedules` / `deleteConnectorSchedules` remove the task and
+  shim
+
+All shell-outs use an explicit argv array (no `shell: true`), so repo or
+config values can't be reinterpreted as shell syntax. Non-`win32` platforms
+fall through to the existing behavior; the win32 path is fully covered by
+`schedules-schtasks.test.ts` (which stubs `process.platform`).

--- a/src/cli/commands.ts
+++ b/src/cli/commands.ts
@@ -1140,7 +1140,8 @@ export const helpContent: HelpContent = {
     },
     {
       label: "openwiki cron list",
-      description: "List saved connector schedules and local launchd status.",
+      description:
+        "List saved connector schedules and native scheduler status.",
     },
     {
       label: "openwiki cron pause all",

--- a/src/cli/schedule-format.ts
+++ b/src/cli/schedule-format.ts
@@ -112,20 +112,20 @@ export function formatPowerScheduleStatus(
 export function formatScheduleStatus(
   schedule: ConnectorScheduleStatus,
 ): string {
-  const launchdStatus =
+  const nativeJobStatus =
     schedule.pausedAt !== undefined
       ? "paused"
-      : schedule.launchAgentPath === undefined
+      : schedule.nativeJobPath === undefined
         ? "not installed"
-        : schedule.launchAgentLoaded
+        : schedule.nativeJobInstalled
           ? "loaded"
-          : schedule.launchAgentPlistExists
-            ? "plist exists, not loaded"
-            : "plist missing";
+          : schedule.nativeJobPathExists
+            ? "job file exists, not loaded"
+            : "job file missing";
   const rows = [
     ["Schedule", schedule.description],
     ["Cron", schedule.expression],
-    ["Launchd", launchdStatus],
+    ["Scheduler", nativeJobStatus],
     ["Updated", schedule.updatedAt],
   ];
 
@@ -133,8 +133,8 @@ export function formatScheduleStatus(
     rows.push(["Paused", schedule.pausedAt]);
   }
 
-  if (schedule.launchAgentPath) {
-    rows.push(["Plist", schedule.launchAgentPath]);
+  if (schedule.nativeJobPath) {
+    rows.push(["Job file", schedule.nativeJobPath]);
   }
 
   if (schedule.warning) {

--- a/src/scheduling/schedules.ts
+++ b/src/scheduling/schedules.ts
@@ -32,7 +32,7 @@ export type CronValidationResult =
 export type ScheduleInstallResult = {
   description: string;
   expression: string;
-  launchAgentPath?: string;
+  nativeJobPath?: string;
   warning?: string;
 };
 
@@ -41,9 +41,9 @@ export type ConnectorScheduleStatus = {
   description: string;
   displayName?: string;
   expression: string;
-  launchAgentLoaded: boolean;
-  launchAgentPath?: string;
-  launchAgentPlistExists: boolean;
+  nativeJobInstalled: boolean;
+  nativeJobPath?: string;
+  nativeJobPathExists: boolean;
   pausedAt?: string;
   sourceInstanceId: string;
   updatedAt: string;
@@ -198,7 +198,7 @@ export async function installConnectorSchedule({
   return {
     description: validation.description,
     expression: validation.expression,
-    launchAgentPath: plistPath,
+    nativeJobPath: plistPath,
   };
 }
 
@@ -210,18 +210,18 @@ export async function listConnectorSchedules(
     return [];
   }
 
-  const launchAgentPath = schedule.launchAgentPath;
+  const nativeJobPath = schedule.nativeJobPath;
   return [
     {
       description: schedule.description,
       displayName: "All ingestion",
       expression: schedule.expression,
-      launchAgentLoaded: schedule.pausedAt
+      nativeJobInstalled: schedule.pausedAt
         ? false
         : await isLaunchAgentLoaded(),
-      launchAgentPath,
-      launchAgentPlistExists: launchAgentPath
-        ? await pathExists(launchAgentPath)
+      nativeJobPath,
+      nativeJobPathExists: nativeJobPath
+        ? await pathExists(nativeJobPath)
         : false,
       pausedAt: schedule.pausedAt,
       sourceInstanceId: "all",
@@ -303,7 +303,7 @@ export async function resumeConnectorSchedules({
     ingestionSchedule: {
       description: result.description,
       expression: result.expression,
-      launchAgentPath: result.launchAgentPath,
+      nativeJobPath: result.nativeJobPath,
       updatedAt: new Date().toISOString(),
       warning: result.warning,
     },

--- a/src/scheduling/schedules.ts
+++ b/src/scheduling/schedules.ts
@@ -17,6 +17,20 @@ import type { OpenWikiOnboardingConfig } from "../setup/onboarding.js";
 const execFileAsync = promisify(execFile);
 const DEFAULT_FIRST_HOUR = 2;
 
+/** Name of the Windows scheduled task installed by `installConnectorSchedule`. */
+const SCHTASKS_TASK_NAME = "OpenWiki Ingestion";
+
+/**
+ * Escapes a value for inclusion inside a double-quoted `cmd.exe` argument.
+ *
+ * The shim runs under `cmd.exe`, where `%` introduces variable expansion and
+ * `"` toggles quoting; both must be neutralized so hostile paths cannot change
+ * what the shim executes.
+ */
+function escapeCmdShimValue(value: string): string {
+  return value.replace(/%/gu, "%%").replace(/"/gu, "^");
+}
+
 export type CronValidationResult =
   | {
       description: string;
@@ -144,12 +158,18 @@ export async function installConnectorSchedule({
     throw new Error(validation.error);
   }
 
+  void connectorId;
+
+  if (process.platform === "win32") {
+    return installConnectorScheduleWindows({ cwd, validation });
+  }
+
   if (process.platform !== "darwin") {
     return {
       description: validation.description,
       expression: validation.expression,
       warning:
-        "Schedule saved, but native installation is currently macOS-only.",
+        "Schedule saved, but native installation is currently supported on macOS and Windows only.",
     };
   }
 
@@ -163,7 +183,6 @@ export async function installConnectorSchedule({
     };
   }
 
-  void connectorId;
   const label = getLaunchAgentLabel();
   const launchAgentsDir = getLaunchAgentsDir();
   const logsDir = path.join(openWikiHomeDir, "logs");
@@ -191,7 +210,7 @@ export async function installConnectorSchedule({
   );
   await chmod(plistPath, 0o600);
 
-  await unloadLaunchAgent();
+  await unloadSchedulerJob();
   const launchdDomain = getLaunchdDomain();
   await execFileAsync("launchctl", ["bootstrap", launchdDomain, plistPath]);
 
@@ -218,7 +237,7 @@ export async function listConnectorSchedules(
       expression: schedule.expression,
       nativeJobInstalled: schedule.pausedAt
         ? false
-        : await isLaunchAgentLoaded(),
+        : await isSchedulerJobInstalled(),
       nativeJobPath,
       nativeJobPathExists: nativeJobPath
         ? await pathExists(nativeJobPath)
@@ -257,7 +276,7 @@ export async function pauseConnectorSchedules(
       updatedAt: new Date().toISOString(),
     },
   };
-  await unloadLaunchAgent();
+  await unloadSchedulerJob();
 
   const reconciled = await reconcileOpenWikiPowerSchedule(nextConfig);
   return {
@@ -339,8 +358,8 @@ export async function deleteConnectorSchedules(
 
   const nextConfig = cloneOnboardingConfig(config);
   delete nextConfig.ingestionSchedule;
-  await unloadLaunchAgent();
-  await removeLaunchAgentPlist();
+  await unloadSchedulerJob();
+  await removeSchedulerJobFile();
 
   const reconciled = await reconcileOpenWikiPowerSchedule(nextConfig);
   return {
@@ -885,6 +904,273 @@ function getLaunchAgentsDir(): string {
 
 function getLaunchAgentPath(): string {
   return path.join(getLaunchAgentsDir(), `${getLaunchAgentLabel()}.plist`);
+}
+
+/**
+ * Translates a simple cron expression into `schtasks /Create` arguments.
+ *
+ * Supports exactly the subset `parseLaunchdCalendarInterval` accepts on macOS,
+ * so behavior stays symmetric across platforms:
+ *
+ * - `M H * * *` → `/SC DAILY /ST HH:MM`
+ * - `M H * * W` → `/SC WEEKLY /D <MON..SUN> /ST HH:MM`
+ * - `M H D * *` → `/SC MONTHLY /D <1..31> /ST HH:MM`
+ *
+ * Cron ORs day-of-month and day-of-week when both are restricted, but a
+ * schtasks trigger ANDs them; the combination is rejected (falling back to the
+ * "too complex" warning) rather than installing a near-dead timer. Month-pinned
+ * expressions are rejected too: schtasks has no /SC MONTHLY month selector.
+ *
+ * @returns The `/Create` argument list, or null when the expression cannot be
+ *   represented directly.
+ */
+export function parseSchtasksTriggerArgs(
+  expression: string,
+): string[] | null {
+  const parsed = parseSimpleCronFields(expression);
+  if (!parsed) {
+    return null;
+  }
+
+  const { day, hour, minute, month, weekday } = parsed;
+
+  const parsedMinute = getSingleCronNumber(minute, { max: 59, min: 0 });
+  if (parsedMinute === null) {
+    return null;
+  }
+
+  const parsedHour = getSingleCronNumber(hour, { max: 23, min: 0 });
+  if (parsedHour === null) {
+    return null;
+  }
+
+  if (month !== "*") {
+    return null;
+  }
+
+  const dayRestricted = day !== "*";
+  const weekdayRestricted = weekday !== "*";
+  if (dayRestricted && weekdayRestricted) {
+    return null;
+  }
+
+  const startTime = `${hour.padStart(2, "0")}:${minute.padStart(2, "0")}`;
+
+  if (weekdayRestricted) {
+    const parsedWeekday = getSingleCronNumber(weekday, { max: 7, min: 0 });
+    if (parsedWeekday === null) {
+      return null;
+    }
+    const dayNames = ["SUN", "MON", "TUE", "WED", "THU", "FRI", "SAT"];
+    return [
+      "/SC",
+      "WEEKLY",
+      "/D",
+      dayNames[parsedWeekday === 7 ? 0 : parsedWeekday],
+      "/ST",
+      startTime,
+    ];
+  }
+
+  if (dayRestricted) {
+    const parsedDay = getSingleCronNumber(day, { max: 31, min: 1 });
+    if (parsedDay === null) {
+      return null;
+    }
+    // /SC MONTHLY /D only accepts day values 1-31, which getSingleCronNumber
+    // already enforces.
+    return ["/SC", "MONTHLY", "/D", String(parsedDay), "/ST", startTime];
+  }
+
+  return ["/SC", "DAILY", "/ST", startTime];
+}
+
+function getSchtasksTaskName(): string {
+  return SCHTASKS_TASK_NAME;
+}
+
+function getSchtasksShimDir(): string {
+  return openWikiHomeDir;
+}
+
+function getSchtasksShimPath(): string {
+  return path.join(getSchtasksShimDir(), "ingestion.schedule.cmd");
+}
+
+/**
+ * Builds the `cmd.exe` shim the scheduled task executes.
+ *
+ * `schtasks /TR` has a ~261-character limit, no working-directory field, and
+ * no output redirection, so the task points at this short shim instead. It
+ * mirrors the launchd plist's ProgramArguments, WorkingDirectory, and
+ * StandardOut/ErrorPath behavior.
+ */
+function createSchtasksShim({
+  cwd,
+  logPath,
+  openWikiConfigDir,
+}: {
+  cwd: string;
+  logPath: string;
+  openWikiConfigDir?: string;
+}): string {
+  const cliPath = process.argv[1] ? path.resolve(process.argv[1]) : "";
+  const node = escapeCmdShimValue(process.execPath);
+  const cli = escapeCmdShimValue(cliPath);
+  const workDir = escapeCmdShimValue(cwd);
+  const log = escapeCmdShimValue(logPath);
+  const configDirLine = openWikiConfigDir
+    ? `set "${OPENWIKI_CONFIG_DIR_ENV_KEY}=${escapeCmdShimValue(openWikiConfigDir)}"\r\n`
+    : "";
+
+  return [
+    "@echo off",
+    configDirLine.trimEnd(),
+    `cd /d "${workDir}" || exit /b 1`,
+    `"${node}" "${cli}" ingest all --scheduled --print >> "${log}" 2>&1`,
+    "",
+  ]
+    .filter((line) => line !== undefined)
+    .join("\r\n");
+}
+
+async function installConnectorScheduleWindows({
+  cwd,
+  validation,
+}: {
+  cwd: string;
+  validation: Extract<
+    CronValidationResult,
+    { description: string; expression: string; valid: true }
+  >;
+}): Promise<ScheduleInstallResult> {
+  const triggerArgs = parseSchtasksTriggerArgs(validation.expression);
+  if (!triggerArgs) {
+    await removeSchtasksTask();
+    await removeSchtasksShim();
+    return {
+      description: validation.description,
+      expression: validation.expression,
+      warning:
+        "Schedule saved, but this cron expression is too complex for direct Windows Task Scheduler installation.",
+    };
+  }
+
+  const shimPath = getSchtasksShimPath();
+  const logsDir = path.join(openWikiHomeDir, "logs");
+  const configuredDir = process.env[OPENWIKI_CONFIG_DIR_ENV_KEY]?.trim();
+
+  await ensureOpenWikiHome();
+  await mkdir(logsDir, { recursive: true });
+  await writeFile(
+    shimPath,
+    createSchtasksShim({
+      cwd,
+      logPath: path.join(logsDir, "ingestion.schedule.log"),
+      openWikiConfigDir: configuredDir
+        ? resolveOpenWikiHomeDir(process.env)
+        : undefined,
+    }),
+    "utf8",
+  );
+
+  try {
+    // triggerArgs is ["/SC", <schedule>, ...]; /F overwrites any existing task
+    // of the same name, matching launchd's bootout-before-bootstrap behavior.
+    await execFileAsync("schtasks", [
+      "/Create",
+      "/F",
+      ...triggerArgs,
+      "/TN",
+      getSchtasksTaskName(),
+      "/TR",
+      shimPath,
+    ]);
+  } catch (error) {
+    await removeSchtasksTask();
+    await removeSchtasksShim();
+    return {
+      description: validation.description,
+      expression: validation.expression,
+      warning: `Schedule saved to the wiki config, but installing the Windows scheduled task failed: ${getErrorMessage(error)}`,
+    };
+  }
+
+  return {
+    description: validation.description,
+    expression: validation.expression,
+    nativeJobPath: shimPath,
+  };
+}
+
+async function removeSchtasksTask(): Promise<void> {
+  await execFileAsync("schtasks", [
+    "/Delete",
+    "/F",
+    "/TN",
+    getSchtasksTaskName(),
+  ]).catch(() => null);
+}
+
+async function removeSchtasksShim(): Promise<void> {
+  await unlink(getSchtasksShimPath()).catch((error: unknown) => {
+    if (isFileNotFoundError(error)) {
+      return;
+    }
+
+    throw error;
+  });
+}
+
+async function isSchtasksTaskInstalled(): Promise<boolean> {
+  try {
+    await execFileAsync("schtasks", [
+      "/Query",
+      "/TN",
+      getSchtasksTaskName(),
+    ]);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Platform dispatcher for uninstalling the native scheduler job. Each
+ * platform-specific helper early-returns on other platforms.
+ */
+async function unloadSchedulerJob(): Promise<void> {
+  if (process.platform === "win32") {
+    await removeSchtasksTask();
+    return;
+  }
+
+  await unloadLaunchAgent();
+}
+
+/**
+ * Platform dispatcher for deleting the native scheduler job file. Each
+ * platform-specific helper early-returns on other platforms.
+ */
+async function removeSchedulerJobFile(): Promise<void> {
+  if (process.platform === "win32") {
+    await removeSchtasksShim();
+    return;
+  }
+
+  await removeLaunchAgentPlist();
+}
+
+/**
+ * Platform dispatcher for querying whether the native scheduler job is
+ * installed. Each platform-specific helper early-returns on other platforms.
+ */
+async function isSchedulerJobInstalled(): Promise<boolean> {
+  if (process.platform === "win32") {
+    return isSchtasksTaskInstalled();
+  }
+
+  return isLaunchAgentLoaded();
 }
 
 async function unloadLaunchAgent(): Promise<void> {

--- a/src/scheduling/schedules.ts
+++ b/src/scheduling/schedules.ts
@@ -924,9 +924,7 @@ function getLaunchAgentPath(): string {
  * @returns The `/Create` argument list, or null when the expression cannot be
  *   represented directly.
  */
-export function parseSchtasksTriggerArgs(
-  expression: string,
-): string[] | null {
+export function parseSchtasksTriggerArgs(expression: string): string[] | null {
   const parsed = parseSimpleCronFields(expression);
   if (!parsed) {
     return null;
@@ -1124,11 +1122,7 @@ async function removeSchtasksShim(): Promise<void> {
 
 async function isSchtasksTaskInstalled(): Promise<boolean> {
   try {
-    await execFileAsync("schtasks", [
-      "/Query",
-      "/TN",
-      getSchtasksTaskName(),
-    ]);
+    await execFileAsync("schtasks", ["/Query", "/TN", getSchtasksTaskName()]);
     return true;
   } catch {
     return false;

--- a/src/setup/credentials/use-init-setup.ts
+++ b/src/setup/credentials/use-init-setup.ts
@@ -2475,7 +2475,7 @@ export function useInitSetup({
         ingestionSchedule: {
           description: result.description,
           expression: result.expression,
-          launchAgentPath: result.launchAgentPath,
+          nativeJobPath: result.nativeJobPath,
           updatedAt: new Date().toISOString(),
           warning: result.warning,
         },

--- a/src/setup/onboarding.ts
+++ b/src/setup/onboarding.ts
@@ -21,7 +21,14 @@ export const REPOSITORY_INSTRUCTIONS_FILE = "INSTRUCTIONS.md";
 export type OnboardingSourceScheduleConfig = {
   description: string;
   expression: string;
+  /**
+   * Path of the installed native scheduler job (launchd plist on macOS).
+   *
+   * @deprecated legacy key spelling retained for reading old configs; new
+   * writes use {@link nativeJobPath}.
+   */
   launchAgentPath?: string;
+  nativeJobPath?: string;
   pausedAt?: string;
   updatedAt: string;
   warning?: string;
@@ -390,10 +397,14 @@ function normalizeSourceScheduleConfig(
   return {
     description: typeof value.description === "string" ? value.description : "",
     expression: typeof value.expression === "string" ? value.expression : "",
-    launchAgentPath:
-      typeof value.launchAgentPath === "string"
-        ? value.launchAgentPath
-        : undefined,
+    // `launchAgentPath` is the legacy key spelling; migrate it so configs
+    // written by older versions keep resolving their installed job.
+    nativeJobPath:
+      typeof value.nativeJobPath === "string"
+        ? value.nativeJobPath
+        : typeof value.launchAgentPath === "string"
+          ? value.launchAgentPath
+          : undefined,
     pausedAt: typeof value.pausedAt === "string" ? value.pausedAt : undefined,
     updatedAt:
       typeof value.updatedAt === "string"

--- a/src/setup/onboarding.ts
+++ b/src/setup/onboarding.ts
@@ -22,7 +22,8 @@ export type OnboardingSourceScheduleConfig = {
   description: string;
   expression: string;
   /**
-   * Path of the installed native scheduler job (launchd plist on macOS).
+   * Path of the installed native scheduler job (a launchd plist on macOS or
+   * a Task Scheduler command shim on Windows).
    *
    * @deprecated legacy key spelling retained for reading old configs; new
    * writes use {@link nativeJobPath}.

--- a/test/cli/schedule-format.test.ts
+++ b/test/cli/schedule-format.test.ts
@@ -38,8 +38,8 @@ function connectorStatus(
   return {
     description: "Daily refresh",
     expression: "0 9 * * *",
-    launchAgentLoaded: false,
-    launchAgentPlistExists: false,
+    nativeJobInstalled: false,
+    nativeJobPathExists: false,
     sourceInstanceId: "src-1",
     updatedAt: "2026-01-01T00:00:00Z",
     ...overrides,
@@ -158,19 +158,19 @@ describe("formatPowerScheduleStatus", () => {
 });
 
 describe("formatScheduleStatus", () => {
-  test("reports not installed when there is no launch agent path", () => {
+  test("reports not installed when there is no native job path", () => {
     const result = formatScheduleStatus(connectorStatus());
 
-    expect(result).toContain("Launchd");
+    expect(result).toContain("Scheduler");
     expect(result).toContain("not installed");
   });
 
-  test("reports loaded when the launch agent is loaded", () => {
+  test("reports loaded when the native job is loaded", () => {
     const result = formatScheduleStatus(
       connectorStatus({
-        launchAgentLoaded: true,
-        launchAgentPath: "/tmp/agent.plist",
-        launchAgentPlistExists: true,
+        nativeJobInstalled: true,
+        nativeJobPath: "/tmp/agent.plist",
+        nativeJobPathExists: true,
       }),
     );
 

--- a/test/scheduling/schedule-operations.test.ts
+++ b/test/scheduling/schedule-operations.test.ts
@@ -106,7 +106,7 @@ describe("installConnectorSchedule", () => {
     expect(result.description.length).toBeGreaterThan(0);
   });
 
-  test("saves without native install on non-macOS platforms", async () => {
+  test("saves without native install on unsupported platforms", async () => {
     stubPlatform("linux");
 
     const result = await installConnectorSchedule({
@@ -117,7 +117,7 @@ describe("installConnectorSchedule", () => {
 
     expect(result.expression).toBe("0 2 * * *");
     expect(result.nativeJobPath).toBeUndefined();
-    expect(result.warning).toMatch(/macOS-only/i);
+    expect(result.warning).toMatch(/macOS and Windows only/i);
   });
 });
 
@@ -354,7 +354,7 @@ describe("resumeConnectorSchedules", () => {
     expect(result.connectorIds).toEqual([]);
   });
 
-  test("clears pausedAt and surfaces the non-macOS install warning", async () => {
+  test("clears pausedAt and surfaces the unsupported-platform warning", async () => {
     stubPlatform("linux");
 
     const config = configWithSchedule("0 2 * * *", {
@@ -369,7 +369,7 @@ describe("resumeConnectorSchedules", () => {
     expect(result.connectorIds).toEqual(["all"]);
     expect(result.config.ingestionSchedule?.pausedAt).toBeUndefined();
     expect(result.warnings).toContain(
-      "Schedule saved, but native installation is currently macOS-only.",
+      "Schedule saved, but native installation is currently supported on macOS and Windows only.",
     );
   });
 });

--- a/test/scheduling/schedule-operations.test.ts
+++ b/test/scheduling/schedule-operations.test.ts
@@ -101,7 +101,7 @@ describe("installConnectorSchedule", () => {
     });
 
     expect(result.expression).toBe("*/15 2 * * *");
-    expect(result.launchAgentPath).toBeUndefined();
+    expect(result.nativeJobPath).toBeUndefined();
     expect(result.warning).toMatch(/too complex/i);
     expect(result.description.length).toBeGreaterThan(0);
   });
@@ -116,7 +116,7 @@ describe("installConnectorSchedule", () => {
     });
 
     expect(result.expression).toBe("0 2 * * *");
-    expect(result.launchAgentPath).toBeUndefined();
+    expect(result.nativeJobPath).toBeUndefined();
     expect(result.warning).toMatch(/macOS-only/i);
   });
 });
@@ -260,16 +260,16 @@ describe("listConnectorSchedules", () => {
     expect(status).toMatchObject({
       displayName: "All ingestion",
       expression: "0 2 * * *",
-      launchAgentLoaded: false,
-      launchAgentPlistExists: false,
+      nativeJobInstalled: false,
+      nativeJobPathExists: false,
       pausedAt: "2026-01-02T00:00:00.000Z",
       sourceInstanceId: "all",
       warning: "some warning",
     });
-    expect(status.launchAgentPath).toBeUndefined();
+    expect(status.nativeJobPath).toBeUndefined();
   });
 
-  test("checks plist existence on disk and treats non-Darwin as never loaded", async () => {
+  test("checks job file existence on disk and treats non-Darwin as never loaded", async () => {
     stubPlatform("linux");
 
     const dir = await mkdtemp(path.join(os.tmpdir(), "openwiki-sched-"));
@@ -278,17 +278,17 @@ describe("listConnectorSchedules", () => {
     await writeFile(plistPath, "<plist/>", "utf8");
 
     const present = await listConnectorSchedules(
-      configWithSchedule("0 2 * * *", { launchAgentPath: plistPath }),
+      configWithSchedule("0 2 * * *", { nativeJobPath: plistPath }),
     );
-    expect(present[0].launchAgentLoaded).toBe(false);
-    expect(present[0].launchAgentPlistExists).toBe(true);
+    expect(present[0].nativeJobInstalled).toBe(false);
+    expect(present[0].nativeJobPathExists).toBe(true);
 
     const absent = await listConnectorSchedules(
       configWithSchedule("0 2 * * *", {
-        launchAgentPath: path.join(dir, "missing.plist"),
+        nativeJobPath: path.join(dir, "missing.plist"),
       }),
     );
-    expect(absent[0].launchAgentPlistExists).toBe(false);
+    expect(absent[0].nativeJobPathExists).toBe(false);
   });
 });
 

--- a/test/scheduling/schedules-launchd.test.ts
+++ b/test/scheduling/schedules-launchd.test.ts
@@ -217,7 +217,7 @@ describe("installConnectorSchedule (darwin native install)", () => {
       cwd,
     });
 
-    expect(result.launchAgentPath).toBe(PLIST_PATH);
+    expect(result.nativeJobPath).toBe(PLIST_PATH);
     expect(result.warning).toBeUndefined();
 
     const plist = await readFile(PLIST_PATH, "utf8");
@@ -322,7 +322,7 @@ describe("isLaunchAgentLoaded via listConnectorSchedules (darwin)", () => {
       configWithSchedule("0 2 * * *"),
     );
 
-    expect(status.launchAgentLoaded).toBe(true);
+    expect(status.nativeJobInstalled).toBe(true);
     const call = findCall("launchctl", "print");
     expect(call?.[1]).toEqual(["print", `${LAUNCHD_DOMAIN}/${LABEL}`]);
     expectSafeArgv(call as unknown[], "launchctl");
@@ -337,7 +337,7 @@ describe("isLaunchAgentLoaded via listConnectorSchedules (darwin)", () => {
       configWithSchedule("0 2 * * *"),
     );
 
-    expect(status.launchAgentLoaded).toBe(false);
+    expect(status.nativeJobInstalled).toBe(false);
   });
 });
 
@@ -412,7 +412,7 @@ describe("resumeConnectorSchedules (darwin reinstall + power reconcile)", () => 
 
     expect(result.connectorIds).toEqual(["all"]);
     expect(result.config.ingestionSchedule?.pausedAt).toBeUndefined();
-    expect(result.config.ingestionSchedule?.launchAgentPath).toBe(PLIST_PATH);
+    expect(result.config.ingestionSchedule?.nativeJobPath).toBe(PLIST_PATH);
     // An active ingestion schedule plus saved pmset drives reconciliation down
     // the install-power-window branch, re-enabling the wake schedule.
     expect(result.powerSchedule?.enabled).toBe(true);

--- a/test/scheduling/schedules-schtasks.test.ts
+++ b/test/scheduling/schedules-schtasks.test.ts
@@ -1,0 +1,373 @@
+import path from "node:path";
+import { afterAll, afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import { createEmptyOnboardingConfig } from "../../src/setup/onboarding.ts";
+import type { OpenWikiOnboardingConfig } from "../../src/setup/onboarding.ts";
+
+// This file drives the Windows native surface of schedules.ts: the
+// schtasks shell-outs and the cron→trigger translator and cmd shim builder
+// that are only reachable through them. The child_process and os mocks are
+// deliberately kept in their own file so they never leak into the
+// pure-surface suites (mirrors schedules-launchd.test.ts).
+
+const HOME = vi.hoisted(() => {
+  const base = (process.env.TEMP ?? process.env.TMPDIR ?? "/tmp").replace(
+    /[\\/]+$/u,
+    "",
+  );
+  return `${base}\\openwiki-schtasks-home-${process.pid}-${Date.now()}`;
+});
+
+vi.mock("node:os", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:os")>();
+  const patched = { ...actual, homedir: () => HOME };
+  return { ...patched, default: patched };
+});
+
+const execFileMock = vi.hoisted(() => vi.fn());
+vi.mock("node:child_process", () => ({
+  execFile: execFileMock,
+}));
+
+import {
+  deleteConnectorSchedules,
+  installConnectorSchedule,
+  listConnectorSchedules,
+  parseSchtasksTriggerArgs,
+  pauseConnectorSchedules,
+} from "../../src/scheduling/schedules.ts";
+
+const SHIM_PATH = path.join(HOME, ".openwiki", "ingestion.schedule.cmd");
+const TASK_NAME = "OpenWiki Ingestion";
+
+const ORIGINAL_PLATFORM = process.platform;
+const ORIGINAL_CONFIG_DIR = process.env.OPENWIKI_CONFIG_DIR;
+
+type ExecOutcome = { error?: Error };
+
+let execFileOutcome: (command: string, args: string[]) => ExecOutcome;
+
+/** Forces the module's `process.platform` reads down the win32 branch. */
+function stubWin32(): void {
+  Object.defineProperty(process, "platform", {
+    configurable: true,
+    value: "win32",
+  });
+}
+
+beforeEach(() => {
+  stubWin32();
+  execFileOutcome = () => ({});
+  execFileMock.mockImplementation((...callArgs: unknown[]) => {
+    const done = callArgs.at(-1) as (
+      error: Error | null,
+      stdout: unknown,
+      stderr: string,
+    ) => void;
+    const command = callArgs[0] as string;
+    const args = (callArgs[1] as string[]) ?? [];
+    const { error } = execFileOutcome(command, args);
+    done(error ?? null, { stdout: "", stderr: "" }, "");
+  });
+});
+
+afterEach(() => {
+  Object.defineProperty(process, "platform", {
+    configurable: true,
+    value: ORIGINAL_PLATFORM,
+  });
+  execFileMock.mockReset();
+  if (ORIGINAL_CONFIG_DIR === undefined) delete process.env.OPENWIKI_CONFIG_DIR;
+  else process.env.OPENWIKI_CONFIG_DIR = ORIGINAL_CONFIG_DIR;
+});
+
+afterAll(async () => {
+  const { rm } = await import("node:fs/promises");
+  await rm(HOME, { force: true, recursive: true });
+});
+
+/** Builds an onboarding config carrying a single ingestion schedule. */
+function configWithSchedule(
+  expression: string,
+  overrides: Partial<
+    NonNullable<OpenWikiOnboardingConfig["ingestionSchedule"]>
+  > = {},
+): OpenWikiOnboardingConfig {
+  return {
+    ...createEmptyOnboardingConfig(),
+    ingestionSchedule: {
+      description: "All ingestion",
+      expression,
+      updatedAt: "2026-01-01T00:00:00.000Z",
+      ...overrides,
+    },
+  };
+}
+
+describe("parseSchtasksTriggerArgs (pure cron→schtasks translation)", () => {
+  test("translates a daily time", () => {
+    expect(parseSchtasksTriggerArgs("30 2 * * *")).toEqual([
+      "/SC",
+      "DAILY",
+      "/ST",
+      "02:30",
+    ]);
+  });
+
+  test("zero-pads single-digit hour and minute", () => {
+    expect(parseSchtasksTriggerArgs("5 7 * * *")).toEqual([
+      "/SC",
+      "DAILY",
+      "/ST",
+      "07:05",
+    ]);
+  });
+
+  test("translates a single weekday", () => {
+    expect(parseSchtasksTriggerArgs("0 9 * * 1")).toEqual([
+      "/SC",
+      "WEEKLY",
+      "/D",
+      "MON",
+      "/ST",
+      "09:00",
+    ]);
+  });
+
+  test("maps cron weekday 7 to Sunday", () => {
+    expect(parseSchtasksTriggerArgs("0 9 * * 7")).toEqual([
+      "/SC",
+      "WEEKLY",
+      "/D",
+      "SUN",
+      "/ST",
+      "09:00",
+    ]);
+  });
+
+  test("translates a day of month", () => {
+    expect(parseSchtasksTriggerArgs("0 6 1 * *")).toEqual([
+      "/SC",
+      "MONTHLY",
+      "/D",
+      "1",
+      "/ST",
+      "06:00",
+    ]);
+  });
+
+  test("rejects ranges, steps, and lists in any field", () => {
+    expect(parseSchtasksTriggerArgs("*/15 2 * * *")).toBeNull();
+    expect(parseSchtasksTriggerArgs("0 2-4 * * *")).toBeNull();
+    expect(parseSchtasksTriggerArgs("0 2,4 * * *")).toBeNull();
+    expect(parseSchtasksTriggerArgs("0 2 * * 1-5")).toBeNull();
+  });
+
+  test("rejects day-of-month and weekday restricted together", () => {
+    // Cron ORs these fields; schtasks ANDs them. The near-dead trigger must
+    // fall back to the saved-only warning instead of installing.
+    expect(parseSchtasksTriggerArgs("0 2 1 * 1")).toBeNull();
+  });
+
+  test("rejects month-pinned expressions", () => {
+    expect(parseSchtasksTriggerArgs("0 2 * 3 *")).toBeNull();
+  });
+
+  test("rejects out-of-range and non-numeric field values", () => {
+    expect(parseSchtasksTriggerArgs("60 2 * * *")).toBeNull();
+    expect(parseSchtasksTriggerArgs("0 24 * * *")).toBeNull();
+    expect(parseSchtasksTriggerArgs("0 2 32 * *")).toBeNull();
+    expect(parseSchtasksTriggerArgs("0 2 * * 8")).toBeNull();
+    expect(parseSchtasksTriggerArgs("0 2 * * SUN")).toBeNull();
+  });
+
+  test("rejects malformed expressions", () => {
+    expect(parseSchtasksTriggerArgs("0 2 * *")).toBeNull();
+    expect(parseSchtasksTriggerArgs("0 2 * * * extra")).toBeNull();
+    expect(parseSchtasksTriggerArgs("")).toBeNull();
+  });
+});
+
+describe("installConnectorSchedule (win32 native install)", () => {
+  test("writes a shim and creates the task with an explicit argv", async () => {
+    const result = await installConnectorSchedule({
+      connectorId: "git-repo",
+      cronExpression: "0 2 * * *",
+      cwd: "C:\\repo",
+    });
+
+    expect(result.nativeJobPath).toBe(SHIM_PATH);
+    expect(result.warning).toBeUndefined();
+
+    const { readFile } = await import("node:fs/promises");
+    const shim = await readFile(SHIM_PATH, "utf8");
+    // The shim cds to the wiki repo, runs the CLI in scheduled mode, and
+    // appends both streams to the ingestion log.
+    expect(shim).toContain(`cd /d "C:\\repo"`);
+    expect(shim).toContain("ingest all --scheduled --print");
+    expect(shim).toContain("ingestion.schedule.log");
+    expect(shim).not.toContain("OPENWIKI_CONFIG_DIR");
+
+    const create = execFileMock.mock.calls.find(
+      ([command]) => command === "schtasks",
+    );
+    expect(create?.[1]).toEqual([
+      "/Create",
+      "/F",
+      "/SC",
+      "DAILY",
+      "/ST",
+      "02:00",
+      "/TN",
+      TASK_NAME,
+      "/TR",
+      SHIM_PATH,
+    ]);
+    // No shell option: schtasks must be spawned directly with an argv array.
+    const options = create
+      ?.slice(2)
+      .find(
+        (arg): arg is Record<string, unknown> =>
+          typeof arg === "object" && arg !== null,
+      );
+    expect(options?.shell ?? false).toBe(false);
+  });
+
+  test("passes the resolved config dir into the shim environment", async () => {
+    const configuredDir = "C:\\openwiki state";
+    process.env.OPENWIKI_CONFIG_DIR = configuredDir;
+
+    await installConnectorSchedule({
+      connectorId: "git-repo",
+      cronExpression: "0 2 * * *",
+      cwd: "C:\\repo",
+    });
+
+    const { readFile } = await import("node:fs/promises");
+    const shim = await readFile(SHIM_PATH, "utf8");
+    expect(shim).toContain(`set "OPENWIKI_CONFIG_DIR=${configuredDir}"`);
+  });
+
+  test("degrades to a saved-only warning when schtasks fails", async () => {
+    const { access, mkdir, writeFile } = await import("node:fs/promises");
+    await mkdir(path.dirname(SHIM_PATH), { recursive: true });
+    await writeFile(SHIM_PATH, "@echo off\r\n", "utf8");
+    execFileOutcome = (command, args) =>
+      command === "schtasks" && args[0] === "/Create"
+        ? { error: new Error("access denied") }
+        : {};
+
+    const result = await installConnectorSchedule({
+      connectorId: "git-repo",
+      cronExpression: "0 2 * * *",
+      cwd: "C:\\repo",
+    });
+
+    expect(result.nativeJobPath).toBeUndefined();
+    expect(result.warning).toMatch(/installing the Windows scheduled task failed/i);
+    const remove = execFileMock.mock.calls.find(
+      ([command, args]) => command === "schtasks" && args[0] === "/Delete",
+    );
+    expect(remove?.[1]).toEqual(["/Delete", "/F", "/TN", TASK_NAME]);
+    await expect(access(SHIM_PATH)).rejects.toThrow();
+  });
+
+  test("removes the old task before saving an expression too complex for schtasks", async () => {
+    const { access, mkdir, writeFile } = await import("node:fs/promises");
+    await mkdir(path.dirname(SHIM_PATH), { recursive: true });
+    await writeFile(SHIM_PATH, "@echo off\r\n", "utf8");
+
+    const result = await installConnectorSchedule({
+      connectorId: "git-repo",
+      cronExpression: "*/15 2 * * *",
+      cwd: "C:\\repo",
+    });
+
+    expect(result.nativeJobPath).toBeUndefined();
+    expect(result.warning).toMatch(/too complex/i);
+    const remove = execFileMock.mock.calls.find(
+      ([command, args]) => command === "schtasks" && args[0] === "/Delete",
+    );
+    expect(remove?.[1]).toEqual(["/Delete", "/F", "/TN", TASK_NAME]);
+    await expect(access(SHIM_PATH)).rejects.toThrow();
+  });
+});
+
+describe("listConnectorSchedules (win32 status)", () => {
+  test("reports the task as installed when schtasks /Query succeeds", async () => {
+    const [status] = await listConnectorSchedules(
+      configWithSchedule("0 2 * * *", { nativeJobPath: SHIM_PATH }),
+    );
+
+    expect(status.nativeJobInstalled).toBe(true);
+    const query = execFileMock.mock.calls.find(
+      ([command, args]) =>
+        command === "schtasks" && (args as string[])[0] === "/Query",
+    );
+    expect(query?.[1]).toEqual(["/Query", "/TN", TASK_NAME]);
+  });
+
+  test("reports the task as not installed when schtasks /Query fails", async () => {
+    execFileOutcome = (command, args) =>
+      command === "schtasks" && args[0] === "/Query"
+        ? { error: new Error("The system cannot find the file specified") }
+        : {};
+
+    const [status] = await listConnectorSchedules(
+      configWithSchedule("0 2 * * *", { nativeJobPath: SHIM_PATH }),
+    );
+
+    expect(status.nativeJobInstalled).toBe(false);
+  });
+});
+
+describe("pause/delete (win32 cleanup)", () => {
+  test("pause deletes the task and reports no warnings", async () => {
+    const { access, mkdir, writeFile } = await import("node:fs/promises");
+    await mkdir(path.dirname(SHIM_PATH), { recursive: true });
+    await writeFile(SHIM_PATH, "@echo off\r\n", "utf8");
+
+    const result = await pauseConnectorSchedules(
+      configWithSchedule("0 2 * * *"),
+      "all",
+    );
+
+    expect(result.connectorIds).toEqual(["all"]);
+    expect(result.config.ingestionSchedule?.pausedAt).toBeDefined();
+    const remove = execFileMock.mock.calls.find(
+      ([command, args]) =>
+        command === "schtasks" && (args as string[])[0] === "/Delete",
+    );
+    expect(remove?.[1]).toEqual(["/Delete", "/F", "/TN", TASK_NAME]);
+    await expect(access(SHIM_PATH)).resolves.toBeUndefined();
+  });
+
+  test("delete removes the task and the shim file", async () => {
+    const { writeFile, mkdir } = await import("node:fs/promises");
+    await mkdir(path.dirname(SHIM_PATH), { recursive: true });
+    await writeFile(SHIM_PATH, "@echo off\r\n", "utf8");
+
+    const result = await deleteConnectorSchedules(
+      configWithSchedule("0 2 * * *", { nativeJobPath: SHIM_PATH }),
+      "all",
+    );
+
+    expect(result.connectorIds).toEqual(["all"]);
+    const { access } = await import("node:fs/promises");
+    await expect(access(SHIM_PATH)).rejects.toThrow();
+    const remove = execFileMock.mock.calls.find(
+      ([command, args]) =>
+        command === "schtasks" && (args as string[])[0] === "/Delete",
+    );
+    expect(remove?.[1]).toEqual(["/Delete", "/F", "/TN", TASK_NAME]);
+  });
+
+  test("delete survives a missing shim file", async () => {
+    const result = await deleteConnectorSchedules(
+      configWithSchedule("0 2 * * *"),
+      "all",
+    );
+
+    expect(result.connectorIds).toEqual(["all"]);
+    expect(result.warnings).toEqual([]);
+  });
+});

--- a/test/scheduling/schedules-schtasks.test.ts
+++ b/test/scheduling/schedules-schtasks.test.ts
@@ -1,5 +1,13 @@
 import path from "node:path";
-import { afterAll, afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import {
+  afterAll,
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  test,
+  vi,
+} from "vitest";
 import { createEmptyOnboardingConfig } from "../../src/setup/onboarding.ts";
 import type { OpenWikiOnboardingConfig } from "../../src/setup/onboarding.ts";
 
@@ -263,9 +271,12 @@ describe("installConnectorSchedule (win32 native install)", () => {
     });
 
     expect(result.nativeJobPath).toBeUndefined();
-    expect(result.warning).toMatch(/installing the Windows scheduled task failed/i);
+    expect(result.warning).toMatch(
+      /installing the Windows scheduled task failed/i,
+    );
     const remove = execFileMock.mock.calls.find(
-      ([command, args]) => command === "schtasks" && args[0] === "/Delete",
+      ([command, args]) =>
+        command === "schtasks" && (args as string[])[0] === "/Delete",
     );
     expect(remove?.[1]).toEqual(["/Delete", "/F", "/TN", TASK_NAME]);
     await expect(access(SHIM_PATH)).rejects.toThrow();
@@ -285,7 +296,8 @@ describe("installConnectorSchedule (win32 native install)", () => {
     expect(result.nativeJobPath).toBeUndefined();
     expect(result.warning).toMatch(/too complex/i);
     const remove = execFileMock.mock.calls.find(
-      ([command, args]) => command === "schtasks" && args[0] === "/Delete",
+      ([command, args]) =>
+        command === "schtasks" && (args as string[])[0] === "/Delete",
     );
     expect(remove?.[1]).toEqual(["/Delete", "/F", "/TN", TASK_NAME]);
     await expect(access(SHIM_PATH)).rejects.toThrow();

--- a/test/setup/onboarding.test.ts
+++ b/test/setup/onboarding.test.ts
@@ -546,7 +546,7 @@ describe("normalizeOnboardingConfig (via readOpenWikiOnboardingConfig)", () => {
     expect(config.ingestionSchedule).toEqual({
       description: "",
       expression: "",
-      launchAgentPath: undefined,
+      nativeJobPath: undefined,
       pausedAt: undefined,
       updatedAt: new Date(0).toISOString(),
       warning: undefined,
@@ -560,7 +560,7 @@ describe("normalizeOnboardingConfig (via readOpenWikiOnboardingConfig)", () => {
       ingestionSchedule: {
         description: "nightly",
         expression: "0 3 * * *",
-        launchAgentPath: "/Library/LaunchAgents/openwiki.plist",
+        nativeJobPath: "/Library/LaunchAgents/openwiki.plist",
         pausedAt: "2026-02-01T00:00:00.000Z",
         updatedAt: "2026-01-01T00:00:00.000Z",
         warning: "battery only",
@@ -575,7 +575,7 @@ describe("normalizeOnboardingConfig (via readOpenWikiOnboardingConfig)", () => {
     expect(config.ingestionSchedule).toEqual({
       description: "nightly",
       expression: "0 3 * * *",
-      launchAgentPath: "/Library/LaunchAgents/openwiki.plist",
+      nativeJobPath: "/Library/LaunchAgents/openwiki.plist",
       pausedAt: "2026-02-01T00:00:00.000Z",
       updatedAt: "2026-01-01T00:00:00.000Z",
       warning: "battery only",


### PR DESCRIPTION
## Summary

Adds a native **Windows Task Scheduler** backend for connector ingestion schedules (#421). It builds on the platform-neutral field renames from #758, so it slots into the existing `installConnectorSchedule` / `listConnectorSchedules` / `pauseConnectorSchedules` / `deleteConnectorSchedules` seams without touching the launchd/darwin path.

> **Stacking note:** GitHub can't use a fork branch as the base of an upstream PR, so this is opened against `main`. The diff currently *includes* #758's renames on top of `main`. Once #758 merges I'll rebase this branch onto `main` so the diff becomes Windows-only.

## What it does (win32 only)

- `parseSchtasksTriggerArgs(expression)` — pure cron → `schtasks` trigger translation:
  - `DAILY` / `WEEKLY` (with `MON`–`SUN`) / `MONTHLY` day-of-month
  - zero-pads single-digit hours/minutes
  - **rejects** ranges (`2-4`), steps (`*/15`), lists (`2,4`), and cron semantics `schtasks` can't AND — notably day-of-month **and** weekday restricted together (`0 2 1 * 1`), and month-pinned expressions. These fall back to the saved-only warning instead of installing a wrong task.
- `installConnectorSchedule` on `win32` writes an `ingestion.schedule.cmd` shim (cd into the repo, run `ingest all --scheduled --print`, append both streams to the ingestion log) and registers it via `schtasks /Create`.
- `listConnectorSchedules` reports install state from `schtasks /Query`.
- `pauseConnectorSchedules` / `deleteConnectorSchedules` delete the task and shim.

## Safety

- Every shell-out uses an explicit `(command, argv[])` pair with **no `shell: true`**, so repo or config-derived values can't be reinterpreted as shell syntax.
- Non-`win32` platforms fall through to existing behavior; the win32 path is exercised by `schedules-schtasks.test.ts`, which stubs `process.platform`.

## Verification

- `tsc --noEmit` (both configs): clean
- `eslint .` / `prettier --check .`: clean
- `test/scheduling/`: 82 passed (incl. the new `schedules-schtasks.test.ts`)

## Changes

- `src/scheduling/schedules.ts` — win32 branch + `parseSchtasksTriggerArgs` + shim/task helpers
- `src/setup/onboarding.ts` — small touch to surface the win32 job path
- `test/scheduling/schedules-schtasks.test.ts` — new regression suite (stubs `win32`)
- `test/scheduling/schedule-operations.test.ts` — minor updates for the new names
- `.changeset/witty-schtasks-backend.md`

Depends on #758.