### PR TITLE
fix: preserve verification metadata on skipped pages

### DIFF
--- a/.changeset/preserve-skipped-verification.md
+++ b/.changeset/preserve-skipped-verification.md
@@ -1,0 +1,5 @@
+---
+"openwiki": patch
+---
+
+Preserve existing verification metadata on skipped pages so partial updates retain matching Markdown, Claims, and page coverage.

--- a/src/claims/brains/code/runtime.ts
+++ b/src/claims/brains/code/runtime.ts
@@ -138,6 +138,7 @@ function buildClaimsRuntime(
           session,
           store,
           result.verificationByPage,
+          excludedPages,
         )),
       );
       for (const warning of warnings) onWarning(warning);
@@ -156,16 +157,19 @@ function buildClaimsRuntime(
  * @param session - Process-local Claims working state.
  * @param store - Repository Claims and Markdown persistence boundary.
  * @param verificationByPage - Durable verification eligibility by factual page.
+ * @param excludedPages - Pages whose restored Markdown must remain unchanged.
  * @returns Page-version synchronization warnings requiring run failure.
  */
 async function finalizeVerificationProjection(
   session: ClaimSession,
   store: ClaimsStore,
   verificationByPage: Parameters<typeof synchronizeClaimsVerification>[1],
+  excludedPages: ReadonlySet<string>,
 ): Promise<string[]> {
   const originals = await synchronizeClaimsVerification(
     store,
     verificationByPage,
+    excludedPages,
   );
   // Deterministic finalizers may have changed code-owned frontmatter without
   // changing the verification event. Refresh every represented page so Claims

--- a/src/okf/claims-verification.ts
+++ b/src/okf/claims-verification.ts
@@ -24,21 +24,24 @@ export type ClaimsVerificationChanges = ReadonlyMap<string, string>;
  * Reconciles OpenWiki-owned OKF verification events against durable Claims
  * state while retaining human, process, and other producer events.
  *
- * Every grounded concept participates. A page without an active durable event
+ * Every non-excluded grounded concept participates. A page without an active durable event
  * loses only events in the `openwiki/<version>` actor family. Bare verifier
  * mappings are normalized to the canonical list representation when touched.
  *
  * @param store - Contained generated-page storage.
  * @param verificationByPage - Active durable event per Claims page.
+ * @param excludedPages - Pages whose existing Markdown must remain untouched.
  * @returns Original Markdown for changed pages, used for transactional rollback.
  */
 export async function synchronizeClaimsVerification(
   store: ClaimsVerificationPageStore,
   verificationByPage: ReadonlyMap<string, ClaimsVerificationEvent | null>,
+  excludedPages: ReadonlySet<string> = new Set(),
 ): Promise<ClaimsVerificationChanges> {
   const changes = new Map<string, string>();
 
   for (const page of await store.discoverPages()) {
+    if (excludedPages.has(page)) continue;
     const content = await store.readMarkdown(page);
     const repaired = repairOkfFrontmatter(content, page).content;
     const current = readVerificationEvents(repaired);

--- a/test/claims/brains/code/runtime.test.ts
+++ b/test/claims/brains/code/runtime.test.ts
@@ -233,6 +233,52 @@ describe("prepareClaimsRuntime", () => {
     ]);
   });
 
+  test("preserves an excluded page's verified Markdown and Claims exactly", async () => {
+    const page = "/openwiki/page.md";
+    await writePage(page, "---\ntype: Reference\n---\n\n# Page\n");
+    await writeFile(
+      path.join(rootDir, "source.ts"),
+      "export const value = 1;\n",
+    );
+    const runtime = await prepareClaimsRuntime(
+      "init",
+      "repository",
+      rootDir,
+      new OpenWikiIgnore([]),
+    );
+    expect(runtime).toBeDefined();
+    await runtime!.session.resolveClaims({
+      page,
+      operations: [
+        {
+          op: "add",
+          statement: "The source exports a value.",
+          evidence: [{ resource: "repo://source.ts" }],
+        },
+      ],
+    });
+    await runtime!.finalize("2026-08-20T12:00:00.000Z");
+    const store = new ClaimsStore(rootDir);
+    const original = await readPage(page);
+    const claims = await store.loadPage(page);
+    expect(claims?.verification).toBeDefined();
+
+    const resumed = await prepareClaimsRuntime(
+      "update",
+      "repository",
+      rootDir,
+      new OpenWikiIgnore([]),
+    );
+    expect(resumed).toBeDefined();
+    await resumed!.finalize("2026-08-20T13:00:00.000Z", new Set([page]));
+
+    expect(await readPage(page)).toBe(original);
+    expect(await store.loadPage(page)).toEqual(claims);
+    expect((await store.loadPage(page))?.pageVersion).toBe(
+      await store.hashPage(page),
+    );
+  });
+
   test("clean preflight preserves the prior event while debt removes only OpenWiki's event", async () => {
     const page = "/openwiki/page.md";
     await writePage(page, "---\ntype: Reference\n---\n\n# Page\n");

--- a/test/generation/skipped-page-verification.test.ts
+++ b/test/generation/skipped-page-verification.test.ts
@@ -1,0 +1,127 @@
+import { execFile } from "node:child_process";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { promisify } from "node:util";
+import { afterEach, expect, test } from "vitest";
+import { ClaimsStore } from "../../src/claims/brains/code/store.ts";
+import {
+  getCurrentRepositoryPageCompletion,
+  readRepositoryPageManifest,
+} from "../../src/generation/page-manifest.ts";
+import {
+  beginRepositoryRun,
+  captureRepositoryPageSnapshot,
+  finishRepositoryRun,
+  getRepositoryRunSourceCheckpoint,
+  nextRepositoryPage,
+  skipRepositoryPage,
+  submitRepositoryPage,
+  submitRepositoryPlan,
+} from "../../src/generation/repository-run.ts";
+import { readRepositoryRunState } from "../../src/generation/run-state.ts";
+
+const execFileAsync = promisify(execFile);
+const actor = {
+  producerActor: "host-agent/test",
+  metadataModel: "test-model",
+};
+let root: string | undefined;
+
+afterEach(async () => {
+  if (root) await rm(root, { recursive: true, force: true });
+  root = undefined;
+});
+
+test("finishing a skipped verified page preserves its Markdown and coverage", async () => {
+  root = await mkdtemp(path.join(tmpdir(), "openwiki-skipped-verification-"));
+  const cwd = root;
+  await execFileAsync("git", ["init", "--quiet"], { cwd });
+  await execFileAsync("git", ["config", "user.name", "OpenWiki Test"], { cwd });
+  await execFileAsync("git", ["config", "user.email", "test@example.com"], {
+    cwd,
+  });
+  await writeFile(path.join(root, "README.md"), "# Repository\n");
+  await execFileAsync("git", ["add", "README.md"], { cwd });
+  await execFileAsync("git", ["commit", "--quiet", "-m", "initial"], { cwd });
+
+  const page = "/openwiki/quickstart.md";
+  const initialized = await beginRepositoryRun({ root, mode: "init", actor });
+  if (!("run" in initialized)) throw new Error("Expected an init run.");
+  await submitRepositoryPlan(initialized.run, {
+    pages: [
+      { path: page, title: "Quickstart", purpose: "Introduce the repository." },
+    ],
+  });
+  const initialJob = await nextRepositoryPage(initialized.run);
+  if (initialJob.status !== "pending") throw new Error("Expected a page job.");
+  const written = await initialized.run.backend.write(
+    page,
+    "---\ntype: Guide\ntitle: Quickstart\n---\n\n# Quickstart\n\nThe repository has a README.\n",
+  );
+  expect(written.error).toBeFalsy();
+  await submitRepositoryPage(initialized.run, {
+    jobId: initialJob.job.id,
+    claims: [
+      {
+        statement: "The repository has a README.",
+        evidence: [{ resource: "repo://README.md" }],
+      },
+    ],
+  });
+  await finishRepositoryRun(initialized.run);
+
+  const store = new ClaimsStore(root);
+  const baseline = await store.loadPage(page);
+  expect(baseline?.verification).toBeDefined();
+  expect(baseline?.claims).toHaveLength(1);
+  expect(baseline?.pageVersion).toBe(await store.hashPage(page));
+  const priorCoverage = (await readRepositoryPageManifest(root)).pages[page];
+  expect(priorCoverage).toBeDefined();
+
+  const updated = await beginRepositoryRun({
+    root,
+    mode: "update",
+    force: true,
+    actor,
+  });
+  if (!("run" in updated)) throw new Error("Expected an update run.");
+  await submitRepositoryPlan(updated.run, {
+    pages: [{ path: page, title: "Quickstart", purpose: "Refresh the guide." }],
+  });
+  const job = await nextRepositoryPage(updated.run);
+  if (job.status !== "pending") throw new Error("Expected a page job.");
+  const snapshot = await captureRepositoryPageSnapshot(updated.run, job.job.id);
+  await updated.run.backend.write(page, "# Incomplete worker output\n");
+  await skipRepositoryPage(updated.run, snapshot);
+  expect(await store.readMarkdown(page)).toBe(snapshot.markdown);
+  expect(await store.loadPage(page)).toEqual(snapshot.claims);
+
+  await expect(
+    finishRepositoryRun(updated.run, {
+      skippedPageSnapshots: [snapshot],
+    }),
+  ).resolves.toEqual({ status: "complete" });
+
+  expect(await store.readMarkdown(page)).toBe(snapshot.markdown);
+  expect(await store.loadPage(page)).toEqual(snapshot.claims);
+  expect((await store.loadPage(page))?.pageVersion).toBe(
+    await store.hashPage(page),
+  );
+  expect((await readRepositoryPageManifest(root)).pages[page]).toEqual(
+    priorCoverage,
+  );
+  expect(
+    await getCurrentRepositoryPageCompletion(
+      root,
+      page,
+      getRepositoryRunSourceCheckpoint(updated.run.state),
+    ),
+  ).toEqual(priorCoverage);
+  expect(await readRepositoryRunState(root)).toBeNull();
+  expect(
+    JSON.parse(
+      await readFile(path.join(root, "openwiki/.last-update.json"), "utf8"),
+    ),
+  ).toMatchObject({ status: "interrupted" });
+}, 20_000);

--- a/test/okf/claims-verification.test.ts
+++ b/test/okf/claims-verification.test.ts
@@ -95,4 +95,30 @@ describe("synchronizeClaimsVerification", () => {
 
     expect(store.pages.get(page)).toBe(original);
   });
+
+  test("preserves excluded pages while removing unjustified events elsewhere", async () => {
+    const skipped = "/openwiki/skipped.md";
+    const unverified = "/openwiki/unverified.md";
+    const original =
+      "---\ntype: Reference\nverified:\n  - by: openwiki/0.3.3\n    at: 2026-08-20T12:00:00.000Z\n---\n\n# Page\n";
+    const store = new MemoryPageStore(
+      new Map([
+        [skipped, original],
+        [unverified, original],
+      ]),
+    );
+
+    const changes = await synchronizeClaimsVerification(
+      store,
+      new Map(),
+      new Set([skipped]),
+    );
+
+    expect(store.pages.get(skipped)).toBe(original);
+    expect(changes.has(skipped)).toBe(false);
+    expect(
+      parseFrontmatterFields(store.pages.get(unverified)!)?.verified,
+    ).toBeUndefined();
+    expect(changes.get(unverified)).toBe(original);
+  });
 });


### PR DESCRIPTION
Fixes #827

---

When a page worker fails, OpenWiki restores that page's original Markdown and Claims. Finalization then visits the skipped page again and removes its existing OpenWiki `verified` metadata, while preserving the Claims sidecar and page-manifest entry. Their stored hashes consequently no longer match the restored Markdown.

Pass the existing excluded-page set through Claims verification projection so skipped pages retain their exact restored bytes and matching coverage. Other pages continue through normal verification reconciliation. Includes a patch changeset.

Validation:

- 19 focused Claims/verification tests passed. Regression coverage spans verification projection, the Claims runtime, and the repository lifecycle.
- Applying this patch alone: `pnpm test` passed typecheck, build, and coverage (**3041 tests passed, 3 skipped**). `pnpm run lint:check` and `pnpm run format:check` also passed.
- A real-filesystem lifecycle probe creates the verified baseline through normal generation APIs. Before the fix, skipping restores consistent state, but finalization removes the verification stamp and breaks both hash comparisons. After the fix, the original Markdown, Claims sidecar, and manifest entry are preserved, and both hashes match. The completed-page control remains consistent.

The probe uses local fixture content without model calls. A skipped update still records `interrupted` metadata so its unfinished work can be retried.
