### PR TITLE
fix: write .last-update.json atomically

### DIFF
--- a/.changeset/fix-last-update-atomic-write.md
+++ b/.changeset/fix-last-update-atomic-write.md
@@ -1,0 +1,5 @@
+---
+"openwiki": patch
+---
+
+Fix `.last-update.json` being written non-atomically, which could leave it truncated/corrupted under a failed or concurrent write and silently discard the crash guard's interrupted-status signal.

--- a/src/agent/utils.ts
+++ b/src/agent/utils.ts
@@ -5,15 +5,7 @@ import {
   type BigIntStats,
   type Dirent,
 } from "node:fs";
-import {
-  lstat,
-  mkdir,
-  open,
-  readdir,
-  readFile,
-  readlink,
-  writeFile,
-} from "node:fs/promises";
+import { lstat, open, readdir, readFile, readlink } from "node:fs/promises";
 import path from "node:path";
 import { promisify } from "node:util";
 import {
@@ -21,6 +13,7 @@ import {
   PAGE_MANIFEST_PATH,
   UPDATE_METADATA_PATH,
 } from "../config/constants.js";
+import { writeTextAtomic } from "../integrations/install/atomic-file.js";
 import {
   isExpectedSnapshotRaceError,
   isFileNotFoundError,
@@ -230,12 +223,7 @@ export async function writeLastUpdateMetadata(
     ...(language ? { language } : {}),
   };
 
-  await mkdir(path.dirname(metadataFile), { recursive: true });
-  await writeFile(
-    metadataFile,
-    `${JSON.stringify(metadata, null, 2)}\n`,
-    "utf8",
-  );
+  await writeTextAtomic(metadataFile, `${JSON.stringify(metadata, null, 2)}\n`);
 }
 
 /**

--- a/test/agent/update-noop.test.ts
+++ b/test/agent/update-noop.test.ts
@@ -3,7 +3,7 @@ import { tmpdir } from "node:os";
 import path from "node:path";
 import { execFile } from "node:child_process";
 import { promisify } from "node:util";
-import { describe, expect, test } from "vitest";
+import { describe, expect, test, vi } from "vitest";
 import { OpenWikiIgnore } from "../../src/agent/openwiki-ignore.ts";
 import {
   getUpdateNoopStatus,
@@ -283,6 +283,77 @@ describe("no-op metadata refresh", () => {
 
     const metadata = await readPersistedMetadata(repo);
     expect(metadata).not.toHaveProperty("language");
+  });
+});
+
+describe("writeLastUpdateMetadata atomicity", () => {
+  // Mirrors the analogous ~/.openwiki/.env fix (#407): a failed write must
+  // not leave .last-update.json truncated. A torn/empty file here reads back
+  // as "no prior metadata" via readLastUpdate's SyntaxError guard, silently
+  // discarding the crash guard's interrupted-status signal and defeating the
+  // update no-op check.
+  test("a failed write leaves the existing .last-update.json intact", async () => {
+    const repo = await createRepoWithOpenWiki();
+    const original = `${JSON.stringify({
+      updatedAt: new Date().toISOString(),
+      command: "update",
+      gitHead: "0000000000000000000000000000000000000000",
+      model: "test-model",
+      status: "complete",
+    })}\n`;
+    await writeFile(
+      path.join(repo, "openwiki", ".last-update.json"),
+      original,
+      "utf8",
+    );
+
+    // Re-import against a writeFile that emulates O_TRUNC-then-ENOSPC: it
+    // truncates whatever path it is handed, then throws. mkdir/readFile/
+    // rename stay real.
+    vi.resetModules();
+    vi.doMock("node:fs/promises", async () => {
+      const actual =
+        await vi.importActual<typeof import("node:fs/promises")>(
+          "node:fs/promises",
+        );
+      return {
+        ...actual,
+        default: actual,
+        writeFile: vi.fn(
+          async (file: Parameters<typeof actual.writeFile>[0]) => {
+            await actual.writeFile(file, "");
+            const error: NodeJS.ErrnoException = new Error(
+              "ENOSPC: no space left on device",
+            );
+            error.code = "ENOSPC";
+            throw error;
+          },
+        ),
+      };
+    });
+
+    try {
+      const failingUtils = await import("../../src/agent/utils.ts");
+      await expect(
+        failingUtils.writeLastUpdateMetadata(
+          "update",
+          repo,
+          "test-model",
+          "repository",
+          "complete",
+          undefined,
+          null,
+        ),
+      ).rejects.toThrow(/ENOSPC/);
+    } finally {
+      vi.doUnmock("node:fs/promises");
+    }
+
+    // The original file survives: the failed write hit only the temp file
+    // and the rename that would have replaced it never ran.
+    await expect(
+      readFile(path.join(repo, "openwiki", ".last-update.json"), "utf8"),
+    ).resolves.toBe(original);
   });
 });
 


### PR DESCRIPTION
### Description

`writeLastUpdateMetadata` wrote `.last-update.json` with a plain `mkdir` + `writeFile`, no temp-file-and-rename. `writeFile` opens the destination with `O_TRUNC`, truncating it before writing, so a failed write (disk full, crash) or a torn concurrent read leaves the file empty or corrupted. `readLastUpdate`'s `catch (SyntaxError) → return null` then silently treats that as "no prior metadata."

This is the same failure mode already fixed for `~/.openwiki/.env` in #407 — `.last-update.json` was missed. It's a realistic scenario here: this file is what `crash-guard.ts` writes on a fatal signal and what `getUpdateNoopStatus` reads for the no-op check, and OpenWiki's own CI-scheduling feature can put two writers against it at once.

Fixes #839

### Changes Made

- `src/agent/utils.ts`: `writeLastUpdateMetadata` now writes through the existing `writeTextAtomic` helper (`src/integrations/install/atomic-file.ts`) instead of a direct `mkdir` + `writeFile`. Same atomic temp-file-and-rename pattern already used for `page-manifest.ts`, `run-state.ts`, and (since #407) `~/.openwiki/.env`. Removed the now-unused `mkdir`/`writeFile` imports.
- `test/agent/update-noop.test.ts`: added a regression test mirroring the existing `.env` atomicity test's pattern (mocking `node:fs/promises` to simulate an ENOSPC failure mid-write) — asserts the original `.last-update.json` content survives a failed write untouched.

### Testing

- `pnpm run format:check`
- `pnpm run lint:check`
- `pnpm test` (typecheck, build, full Vitest suite with coverage) — all green
- Verified the actual bug with real execution before writing the fix: ran the real exported `writeLastUpdateMetadata` from two concurrent writers plus a reader against a real file — 57% of reads got invalid/empty JSON.
- Regression test verified against the actual bug: reverted only the `src/agent/utils.ts` fix (kept the new test), confirmed the new test fails (`.last-update.json` reads back empty), then restored the fix and confirmed it passes; the other 16 existing tests in the file were unaffected throughout.
