### PR TITLE
fix: only claim a scheduled workflow in AGENTS.md when the repo has one

### DIFF
--- a/.changeset/clever-donkeys-shout.md
+++ b/.changeset/clever-donkeys-shout.md
@@ -1,0 +1,5 @@
+---
+"openwiki": patch
+---
+
+Stop the managed `AGENTS.md` block from claiming that a scheduled GitHub Actions workflow refreshes the wiki unless the repository actually has one. The sentence is now stated only when `.github/workflows/openwiki-update.yml` exists and still declares a `schedule` trigger, and is otherwise left out rather than replaced with a different recurrence claim — OpenWiki cannot see a GitLab CI or Bitbucket Pipelines schedule.

--- a/src/ingestion/code-mode.ts
+++ b/src/ingestion/code-mode.ts
@@ -1,5 +1,6 @@
 import { mkdir, readFile, writeFile } from "node:fs/promises";
 import path from "node:path";
+import { parse as parseYaml } from "yaml";
 import {
   getProviderAuthMethod,
   getProviderConfig,
@@ -14,6 +15,25 @@ import { createConnectorRegistry } from "../connectors/registry.js";
 import { UPDATE_METADATA_PATH } from "../config/constants.js";
 import { createConnectorSynthesisGuidance } from "./ingestion.js";
 import type { OpenWikiRunEvent } from "../agent/types.js";
+
+// The scheduled-update workflow OpenWiki manages. The create-if-missing step and
+// the managed agent snippet both resolve it from here, so the snippet cannot
+// look for a schedule somewhere the create step would not have written one.
+const CODE_MODE_WORKFLOW_SEGMENTS = [
+  ".github",
+  "workflows",
+  "openwiki-update.yml",
+] as const;
+
+// GitHub Actions trigger keys read out of the managed workflow. `yaml` keeps a
+// bare `on` as the string key (YAML 1.2 core schema), so no boolean-key dance.
+const WORKFLOW_TRIGGER_KEY = "on";
+const WORKFLOW_SCHEDULE_KEY = "schedule";
+
+const SCHEDULED_WORKFLOW_SENTENCE =
+  "The scheduled OpenWiki GitHub Actions workflow refreshes the repository wiki.";
+const HAND_EDIT_GUIDANCE =
+  "Do not hand-edit generated OpenWiki pages unless explicitly asked; prefer updating source code/docs and letting OpenWiki regenerate.";
 
 const OPENWIKI_AGENTS_SNIPPET_START = "<!-- OPENWIKI:START -->";
 const OPENWIKI_AGENTS_SNIPPET_END = "<!-- OPENWIKI:END -->";
@@ -58,7 +78,62 @@ export async function ensureCodeModeRepoSetup(
       options.env ?? process.env,
     );
   }
