### PR TITLE
fix: render model request output

### DIFF
--- a/.changeset/render-primary-model-stream.md
+++ b/.changeset/render-primary-model-stream.md
@@ -1,0 +1,5 @@
+---
+"openwiki": patch
+---
+
+fix: render assistant text emitted from top-level model request streams

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -1838,12 +1838,23 @@ function parseToolStreamEvent(payload: unknown): OpenWikiRunEvent | null {
   return null;
 }
 
+const MODEL_REQUEST_NAMESPACE_PREFIX = "model_request:";
+
 /**
- * Classifies a stream namespace. LangGraph reserves the empty namespace for
- * the root graph; even a single namespace segment therefore belongs to a
- * subgraph.
+ * Classifies a stream namespace. DeepAgents wraps the primary model call in a
+ * single model_request namespace, while deeper namespaces still represent
+ * subgraphs whose prose should stay hidden from the main transcript.
  */
 function getStreamSource(namespace: unknown): "main" | "subgraph" {
+  if (
+    Array.isArray(namespace) &&
+    namespace.length === 1 &&
+    typeof namespace[0] === "string" &&
+    namespace[0].startsWith(MODEL_REQUEST_NAMESPACE_PREFIX)
+  ) {
+    return "main";
+  }
+
   return Array.isArray(namespace) && namespace.length > 0 ? "subgraph" : "main";
 }
 

--- a/test/agent/stream-redaction.test.ts
+++ b/test/agent/stream-redaction.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, test } from "vitest";
 import { parseAgentStreamChunk } from "../../src/agent/index.ts";
+import { appendRunLogEvent } from "../../src/cli/run-log/reducer.ts";
+
+const MODEL_REQUEST_NAMESPACE = "model_request:fake-request-id";
+const MODEL_RESPONSE_TEXT = "Hello from the primary model.";
 
 function makeChunk(
   contentBlocks: unknown[],
@@ -79,6 +83,35 @@ describe("parseAgentStreamChunk", () => {
       text: "Task output",
       type: "text",
     });
+  });
+
+  test("renders top-level model request text as main assistant output", () => {
+    const event = parseAgentStreamChunk(
+      makeChunk(
+        [{ type: "text", text: MODEL_RESPONSE_TEXT }],
+        [MODEL_REQUEST_NAMESPACE],
+      ),
+    );
+
+    expect(event).toMatchObject({
+      source: "main",
+      text: MODEL_RESPONSE_TEXT,
+      type: "text",
+    });
+    expect(
+      event === null ? [] : appendRunLogEvent([], event, { current: 0 }),
+    ).toEqual([{ content: MODEL_RESPONSE_TEXT, id: 0, type: "text" }]);
+  });
+
+  test("keeps nested model request text classified as subgraph output", () => {
+    const event = parseAgentStreamChunk(
+      makeChunk(
+        [{ type: "text", text: MODEL_RESPONSE_TEXT }],
+        ["task", MODEL_REQUEST_NAMESPACE],
+      ),
+    );
+
+    expect(event).toMatchObject({ source: "subgraph", type: "text" });
   });
 
   test("normalizes tool lifecycle events", () => {


### PR DESCRIPTION
## Motivation

DeepAgents wraps primary model output in a single `model_request:<id>` namespace. OpenWiki treated every non-empty namespace as subgraph output, so interactive chat discarded the assistant response and displayed "No assistant output captured."

Closes #844.

## Changes

- Classify a single top-level `model_request:<id>` namespace as main-agent output.
- Keep deeper model-request namespaces and other non-empty namespaces classified as subgraph output.
- Cover the parser-to-run-log path and the nested-subgraph guard.
- Add a patch changeset for the user-visible fix.

## Validation

- RED on untouched `origin/main`: the focused regression received `source: "subgraph"` instead of `source: "main"`.
- GREEN with the patch: `test/agent/stream-redaction.test.ts` passes 15/15.
- Production-fix revert proof: the same focused regression returns to RED.
- Full local suite: formatting, lint, typecheck, build, CLI dry-run, coverage suite, and Windows-selected tests completed successfully.
- Baseline: 3,046 passed, 2 unrelated timeout failures, 3 skipped. Patched: 3,050 passed, 0 failed, 3 skipped.
- Changed production-line coverage: 100% (3/3 executable lines).
