### PR TITLE
fix: normalize openai-compatible text content wrappers

### DIFF
--- a/.changeset/openai-compatible-vllm-content.md
+++ b/.changeset/openai-compatible-vllm-content.md
@@ -1,0 +1,5 @@
+---
+"openwiki": patch
+---
+
+Normalize redundant nested text content arrays for OpenAI-compatible Chat Completions requests so strict vLLM servers accept replayed tool output.

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -1241,14 +1241,21 @@ export function createModel(
   }
 
   const baseURL = resolveProviderBaseUrl(provider);
+  const configuration =
+    provider === "openai-compatible" && !chatOpenAiUsesResponsesApi
+      ? {
+          ...(baseURL ? { baseURL } : {}),
+          fetch: createOpenAiCompatibleFetch(),
+        }
+      : baseURL
+        ? {
+            baseURL,
+          }
+        : undefined;
 
   return new ChatOpenAI({
     apiKey: getProviderApiKey(provider),
-    configuration: baseURL
-      ? {
-          baseURL,
-        }
-      : undefined,
+    configuration,
     model: modelId,
     useResponsesApi: chatOpenAiUsesResponsesApi,
     ...maxTokensOptions,
@@ -1261,6 +1268,114 @@ export function createModel(
     ...(providerUsesStreaming(provider) ? { streaming: true } : {}),
     ...retryOptions,
   });
+}
+
+function createOpenAiCompatibleFetch(): typeof fetch {
+  return (input, init) =>
+    globalThis.fetch(
+      input,
+      normalizeOpenAiCompatibleChatCompletionsInit(input, init) ?? init,
+    );
+}
+
+function normalizeOpenAiCompatibleChatCompletionsInit(
+  input: Parameters<typeof fetch>[0],
+  init: Parameters<typeof fetch>[1],
+): Parameters<typeof fetch>[1] | null {
+  if (!isOpenAiCompatibleChatCompletionsRequest(input, init)) {
+    return null;
+  }
+
+  const body = typeof init?.body === "string" ? init.body : null;
+  const parsedBody = parseJsonRecord(body);
+  const normalizedBody =
+    parsedBody === null
+      ? null
+      : normalizeOpenAiCompatibleChatCompletionsBody(parsedBody);
+
+  return normalizedBody === null
+    ? null
+    : {
+        ...init,
+        body: JSON.stringify(normalizedBody),
+      };
+}
+
+function isOpenAiCompatibleChatCompletionsRequest(
+  input: Parameters<typeof fetch>[0],
+  init: Parameters<typeof fetch>[1],
+): boolean {
+  const method = init?.method;
+
+  if (method !== undefined && method.toUpperCase() !== "POST") {
+    return false;
+  }
+
+  const url = getFetchInputUrl(input);
+
+  if (url === null) {
+    return false;
+  }
+
+  try {
+    return new URL(url).pathname.endsWith("/chat/completions");
+  } catch {
+    return url.includes("/chat/completions");
+  }
+}
+
+function normalizeOpenAiCompatibleChatCompletionsBody(
+  body: Record<string, unknown>,
+): Record<string, unknown> | null {
+  const messages = body.messages;
+
+  if (!Array.isArray(messages)) {
+    return null;
+  }
+
+  let changed = false;
+  const normalizedMessages = (messages as unknown[]).map((message) => {
+    if (!isRecord(message)) {
+      return message;
+    }
+
+    const content = normalizeOpenAiCompatibleTextContent(message.content);
+
+    if (content === null) {
+      return message;
+    }
+
+    changed = true;
+    return { ...message, content };
+  });
+
+  return changed ? { ...body, messages: normalizedMessages } : null;
+}
+
+function normalizeOpenAiCompatibleTextContent(
+  content: unknown,
+): Record<string, unknown>[] | null {
+  if (!Array.isArray(content) || content.length !== 1) {
+    return null;
+  }
+
+  const [nestedContent] = content as unknown[];
+
+  if (!Array.isArray(nestedContent) || nestedContent.length === 0) {
+    return null;
+  }
+
+  return nestedContent.every(isOpenAiCompatibleTextContentBlock)
+    ? nestedContent
+    : null;
+}
+
+function isOpenAiCompatibleTextContentBlock(
+  block: unknown,
+): block is Record<string, unknown> {
+  return (
+    isRecord(block) && block.type === "text" && typeof block.text === "string"
+  );
 }
 
 const CHATGPT_LOGIN_INCOMPLETE_MESSAGE =

--- a/test/agent/create-model.test.ts
+++ b/test/agent/create-model.test.ts
@@ -17,6 +17,7 @@ const OPENAI_COMPATIBLE_REASONING_EFFORT_SUPPORTED_KEY =
   "OPENWIKI_OPENAI_COMPATIBLE_REASONING_EFFORT_SUPPORTED";
 const OPENAI_COMPATIBLE_USE_RESPONSES_API_KEY =
   "OPENWIKI_OPENAI_COMPATIBLE_USE_RESPONSES_API";