-  await writeCodeModeAgentSnippets(cwd);
+  // Read the workflow state after the create step, so an `--init` that just
+  // wrote the file and an `--update` on a repo that already had one are both
+  // described accurately.
+  await writeCodeModeAgentSnippets(
+    cwd,
+    await hasConfirmedCodeModeSchedule(cwd),
+  );
+}
+
+/** Absolute path of the scheduled-update workflow OpenWiki manages for `cwd`. */
+function codeModeWorkflowPath(cwd: string): string {
+  return path.join(cwd, ...CODE_MODE_WORKFLOW_SEGMENTS);
+}
+
+/**
+ * Whether this repo is confirmed to refresh its wiki on a schedule: the managed
+ * workflow exists *and* still declares a `schedule` trigger. The file alone is
+ * not enough -- OpenWiki stopped overwriting it so operators can customize it,
+ * and one reduced to `workflow_dispatch` runs only when someone asks. Anything
+ * that stops us confirming a schedule -- absent, a directory in its place, a
+ * permission error, unparseable YAML -- answers `false`, because the snippet may
+ * only assert a schedule it can positively confirm. Deliberately not fatal: the
+ * `--update` and MCP paths never read this path before, and an odd `.github`
+ * must not turn a docs refresh into a failed run.
+ */
+async function hasConfirmedCodeModeSchedule(cwd: string): Promise<boolean> {
+  try {
+    return declaresScheduleTrigger(
+      await readFile(codeModeWorkflowPath(cwd), "utf8"),
+    );
+  } catch {
+    return false;
+  }
+}
+
+/** True when a workflow document declares at least one `on.schedule` entry. */
+function declaresScheduleTrigger(workflow: string): boolean {
+  let parsed: unknown;
+  try {
+    parsed = parseYaml(workflow);
+  } catch {
+    // A workflow OpenWiki cannot parse is one whose recurrence it cannot vouch
+    // for. The run itself is unaffected.
+    return false;
+  }
+
+  const triggers = readRecord(parsed)?.[WORKFLOW_TRIGGER_KEY];
+  const schedule = readRecord(triggers)?.[WORKFLOW_SCHEDULE_KEY];
+  return Array.isArray(schedule) && schedule.length > 0;
+}
+
+/** The value as a plain keyed object, or undefined when it is not one. */
+function readRecord(value: unknown): Record<string, unknown> | undefined {
+  return typeof value === "object" && value !== null
+    ? (value as Record<string, unknown>)
+    : undefined;
 }
 
 /**
@@ -71,12 +146,7 @@ async function ensureCodeModeWorkflow(
   cronExpression: string,
   env: NodeJS.ProcessEnv,
 ): Promise<void> {
-  const workflowPath = path.join(
-    cwd,
-    ".github",
-    "workflows",
-    "openwiki-update.yml",
-  );
+  const workflowPath = codeModeWorkflowPath(cwd);
 
   try {
     await readFile(workflowPath, "utf8");
@@ -188,8 +258,11 @@ async function readLastUpdatedAt(
   }
 }
 
-async function writeCodeModeAgentSnippets(cwd: string): Promise<void> {
-  const agentsSnippet = createCodeModeAgentsSnippet();
+async function writeCodeModeAgentSnippets(
+  cwd: string,
+  hasScheduledWorkflow: boolean,
+): Promise<void> {
+  const agentsSnippet = createCodeModeAgentsSnippet(hasScheduledWorkflow);
   const claudeSnippet = createCodeModeClaudeSnippet();
   const snippetByFile: Record<string, string> = {
     "AGENTS.md": agentsSnippet,
@@ -402,7 +475,23 @@ jobs:
 `;
 }
 
-function createCodeModeAgentsSnippet(): string {
+/**
+ * The maintenance paragraph of the managed AGENTS.md block. The scheduled-workflow
+ * sentence is only stated for a repo that has the workflow; otherwise it is left
+ * out entirely rather than replaced with a claim about how the wiki *is* kept
+ * current. OpenWiki cannot know that: the README also documents GitLab CI and
+ * Bitbucket Pipelines schedules, which leave no `.github/workflows` file, so
+ * asserting "on demand" there would trade one wrong statement for another.
+ */
+function createCodeModeMaintenanceParagraph(
+  hasScheduledWorkflow: boolean,
+): string {
+  return hasScheduledWorkflow
+    ? `${SCHEDULED_WORKFLOW_SENTENCE} ${HAND_EDIT_GUIDANCE}`
+    : HAND_EDIT_GUIDANCE;
+}
+
+function createCodeModeAgentsSnippet(hasScheduledWorkflow: boolean): string {
   return `${OPENWIKI_AGENTS_SNIPPET_START}
 
 ## OpenWiki
@@ -412,7 +501,7 @@ This repository has a generated \`openwiki/\` evidence index. It is optional jus
 - Treat source code and tests as authoritative. A brief's unknowns and review items are verification gaps, not automatic requirements.
 - Prefer the narrowest quiet validation that proves the changed behavior. Preserve complete failure output.
 
-The scheduled OpenWiki GitHub Actions workflow refreshes the repository wiki. Do not hand-edit generated OpenWiki pages unless explicitly asked; prefer updating source code/docs and letting OpenWiki regenerate.
+${createCodeModeMaintenanceParagraph(hasScheduledWorkflow)}
 
 ${OPENWIKI_AGENTS_SNIPPET_END}`;
 }

--- a/test/ingestion/code-mode.test.ts
+++ b/test/ingestion/code-mode.test.ts
@@ -265,6 +265,167 @@ ${SNIPPET_END}
   }
 });
 
