### PR TITLE
fix: skip README aliases during index sync

### DIFF
--- a/.changeset/quiet-readmes-smile.md
+++ b/.changeset/quiet-readmes-smile.md
@@ -1,0 +1,5 @@
+---
+"openwiki": patch
+---
+
+Skip README.md aliases when synchronizing wiki indexes so GitHub README links to index.md do not break finalization.

--- a/src/okf/index-sync.ts
+++ b/src/okf/index-sync.ts
@@ -14,6 +14,7 @@ import {
 const INDEX_FILE = "index.md";
 const LOG_FILE = "log.md";
 const EXCLUDED_FILES = new Set([INDEX_FILE, LOG_FILE, "INSTRUCTIONS.md"]);
+const README_ALIAS_FILE = "readme.md";
 
 /**
  * A wiki directory paired with the entries it directly contains.
@@ -105,7 +106,7 @@ export async function listWikiConceptPaths(
           name &&
           !name.startsWith(".") &&
           path.posix.extname(name).toLowerCase() === ".md" &&
-          !EXCLUDED_FILES.has(name)
+          !isStructuralMarkdownFile(name)
           ? [path.posix.join(directory.path, name)]
           : [];
       }),
@@ -188,7 +189,7 @@ async function synchronizeDirectory(
     }
     if (
       path.posix.extname(name).toLowerCase() !== ".md" ||
-      EXCLUDED_FILES.has(name)
+      isStructuralMarkdownFile(name)
     ) {
       continue;
     }
@@ -223,6 +224,13 @@ async function synchronizeDirectory(
   if (result.error) {
     throw new Error(`Unable to write ${indexPath}: ${result.error}`);
   }
+}
+
+/**
+ * Identifies Markdown documents owned by wiki structure rather than concepts.
+ */
+function isStructuralMarkdownFile(name: string): boolean {
+  return EXCLUDED_FILES.has(name) || name.toLowerCase() === README_ALIAS_FILE;
 }
 
 /**

--- a/test/agent/index-middleware.test.ts
+++ b/test/agent/index-middleware.test.ts
@@ -244,6 +244,32 @@ describe("synchronizeWikiIndexes", () => {
     expect(repaired).not.toContain("INSTRUCTIONS.md");
   });
 
+  test("ignores README aliases when building indexes", async () => {
+    const { backend, rootDir } = await setup();
+    await backend.write(
+      "/openwiki/specifications/page.md",
+      document("Spec", "Specification page."),
+    );
+    await backend.write(
+      "/openwiki/specifications/README.md",
+      "# Specifications\n\nGitHub displays this alias.\n",
+    );
+
+    await synchronizeWikiIndexes(backend, "repository");
+
+    const index = await readFile(
+      path.join(rootDir, "openwiki/specifications/index.md"),
+      "utf8",
+    );
+    const readme = await readFile(
+      path.join(rootDir, "openwiki/specifications/README.md"),
+      "utf8",
+    );
+    expect(index).toContain("- [Spec](page.md) - Specification page.");
+    expect(index).not.toContain("README.md");
+    expect(readme).toBe("# Specifications\n\nGitHub displays this alias.\n");
+  });
+
   test("does not index the reserved OKF log document", async () => {
     const { backend, rootDir } = await setup();
     await backend.write(
@@ -427,6 +453,8 @@ describe("migrateWikiToOkf", () => {
       "index.md",
       "log.md",
       "INSTRUCTIONS.md",
+      "README.md",
+      "readme.md",
       ".secret.md",
     ]) {
       await writeFile(path.join(dir, name), "# No front matter\n\nBody.\n");
@@ -440,9 +468,11 @@ describe("migrateWikiToOkf", () => {
     await migrateWikiToOkf(backend, "repository");
 
     expect(edit).not.toHaveBeenCalled();
-    await expect(
-      readFile(path.join(dir, "INSTRUCTIONS.md"), "utf8"),
-    ).resolves.not.toContain("openwiki_generated");
+    for (const name of ["INSTRUCTIONS.md", "README.md", "readme.md"]) {
+      await expect(
+        readFile(path.join(dir, name), "utf8"),
+      ).resolves.not.toContain("openwiki_generated");
+    }
   });
 
   test("migrates from the local-wiki root", async () => {

--- a/test/okf/index-sync-errors.test.ts
+++ b/test/okf/index-sync-errors.test.ts
@@ -84,6 +84,29 @@ describe("readText error handling", () => {
       /is not a text file/u,
     );
   });
+
+  test("does not read README aliases during index synchronization", async () => {
+    const readRaw = vi.fn((filePath: string) =>
+      filePath === "/openwiki/page.md"
+        ? textData("---\ntype: Reference\ntitle: Page\n---\n")
+        : { error: "too many symbolic links" },
+    );
+    const backend = stubBackend({
+      ls: () => ({
+        files: [
+          { path: "/openwiki/page.md", is_dir: false },
+          { path: "/openwiki/README.md", is_dir: false },
+        ],
+      }),
+      readRaw,
+    });
+
+    await expect(
+      synchronizeWikiIndexes(backend, "repository"),
+    ).resolves.toBeUndefined();
+    expect(readRaw).toHaveBeenCalledWith("/openwiki/page.md");
+    expect(readRaw).not.toHaveBeenCalledWith("/openwiki/README.md");
+  });
 });
 
 describe("write error handling", () => {


### PR DESCRIPTION
﻿## Summary

- Treat generated-wiki `README.md` / `readme.md` files as structural Markdown, alongside `index.md`, `log.md`, and `INSTRUCTIONS.md`.
- Skip README aliases during OKF migration and deterministic index synchronization so a GitHub-rendered `README.md -> index.md` alias is preserved instead of read, normalized, or indexed as a concept page.
- Add regression coverage for disk-backed README aliases and for the backend-read path that would surface an ELOOP if README were touched.

Fixes #700.

## Testing

- Windows: `pnpm exec vitest run test/agent/index-middleware.test.ts test/okf/index-sync-errors.test.ts --reporter=dot --testNamePattern="README aliases|reserved files"`
- Windows: `pnpm exec vitest run test/agent/index-middleware.test.ts test/okf/index-sync-errors.test.ts --reporter=dot --testTimeout=30000`
- Windows: `pnpm run format:check`
- Windows: `pnpm run lint:check`
- Windows: `pnpm run typecheck`
- DGX Spark Linux: `pnpm run format:check`
- DGX Spark Linux: `pnpm run lint:check`
- DGX Spark Linux: `pnpm run typecheck`
- DGX Spark Linux: `pnpm exec vitest run test/agent/index-middleware.test.ts test/okf/index-sync-errors.test.ts --reporter=dot --testTimeout=30000`
- DGX Spark Linux: real symlink smoke for `README.md -> index.md` and a cyclic `README.md` symlink
- DGX Spark Linux: `pnpm test`
