### PR TITLE
fix: route vertex grok ids to the openai-compatible surface

### DIFF
--- a/.changeset/route-vertex-grok-to-maas.md
+++ b/.changeset/route-vertex-grok-to-maas.md
@@ -1,0 +1,5 @@
+---
+"openwiki": patch
+---
+
+fix: route Vertex AI xAI Grok model IDs to the OpenAI-compatible surface

--- a/src/agent/vertex-surface.ts
+++ b/src/agent/vertex-surface.ts
@@ -12,18 +12,20 @@ import { ANTHROPIC_API_KEY_ENV_KEY } from "../config/constants.js";
  * - `anthropic`: Claude over `rawPredict`/`streamRawPredict`, Anthropic's own
  *   wire protocol, reached via the Anthropic Vertex SDK.
  * - `openai-maas`: partner/open-weight models (Llama, Mistral, DeepSeek, Qwen,
- *   …) over the OpenAI-compatible `/endpoints/openapi/chat/completions` surface.
+ *   Grok, …) over the OpenAI-compatible `/endpoints/openapi/chat/completions`
+ *   surface.
  */
 export type VertexSurface = "anthropic" | "gemini" | "openai-maas";
 
 // These two patterns are the maintenance point when Vertex adds publishers:
-// extend the relevant alternation. `meta`/`llama` are both listed intentionally
-// so IDs are tolerated whether given as the publisher (`meta/…`) or the model
-// family (`llama-…`). `codellama` is listed separately because the `(^|\/)`
-// boundary means the `llama` token would not match the bare `codellama-…` form.
+// extend the relevant alternation. `meta`/`llama` and `xai`/`grok` are both
+// listed intentionally so IDs are tolerated whether given as the publisher
+// (`meta/…`, `xai/…`) or the model family (`llama-…`, `grok-…`). `codellama` is
+// listed separately because the `(^|\/)` boundary means the `llama` token would
+// not match the bare `codellama-…` form.
 const ANTHROPIC_MODEL_PATTERN = /(^|\/)(anthropic|claude)/u;
 const OPENAI_MAAS_MODEL_PATTERN =
-  /(^|\/)(ai21|codellama|codestral|deepseek|jamba|llama|meta|mistral|qwen)/u;
+  /(^|\/)(ai21|codellama|codestral|deepseek|grok|jamba|llama|meta|mistral|qwen|xai)/u;
 
 /**
  * Classifies a Vertex model ID into the API surface used to serve it. Tolerant

--- a/test/agent/vertex-surface.test.ts
+++ b/test/agent/vertex-surface.test.ts
@@ -38,6 +38,17 @@ describe("resolveVertexSurface", () => {
     expect(resolveVertexSurface("qwen/qwen3-235b")).toBe("openai-maas");
   });
 
+  test("routes xAI Grok ids to the openai-maas surface", () => {
+    // Grok is served over the OpenAI-compatible endpoint like every other
+    // partner model. Falling through to gemini would address it as
+    // `publishers/google/models/grok-…:generateContent`, which does not exist.
+    expect(resolveVertexSurface("xai/grok-4.6")).toBe("openai-maas");
+    expect(resolveVertexSurface("grok-4.1-fast-reasoning")).toBe("openai-maas");
+    expect(resolveVertexSurface("publishers/xai/models/grok-4.6")).toBe(
+      "openai-maas",
+    );
+  });
+
   test("defaults Gemini and Gemma ids to the gemini surface", () => {
     expect(resolveVertexSurface("gemini-3.1-pro")).toBe("gemini");
     expect(resolveVertexSurface("gemma-3-27b-it")).toBe("gemini");


### PR DESCRIPTION
Fixes #855.

`resolveVertexSurface()` had no `xai`/`grok` token, so Grok model IDs fell through to the `gemini` default and got sent to `publishers/google/models/grok-…:generateContent`, which doesn't exist. Grok is a Model Garden partner model and is only served over the OpenAI-compatible endpoint, so `gemini-enterprise` with `xai/grok-4.6` failed on the first model call every time.

Adds both tokens to `OPENAI_MAAS_MODEL_PATTERN`, the same way `meta`/`llama` are both listed, so the ID works whether you pass the publisher or the model family. Nothing else needed changing — `toVertexPublisherModel()` already passes `xai/grok-4.6` through unchanged, which is exactly what the endpoint wants.

Tested with three new cases in `test/agent/vertex-surface.test.ts` covering `xai/grok-4.6`, the bare `grok-4.1-fast-reasoning`, and the full `publishers/xai/models/grok-4.6` path. They fail on main and pass with the change. `pnpm run typecheck`, `pnpm run build`, `pnpm run lint:check` and `pnpm run format:check` are all clean.