### PR TITLE
feat: show the error stack in the debug diagnostics panel

### DIFF
--- a/.changeset/lucky-badgers-shout.md
+++ b/.changeset/lucky-badgers-shout.md
@@ -1,0 +1,5 @@
+---
+"openwiki": patch
+---
+
+feat: show the error stack in the debug diagnostics panel

--- a/src/cli/diagnostics/error-diagnostics.ts
+++ b/src/cli/diagnostics/error-diagnostics.ts
@@ -29,7 +29,9 @@ export interface ErrorDiagnostic {
  * Extracts a deduped list of allowlisted, non-secret diagnostic fields from an
  * arbitrary (often untrusted) error object for the `--debug` diagnostics panel.
  * Only known-safe keys are read; every value is sanitized and secret-like keys
- * are redacted, so raw secret material never leaves. Walks the error, its
+ * are redacted, so raw secret material never leaves. In debug mode this
+ * includes the error's stack, sanitized and truncated like every other
+ * long value. Walks the error, its
  * OpenRouter metadata, any attached debug payload, and (in debug mode) its
  * `cause`/`error`/`response` nesting.
  */
@@ -42,6 +44,13 @@ export function getErrorDiagnostics(error: unknown): ErrorDiagnostic[] {
       { label: "name", value: error.name },
       { label: "message", value: sanitizeDiagnosticText(error.message) },
     );
+
+    if (error.stack) {
+      diagnostics.push({
+        label: "stack",
+        value: truncateDiagnosticValue(sanitizeDiagnosticText(error.stack)),
+      });
+    }
 
     const messageStatus = error.message.match(/\b([45]\d{2})\b/)?.[1];
 

--- a/test/cli/diagnostics/error-diagnostics.test.ts
+++ b/test/cli/diagnostics/error-diagnostics.test.ts
@@ -42,6 +42,28 @@ describe("getErrorDiagnostics", () => {
     expect(lookup.httpStatusFromMessage).toBe("503");
   });
 
+  test("extracts the stack in debug mode and omits it when debug is off", () => {
+    const error = new Error("boom");
+
+    expect(toLookup(getErrorDiagnostics(error)).stack).toBeUndefined();
+
+    process.env[DEBUG] = "1";
+
+    expect(toLookup(getErrorDiagnostics(error)).stack).toContain("at ");
+  });
+
+  test("redacts and truncates the stack", () => {
+    process.env[DEBUG] = "1";
+    const error = new Error("boom");
+    error.stack = `Error: boom\n    at call (bearer sk-or-v1-supersecret)\n${"    at frame\n".repeat(300)}`;
+    const stack = toLookup(getErrorDiagnostics(error)).stack;
+
+    expect(stack).not.toContain("sk-or-v1-supersecret");
+    expect(stack).toContain("[REDACTED:OPENROUTER_API_KEY]");
+    expect(stack).toHaveLength(2_000);
+    expect(stack.endsWith("...")).toBe(true);
+  });
+
   test("extracts status and case-insensitive headers in debug mode", () => {
     process.env[DEBUG] = "1";
     const lookup = toLookup(


### PR DESCRIPTION
### What

Adds the error's `stack` to the `--debug` Error Diagnostics panel.

### Why

The panel currently reads `name`, `message`, OpenRouter metadata and `openRouterDebug`, so a crash raised inside a dependency cannot be traced to its origin from a CLI run alone. Debugging a `TypeError: Cannot read properties of undefined (reading '0')` thrown during a model invocation required patching this file locally to print the stack; with the stack in the panel, the same run reports the frames it came from and the bug can be filed with something actionable in it.

### How

One diagnostic entry inside the existing `debugMode && error instanceof Error` block, guarded on `error.stack` being present:

```ts
value: truncateDiagnosticValue(sanitizeDiagnosticText(error.stack));
```

- `sanitizeDiagnosticText` is the same security boundary the `message` field already passes through, and a stack begins with `${name}: ${message}`, so the embedded message gets the identical redaction it gets today.
- `truncateDiagnosticValue` (the local 2000-character cap already used for `metadata.raw`, `openRouterDebug` and `previous_errors`) keeps a deep async stack from flooding the panel. `name` and `message` are uncapped, but a stack is the kind of value that needs the metadata treatment rather than the message treatment.
- Debug mode only; nothing changes when `--debug` / `OPENWIKI_DEBUG` is off.
- No change to `panels.tsx`: it renders whatever diagnostics it is given, and Ink's `<Text>` keeps the embedded newlines.

One note for reviewers: stack frames contain local filesystem paths, so a pasted panel can reveal a home directory name. That exposure already exists for `metadata.raw` and `openRouterDebug`, and path redaction would be a separate change rather than part of this one.

### Tests

`test/cli/diagnostics/error-diagnostics.test.ts` gains two cases: the stack appears in debug mode and is absent with debug off, and a stack carrying a `sk-or-v1-…` key is redacted and truncated to the 2000-character cap.

`pnpm run format`, `pnpm run lint` and the `error-diagnostics` suite pass. The full `pnpm test` has 36 pre-existing failures on this Windows checkout (CRLF-sensitive assertions in `evals/ledger/replay` and friends); they reproduce unchanged on a clean tree at the same commit and are unrelated to this change.
