### PR TITLE
fix: tolerate windows stat identity drift while fingerprinting

### DIFF
--- a/.changeset/two-goats-attack.md
+++ b/.changeset/two-goats-attack.md
@@ -1,0 +1,5 @@
+---
+"openwiki": patch
+---
+
+fix: tolerate windows stat identity drift while fingerprinting

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -146,7 +146,7 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Run Windows portability tests
-        run: pnpm exec vitest run test/agent/skills.test.ts test/config/env-behavior.test.ts
+        run: pnpm exec vitest run test/agent/skills.test.ts test/config/env-behavior.test.ts test/agent/repository-source-fingerprint.test.ts
 
   audit:
     name: Audit

--- a/src/agent/utils.ts
+++ b/src/agent/utils.ts
@@ -627,11 +627,7 @@ async function readFingerprintRegularFile(
 
   try {
     const openedStats = await fileHandle.stat({ bigint: true });
-    if (
-      !openedStats.isFile() ||
-      openedStats.dev !== inspectedStats.dev ||
-      openedStats.ino !== inspectedStats.ino
-    ) {
+    if (!isSameFingerprintRegularFile(inspectedStats, openedStats)) {
       throw new Error(
         `Source path changed while fingerprinting ${sourcePath}.`,
       );
@@ -644,6 +640,32 @@ async function readFingerprintRegularFile(
   } finally {
     await fileHandle.close();
   }
+}
+
+function isSameFingerprintRegularFile(
+  inspectedStats: BigIntStats,
+  openedStats: BigIntStats,
+): boolean {
+  if (!openedStats.isFile()) {
+    return false;
+  }
+
+  if (process.platform !== "win32") {
+    return (
+      openedStats.dev === inspectedStats.dev &&
+      openedStats.ino === inspectedStats.ino
+    );
+  }
+
+  // Windows can report different dev/ino values for the same file depending on
+  // which stat API produced them. Keep the same-file guard, but use metadata
+  // that is stable across lstat() and FileHandle.stat() on that platform.
+  return (
+    openedStats.size === inspectedStats.size &&
+    openedStats.mtimeNs === inspectedStats.mtimeNs &&
+    openedStats.ctimeNs === inspectedStats.ctimeNs &&
+    openedStats.birthtimeNs === inspectedStats.birthtimeNs
+  );
 }
 
 /**

--- a/test/agent/repository-source-fingerprint.test.ts
+++ b/test/agent/repository-source-fingerprint.test.ts
@@ -210,13 +210,18 @@ describe("createRepositorySourceFingerprint", () => {
     expect(await fingerprint()).not.toBe(before);
   });
 
-  test("changes when a source file executable bit changes", async () => {
+  test("tracks executable bit changes when the platform exposes them", async () => {
     const trackedPath = path.join(repositoryRoot, "src", "tracked.ts");
     const before = await fingerprint();
 
     await chmod(trackedPath, 0o755);
 
-    expect(await fingerprint()).not.toBe(before);
+    const after = await fingerprint();
+    if (process.platform === "win32") {
+      expect(after).toBe(before);
+    } else {
+      expect(after).not.toBe(before);
+    }
   });
 
   test("hashes a symlink target string without following the target", async () => {
@@ -352,7 +357,10 @@ describe("createRepositorySourceFingerprint", () => {
   });
 
   test("parses unusual tracked filenames from NUL-delimited Git output", async () => {
-    const unusualName = " leading space\nsecond line\t雪.ts";
+    const unusualName =
+      process.platform === "win32"
+        ? "unicode-filename-雪.ts"
+        : " leading space\nsecond line\t雪.ts";
     const unusualPath = path.join(repositoryRoot, unusualName);
     await writeFile(unusualPath, "export const unusual = 1;\n", "utf8");
     await git(["add", "--", unusualName]);

--- a/test/agent/repository-source-fingerprint.test.ts
+++ b/test/agent/repository-source-fingerprint.test.ts
@@ -1,5 +1,5 @@
 import { execFile } from "node:child_process";
-import type { Mode, PathLike } from "node:fs";
+import type { BigIntStats, Mode, PathLike } from "node:fs";
 import {
   chmod,
   mkdir,
@@ -21,6 +21,7 @@ import {
 
 const fingerprintRace = vi.hoisted(() => ({
   replacementPath: null as string | null,
+  statIdentityMismatchPath: null as string | null,
   symlinkTarget: null as string | null,
 }));
 
@@ -42,12 +43,28 @@ vi.mock("node:fs/promises", async (importOriginal) => {
         await actual.rm(filePath);
         await actual.symlink(symlinkTarget, filePath);
       }
-      return actual.open(filePath, flags, mode);
+      const handle = await actual.open(filePath, flags, mode);
+      if (
+        typeof filePath === "string" &&
+        filePath === fingerprintRace.statIdentityMismatchPath
+      ) {
+        const originalStat = handle.stat.bind(handle) as (options: {
+          bigint: true;
+        }) => Promise<BigIntStats>;
+        handle.stat = (async () => {
+          const stats = await originalStat({ bigint: true });
+          stats.dev += 1n;
+          stats.ino += 1n;
+          return stats;
+        }) as typeof handle.stat;
+      }
+      return handle;
     },
   };
 });
 
 const execFileAsync = promisify(execFile);
+const ORIGINAL_PLATFORM = process.platform;
 let repositoryRoot: string;
 
 /**
@@ -110,15 +127,28 @@ async function createRepository(): Promise<string> {
   return root;
 }
 
+function stubPlatform(value: NodeJS.Platform): void {
+  Object.defineProperty(process, "platform", {
+    configurable: true,
+    value,
+  });
+}
+
 beforeEach(async () => {
   fingerprintRace.replacementPath = null;
+  fingerprintRace.statIdentityMismatchPath = null;
   fingerprintRace.symlinkTarget = null;
   await createRepository();
 });
 
 afterEach(async () => {
   fingerprintRace.replacementPath = null;
+  fingerprintRace.statIdentityMismatchPath = null;
   fingerprintRace.symlinkTarget = null;
+  Object.defineProperty(process, "platform", {
+    configurable: true,
+    value: ORIGINAL_PLATFORM,
+  });
   await rm(repositoryRoot, { recursive: true, force: true });
 });
 
@@ -237,6 +267,17 @@ describe("createRepositorySourceFingerprint", () => {
     } finally {
       await rm(outside, { recursive: true, force: true });
     }
+  });
+
+  test("does not reject Windows file handles solely because dev and ino differ", async () => {
+    fingerprintRace.statIdentityMismatchPath = path.join(
+      repositoryRoot,
+      "src",
+      "tracked.ts",
+    );
+    stubPlatform("win32");
+
+    await expect(fingerprint()).resolves.toMatch(/^sha256:[a-f0-9]{64}$/u);
   });
 
   test("changes with .openwikiignore while excluding paths it ignores", async () => {


### PR DESCRIPTION
## Summary

Repository source fingerprinting compares the file identity observed by `lstat()` with the identity observed after opening the file handle, so OpenWiki can fail closed if a source path changes between inspection and read.

On Windows, `dev` / `ino` can differ between those stat APIs for the same regular file, causing `openwiki code --init` to fail before model invocation with:

```text
Source path changed while fingerprinting <filename>
```

This keeps the strict dev / ino check on non-Windows platforms, and uses stable file metadata on Windows (size, mtimeNs, ctimeNs, birthtimeNs) so normal files are not rejected as changed.

Also adds the repository source fingerprint suite to the Windows portability CI job.

## Tests

pnpm exec vitest run test/agent/repository-source-fingerprint.test.ts
pnpm exec tsc --noEmit -p tsconfig.json
pnpm exec eslint src/agent/utils.ts test/agent/repository-source-fingerprint.test.ts
pnpm exec prettier --check .github/workflows/checks.yml src/agent/utils.ts test/agent/repository-source-fingerprint.test.ts

---

Fixes: https://github.com/langchain-ai/openwiki/issues/778