### PR TITLE
fix: handle updates-mode stream chunks for openai-compatible provider

### DIFF
--- a/.changeset/wobbly-foxes-stream.md
+++ b/.changeset/wobbly-foxes-stream.md
@@ -1,0 +1,5 @@
+---
+"openwiki": patch
+---
+
+fix: handle updates-mode stream chunks for openai-compatible provider

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -1439,6 +1439,10 @@ export function parseAgentStreamChunk(chunk: unknown): OpenWikiRunEvent | null {
     return parseToolStreamEvent(payload);
   }
 
+  if (mode === "updates") {
+    return parseUpdatesChunk(namespace, payload);
+  }
+
   const text = extractMessageText(payload);
 
   return text.length > 0
@@ -1489,14 +1493,43 @@ function isProtocolStreamEvent(value: unknown): value is ProtocolEvent {
 
 function isAgentStreamChunk(
   value: unknown,
-): value is [string[], "messages" | "tools", unknown] {
+): value is [string[], "messages" | "tools" | "updates", unknown] {
   return (
     Array.isArray(value) &&
     value.length === 3 &&
     Array.isArray(value[0]) &&
     value[0].every((part) => typeof part === "string") &&
-    (value[1] === "messages" || value[1] === "tools")
+    (value[1] === "messages" || value[1] === "tools" || value[1] === "updates")
   );
+}
+
+/**
+ * Extracts the last assistant text from an "updates" mode state-delta chunk.
+ * LangGraph "updates" chunks carry the per-node state diff rather than raw
+ * message tokens, so the payload is { nodeName: { messages: [...] }, ... }.
+ * We iterate the node outputs and return the first non-empty assistant text.
+ */
+function parseUpdatesChunk(
+  namespace: string[],
+  payload: unknown,
+): OpenWikiRunEvent | null {
+  if (!isRecord(payload)) {
+    return null;
+  }
+
+  for (const nodeOutput of Object.values(payload)) {
+    const text = extractMessageText(nodeOutput);
+
+    if (text.length > 0) {
+      return {
+        source: getStreamSource(namespace),
+        type: "text",
+        text,
+      };
+    }
+  }
+
+  return null;
 }
 
 function extractMessageText(payload: unknown): string {

--- a/test/agent/stream-redaction.test.ts
+++ b/test/agent/stream-redaction.test.ts
@@ -130,4 +130,76 @@ describe("parseAgentStreamChunk", () => {
       parseAgentStreamChunk([["namespace"], ["not a message"]]),
     ).toBeNull();
   });
+
+  // "updates" mode is the default stream mode for the openai-compatible
+  // provider. The payload is a per-node state diff rather than raw message
+  // tokens, so the shape is { nodeName: { messages: [...] } }. Without
+  // handling this mode, plain-text replies from openai-compatible endpoints
+  // are silently dropped and the TUI shows "No assistant output captured".
+  test("extracts assistant text from an updates-mode state diff", () => {
+    const chunk = [
+      [],
+      "updates",
+      {
+        agent: {
+          messages: [
+            {
+              role: "assistant",
+              content: "Who am I? I am OpenWiki.",
+            },
+          ],
+        },
+      },
+    ];
+
+    const event = parseAgentStreamChunk(chunk);
+
+    expect(event).not.toBeNull();
+    expect(event?.type).toBe("text");
+    expect((event as { text: string }).text).toBe("Who am I? I am OpenWiki.");
+    expect((event as { source: string }).source).toBe("main");
+  });
+
+  test("tags updates from a subgraph namespace as subgraph source", () => {
+    const chunk = [
+      ["task"],
+      "updates",
+      { agent: { messages: [{ role: "assistant", content: "sub answer" }] } },
+    ];
+
+    const event = parseAgentStreamChunk(chunk);
+
+    expect(event).toMatchObject({ source: "subgraph", type: "text" });
+  });
+
+  test("returns null for an updates chunk with no node outputs", () => {
+    // An empty state diff carries no messages to display.
+    expect(parseAgentStreamChunk([[], "updates", {}])).toBeNull();
+  });
+
+  test("returns null for an updates chunk with a non-record payload", () => {
+    expect(parseAgentStreamChunk([[], "updates", "not-a-record"])).toBeNull();
+    expect(parseAgentStreamChunk([[], "updates", null])).toBeNull();
+  });
+
+  test("skips tool-call messages in updates chunks, surfaces adjacent text", () => {
+    const chunk = [
+      [],
+      "updates",
+      {
+        agent: {
+          messages: [
+            {
+              role: "assistant",
+              content: "",
+              tool_calls: [{ name: "read_file", args: {} }],
+            },
+          ],
+        },
+      },
+    ];
+
+    // A message that carries only tool calls has no renderable text.
+    expect(parseAgentStreamChunk(chunk)).toBeNull();
+  });
 });


### PR DESCRIPTION
## Summary

- The openai-compatible provider uses LangGraph "updates" stream mode by default (to avoid the reasoning-delta crash from issue #659). However, `isAgentStreamChunk` only accepted `"messages"` and `"tools"` mode chunks, so `"updates"` chunks were silently dropped and the interactive TUI showed "No assistant output captured" for every response.
- Adds `parseUpdatesChunk`, which extracts assistant text from the per-node state diff that LangGraph emits in `updates` mode. The diff shape is `{ nodeName: { messages: [...] }, ... }`; iterating its values and delegating to the existing `extractMessageText` routine surfaces the assistant reply.
- Extends `isAgentStreamChunk` to accept the `"updates"` mode string, then routes those chunks to the new handler instead of silently discarding them.

Fixes #803

## Test plan

- [x] Added unit tests in `test/agent/stream-redaction.test.ts` covering: basic updates-mode extraction, subgraph namespace tagging, empty state diff (null), non-record payload (null), and tool-call-only messages (null).
- [x] Manually verified extraction logic with a standalone JS script against all test cases before adding vitest tests.
