### PR TITLE
fix: tolerate duplicate planner submit_plan

### DIFF
--- a/.changeset/planner-submit-plan-idempotent.md
+++ b/.changeset/planner-submit-plan-idempotent.md
@@ -2,4 +2,4 @@
 "openwiki": patch
 ---
 
-Allow the native repository planner to repeat an accepted plan without aborting the run.
+fix: allow the native repository planner to repeat an accepted plan without aborting the run.

--- a/.changeset/planner-submit-plan-idempotent.md
+++ b/.changeset/planner-submit-plan-idempotent.md
@@ -1,0 +1,5 @@
+---
+"openwiki": patch
+---
+
+Allow the native repository planner to repeat an accepted plan without aborting the run.

--- a/src/agent/repository-runner.ts
+++ b/src/agent/repository-runner.ts
@@ -276,7 +276,7 @@ async function beginNativeRepositoryRun(
 }
 
 /**
- * Runs one bounded planner that must submit exactly one durable plan.
+ * Runs one bounded planner that must submit a durable plan.
  *
  * @param run - Active durable repository run.
  * @param view - Current host-facing planning context.
@@ -310,11 +310,6 @@ async function runPlanningAgent(
       "Submit the final canonical OpenWiki page plan. This is the only completion action for planning.",
     schema: PlanSchema,
     func: async (input, _runManager, config) => {
-      if (submitted) {
-        throw new Error(
-          "submit_plan was already called for this planning worker.",
-        );
-      }
       try {
         const result = await submitRepositoryPlan(run, input);
         submitted = true;

--- a/test/agent/repository-runner.test.ts
+++ b/test/agent/repository-runner.test.ts
@@ -67,6 +67,8 @@ const harness = vi.hoisted(() => ({
   changedPaths: ["README.md"],
   currentRun: undefined as HarnessRun | undefined,
   driftOnce: false,
+  duplicatePlanSubmission: false,
+  duplicatePlanToolResults: [] as unknown[],
   filesystemTools: [] as string[][],
   finishCalls: 0,
   invalidPageSubmissions: 0,
@@ -231,6 +233,13 @@ vi.mock("deepagents", async (importOriginal) => {
             } else {
               await completionTool.invoke(input);
               if (
+                toolName === "submit_plan" &&
+                harness.duplicatePlanSubmission
+              ) {
+                const duplicate = await completionTool.invoke(input);
+                harness.duplicatePlanToolResults.push(duplicate);
+              }
+              if (
                 toolName === "submit_page" &&
                 harness.pageWorkerPostSubmitFailures > 0
               ) {
@@ -327,6 +336,51 @@ vi.mock("../../src/generation/repository-run.js", () => ({
         "Invalid or reserved OpenWiki page path: /openwiki/_plan.md",
       );
     }
+    if (run.state.plan) {
+      const proposed = {
+        pages: input.pages.map((page) => ({
+          path: page.path,
+          title: page.title,
+          purpose: page.purpose,
+          seedPaths: [],
+          relatedPages: [],
+          instructions: page.instructions ?? [],
+        })),
+        deletePages: input.deletePages ?? [],
+      };
+      const current = {
+        pages: run.state.plan.pages.map(
+          ({
+            path,
+            title,
+            purpose,
+            seedPaths,
+            relatedPages,
+            instructions,
+          }) => ({
+            path,
+            title,
+            purpose,
+            seedPaths,
+            relatedPages,
+            instructions,
+          }),
+        ),
+        deletePages: run.state.plan.deletePages,
+      };
+      if (JSON.stringify(proposed) !== JSON.stringify(current)) {
+        const { RepositoryRunError } =
+          await import("../../src/generation/errors.js");
+        throw new RepositoryRunError(
+          "invalid_state",
+          "This OpenWiki run already has a different persisted plan.",
+        );
+      }
+      return Promise.resolve({
+        status: "accepted",
+        totalPages: run.state.plan.pages.length,
+      });
+    }
     run.state.phase = "generating";
     run.state.plan = {
       pages: input.pages.map((page, index) => ({
@@ -422,6 +476,8 @@ beforeEach(() => {
   harness.changedPaths = ["README.md"];
   harness.currentRun = undefined;
   harness.driftOnce = false;
+  harness.duplicatePlanSubmission = false;
+  harness.duplicatePlanToolResults = [];
   harness.filesystemTools = [];
   harness.finishCalls = 0;
   harness.invalidPageSubmissions = 0;
@@ -543,6 +599,21 @@ describe("runNativeRepositoryGeneration", () => {
     expect(rejection.text).toContain(
       '"retry":"Correct the plan and call submit_plan again."',
     );
+    expect(harness.finishCalls).toBe(1);
+  });
+
+  test("continues when the planner repeats the same accepted plan", async () => {
+    harness.duplicatePlanSubmission = true;
+    harness.planPaths = ["/openwiki/quickstart.md"];
+
+    await expect(runHarness()).resolves.toBeDefined();
+
+    expect(harness.planSubmissionCalls).toBe(2);
+    expect(harness.duplicatePlanToolResults).toEqual([
+      '{"status":"accepted","totalPages":1}',
+    ]);
+    expect(harness.pageSubmissionCalls).toBe(1);
+    expect(harness.currentRun?.state.plan?.pages[0]?.status).toBe("complete");
     expect(harness.finishCalls).toBe(1);
   });
 


### PR DESCRIPTION
## Summary

- Let duplicate native planner `submit_plan` calls reach the durable repository lifecycle instead of aborting locally.
- Add regression coverage for repeating the same accepted plan.
- Add a patch changeset for the planner behavior fix.

Fixes #787

## Testing

- Windows: `npm exec --yes pnpm@10.33.2 -- pnpm run format`
- Windows: `npm exec --yes pnpm@10.33.2 -- pnpm run lint`
- Windows: `npm exec --yes pnpm@10.33.2 -- pnpm exec vitest run test/agent/repository-runner.test.ts test/generation/repository-run.test.ts -t "same semantic plan|repeats the same accepted plan|keeps in-memory state unchanged until plan persistence succeeds"`
- Windows: attempted `npm exec --yes pnpm@10.33.2 -- pnpm test`; typecheck/build passed, but the coverage phase is blocked on this local Windows account because `fs.symlinkSync` fails with `EPERM`.
- DGX Spark Ubuntu: `pnpm install --frozen-lockfile && pnpm run format:check && pnpm run lint:check && pnpm test` passed. Summary: 225 test files passed, 3032 tests passed, 2 files/3 tests skipped.