### PR TITLE
feat: declutter visualizer graph labels

### DIFF
--- a/.changeset/polite-oranges-doubt.md
+++ b/.changeset/polite-oranges-doubt.md
@@ -1,0 +1,5 @@
+---
+"openwiki": patch
+---
+
+feat: declutter visualizer graph labels

--- a/src/visualize/client-lib.ts
+++ b/src/visualize/client-lib.ts
@@ -98,6 +98,41 @@ export function nodeRadius(size: number, isAnchor: boolean): number {
 }
 
 /**
+ * Interaction context used to decide whether a node label should be painted on
+ * the graph canvas.
+ */
+export interface NodeLabelContext {
+  /**
+   * The selected page id, or null when the user has not selected a graph node.
+   */
+  selectedId: string | null;
+
+  /**
+   * The hovered page id, or null when no graph node is under the pointer.
+   */
+  hoveredId: string | null;
+
+  /**
+   * Whether this node is part of the selected node's immediate neighbourhood.
+   */
+  isInSelectedNeighborhood: boolean;
+}
+
+/**
+ * Keep graph labels contextual: hover reveals only the hovered node, while a
+ * selected node reveals itself plus its immediate neighbours.
+ */
+export function shouldShowNodeLabel(
+  node: Pick<FilterableNode, "id">,
+  context: NodeLabelContext,
+): boolean {
+  if (context.selectedId) {
+    return node.id === context.selectedId || context.isInSelectedNeighborhood;
+  }
+  return node.id === context.hoveredId;
+}
+
+/**
  * Whether a node survives the active search text and type filter. An empty query
  * or empty type matches everything.
  */

--- a/src/visualize/client.ts
+++ b/src/visualize/client.ts
@@ -6,6 +6,7 @@ import {
   matchesFilter,
   nodeRadius,
   normalize,
+  shouldShowNodeLabel,
   signature,
   stripFrontmatter,
 } from "./client-lib.js";
@@ -305,6 +306,11 @@ let current: string | null = null;
 let readerId: string | null = null;
 
 /**
+ * Id of the node under the pointer, used only for contextual label display.
+ */
+let hoverId: string | null = null;
+
+/**
  * Id of the entry page, drawn larger and always labelled, or null before load.
  */
 let anchorId: string | null = null;
@@ -590,9 +596,15 @@ function paintNode(
     ctx.stroke();
   }
 