+const OPENAI_COMPATIBLE_STREAMING_KEY = "OPENWIKI_OPENAI_COMPATIBLE_STREAMING";
 const CHATGPT_TOKEN_KEYS = [
   "OPENAI_CHATGPT_ACCESS_TOKEN",
   "OPENAI_CHATGPT_REFRESH_TOKEN",
@@ -253,6 +254,189 @@ describe("createModel Anthropic output-token limit", () => {
 });
 
 describe("createModel OpenAI-compatible transport selection", () => {
+  test("normalizes redundant OpenAI-compatible content array wrappers before Chat Completions", async () => {
+    const savedApiKey = process.env.OPENAI_COMPATIBLE_API_KEY;
+    const savedBaseUrl = process.env.OPENAI_COMPATIBLE_BASE_URL;
+    const savedUseResponsesApi =
+      process.env[OPENAI_COMPATIBLE_USE_RESPONSES_API_KEY];
+    const savedStreaming = process.env[OPENAI_COMPATIBLE_STREAMING_KEY];
+    process.env.OPENAI_COMPATIBLE_API_KEY = "test-compatible-key";
+    process.env.OPENAI_COMPATIBLE_BASE_URL = "https://vllm.example/v1";
+    delete process.env[OPENAI_COMPATIBLE_USE_RESPONSES_API_KEY];
+    delete process.env[OPENAI_COMPATIBLE_STREAMING_KEY];
+    const fetchMock = vi.fn(() =>
+      Promise.resolve(
+        new Response(
+          JSON.stringify({
+            id: "chatcmpl-test",
+            object: "chat.completion",
+            created: 0,
+            model: "local-model",
+            choices: [
+              {
+                index: 0,
+                message: { role: "assistant", content: "ok" },
+                finish_reason: "stop",
+              },
+            ],
+          }),
+          { headers: { "content-type": "application/json" } },
+        ),
+      ),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    try {
+      const model = createModel("openai-compatible", "local-model", 0);
+
+      await model.invoke([
+        {
+          role: "user",
+          content: [[[{ type: "text", text: "     1\t# Tech Stack" }]]],
+        },
+      ]);
+
+      const [url, init] = fetchMock.mock.calls[0] as [
+        string | URL,
+        { body: string },
+      ];
+      expect(String(url)).toBe("https://vllm.example/v1/chat/completions");
+      expect(JSON.parse(init.body)).toMatchObject({
+        messages: [
+          {
+            content: [{ type: "text", text: "     1\t# Tech Stack" }],
+          },
+        ],
+      });
+    } finally {
+      restoreEnv("OPENAI_COMPATIBLE_API_KEY", savedApiKey);
+      restoreEnv("OPENAI_COMPATIBLE_BASE_URL", savedBaseUrl);
+      restoreEnv(OPENAI_COMPATIBLE_USE_RESPONSES_API_KEY, savedUseResponsesApi);
+      restoreEnv(OPENAI_COMPATIBLE_STREAMING_KEY, savedStreaming);
+      vi.unstubAllGlobals();
+    }
+  });
+
+  test("does not install content normalization for other ChatOpenAI providers", () => {
+    const savedApiKey = process.env.NVIDIA_API_KEY;
+    process.env.NVIDIA_API_KEY = "test-nvidia-key";
+
+    try {
+      const model = createModel(
+        "nvidia",
+        "nvidia/nemotron-3-super-120b-a12b",
+        0,
+      ) as { clientConfig?: { fetch?: typeof fetch } };
+
+      expect(model.clientConfig?.fetch).toBeUndefined();
+    } finally {
+      restoreEnv("NVIDIA_API_KEY", savedApiKey);
+    }
+  });
+
+  test("passes through non-target OpenAI-compatible fetch bodies unchanged", async () => {
+    const savedApiKey = process.env.OPENAI_COMPATIBLE_API_KEY;
+    const savedBaseUrl = process.env.OPENAI_COMPATIBLE_BASE_URL;
+    const savedUseResponsesApi =
+      process.env[OPENAI_COMPATIBLE_USE_RESPONSES_API_KEY];
+    process.env.OPENAI_COMPATIBLE_API_KEY = "test-compatible-key";
+    process.env.OPENAI_COMPATIBLE_BASE_URL = "https://vllm.example/v1";
+    delete process.env[OPENAI_COMPATIBLE_USE_RESPONSES_API_KEY];
+    const fetchMock = vi.fn(() =>
+      Promise.resolve(
+        new Response("{}", { headers: { "content-type": "application/json" } }),
+      ),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    try {
+      const model = createModel("openai-compatible", "local-model", 0) as {
+        clientConfig?: { fetch?: typeof fetch };
+      };
+      const compatibleFetch = model.clientConfig?.fetch;
+
+      expect(compatibleFetch).toBeTypeOf("function");
+      if (!compatibleFetch) {
+        throw new Error(
+          "Expected openai-compatible to install a fetch wrapper.",
+        );
+      }
+
+      const nonChatBody = JSON.stringify({
+        messages: [{ content: [[{ type: "text", text: "non-chat request" }]] }],
+      });
+      const validContentBody = JSON.stringify({
+        messages: [{ content: [{ type: "text", text: "already flat" }] }],
+      });
+      const multimodalBody = JSON.stringify({
+        messages: [
+          {
+            content: [
+              [
+                {
+                  type: "image_url",
+                  image_url: { url: "data:image/png;base64,a" },
+                },
+              ],
+            ],
+          },
+        ],
+      });
+
+      await compatibleFetch("https://vllm.example/v1/models", {
+        body: nonChatBody,
+        method: "POST",
+      });
+      await compatibleFetch("https://vllm.example/v1/chat/completions", {
+        body: "not json",
+        method: "POST",
+      });
+      await compatibleFetch("https://vllm.example/v1/chat/completions", {
+        body: validContentBody,
+        method: "POST",
+      });
+      await compatibleFetch("https://vllm.example/v1/chat/completions", {
+        body: multimodalBody,
+        method: "POST",
+      });
+
+      expect(
+        fetchMock.mock.calls.map(
+          ([, init]) => (init as { body: string } | undefined)?.body,
+        ),
+      ).toEqual([nonChatBody, "not json", validContentBody, multimodalBody]);
+    } finally {
+      restoreEnv("OPENAI_COMPATIBLE_API_KEY", savedApiKey);
+      restoreEnv("OPENAI_COMPATIBLE_BASE_URL", savedBaseUrl);
+      restoreEnv(OPENAI_COMPATIBLE_USE_RESPONSES_API_KEY, savedUseResponsesApi);
+      vi.unstubAllGlobals();
+    }
+  });
+
+  test("does not install content normalization for OpenAI-compatible Responses API requests", () => {
+    const savedApiKey = process.env.OPENAI_COMPATIBLE_API_KEY;
+    const savedBaseUrl = process.env.OPENAI_COMPATIBLE_BASE_URL;
+    const savedUseResponsesApi =
+      process.env[OPENAI_COMPATIBLE_USE_RESPONSES_API_KEY];
+    process.env.OPENAI_COMPATIBLE_API_KEY = "test-compatible-key";
+    process.env.OPENAI_COMPATIBLE_BASE_URL = "https://vllm.example/v1";
+    process.env[OPENAI_COMPATIBLE_USE_RESPONSES_API_KEY] = "true";
+
+    try {
+      const model = createModel("openai-compatible", "local-model", 0) as {
+        clientConfig?: { fetch?: typeof fetch };
+        useResponsesApi?: boolean;
+      };
+
+      expect(model.useResponsesApi).toBe(true);
+      expect(model.clientConfig?.fetch).toBeUndefined();
+    } finally {
+      restoreEnv("OPENAI_COMPATIBLE_API_KEY", savedApiKey);
+      restoreEnv("OPENAI_COMPATIBLE_BASE_URL", savedBaseUrl);
+      restoreEnv(OPENAI_COMPATIBLE_USE_RESPONSES_API_KEY, savedUseResponsesApi);
+    }
+  });
+
   test("routes Copilot GPT-5 models through the Responses API", () => {
     const model = createModel("copilot", "gpt-5.5", 0) as {
       useResponsesApi?: boolean;


### PR DESCRIPTION
﻿## Summary
- Normalize redundant nested text content arrays on OpenAI-compatible Chat Completions requests before strict vLLM servers validate the payload.
- Keep the change scoped to the OpenAI-compatible chat-completions transport; other ChatOpenAI providers, Responses API opt-in, non-chat requests, non-JSON bodies, already-flat content, and non-text/multimodal blocks pass through unchanged.
- Add regression coverage that reproduces the nested wire payload before the fetch normalizer and verifies the pass-through cases.

Fixes #626.

## Testing
- Windows: `pnpm exec vitest run test/agent/create-model.test.ts test/openai-compatible-streaming.test.ts test/openai-compatible-responses.test.ts --reporter=dot`
- Windows: `pnpm run format`
- Windows: `pnpm run format:check`
- Windows: `pnpm run lint`
- Windows: `pnpm run lint:check`
- Windows: `pnpm run typecheck`
- Windows: `git diff --check`
- DGX Spark Linux: `pnpm exec vitest run test/agent/create-model.test.ts test/openai-compatible-streaming.test.ts test/openai-compatible-responses.test.ts --reporter=dot`
- DGX Spark Linux: `pnpm run format:check`
- DGX Spark Linux: `pnpm run lint:check`
- DGX Spark Linux: `pnpm run typecheck`
- DGX Spark Linux: `pnpm test`
