### PR TITLE
fix: complete legacy page coverage and recover interrupted update plans

### DIFF
--- a/.changeset/restore-legacy-page-coverage.md
+++ b/.changeset/restore-legacy-page-coverage.md
@@ -1,0 +1,5 @@
+---
+"openwiki": patch
+---
+
+Include existing pages without verified Claims in update plans and recover older interrupted queues that omitted them, preserving already-completed work and the final durability checks.

--- a/src/generation/page-jobs.ts
+++ b/src/generation/page-jobs.ts
@@ -117,6 +117,7 @@ export interface ProposedRepositoryPlan {
  * @param proposed - Complete proposed page and deletion set.
  * @param claimIssues - Stable preflight issues that require page work.
  * @param requiredRewritePages - Existing pages requiring language rewrites.
+ * @param requiredCoveragePages - Existing pages requiring verified Claims.
  * @returns Complete normalized plan ready for durable persistence.
  * @throws RepositoryRunError when paths, deletion intent, or init shape is invalid.
  */
@@ -125,6 +126,7 @@ export function createRepositoryPlan(
   proposed: ProposedRepositoryPlan,
   claimIssues: readonly GroundingIssue[],
   requiredRewritePages: readonly string[] = [],
+  requiredCoveragePages: readonly string[] = [],
 ): RepositoryRunPlan {
   const pages = proposed.pages.map(normalizePlanPage);
   const deletePages = uniqueSorted(
@@ -176,6 +178,7 @@ export function createRepositoryPlan(
     const deleted = new Set(deletePages);
     addRequiredClaimIssueJobs(pages, pagePaths, deleted, claimIssues);
     addRequiredRewriteJobs(pages, pagePaths, deleted, requiredRewritePages);
+    addRequiredCoverageJobs(pages, pagePaths, deleted, requiredCoveragePages);
   }
 
   // Quickstart is the synthesis/navigation page; generate it after domain pages.
@@ -313,6 +316,31 @@ function addRequiredRewriteJobs(
       title: titleFromPath(page),
       purpose:
         "Rewrite this existing page in the run's target language while preserving every accurate repository-supported fact and reconciling its complete Claim set.",
+      seedPaths: [],
+      relatedPages: [],
+      instructions: [],
+      status: "pending",
+    });
+    pagePaths.add(page);
+  }
+}
+
+/** Inserts missing existing pages whose Markdown and Claims need verification. */
+function addRequiredCoverageJobs(
+  pages: PageJob[],
+  pagePaths: Set<string>,
+  deletePages: Set<string>,
+  requiredPages: readonly string[],
+): void {
+  for (const pageInput of requiredPages) {
+    const page = normalizeWikiPagePath(pageInput);
+    if (pagePaths.has(page) || deletePages.has(page)) continue;
+    pages.push({
+      id: randomUUID(),
+      path: page,
+      title: titleFromPath(page),
+      purpose:
+        "Establish verified Claims for this existing page from current repository evidence while preserving accurate content.",
       seedPaths: [],
       relatedPages: [],
       instructions: [],

--- a/src/generation/page-manifest.ts
+++ b/src/generation/page-manifest.ts
@@ -240,6 +240,36 @@ export async function seedRepositoryPageManifest(
 }
 
 /**
+ * Finds existing pages that cannot establish a verified coverage entry.
+ *
+ * A valid earlier source checkpoint does not require regenerating a page.
+ * This checks only the Markdown/Claims proof used by manifest finalization;
+ * unreadable or malformed state still rejects instead of becoming model work.
+ *
+ * @param root - Repository root that owns the pages.
+ * @param pages - Existing factual pages to check.
+ * @returns Canonical pages requiring verified Claims before finish.
+ */
+export async function findUnverifiedRepositoryPages(
+  root: string,
+  pages: readonly string[],
+): Promise<string[]> {
+  const store = new ClaimsStore(root);
+  const unverified: string[] = [];
+  for (const page of pages) {
+    const canonical = normalizeWikiPagePath(page);
+    const claims = await store.loadPage(canonical);
+    if (
+      !claims?.verification ||
+      claims.pageVersion !== (await store.hashPage(canonical))
+    ) {
+      unverified.push(canonical);
+    }
+  }
+  return unverified;
+}
+
+/**
  * Replaces coverage with the complete surviving factual page inventory.
  *
  * @param root - Absolute repository root.

--- a/src/generation/repository-run.ts
+++ b/src/generation/repository-run.ts
@@ -23,6 +23,7 @@ import {
   prepareClaimsRuntime,
   type ClaimsRuntime,
 } from "../claims/brains/code/runtime.js";
+import { normalizeClaimsToolPagePath } from "../claims/brains/code/paths.js";
 import { ClaimsStore } from "../claims/brains/code/store.js";
 import type {
   GroundingIssue,
@@ -46,6 +47,7 @@ import {
 import { isFileNotFoundError } from "../platform/fs-errors.js";
 import { RepositoryRunError } from "./errors.js";
 import {
+  findUnverifiedRepositoryPages,
   getCurrentRepositoryPageCompletion,
   readRepositoryPageManifest,
   recordRepositoryPageCompletion,
@@ -405,6 +407,10 @@ export async function beginRepositoryRun(
     const hasCompleteBaselineCoverage =
       input.mode !== "update" ||
       initialPages.every((page) => seededManifest?.pages[page] !== undefined);
+    const requiredCoveragePages =
+      input.mode === "update"
+        ? await findUnverifiedRepositoryPages(input.root, initialPages)
+        : [];
 
     // Claims validation precedes update no-op detection. A clean Git status
     // cannot hide stale or unresolved grounding state.
@@ -417,7 +423,8 @@ export async function beginRepositoryRun(
       if (
         preflight.shouldSkip &&
         claimsRuntime.issueCount === 0 &&
-        hasCompleteBaselineCoverage
+        hasCompleteBaselineCoverage &&
+        requiredCoveragePages.length === 0
       ) {
         const source = await createRepositorySourceSnapshot(input.root, ignore);
         await claimsRuntime.finalize(now().toISOString());
@@ -478,6 +485,7 @@ export async function beginRepositoryRun(
       language,
       languageChanged,
       requiredRewritePages,
+      requiredCoveragePages,
       initialPages,
       sourceFingerprint: source.fingerprint,
       ...(source.gitHead ? { targetGitHead: source.gitHead } : {}),
@@ -624,6 +632,13 @@ async function resumeRepositoryRun(
       state.actor.producerActor,
     );
   }
+  if (nextState.mode === "update") {
+    nextState = await reconcileRequiredCoverage(
+      input.root,
+      nextState,
+      sourceChanged,
+    );
+  }
   // A finish-time drift check already stores the replacement fingerprint, so
   // the next begin may see sourceChanged=false. Plan absence is the durable
   // signal that new planning context may replace the prior context.
@@ -658,6 +673,50 @@ async function resumeRepositoryRun(
   return {
     run,
     view: await toActiveBeginView(run, true),
+  };
+}
+
+/**
+ * Adds missing verification jobs to old queues without replacing accepted work.
+ *
+ * The stable required set also keeps duplicate plan submission idempotent after
+ * those jobs complete. Source drift starts a new plan and recomputes that set.
+ */
+async function reconcileRequiredCoverage(
+  root: string,
+  state: RepositoryRunState,
+  sourceChanged: boolean,
+): Promise<RepositoryRunState> {
+  const existing = new Set(await new ClaimsStore(root).discoverPages());
+  const missing = await findUnverifiedRepositoryPages(
+    root,
+    state.initialPages.filter((page) => existing.has(page)),
+  );
+  const requiredCoveragePages = [
+    ...new Set([
+      ...(sourceChanged ? [] : (state.requiredCoveragePages ?? [])),
+      ...missing,
+    ]),
+  ].sort(compareCodeUnits);
+  if (!state.plan) return { ...state, requiredCoveragePages };
+
+  const originalJobs = new Map(
+    state.plan.pages.map((page) => [page.path, page]),
+  );
+  const augmented = createRepositoryPlan(
+    state.mode,
+    state.plan,
+    [],
+    [],
+    requiredCoveragePages,
+  );
+  return {
+    ...state,
+    requiredCoveragePages,
+    plan: {
+      ...state.plan,
+      pages: augmented.pages.map((page) => originalJobs.get(page.path) ?? page),
+    },
   };
 }
 
@@ -892,6 +951,22 @@ export async function submitRepositoryPlan(
       input,
       run.claimsRuntime.issues,
       run.state.requiredRewritePages,
+      run.state.requiredCoveragePages,
+    );
+    // A completed required page may no longer have its original Claim issues.
+    // Keep the accepted semantics of omitted, code-added coverage jobs rather
+    // than comparing newly synthesized purpose/seed text after recovery.
+    const explicitPages = new Set(
+      input.pages.map((page) => normalizeClaimsToolPagePath(page.path)),
+    );
+    const requiredPages = new Set(run.state.requiredCoveragePages);
+    const acceptedJobs = new Map(
+      run.state.plan.pages.map((page) => [page.path, page]),
+    );
+    proposed.pages = proposed.pages.map((page) =>
+      requiredPages.has(page.path) && !explicitPages.has(page.path)
+        ? (acceptedJobs.get(page.path) ?? page)
+        : page,
     );
     if (!samePlanIgnoringJobIds(run.state.plan, proposed)) {
       throw new RepositoryRunError(
@@ -914,6 +989,7 @@ export async function submitRepositoryPlan(
     input,
     run.claimsRuntime.issues,
     run.state.requiredRewritePages,
+    run.state.requiredCoveragePages,
   );
   const nextState: RepositoryRunState = {
     ...run.state,

--- a/src/generation/run-state.ts
+++ b/src/generation/run-state.ts
@@ -160,6 +160,13 @@ export interface RepositoryRunState {
   requiredRewritePages: string[];
 
   /**
+   * Stable required-page set for establishing missing Markdown/Claims proof.
+   *
+   * @default [] when reading checkpoints written before coverage jobs existed.
+   */
+  requiredCoveragePages: string[];
+
+  /**
    * Factual pages present before this run began semantic generation.
    */
   initialPages: string[];
@@ -272,6 +279,7 @@ const RepositoryRunStateSchema = z
     language: z.string().min(1),
     languageChanged: z.boolean(),
     requiredRewritePages: z.array(z.string().min(1)),
+    requiredCoveragePages: z.array(z.string().min(1)).default([]),
     initialPages: z.array(z.string().min(1)),
     sourceFingerprint: z.string().regex(/^sha256:[a-f0-9]{64}$/u),
     targetGitHead: z.string().min(1).optional(),

--- a/test/generation/repository-run.test.ts
+++ b/test/generation/repository-run.test.ts
@@ -122,6 +122,7 @@ import {
 import {
   readRepositoryRunState,
   repositoryRunStatePath,
+  type RepositoryRunState,
 } from "../../src/generation/run-state.ts";
 
 const execFileAsync = promisify(execFile);
@@ -227,6 +228,305 @@ async function createRepository(extraPages: string[] = []): Promise<string> {
   );
   return root;
 }
+
+/** Creates ordinary legacy Markdown input without Claims or run state. */
+async function createLegacyRepository(): Promise<string> {
+  const root = await mkdtemp(path.join(tmpdir(), "openwiki-legacy-coverage-"));
+  temporaryDirectories.push(root);
+  await git(root, ["init", "--quiet"]);
+  await git(root, ["config", "user.email", "test@example.com"]);
+  await git(root, ["config", "user.name", "OpenWiki Test"]);
+  await writeFile(path.join(root, "README.md"), "# Repository\n", "utf8");
+  await writeWikiPage(root, "quickstart.md", validPage("Quickstart"));
+  await writeWikiPage(root, "legacy.md", validPage("Legacy"));
+  await ensureCodeModeRepoSetup(root);
+  await git(root, ["add", "."]);
+  await git(root, ["commit", "--quiet", "-m", "legacy wiki without Claims"]);
+  return root;
+}
+
+describe("legacy page coverage", () => {
+  test.each([false, true])(
+    "adds omitted unverified pages and completes an update (empty plan: %s)",
+    async (emptyPlan) => {
+      const root = await createLegacyRepository();
+      const run = await beginForcedUpdate(root);
+      const proposal = {
+        pages: emptyPlan
+          ? []
+          : [
+              {
+                path: "/openwiki/quickstart.md",
+                title: "Keep this title",
+                purpose: "Keep this purpose.",
+                instructions: ["Keep this instruction."],
+              },
+            ],
+      };
+      await submitRepositoryPlan(run, proposal);
+      expect(run.state.plan?.pages.map(({ path }) => path)).toEqual([
+        "/openwiki/legacy.md",
+        "/openwiki/quickstart.md",
+      ]);
+      if (!emptyPlan) {
+        expect(run.state.plan?.pages[1]).toMatchObject({
+          title: "Keep this title",
+          purpose: "Keep this purpose.",
+          instructions: ["Keep this instruction."],
+        });
+      }
+      await expect(submitRepositoryPlan(run, proposal)).resolves.toMatchObject({
+        totalPages: 2,
+      });
+      await completeCurrentPage(run, "Legacy reviewed");
+      await completeCurrentPage(run, "Quickstart reviewed");
+      await expect(submitRepositoryPlan(run, proposal)).resolves.toMatchObject({
+        totalPages: 2,
+      });
+      const resumed = requireActiveRun(
+        await beginRepositoryRun({ root, mode: "update", actor: ACTOR }),
+      );
+      await expect(
+        submitRepositoryPlan(resumed, proposal),
+      ).resolves.toMatchObject({ totalPages: 2 });
+      await expect(finishRepositoryRun(resumed)).resolves.toEqual({
+        status: "complete",
+      });
+      expect(await readRepositoryRunState(root)).toBeNull();
+    },
+  );
+
+  test("does not add an explicitly deleted legacy page", async () => {
+    const root = await createLegacyRepository();
+    const run = await beginForcedUpdate(root);
+    await submitRepositoryPlan(run, { pages: [], deletePages: ["legacy.md"] });
+    expect(run.state.plan?.pages.map(({ path }) => path)).toEqual([
+      "/openwiki/quickstart.md",
+    ]);
+    await completeCurrentPage(run, "Quickstart reviewed");
+    await finishRepositoryRun(run);
+    expect(await new ClaimsStore(root).discoverPages()).toEqual([
+      "/openwiki/quickstart.md",
+    ]);
+  });
+
+  test("does not requeue verified pages merely because their source checkpoint is older", async () => {
+    const root = await createLegacyRepository();
+    const first = await beginForcedUpdate(root);
+    await submitRepositoryPlan(first, {
+      pages: [
+        {
+          path: "/openwiki/quickstart.md",
+          title: "Quickstart",
+          purpose: "Review.",
+        },
+        { path: "/openwiki/legacy.md", title: "Legacy", purpose: "Review." },
+      ],
+    });
+    await completeCurrentPage(first, "Legacy reviewed");
+    await completeCurrentPage(first, "Quickstart reviewed");
+    await finishRepositoryRun(first);
+    await writeFile(path.join(root, "unrelated.txt"), "new source\n", "utf8");
+    await git(root, ["add", "."]);
+    await git(root, ["commit", "--quiet", "-m", "add unrelated source"]);
+    const next = await beginForcedUpdate(root);
+    await submitRepositoryPlan(next, { pages: [] });
+    expect(next.state.plan?.pages).toEqual([]);
+    await expect(finishRepositoryRun(next)).resolves.toEqual({
+      status: "complete",
+    });
+  });
+
+  test("recovers an old accepted plan without replacing completed jobs", async () => {
+    const root = await createLegacyRepository();
+    const original = await beginForcedUpdate(root);
+    const proposal = {
+      pages: [
+        {
+          path: "/openwiki/quickstart.md",
+          title: "Quickstart",
+          purpose: "Review quickstart.",
+        },
+      ],
+    };
+    await submitRepositoryPlan(original, proposal);
+    // A pre-fix checkpoint could persist this incomplete plan. Exercise the
+    // old format explicitly; Markdown and Claims are still produced by submit.
+    const acceptedPlan = original.state.plan;
+    if (!acceptedPlan) throw new Error("Expected an accepted plan.");
+    original.state = {
+      ...original.state,
+      requiredCoveragePages: [],
+      plan: {
+        ...acceptedPlan,
+        pages: acceptedPlan.pages.filter(
+          ({ path }) => path === "/openwiki/quickstart.md",
+        ),
+      },
+    };
+    await completeCurrentPage(original, "Completed before upgrade");
+    const oldCheckpoint: Partial<RepositoryRunState> = { ...original.state };
+    delete oldCheckpoint.requiredCoveragePages;
+    await writeFile(
+      repositoryRunStatePath(root),
+      `${JSON.stringify(oldCheckpoint, null, 2)}\n`,
+      "utf8",
+    );
+    const completed = original.state.plan?.pages[0];
+    if (!completed) throw new Error("Expected completed legacy work.");
+    const previousCoverage = (await readRepositoryPageManifest(root)).pages[
+      completed.path
+    ];
+    const resumed = requireActiveRun(
+      await beginRepositoryRun({ root, mode: "update", actor: OTHER_ACTOR }),
+    );
+    expect(
+      resumed.state.plan?.pages.find(({ path }) => path === completed.path),
+    ).toEqual(completed);
+    expect(
+      (await readRepositoryPageManifest(root)).pages[completed.path],
+    ).toEqual(previousCoverage);
+    expect(
+      resumed.state.plan?.pages
+        .filter(({ status }) => status === "pending")
+        .map(({ path }) => path),
+    ).toEqual(["/openwiki/legacy.md"]);
+    const ids = resumed.state.plan?.pages.map(({ id }) => id);
+    const again = requireActiveRun(
+      await beginRepositoryRun({ root, mode: "update", actor: OTHER_ACTOR }),
+    );
+    expect(again.state.plan?.pages.map(({ id }) => id)).toEqual(ids);
+    await expect(submitRepositoryPlan(again, proposal)).resolves.toMatchObject({
+      totalPages: 2,
+    });
+    await completeCurrentPage(again, "Legacy reviewed after upgrade");
+    await expect(finishRepositoryRun(again)).resolves.toEqual({
+      status: "complete",
+    });
+  });
+
+  test("recomputes coverage requirements when source drift discards the old plan", async () => {
+    const root = await createLegacyRepository();
+    const run = await beginForcedUpdate(root);
+    await submitRepositoryPlan(run, { pages: [] });
+    await completeCurrentPage(run, "Legacy reviewed");
+    await completeCurrentPage(run, "Quickstart reviewed");
+    await writeFile(path.join(root, "unrelated.txt"), "new source\n", "utf8");
+    await git(root, ["add", "."]);
+    await git(root, [
+      "commit",
+      "--quiet",
+      "-m",
+      "source drift after page completion",
+    ]);
+    const resumed = requireActiveRun(
+      await beginRepositoryRun({ root, mode: "update", actor: ACTOR }),
+    );
+    expect(resumed.state.phase).toBe("planning");
+    await submitRepositoryPlan(resumed, { pages: [] });
+    expect(resumed.state.plan?.pages).toEqual([]);
+    await expect(finishRepositoryRun(resumed)).resolves.toEqual({
+      status: "complete",
+    });
+  });
+  test("keeps duplicate plans idempotent when coverage and stale Claims jobs overlap", async () => {
+    const root = await createLegacyRepository();
+    const first = await beginForcedUpdate(root);
+    await submitRepositoryPlan(first, { pages: [] });
+    await completeCurrentPage(first, "Legacy reviewed");
+    await completeCurrentPage(first, "Quickstart reviewed");
+    await finishRepositoryRun(first);
+    const store = new ClaimsStore(root);
+    const claims = await store.loadPage("/openwiki/legacy.md");
+    if (!claims) throw new Error("Expected persisted Claims.");
+    delete claims.verification;
+    await store.writePage("/openwiki/legacy.md", claims);
+    await writeFile(
+      path.join(root, "README.md"),
+      "# Changed repository\n",
+      "utf8",
+    );
+    await git(root, ["add", "."]);
+    await git(root, ["commit", "--quiet", "-m", "change Claim evidence"]);
+    const run = await beginForcedUpdate(root);
+    const proposal = {
+      pages: [
+        {
+          path: "/openwiki/quickstart.md",
+          title: "Quickstart",
+          purpose: "Review quickstart.",
+        },
+      ],
+    };
+    await submitRepositoryPlan(run, proposal);
+    await completeCurrentPage(run, "Legacy reverified");
+    await completeCurrentPage(run, "Quickstart reverified");
+    const resumed = requireActiveRun(
+      await beginRepositoryRun({ root, mode: "update", actor: ACTOR }),
+    );
+    await expect(
+      submitRepositoryPlan(resumed, proposal),
+    ).resolves.toMatchObject({ totalPages: 2 });
+    await expect(
+      submitRepositoryPlan(resumed, {
+        pages: [
+          ...proposal.pages,
+          {
+            path: "/openwiki/legacy.md",
+            title: "Different title",
+            purpose: "Different purpose.",
+          },
+        ],
+      }),
+    ).rejects.toThrow("different persisted plan");
+    await expect(finishRepositoryRun(resumed)).resolves.toEqual({
+      status: "complete",
+    });
+  });
+
+  test("does not rewrite verified pages solely to create a missing manifest", async () => {
+    const root = await createLegacyRepository();
+    const first = await beginForcedUpdate(root);
+    await submitRepositoryPlan(first, { pages: [] });
+    await completeCurrentPage(first, "Legacy reviewed");
+    await completeCurrentPage(first, "Quickstart reviewed");
+    await finishRepositoryRun(first);
+    await rm(path.join(root, "openwiki/.page-manifest.json"));
+    await rm(path.join(root, "openwiki/.last-update.json"));
+    const next = requireActiveRun(
+      await beginRepositoryRun({ root, mode: "update", actor: ACTOR }),
+    );
+    await submitRepositoryPlan(next, { pages: [] });
+    expect(next.state.plan?.pages).toEqual([]);
+    await expect(finishRepositoryRun(next)).resolves.toEqual({
+      status: "complete",
+    });
+    expect(
+      Object.keys((await readRepositoryPageManifest(root)).pages),
+    ).toHaveLength(2);
+  });
+
+  test("does not silently no-op over a page whose Markdown no longer matches its Claims", async () => {
+    const root = await createLegacyRepository();
+    const first = await beginForcedUpdate(root);
+    await submitRepositoryPlan(first, { pages: [] });
+    await completeCurrentPage(first, "Legacy reviewed");
+    await completeCurrentPage(first, "Quickstart reviewed");
+    await finishRepositoryRun(first);
+    await writeWikiPage(root, "legacy.md", validPage("Manually edited"));
+    const next = requireActiveRun(
+      await beginRepositoryRun({ root, mode: "update", actor: ACTOR }),
+    );
+    await submitRepositoryPlan(next, { pages: [] });
+    expect(next.state.plan?.pages.map(({ path }) => path)).toEqual([
+      "/openwiki/legacy.md",
+    ]);
+    await completeCurrentPage(next, "Reviewed edit");
+    await expect(finishRepositoryRun(next)).resolves.toEqual({
+      status: "complete",
+    });
+  });
+});
 
 /**
  * Narrows a begin result to an active repository run.

--- a/test/generation/run-state.test.ts
+++ b/test/generation/run-state.test.ts
@@ -33,6 +33,7 @@ function createRunState(): RepositoryRunState {
     language: "en",
     languageChanged: false,
     requiredRewritePages: [],
+    requiredCoveragePages: [],
     initialPages: ["/openwiki/quickstart.md"],
     sourceFingerprint: `sha256:${"a".repeat(64)}`,
     targetGitHead: "0123456789abcdef",
@@ -91,6 +92,23 @@ afterEach(async () => {
 });
 
 describe("repository run-state persistence", () => {
+  test("loads old checkpoints without coverage requirements", async () => {
+    const legacy: Partial<RepositoryRunState> = createRunState();
+    delete legacy.requiredCoveragePages;
+    await mkdir(path.dirname(repositoryRunStatePath(root)), {
+      recursive: true,
+    });
+    await writeFile(
+      repositoryRunStatePath(root),
+      JSON.stringify(legacy),
+      "utf8",
+    );
+    expect(await readRepositoryRunState(root)).toEqual({
+      ...legacy,
+      requiredCoveragePages: [],
+    });
+  });
+
   test("atomically writes and reads the complete checkpoint", async () => {
     const state = createRunState();
 


### PR DESCRIPTION
Fixes #826

An update can accept a plan that omits an existing page without verified Claims. The selected pages complete, but finalization rejects the omitted page. Subsequent runs restore an already-complete queue and fail again without giving the planner or workers a chance to fill the gap.

This change adds required verification jobs for those existing pages and repairs older interrupted queues by adding omitted work while preserving completed jobs and their provenance. The required-page set is persisted so repeated plan submissions remain idempotent, including after recovery and when Claims issues have been resolved.

Explicit deletions and caller-provided page instructions are respected. Pages with valid verified Claims are not rewritten solely because their manifest is missing or their source checkpoint is older. Final durability checks remain enforced. A patch changeset is included.

## Validation

- Added regressions for partial/empty legacy plans, old checkpoint recovery, duplicate submission, overlapping Claims/coverage jobs, source drift, explicit deletion, and valid existing coverage.
- Applying this patch alone: **89 focused generation tests passed**. The full `pnpm test` command passed typecheck, build, and coverage: **3048 tests passed, 3 skipped**. `pnpm run lint:check` and `pnpm run format:check` also passed.
- Actual CLI checks with deterministic local HTTP model responses: two-page and fifteen-page partial plans now complete. Copies of the failed 0.5.0 directories recover by authoring only omitted pages; the already-completed quickstart is not reauthored.

The reproduction establishes one concrete path matching #826; it does not claim to identify every trigger in the reporter's original OpenRouter environment.
