### PR TITLE
fix: accept empty-string env vars in MCP connector env resolution

### DIFF
--- a/.changeset/mcp-empty-env-var.md
+++ b/.changeset/mcp-empty-env-var.md
@@ -1,0 +1,5 @@
+---
+"openwiki": patch
+---
+
+Accept MCP connector env vars that are explicitly set to an empty string. Previously a variable set to `""` was treated as missing and aborted ingestion with "<VAR> is required for MCP connector ingestion.".

--- a/.changeset/mcp-empty-env-var.md
+++ b/.changeset/mcp-empty-env-var.md
@@ -2,4 +2,4 @@
 "openwiki": patch
 ---
 
-Accept MCP connector env vars that are explicitly set to an empty string. Previously a variable set to `""` was treated as missing and aborted ingestion with "<VAR> is required for MCP connector ingestion.".
+fix: accept empty-string env vars in MCP connector env resolution

--- a/src/connectors/mcp-client.ts
+++ b/src/connectors/mcp-client.ts
@@ -900,7 +900,10 @@ function resolveEnvReference(value: string): string {
   validateEnvKey(envKey);
   const envValue = process.env[envKey];
 
-  if (!envValue) {
+  // An env var explicitly set to "" is present, not missing. Only a truly
+  // unset variable (undefined) is a missing required credential; mirror the
+  // `typeof value === "string"` check buildChildEnv uses for base vars.
+  if (envValue === undefined) {
     throw new Error(`${envKey} is required for MCP connector ingestion.`);
   }
 

--- a/test/connectors/mcp-client.test.ts
+++ b/test/connectors/mcp-client.test.ts
@@ -32,6 +32,7 @@ describe("buildChildEnv", () => {
       "APPDATA",
       "LOCALAPPDATA",
       "MCP_SERVER_TOKEN",
+      "MCP_EMPTY",
     ]) {
       saved[key] = process.env[key];
     }
@@ -60,9 +61,9 @@ describe("buildChildEnv", () => {
       expect(childEnv).not.toHaveProperty(key);
     }
     // A random full-process.env secret must never leak by value either.
-    expect(Object.values(childEnv)).not.toContain(
-      "secret-value-for-ANTHROPIC_API_KEY",
-    );
+    for (const key of SECRET_KEYS) {
+      expect(Object.values(childEnv)).not.toContain(`secret-value-for-${key}`);
+    }
   });
 
   test("passes through allow-listed base variables like PATH", () => {
@@ -87,6 +88,12 @@ describe("buildChildEnv", () => {
     expect(() => buildChildEnv({ MCP_TOKEN: "${DOES_NOT_EXIST}" })).toThrow(
       /DOES_NOT_EXIST is required/u,
     );
+  });
+
+  test("accepts a declared env var set to an empty string", () => {
+    process.env.MCP_EMPTY = "";
+    const childEnv = buildChildEnv({ MCP_TOKEN: "${MCP_EMPTY}" });
+    expect(childEnv.MCP_TOKEN).toBe("");
   });
 
   test("rejects invalid child env key names", () => {


### PR DESCRIPTION
## What and why

`resolveEnvReference` in the MCP connector guarded its "missing required
credential" error with a falsy check:

```ts
const envValue = process.env[envKey];
if (!envValue) {
  throw new Error(`${envKey} is required for MCP connector ingestion.`);
}
```

`!envValue` treats an env var explicitly set to an empty string (`""`) the same
as an unset one, so an MCP connector declaring `env: { MY_KEY: "${MCP_EMPTY}" }`
with `MCP_EMPTY=""` aborts ingestion even though the variable **is** present.
This is inconsistent with `buildChildEnv`'s own base-var handling a few lines up,
which already accepts empty strings via `typeof value === "string"`.

The fix switches to a strict `envValue === undefined` check so only a truly unset
variable counts as missing. An empty string is a present value and passes through.

This PR also closes a test gap in the same suite: the child-env value-leak
assertion only checked one of the six seeded `SECRET_KEYS`, so a regression
leaking any of the other five by value would have gone undetected. It now loops
over every secret key.

Fixes #800

## How it was tested

New test `accepts a declared env var set to an empty string` in
`test/connectors/mcp-client.test.ts`, plus the widened value-leak loop.

### Test verification (RED → GREEN)

RED — new test on the unmodified source (before the `=== undefined` fix):

```
 ❯ test/connectors/mcp-client.test.ts (53 tests | 1 failed)
     × accepts a declared env var set to an empty string
 Tests  1 failed | 52 passed (53)
```

GREEN — with the fix applied:

```
 Test Files  1 passed (1)
      Tests  53 passed (53)
```

Full suite (`pnpm run format:check`, `lint:check`, `typecheck`, `build`, smoke,
`pnpm test` with coverage):

```
 Test Files  225 passed | 2 skipped (227)
      Tests  3039 passed | 3 skipped (3042)
```

The one changed production line (`src/connectors/mcp-client.ts` guard) is covered
by the suite. A changeset (`patch`) is included.
