### PR TITLE
fix: update fast-uri to address high severity security vulnerabilities

### DIFF
--- a/.changeset/upset-canyons-cheer.md
+++ b/.changeset/upset-canyons-cheer.md
@@ -1,0 +1,5 @@
+---
+"openwiki": patch
+---
+
+fix: update fast-uri to address high severity security vulnerabilities

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -159,9 +159,25 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       # `pnpm audit` calls npm's retired quick-audit endpoint (HTTP 410), so we
-      # scan the lockfile with Trivy instead. `severity: HIGH,CRITICAL` +
-      # `exit-code: 1` preserves the previous `--audit-level=high` gate.
+      # scan the lockfile with Trivy instead. Keep the blocking gate in table
+      # mode so Trivy applies the severity filter to the exit code and prints
+      # the vulnerable package in the job log.
       - name: Audit dependencies
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
+        with:
+          scan-type: fs
+          scan-ref: .
+          scanners: vuln
+          format: table
+          severity: HIGH,CRITICAL
+          exit-code: "1"
+          ignore-unfixed: false
+
+      # Generate all-severity SARIF for the Security tab separately from the
+      # blocking gate. Trivy's SARIF mode intentionally builds the report with
+      # all severities unless limit-severities-for-sarif is set.
+      - name: Build Trivy SARIF report
+        if: always()
         uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
           scan-type: fs
@@ -169,8 +185,7 @@ jobs:
           scanners: vuln
           format: sarif
           output: trivy-results.sarif
-          severity: HIGH,CRITICAL
-          exit-code: "1"
+          exit-code: "0"
           ignore-unfixed: false
 
       # Populates the Security tab. Fork PRs run with a read-only GITHUB_TOKEN

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,6 +6,7 @@ settings:
 
 overrides:
   brace-expansion: 5.0.9
+  fast-uri: 3.1.6
   js-yaml@3: ^3.15.1
   js-yaml@4: ^4.3.1
   nanoid: 3.3.17
@@ -1802,8 +1803,8 @@ packages:
   fast-sha256@1.3.0:
     resolution: {integrity: sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==}
 
-  fast-uri@3.1.5:
-    resolution: {integrity: sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==}
+  fast-uri@3.1.6:
+    resolution: {integrity: sha512-7Ical1vFEMr0onbVzEDIreM22I4khW+fzyQPwvAFWBp1iwdshSZRsL4jjRvPG9JP1uiqMHRto+YU6R2/CzDz5Q==}
 
   fastq@1.20.1:
     resolution: {integrity: sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==}
@@ -4412,7 +4413,7 @@ snapshots:
   ajv@8.20.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.5
+      fast-uri: 3.1.6
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -5062,7 +5063,7 @@ snapshots:
 
   fast-sha256@1.3.0: {}
 
-  fast-uri@3.1.5: {}
+  fast-uri@3.1.6: {}
 
   fastq@1.20.1:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,17 +1,19 @@
 allowBuilds:
   better-sqlite3: true
   esbuild: true
-# Force patched versions of transitive dev-only dependencies flagged by
-# Dependabot or pnpm audit. js-yaml is pulled in only by @changesets/cli (both
-# majors coexist, so each keeps its own patched line); the remaining packages
-# come through lint or test tooling. None ship in the published runtime.
+# Force patched versions of transitive dependencies flagged by Dependabot,
+# pnpm audit, or Trivy. js-yaml is pulled in only by @changesets/cli (both
+# majors coexist, so each keeps its own patched line); fast-uri is pulled
+# through @modelcontextprotocol/sdk -> ajv in the published runtime.
 #   brace-expansion GHSA-mh99-v99m-4gvg, GHSA-rgw5-rvv9-x895
+#   fast-uri CVE-2026-75899, CVE-2026-75931, CVE-2026-75975, CVE-2026-76172
 #   js-yaml GHSA-5p4m-2wfm-xmqj  (quadratic-CPU DoS in !!omap resolution)
 #   nanoid GHSA-2v37-7h3g-55p8
 #   undici  GHSA-4cwx-7wf7-3272, -m8rv-5g2x-5cg5, -jr45-8vmc-qm54,
 #           -v3r7-h72x-cjcm, -8xcm-r25x-g524
 overrides:
   brace-expansion: 5.0.9
+  fast-uri: 3.1.6
   js-yaml@3: ^3.15.1
   js-yaml@4: ^4.3.1
   nanoid: 3.3.17


### PR DESCRIPTION
## Summary

Updates `fast-uri` to address 4 high-severity vulnerabilities reported in `pnpm-lock.yaml`.

**Summary:** 4 HIGH, 0 CRITICAL

| Vulnerability                                                | Severity | Installed | Fixed in | Description                                                         |
| ------------------------------------------------------------ | -------- | --------: | -------: | ------------------------------------------------------------------- |
| [[CVE-2026-75899](https://avd.aquasec.com/nvd/cve-2026-75899)](https://avd.aquasec.com/nvd/cve-2026-75899) | HIGH     |   `3.1.5` |  `3.1.6` | Server-side request forgery via repeated hostname percent-decoding  |
| [[CVE-2026-75931](https://avd.aquasec.com/nvd/cve-2026-75931)](https://avd.aquasec.com/nvd/cve-2026-75931) | HIGH     |   `3.1.5` |  `3.1.6` | Host confusion via skipped IDN canonicalization                     |
| [[CVE-2026-75975](https://avd.aquasec.com/nvd/cve-2026-75975)](https://avd.aquasec.com/nvd/cve-2026-75975) | HIGH     |   `3.1.5` |  `3.1.6` | Server-side request forgery via malformed IPv6 normalization        |
| [[CVE-2026-76172](https://avd.aquasec.com/nvd/cve-2026-76172)](https://avd.aquasec.com/nvd/cve-2026-76172) | HIGH     |   `3.1.5` |  `3.1.6` | URI parsing flaw enabling server-side request forgery and redirects |