### PR TITLE
fix: coerce roleless repository worker stream messages

### DIFF
--- a/.changeset/openai-compatible-worker-streaming.md
+++ b/.changeset/openai-compatible-worker-streaming.md
@@ -1,0 +1,5 @@
+---
+"openwiki": patch
+---
+
+fix: coerce roleless OpenAI-compatible streaming worker responses

--- a/src/agent/repository-runner.ts
+++ b/src/agent/repository-runner.ts
@@ -1,6 +1,17 @@
 import { scheduler } from "node:timers/promises";
 import type { BaseChatModel } from "@langchain/core/language_models/chat_models";
-import { ToolMessage } from "@langchain/core/messages";
+import {
+  AIMessage,
+  AIMessageChunk,
+  ChatMessage,
+  ChatMessageChunk,
+  ToolMessage,
+  collapseToolCallChunks,
+  defaultToolCallParser,
+  type InvalidToolCall,
+  type ToolCall,
+  type ToolCallChunk,
+} from "@langchain/core/messages";
 import { DynamicStructuredTool } from "@langchain/core/tools";
 import { createDeepAgent, createFilesystemMiddleware } from "deepagents";
 import { createMiddleware } from "langchain";
@@ -89,17 +100,123 @@ const WORKER_TOOL_NAMES = new Set<string>([
 // model-facing capability after all tool-contributing middleware has run.
 const NO_DELEGATION_MIDDLEWARE = createMiddleware({
   name: "OpenWikiRepositoryWorkerNoDelegation",
-  wrapModelCall: (request, handler) =>
-    handler({
+  wrapModelCall: async (request, handler) => {
+    const response = await handler({
       ...request,
       tools: request.tools?.filter(({ name }) => name !== "task"),
-    }),
+    });
+
+    return coerceRepositoryWorkerModelResponse(response);
+  },
 });
 
 type PendingPageJob = Extract<
   NextRepositoryPageResult,
   { status: "pending" }
 >["job"];
+
+/**
+ * Normalizes provider-streaming aggregates that are assistant output but were
+ * typed as generic chat messages because the first OpenAI-compatible SSE delta
+ * arrived without `role:"assistant"` (for example reasoning-only first deltas).
+ *
+ * LangChain validates each wrapModelCall response before the agent node can
+ * continue. Coerce only this repository-worker boundary so provider transport
+ * handling stays owned by the model client.
+ */
+function coerceRepositoryWorkerModelResponse(response: AIMessage): AIMessage {
+  const candidate: unknown = response;
+
+  if (AIMessage.isInstance(candidate)) {
+    return candidate;
+  }
+
+  if (
+    ChatMessageChunk.isInstance(candidate) &&
+    isGenericAssistantModelResponse(candidate)
+  ) {
+    const rawToolCalls = getOpenAiRawToolCalls(candidate.additional_kwargs);
+    const toolCallFields =
+      rawToolCalls === null
+        ? {}
+        : collapseToolCallChunks(rawToolCalls.map(toToolCallChunk));
+
+    return new AIMessageChunk({
+      content: candidate.content,
+      additional_kwargs: candidate.additional_kwargs,
+      response_metadata: candidate.response_metadata,
+      id: candidate.id,
+      name: candidate.name,
+      ...toolCallFields,
+    });
+  }
+
+  if (
+    ChatMessage.isInstance(candidate) &&
+    isGenericAssistantModelResponse(candidate)
+  ) {
+    const rawToolCalls = getOpenAiRawToolCalls(candidate.additional_kwargs);
+    const toolCallFields =
+      rawToolCalls === null ? {} : parseRawOpenAiToolCalls(rawToolCalls);
+
+    return new AIMessage({
+      content: candidate.content,
+      additional_kwargs: candidate.additional_kwargs,
+      response_metadata: candidate.response_metadata,
+      id: candidate.id,
+      name: candidate.name,
+      ...toolCallFields,
+    });
+  }
+
+  return response;
+}
+
+function isGenericAssistantModelResponse(response: { role?: string }): boolean {
+  return response.role === undefined || response.role === "assistant";
+}
+
+function getOpenAiRawToolCalls(
+  additionalKwargs: Record<string, unknown> | undefined,
+): Record<string, unknown>[] | null {
+  const rawToolCalls = additionalKwargs?.tool_calls;
+
+  if (!Array.isArray(rawToolCalls)) {
+    return null;
+  }
+
+  return rawToolCalls.filter(isRecord);
+}
+
+function parseRawOpenAiToolCalls(rawToolCalls: Record<string, unknown>[]): {
+  invalid_tool_calls: InvalidToolCall[];
+  tool_calls: ToolCall[];
+} {
+  const [toolCalls, invalidToolCalls] = defaultToolCallParser(rawToolCalls);
+
+  return {
+    invalid_tool_calls: invalidToolCalls,
+    tool_calls: toolCalls,
+  };
+}
+
+function toToolCallChunk(rawToolCall: Record<string, unknown>): ToolCallChunk {
+  const rawFunction = rawToolCall.function;
+  const functionFields = isRecord(rawFunction) ? rawFunction : {};
+
+  return {
+    id: typeof rawToolCall.id === "string" ? rawToolCall.id : undefined,
+    index:
+      typeof rawToolCall.index === "number" ? rawToolCall.index : undefined,
+    name:
+      typeof functionFields.name === "string" ? functionFields.name : undefined,
+    args:
+      typeof functionFields.arguments === "string"
+        ? functionFields.arguments
+        : undefined,
+    type: "tool_call_chunk",
+  };
+}
 
 /**
  * Converts a correctable submission rejection into a failed tool result.

--- a/test/agent/repository-runner.test.ts
+++ b/test/agent/repository-runner.test.ts
@@ -1,4 +1,10 @@
-import { ToolMessage } from "@langchain/core/messages";
+import {
+  AIMessage,
+  AIMessageChunk,
+  ChatMessage,
+  ChatMessageChunk,
+  ToolMessage,
+} from "@langchain/core/messages";
 import { beforeEach, describe, expect, test, vi } from "vitest";
 
 type HarnessPage = {
@@ -40,8 +46,8 @@ type ModelToolRequest = {
 type CapturedMiddleware = {
   wrapModelCall?: (
     request: ModelToolRequest,
-    handler: (request: ModelToolRequest) => Promise<ModelToolRequest>,
-  ) => Promise<ModelToolRequest>;
+    handler: (request: ModelToolRequest) => Promise<unknown>,
+  ) => Promise<unknown>;
 };
 
 type CapturedAgentOptions = {
@@ -470,6 +476,18 @@ async function runHarness(): Promise<OpenWikiRunEvent[]> {
   return events;
 }
 
+async function getNoDelegationWrapModelCall(): Promise<
+  NonNullable<CapturedMiddleware["wrapModelCall"]>
+> {
+  await runHarness();
+  const wrapModelCall =
+    harness.agentOptions[0]?.middleware.at(-1)?.wrapModelCall;
+  if (!wrapModelCall) {
+    throw new Error("Expected the no-delegation model-call middleware.");
+  }
+  return wrapModelCall;
+}
+
 beforeEach(() => {
   harness.agentOptions = [];
   harness.beginCalls = 0;
@@ -641,22 +659,115 @@ describe("runNativeRepositoryGeneration", () => {
   });
 
   test("filters DeepAgents' automatic task capability at the model boundary", async () => {
-    await runHarness();
-    const noDelegation = harness.agentOptions[0]?.middleware.at(-1);
-    if (!noDelegation?.wrapModelCall) {
-      throw new Error("Expected the no-delegation model-call middleware.");
-    }
+    const wrapModelCall = await getNoDelegationWrapModelCall();
     const request = {
       tools: [{ name: "read_file" }, { name: "task" }, { name: "submit_plan" }],
     };
-    const filtered = await noDelegation.wrapModelCall(request, (next) =>
+    const filtered = await wrapModelCall(request, (next) =>
       Promise.resolve(next),
     );
 
-    expect(filtered.tools.map(({ name }) => name)).toEqual([
-      "read_file",
-      "submit_plan",
+    expect(
+      (filtered as ModelToolRequest).tools.map(({ name }) => name),
+    ).toEqual(["read_file", "submit_plan"]);
+  });
+
+  test("coerces roleless generic streaming aggregates before LangChain validates wrapModelCall", async () => {
+    const wrapModelCall = await getNoDelegationWrapModelCall();
+    const request = {
+      tools: [{ name: "read_file" }, { name: "task" }, { name: "submit_plan" }],
+    };
+    const genericAggregate = new ChatMessageChunk({
+      additional_kwargs: {
+        reasoning_content: "thinking before assistant role",
+        tool_calls: [
+          {
+            id: "call_submit_plan",
+            index: 0,
+            function: {
+              name: "submit_plan",
+              arguments: '{"pages":[]}',
+            },
+          },
+        ],
+      },
+      content: "planning complete",
+      response_metadata: { model_provider: "openai" },
+      role: undefined as unknown as string,
+    });
+
+    const coerced = await wrapModelCall(request, (next) => {
+      expect(next.tools.map(({ name }) => name)).toEqual([
+        "read_file",
+        "submit_plan",
+      ]);
+      return Promise.resolve(genericAggregate);
+    });
+
+    expect(AIMessage.isInstance(coerced)).toBe(true);
+    expect(coerced).toBeInstanceOf(AIMessageChunk);
+    const aiResponse = coerced as AIMessageChunk;
+    expect(aiResponse.text).toBe("planning complete");
+    expect(aiResponse.additional_kwargs.reasoning_content).toBe(
+      "thinking before assistant role",
+    );
+    expect(aiResponse.tool_calls).toEqual([
+      {
+        args: { pages: [] },
+        id: "call_submit_plan",
+        name: "submit_plan",
+        type: "tool_call",
+      },
     ]);
+  });
+
+  test("coerces generic assistant messages before LangChain validates wrapModelCall", async () => {
+    const wrapModelCall = await getNoDelegationWrapModelCall();
+    const genericMessage = new ChatMessage({
+      additional_kwargs: {
+        tool_calls: [
+          {
+            id: "call_submit_plan",
+            function: {
+              name: "submit_plan",
+              arguments: '{"pages":[]}',
+            },
+          },
+        ],
+      },
+      content: "planning complete",
+      role: "assistant",
+    });
+
+    const coerced = await wrapModelCall({ tools: [] }, () =>
+      Promise.resolve(genericMessage),
+    );
+
+    expect(AIMessage.isInstance(coerced)).toBe(true);
+    expect(coerced).toBeInstanceOf(AIMessage);
+    const aiResponse = coerced as AIMessage;
+    expect(aiResponse.text).toBe("planning complete");
+    expect(aiResponse.tool_calls).toEqual([
+      {
+        args: { pages: [] },
+        id: "call_submit_plan",
+        name: "submit_plan",
+      },
+    ]);
+  });
+
+  test("leaves non-assistant generic model responses untouched", async () => {
+    const wrapModelCall = await getNoDelegationWrapModelCall();
+    const genericUserResponse = new ChatMessageChunk({
+      content: "not assistant output",
+      role: "user",
+    });
+    const response = await wrapModelCall({ tools: [] }, () =>
+      Promise.resolve(genericUserResponse),
+    );
+
+    expect(response).toBe(genericUserResponse);
+    expect(AIMessage.isInstance(response)).toBe(false);
   });
 
   test("resumes a durable queue without recreating the planner", async () => {


### PR DESCRIPTION
## Summary

- Coerce repository worker `wrapModelCall` responses that are assistant-like `ChatMessage` / `ChatMessageChunk` objects into `AIMessage` / `AIMessageChunk` before LangChain validates the middleware return value.
- Preserve message content, response metadata, reasoning kwargs, and raw OpenAI tool calls during the coercion.
- Leave non-assistant generic model responses untouched so unrelated invalid responses still fail closed.

## Why

OpenAI-compatible endpoints that require `OPENWIKI_OPENAI_COMPATIBLE_STREAMING=true` can emit a reasoning delta before the first `role: "assistant"` delta. LangChain then aggregates the response as a generic `ChatMessageChunk`, and the repository worker fails its first model call with:

```text
Invalid response from "wrapModelCall" in middleware "OpenWikiRepositoryWorkerNoDelegation": expected AIMessage or Command, got object
```

This keeps the compatibility shim at the repository worker boundary where the invalid response surfaces, without changing the lower-level OpenAI-compatible request normalization path.

Fixes #849.
Related #813.

## Tests

- Windows: `pnpm exec vitest run test/openai-compatible-streaming.test.ts test/agent/stream-modes.test.ts test/agent/repository-runner.test.ts --reporter=dot`
- Windows: `pnpm run typecheck`
- Windows: `pnpm run format:check`
- Windows: `pnpm run lint:check`
- Windows: build-equivalent `tsc -p tsconfig.json`, `tsc -p tsconfig.client.json`, `node scripts/copy-visualize-assets.cjs`, and postbuild chmod
- DGX Spark Ubuntu fresh clone: `pnpm install --frozen-lockfile`
- DGX Spark Ubuntu fresh clone: focused 3-file Vitest suite above
- DGX Spark Ubuntu fresh clone: `pnpm run format:check`
- DGX Spark Ubuntu fresh clone: `pnpm run lint:check`
- DGX Spark Ubuntu fresh clone: `pnpm run typecheck`
- DGX Spark Ubuntu fresh clone: `pnpm test` (225 files passed, 2 skipped; 3069 tests passed, 3 skipped)
