### PR TITLE
fix: tolerate human-readable not-found errors from deepagents backends

### DIFF
--- a/.changeset/tolerant-not-found-restore.md
+++ b/.changeset/tolerant-not-found-restore.md
@@ -1,0 +1,5 @@
+---
+"openwiki": patch
+---
+
+fix: tolerate human-readable "not found" errors from DeepAgents backends when rolling back failed page workers and deleting non-existent pages, instead of aborting the whole run

--- a/src/generation/repository-run.ts
+++ b/src/generation/repository-run.ts
@@ -544,6 +544,17 @@ export async function beginRepositoryRun(
 }
 
 /**
+ * True when a backend result error indicates a file does not exist.
+ *
+ * Matches both the standard `"file_not_found"` error code used by some backends
+ * and the human-readable `"Error: File '...' not found"` string returned by
+ * DeepAgents' filesystem backends (see #765).
+ */
+function isNotFoundBackendError(error: string): boolean {
+  return error === "file_not_found" || error.includes("not found");
+}
+
+/**
  * Reconstructs a durable run and invalidates its complete plan on source drift.
  *
  * @param input - Current begin request used to validate the durable owner.
@@ -1014,7 +1025,7 @@ export async function captureRepositoryPageSnapshot(
   let markdown: string | null = null;
   try {
     const read = await run.backend.readRaw(current.path);
-    if (read.error && read.error !== "file_not_found") {
+    if (read.error && !isNotFoundBackendError(read.error)) {
       throw new RepositoryRunError(
         "invalid_state",
         `Could not snapshot ${current.path}: ${read.error}`,
@@ -1118,7 +1129,7 @@ async function restoreRepositoryPageMarkdown(
       : await run.backend.write(snapshot.path, snapshot.markdown);
   if (
     result.error &&
-    !(snapshot.markdown === null && result.error === "file_not_found")
+    !(snapshot.markdown === null && isNotFoundBackendError(result.error))
   ) {
     throw new RepositoryRunError(
       "invalid_state",
@@ -1581,7 +1592,7 @@ async function applyAbandonedGeneratedPageDeletions(
   for (const page of await store.discoverPages()) {
     if (initial.has(page) || planned.has(page)) continue;
     const result = await run.backend.delete(page);
-    if (result.error && result.error !== "file_not_found") {
+    if (result.error && !isNotFoundBackendError(result.error)) {
       throw new RepositoryRunError(
         "invalid_state",
         `Could not remove page abandoned by an invalidated plan ${page}: ${result.error}`,
@@ -1603,7 +1614,7 @@ async function applyPlannedDeletions(
 ): Promise<void> {
   for (const page of pages) {
     const result = await run.backend.delete(page);
-    if (result.error && result.error !== "file_not_found") {
+    if (result.error && !isNotFoundBackendError(result.error)) {
       throw new RepositoryRunError(
         "invalid_state",
         `Could not delete planned OpenWiki page ${page}: ${result.error}`,

--- a/test/generation/repository-run.test.ts
+++ b/test/generation/repository-run.test.ts
@@ -461,6 +461,38 @@ test.each([
   },
 );
 
+test("tolerates a human-readable not-found error from the backend when skipping a never-written page", async () => {
+  // Regression for #765: DeepAgents filesystem backends return
+  // `"Error: File '...' not found"` (human-readable) rather than the
+  // `"file_not_found"` error code when deleting a file that never existed.
+  // Rolling back a new page worker must not abort the whole run.
+  const root = await createRepository();
+  const page = "/openwiki/never-written.md";
+  const run = await beginForcedUpdate(root);
+  await submitRepositoryPlan(run, {
+    pages: [
+      {
+        path: page,
+        title: "Never Written",
+        purpose: "Document a page whose worker fails before writing anything.",
+      },
+    ],
+  });
+  const next = await nextRepositoryPage(run);
+  if (next.status !== "pending") throw new Error("Expected pending page.");
+
+  const snapshot = await captureRepositoryPageSnapshot(run, next.job.id);
+  expect(snapshot).toMatchObject({ path: page, markdown: null, claims: null });
+
+  const deleteSpy = vi
+    .spyOn(run.backend, "delete")
+    .mockResolvedValue({ error: `Error: File '${page}' not found` });
+
+  await expect(skipRepositoryPage(run, snapshot)).resolves.toBeUndefined();
+  expect(deleteSpy).toHaveBeenCalledWith(page);
+  expect(run.state.plan?.pages[0]?.status).toBe("skipped");
+});
+
 beforeEach(() => {
   failureHarness.manifestReplacements = 0;
   failureHarness.manifestWrites = 0;


### PR DESCRIPTION
## Summary

Fixes the run-aborting crash described in #765: DeepAgents filesystem backends return a **human-readable** `"Error: File '...' not found"` string — not the `"file_not_found"` error code — when a `delete`/`readRaw` targets a file that never existed. The restore/skip path compared only against the error code, so **any** page-worker failure on a new page threw `invalid_state` and aborted the whole generation run.

## Problem

In `restoreRepositoryPageMarkdown` (introduced in #732), the tolerance check was:

```typescript
!(snapshot.markdown === null && result.error === "file_not_found")
```

When a new-page worker fails, `skipRepositoryPage` rolls back by `delete`-ing the page. For a page that was never written, `snapshot.markdown` is `null` and the backend returns `"Error: File '...' not found"` — which does **not** equal `"file_not_found"` — so the rollback threw and the entire run crashed. 15/19 pages could be on disk and the run still never finalized, wasting tokens on every retry.

## Change

Centralize not-found classification in `isNotFoundBackendError` (matches both the error code and the human-readable string) and apply it to all four backend `file_not_found` tolerance sites in `src/generation/repository-run.ts`:

- `captureRepositoryPageSnapshot` read
- `restoreRepositoryPageMarkdown` (the crash site)
- `applyAbandonedGeneratedPageDeletions`
- `applyPlannedDeletions`

Plus a regression test: mock `backend.delete` to return the human-readable not-found error and assert `skipRepositoryPage` resolves instead of throwing.

## Verification

- `pnpm run typecheck` — pass
- `npx vitest run test/generation/repository-run.test.ts` — 44 passed
- `eslint` and `prettier` on changed files — pass

Fixes #765
