### PR TITLE
fix: require current node runtime

### DIFF
--- a/.changeset/ninety-node-runtimes.md
+++ b/.changeset/ninety-node-runtimes.md
@@ -1,0 +1,5 @@
+---
+"openwiki": patch
+---
+
+fix: require Node.js 22.22.0 or newer

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -4,7 +4,7 @@
 
 Prerequisites:
 
-- Node.js 20 or newer
+- Node.js 22.22.0 or newer
 - pnpm
 
 Set up pnpm's global bin directory once if `pnpm link --global` has not worked

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ OpenWiki is a CLI that writes and maintains a wiki for your codebase or your per
 
 ## Quick start
 
-Install the CLI (Node.js 22 or newer):
+Install the CLI (Node.js 22.22.0 or newer):
 
 ```sh
 npm install -g openwiki

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "license": "MIT",
   "type": "module",
   "engines": {
-    "node": ">=22"
+    "node": ">=22.22.0"
   },
   "bin": {
     "openwiki": "./dist/cli/cli.js"

--- a/test/node-runtime.test.ts
+++ b/test/node-runtime.test.ts
@@ -1,0 +1,30 @@
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { describe, expect, test } from "vitest";
+
+const repositoryRoot = path.join(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "..",
+);
+const minimumNodeVersion = "22.22.0";
+
+describe("Node.js runtime requirement", () => {
+  test("matches package metadata and user-facing setup docs", () => {
+    const packageJson = JSON.parse(
+      readFileSync(path.join(repositoryRoot, "package.json"), "utf8"),
+    ) as { engines?: { node?: string } };
+    const readme = readFileSync(path.join(repositoryRoot, "README.md"), "utf8");
+    const developmentGuide = readFileSync(
+      path.join(repositoryRoot, "DEVELOPMENT.md"),
+      "utf8",
+    );
+
+    expect(packageJson.engines?.node).toBe(`>=${minimumNodeVersion}`);
+    expect(readme).toContain(`Node.js ${minimumNodeVersion} or newer`);
+    expect(developmentGuide).toContain(
+      `Node.js ${minimumNodeVersion} or newer`,
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- Raise OpenWiki's declared Node.js runtime requirement from `>=22` to `>=22.22.0`.
- Align the README quick start and DEVELOPMENT prerequisites with the package engine.
- Add a regression test so package metadata and setup docs cannot drift apart again.

## Why

`package.json` still allowed every Node 22 release, but current dependencies already require newer Node 22 builds. In the checked-in lockfile, runtime dependency `posthog-node` requires `^20.20.0 || >=22.22.0`, while OpenWiki only supports the Node 22 line. The old `>=22` metadata also admitted the Node 22.0-22.6 range reported in #442, where bundled ESM dependencies can fail to load.

Fixes #442.

## Tests

- Windows: `pnpm install --frozen-lockfile`
- Windows: `pnpm exec vitest run test/node-runtime.test.ts --reporter=dot`
- Windows: `pnpm exec vitest run test/node-runtime.test.ts test/version.test.ts --reporter=dot`
- Windows: `pnpm run format:check`
- Windows: `pnpm run lint:check`
- Windows: `pnpm run typecheck`
- Windows: build-equivalent `pnpm run clean`, `tsc -p tsconfig.json`, `tsc -p tsconfig.client.json`, `node scripts/copy-visualize-assets.cjs`, and postbuild chmod
- Windows: `npm pack --dry-run --json --ignore-scripts`
- DGX Spark Ubuntu fresh clone: `pnpm install --frozen-lockfile`
- DGX Spark Ubuntu fresh clone: `pnpm exec vitest run test/node-runtime.test.ts test/version.test.ts --reporter=dot`
- DGX Spark Ubuntu fresh clone: `pnpm run format:check`
- DGX Spark Ubuntu fresh clone: `pnpm run lint:check`
- DGX Spark Ubuntu fresh clone: `pnpm run typecheck`
- DGX Spark Ubuntu fresh clone: `pnpm test` (226 files passed, 2 skipped; 3067 tests passed, 3 skipped)