+describe("ensureCodeModeRepoSetup scheduled-workflow claim", () => {
+  const SCHEDULED_CLAIM =
+    "The scheduled OpenWiki GitHub Actions workflow refreshes the repository wiki.";
+  const HAND_EDIT_GUIDANCE = "Do not hand-edit generated OpenWiki pages";
+  const CODE_MODE_WORKFLOW_SEGMENTS = [
+    ".github",
+    "workflows",
+    "openwiki-update.yml",
+  ] as const;
+
+  function workflowPath(repo: string): string {
+    return path.join(repo, ...CODE_MODE_WORKFLOW_SEGMENTS);
+  }
+
+  const SCHEDULED_WORKFLOW = `name: Update OpenWiki
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 8 * * *"
+`;
+  const MANUAL_ONLY_WORKFLOW = `name: Update OpenWiki
+on:
+  workflow_dispatch:
+`;
+
+  async function writeWorkflow(repo: string, body: string): Promise<void> {
+    await mkdir(path.dirname(workflowPath(repo)), { recursive: true });
+    await writeFile(workflowPath(repo), body, "utf8");
+  }
+
+  async function readAgents(repo: string): Promise<string> {
+    const content = await readIfPresent(path.join(repo, "AGENTS.md"));
+    if (content === null) {
+      throw new Error("expected AGENTS.md to exist");
+    }
+    return content;
+  }
+
+  test("does not claim a scheduled workflow when the repo has none", async () => {
+    const repo = await createTempRepo();
+
+    // The `--update` and MCP-host paths never create the workflow, so a repo
+    // without one must not be told a schedule refreshes its wiki.
+    await ensureCodeModeRepoSetup(repo);
+
+    const content = await readAgents(repo);
+    expect(content).not.toContain(SCHEDULED_CLAIM);
+    // The sentence is dropped, not swapped for a different recurrence claim,
+    // and the rest of the managed guidance is untouched.
+    expect(content).toContain(HAND_EDIT_GUIDANCE);
+    expect(content).toContain(SNIPPET_START);
+    expect(content).toContain(SNIPPET_END);
+  });
+
+  test("stops claiming a scheduled workflow once the workflow is deleted", async () => {
+    const repo = await createTempRepo();
+    await ensureCodeModeRepoSetup(repo, { createWorkflow: true });
+    expect(await readAgents(repo)).toContain(SCHEDULED_CLAIM);
+
+    await rm(workflowPath(repo));
+    await ensureCodeModeRepoSetup(repo);
+
+    const content = await readAgents(repo);
+    expect(content).not.toContain(SCHEDULED_CLAIM);
+    expect(content).toContain(HAND_EDIT_GUIDANCE);
+  });
+
+  test("makes no recurrence claim for a repo scheduled outside GitHub Actions", async () => {
+    const repo = await createTempRepo();
+    // The README also documents GitLab CI and Bitbucket Pipelines schedules,
+    // neither of which leaves a .github/workflows file. OpenWiki cannot see
+    // those, so it must not assert that such a repo is refreshed on demand.
+    await writeFile(
+      path.join(repo, ".gitlab-ci.yml"),
+      "openwiki-update:\n  script: openwiki code --update\n",
+      "utf8",
+    );
+
+    await ensureCodeModeRepoSetup(repo);
+
+    const content = await readAgents(repo);
+    expect(content).not.toContain(SCHEDULED_CLAIM);
+    expect(content).not.toMatch(/refreshed when OpenWiki is run/u);
+    expect(content).not.toMatch(/on[- ]demand/iu);
+    expect(content).toContain(HAND_EDIT_GUIDANCE);
+  });
+
+  test("makes no recurrence claim when the workflow path cannot be read", async () => {
+    const repo = await createTempRepo();
+    // A directory where the workflow file belongs is not a workflow. Setup must
+    // still write the agent files -- the update path never read this path
+    // before, so an odd .github must not turn a docs refresh into a failed run.
+    await mkdir(workflowPath(repo), { recursive: true });
+
+    await ensureCodeModeRepoSetup(repo);
+
+    const content = await readAgents(repo);
+    expect(content).not.toContain(SCHEDULED_CLAIM);
+    expect(content).toContain(HAND_EDIT_GUIDANCE);
+  });
+
+  test("makes no recurrence claim when the workflow is manual-only", async () => {
+    const repo = await createTempRepo();
+    // OpenWiki stopped overwriting this file so operators can customize it. One
+    // whose `schedule` trigger was removed runs only when someone asks, so the
+    // file existing is not proof of a schedule.
+    await writeWorkflow(repo, MANUAL_ONLY_WORKFLOW);
+
+    await ensureCodeModeRepoSetup(repo);
+
+    const content = await readAgents(repo);
+    expect(content).not.toContain(SCHEDULED_CLAIM);
+    expect(content).toContain(HAND_EDIT_GUIDANCE);
+  });
+
+  test("makes no recurrence claim when the workflow declares no triggers", async () => {
+    const repo = await createTempRepo();
+    // A comments-only workflow parses to null rather than a mapping, so there
+    // is no `on` block to read a schedule out of.
+    await writeWorkflow(repo, "# no triggers here\n");
+
+    await ensureCodeModeRepoSetup(repo);
+
+    const content = await readAgents(repo);
+    expect(content).not.toContain(SCHEDULED_CLAIM);
+    expect(content).toContain(HAND_EDIT_GUIDANCE);
+  });
+
+  test("makes no recurrence claim when the workflow cannot be parsed", async () => {
+    const repo = await createTempRepo();
+    await writeWorkflow(repo, "name: [unterminated\n  on: {{{\n");
+
+    await ensureCodeModeRepoSetup(repo);
+
+    const content = await readAgents(repo);
+    expect(content).not.toContain(SCHEDULED_CLAIM);
+    expect(content).toContain(HAND_EDIT_GUIDANCE);
+  });
+
+  test("claims the scheduled workflow that init just created", async () => {
+    const repo = await createTempRepo();
+
+    await ensureCodeModeRepoSetup(repo, { createWorkflow: true });
+
+    const content = await readAgents(repo);
+    expect(content).toContain(SCHEDULED_CLAIM);
+  });
+
+  test("claims a pre-existing scheduled workflow on an update run", async () => {
+    const repo = await createTempRepo();
+    await writeWorkflow(repo, SCHEDULED_WORKFLOW);
+
+    // `--update` leaves the operator's workflow alone, but the snippet must
+    // still reflect that the repo has one.
+    await ensureCodeModeRepoSetup(repo);
+
+    const content = await readAgents(repo);
+    expect(content).toContain(SCHEDULED_CLAIM);
+  });
+});
+
 describe("ensureCodeModeRepoSetup workflow", () => {
   test("generated PR includes agent files and the workflow in add-paths", async () => {
     const repo = await createTempRepo();


### PR DESCRIPTION
## What and why

`ensureCodeModeRepoSetup` refreshes the managed `<!-- OPENWIKI:START -->` block in
`AGENTS.md` on every code-mode run, and that block always ended with:

> The scheduled OpenWiki GitHub Actions workflow refreshes the repository wiki.

Only `code --init` creates `.github/workflows/openwiki-update.yml`. Every other path —
`code --update`, MCP host runs (`openwiki_begin` / `openwiki_finish`), and any repo whose
operator removed or de-scheduled the workflow — kept that sentence while nothing backed it.
The next agent reads the managed block as fact and concludes the wiki is already kept
current, so nothing refreshes it. Correcting the sentence by hand does not stick, because
finalization rewrites the managed block on the next run.

The sentence is now stated only when OpenWiki can confirm a schedule: the managed workflow
exists **and** still declares an `on.schedule` trigger. The file alone is not enough —
OpenWiki deliberately stopped overwriting it so operators can customize it, and one reduced
to `workflow_dispatch:` runs only when someone asks.

When a schedule cannot be confirmed the sentence is **left out**, not replaced with a
different recurrence claim. OpenWiki cannot see how such a repo is actually maintained: the
README documents GitLab CI and Bitbucket Pipelines schedules too, and neither leaves a
`.github/workflows` file, so asserting "refreshed on demand" would trade one wrong statement
for another.

Everything else in the managed block, including the "Do not hand-edit generated OpenWiki
pages" guidance, is unchanged. This repository's own workflow declares a cron, so its
`AGENTS.md` is byte-identical after the change.

Two deliberate non-goals, so the diff stays one change:

- The probe is not fatal. `ensureCodeModeWorkflow`'s create-if-missing path keeps its exact
  behaviour from `main` (strict `ENOENT`-only rethrow). The new read is separate and answers
  "false" for a missing file, a directory in its place, a permission error, or unparseable
  YAML — an odd `.github` must not turn a docs refresh into a failed run.
- The persistent `codeMode.workflow.policy` config that #742 also proposes is **not**
  implemented. This is the issue's own "simpler compatible first step", so #742 should stay
  open for the policy half.

Partially addresses #742.

Existing users with no scheduled workflow whose `AGENTS.md` already carries the sentence will
see a one-time managed-block diff on their next run. That is the fix landing.

## Test verification (RED → GREEN)

RED — the nine new tests applied to unmodified `main` (`b5d2407`) in a detached worktree,
with **no** production change present:

```
 ❯ test/ingestion/code-mode.test.ts (34 tests | 7 failed | 25 skipped)
     × does not claim a scheduled workflow when the repo has none
     × stops claiming a scheduled workflow once the workflow is deleted
     × makes no recurrence claim for a repo scheduled outside GitHub Actions
     × makes no recurrence claim when the workflow path cannot be read
     × makes no recurrence claim when the workflow is manual-only
     × makes no recurrence claim when the workflow declares no triggers
     × makes no recurrence claim when the workflow cannot be parsed

 FAIL  ensureCodeModeRepoSetup scheduled-workflow claim > does not claim a scheduled workflow when the repo has none
AssertionError: expected '<!-- OPENWIKI:START -->\n\n## OpenWik…' not to contain 'The scheduled OpenWiki GitHub Actions…'

      Tests  7 failed | 2 passed | 25 skipped (34)
```

The two that pass on `main` are deliberate guards for the has-schedule branch, which must
keep emitting the original sentence.

GREEN — the same tests on this branch:

```
$ pnpm exec vitest run test/ingestion/code-mode.test.ts -t "ensureCodeModeRepoSetup scheduled-workflow claim"
 Test Files  1 passed (1)
      Tests  9 passed | 25 skipped (34)
```

## Full local suite

Every job class in `.github/workflows/checks.yml`, replayed on `main` first and then on this
branch.

| Stage | main (`b5d2407`) | this branch |
| --- | --- | --- |
| `pnpm run format:check` | PASS | PASS |
| `pnpm run lint:check` | PASS | PASS |
| `pnpm run typecheck` (Node 22 / 24) | PASS | PASS |
| `pnpm run build` (Node 22 / 24) | PASS | PASS |
| CLI smoke `code --dry-run --init` (Node 22 / 24) | PASS | PASS |
| `pnpm test` (Node 22) | 3038 passed, 0 failed, 3 skipped | 3047 passed, 0 failed, 3 skipped |
| `pnpm test` (Node 24) | 3038 passed, 0 failed, 3 skipped | 3047 passed, 0 failed, 3 skipped |
| Windows portability test files (run on Linux) | PASS | PASS |
| Trivy lockfile scan, `HIGH,CRITICAL`, exit-code 1 | PASS | PASS |

No new failures and no changed failure signatures; the nine added tests are green. Coverage
of the changed executable lines under the `src/**` set `vitest.config.ts` declares coverable
is 100% (20/20).

Not reproducible locally: the `windows-latest` runner OS, so those test files were exercised
on Linux only and that job is confirmed by CI rather than by this replay.

One caveat worth stating rather than hiding: `test/cli/components/run-view.test.tsx` and
`chat.test.tsx` are intermittently flaky under full-suite load. `run-view` failed on 1 of 8
full runs of unmodified `main` as well as on this branch, and `test/cli/components/` in
isolation was 6/6 green. Neither test executes the changed code path, and both refs reach
fully green runs, so this is pre-existing flakiness rather than a regression from this PR.

## Changeset

`patch` — the managed block OpenWiki writes into user repositories changes for repos it
cannot confirm are on a schedule.