-  // Label: always drawn when zoomed in enough (or for notable nodes), with a
-  // dark halo behind the text so it stays readable over links and glows.
-  if (scale > 0.5 || sel || hot || n.anchor) {
+  // Label: contextual only. The sidebar is the always-visible index; the graph
+  // labels the current interaction target or selected neighbourhood.
+  if (
+    shouldShowNodeLabel(n, {
+      selectedId: current,
+      hoveredId: hoverId,
+      isInSelectedNeighborhood: hot,
+    })
+  ) {
     const fs = Math.max(10 / scale, 3.2);
     ctx.font = `${sel || n.anchor ? 700 : 600} ${fs}px Inter, sans-serif`;
     ctx.textAlign = "center";
@@ -637,9 +649,10 @@ function neighborsOf(node: GraphNode | undefined): void {
  * Highlight a node's neighbourhood on hover, unless a page is already selected.
  */
 function hoverHighlight(node: GraphNode | null): void {
-  if (current) return; // a selected page keeps its own highlight
-  neighborsOf(node ?? undefined);
   $("#graph").style.cursor = node ? "pointer" : "";
+  if (current) return; // a selected page keeps its own highlight
+  hoverId = node?.id ?? null;
+  neighborsOf(node ?? undefined);
 }
 
 // --- Selection and reader ---------------------------------------------------
@@ -652,6 +665,7 @@ function hoverHighlight(node: GraphNode | null): void {
  */
 function selectNode(id: string): void {
   current = id;
+  hoverId = null;
   neighborsOf(nodeById.get(id));
   renderReader(id);
 }

--- a/test/visualize/client-interaction.test.ts
+++ b/test/visualize/client-interaction.test.ts
@@ -15,8 +15,20 @@ import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 interface RecordedHandlers {
   onNodeClick?: (node: unknown) => void;
   onNodeHover?: (node: unknown) => void;
+  nodeCanvasObject?: (
+    node: Record<string, unknown>,
+    ctx: CanvasRenderingContext2D,
+    scale: number,
+  ) => void;
   onBackgroundClick?: (handler: () => void) => void;
   backgroundClickHandler?: () => void;
+  graphData?: {
+    nodes: Record<string, unknown>[];
+    links: {
+      source: Record<string, unknown>;
+      target: Record<string, unknown>;
+    }[];
+  };
 }
 
 const handlers: RecordedHandlers = {};
@@ -84,7 +96,16 @@ function stubGlobals(): void {
     backgroundColor: chain,
     nodeRelSize: chain,
     nodeCanvasObjectMode: chain,
-    nodeCanvasObject: chain,
+    nodeCanvasObject: (
+      h: (
+        node: Record<string, unknown>,
+        ctx: CanvasRenderingContext2D,
+        scale: number,
+      ) => void,
+    ) => {
+      handlers.nodeCanvasObject = h;
+      return instance;
+    },
     nodePointerAreaPaint: chain,
     linkColor: chain,
     linkWidth: chain,
@@ -98,8 +119,22 @@ function stubGlobals(): void {
     width: chain,
     height: chain,
     zoom: chain,
-    graphData: (data?: unknown) =>
-      data === undefined ? { nodes: [], links: [] } : instance,
+    graphData: (data?: {
+      nodes: Record<string, unknown>[];
+      links: { source: string; target: string }[];
+    }) => {
+      if (data === undefined)
+        return handlers.graphData ?? { nodes: [], links: [] };
+      const byId = new Map(data.nodes.map((node) => [node.id, node]));
+      handlers.graphData = {
+        nodes: data.nodes,
+        links: data.links.map((link) => ({
+          source: byId.get(link.source)!,
+          target: byId.get(link.target)!,
+        })),
+      };
+      return instance;
+    },
     d3Force: () => ({ strength: () => {} }),
     onNodeClick: (h: (node: unknown) => void) => {
       handlers.onNodeClick = h;
@@ -138,6 +173,44 @@ function stubGlobals(): void {
   Element.prototype.scrollIntoView = () => {};
 }
 
+function recordingCanvas(): {
+  ctx: CanvasRenderingContext2D;
+  fills: string[];
+  strokes: string[];
+} {
+  const fills: string[] = [];
+  const strokes: string[] = [];
+  const ctx = {
+    globalAlpha: 1,
+    fillStyle: "",
+    font: "",
+    lineWidth: 1,
+    strokeStyle: "",
+    textAlign: "center",
+    textBaseline: "top",
+    arc: () => {},
+    beginPath: () => {},
+    createRadialGradient: () => ({
+      addColorStop: () => {},
+    }),
+    fill: () => {},
+    fillText: (text: string) => fills.push(text),
+    stroke: () => {},
+    strokeText: (text: string) => strokes.push(text),
+  } as unknown as CanvasRenderingContext2D;
+  return { ctx, fills, strokes };
+}
+
+function paintLabels(): string[] {
+  const canvas = recordingCanvas();
+  for (const node of handlers.graphData?.nodes ?? []) {
+    node.x = 0;
+    node.y = 0;
+    handlers.nodeCanvasObject!(node, canvas.ctx, 1);
+  }
+  return canvas.fills;
+}
+
 async function importClient(): Promise<void> {
   mountDom();
   stubGlobals();
@@ -156,8 +229,10 @@ describe("visualizer client graph interaction", () => {
     vi.clearAllMocks();
     handlers.onNodeClick = undefined;
     handlers.onNodeHover = undefined;
+    handlers.nodeCanvasObject = undefined;
     handlers.onBackgroundClick = undefined;
     handlers.backgroundClickHandler = undefined;
+    handlers.graphData = undefined;
   });
 
   afterEach(() => {
@@ -194,5 +269,28 @@ describe("visualizer client graph interaction", () => {
     handlers.onNodeClick!({ id: "overview" });
     const active = document.querySelector(".nav-item.active");
     expect(active?.textContent).toContain("Overview");
+  });
+
+  test("does not draw graph labels by default", async () => {
+    await importClient();
+    expect(paintLabels()).toEqual([]);
+  });
+
+  test("hover draws only the hovered node label", async () => {
+    await importClient();
+    const quickstart = handlers.graphData!.nodes.find(
+      (node) => node.id === "quickstart",
+    )!;
+    handlers.onNodeHover!(quickstart);
+    expect(paintLabels()).toEqual(["Quickstart"]);
+  });
+
+  test("click draws selected and directly connected node labels", async () => {
+    await importClient();
+    const quickstart = handlers.graphData!.nodes.find(
+      (node) => node.id === "quickstart",
+    )!;
+    handlers.onNodeClick!(quickstart);
+    expect(paintLabels()).toEqual(["Quickstart", "Overview"]);
   });
 });

--- a/test/visualize/visualize-client-lib.test.ts
+++ b/test/visualize/visualize-client-lib.test.ts
@@ -7,6 +7,7 @@ import {
   matchesFilter,
   nodeRadius,
   normalize,
+  shouldShowNodeLabel,
   signature,
   stripFrontmatter,
 } from "../../src/visualize/client-lib.ts";
@@ -61,6 +62,67 @@ describe("nodeRadius", () => {
 
   test("adds a bonus for the anchor page", () => {
     expect(nodeRadius(0, true)).toBe(8);
+  });
+});
+
+describe("shouldShowNodeLabel", () => {
+  test("shows only the hovered node when nothing is selected", () => {
+    expect(
+      shouldShowNodeLabel(
+        { id: "quickstart" },
+        {
+          selectedId: null,
+          hoveredId: "quickstart",
+          isInSelectedNeighborhood: false,
+        },
+      ),
+    ).toBe(true);
+    expect(
+      shouldShowNodeLabel(
+        { id: "overview" },
+        {
+          selectedId: null,
+          hoveredId: "quickstart",
+          isInSelectedNeighborhood: true,
+        },
+      ),
+    ).toBe(false);
+  });
+
+  test("shows the selected node and its immediate neighbours", () => {
+    expect(
+      shouldShowNodeLabel(
+        { id: "quickstart" },
+        {
+          selectedId: "quickstart",
+          hoveredId: null,
+          isInSelectedNeighborhood: false,
+        },
+      ),
+    ).toBe(true);
+    expect(
+      shouldShowNodeLabel(
+        { id: "overview" },
+        {
+          selectedId: "quickstart",
+          hoveredId: null,
+          isInSelectedNeighborhood: true,
+        },
+      ),
+    ).toBe(true);
+  });
+
+  test("hides unrelated nodes after selection", () => {
+    expect(
+      shouldShowNodeLabel(
+        { id: "operations" },
+        {
+          selectedId: "quickstart",
+          hoveredId: "operations",
+          isInSelectedNeighborhood: false,
+        },
+      ),
+    ).toBe(false);
   });
 });
 


### PR DESCRIPTION
## Summary

The visualizer is really messy and cluttered when there are a lot of nodes. The node labels overlap and make the experience feel really overwhelming.

This PR keeps the node labels hidden by default and only reveals them on hover or on click. Clicking a node in the visualizer also reveals any connected nodes.

## Demo

<img width="792" height="480" alt="openwiki-visualize-declutter" src="https://github.com/user-attachments/assets/3e2d4269-768e-440c-9c4c-26d922ad78b0" />

