### PR TITLE
chore: remove dependency update changeset

### DIFF
--- a/.changeset/broad-dependency-modernization.md
+++ b/.changeset/broad-dependency-modernization.md
@@ -1,5 +1,0 @@
----
-"openwiki": patch
----
-
-Modernize runtime and development dependencies, upgrade pnpm, and pin the patched `qs` transitive dependency.


### PR DESCRIPTION
### Summary

- remove the changeset added by the merged dependency-modernization PR
- retain the dependency upgrades, regenerated lockfile, package-manager cleanup, and `qs` security override because each is required by that PR's stated intent

### Validation

- `CI=true pnpm install --frozen-lockfile`
- `pnpm run format:check`
- `pnpm run lint:check`
- `pnpm run typecheck`

Made by [Open SWE](https://openswe.vercel.app/agents/e99f2558-aaac-5beb-b168-0fbf3ee574c4)