### PR TITLE
fix: retry transient openrouter provider 404 errors

### DIFF
--- a/.changeset/openrouter-provider-404-retry.md
+++ b/.changeset/openrouter-provider-404-retry.md
@@ -1,0 +1,5 @@
+---
+"openwiki": patch
+---
+
+Retry transient OpenRouter provider 404 errors before surfacing the failure.

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -184,6 +184,7 @@ export async function runOpenWikiAgent(
       const config = await resolveRunConfig(options, (resolved) => {
         telemetryContext.provider = resolved;
       });
+      debugFetchCapture.setRetryAttempts(config.providerRetryAttempts);
       const model = inStageSync(
         "build",
         () =>
@@ -248,6 +249,7 @@ export async function runOpenWikiAgent(
     const config = await resolveRunConfig(options, (resolved) => {
       telemetryContext.provider = resolved;
     });
+    debugFetchCapture.setRetryAttempts(config.providerRetryAttempts);
 
     return await runOpenWikiAgentCore(
       command,
@@ -1957,6 +1959,11 @@ type OpenRouterFetchCapture = {
   clearLastFailure: () => void;
   getLastFailure: () => OpenRouterFetchFailure | null;
   restore: () => void;
+  setRetryAttempts: (retryAttempts: number) => void;
+};
+
+type OpenRouterFetchOptions = {
+  sleep?: (ms: number) => Promise<void>;
 };
 
 type OpenRouterFetchFailure = {
@@ -1998,10 +2005,14 @@ const OPENROUTER_DEBUG_BODY_LIMIT = 4_000;
 type OpenRouterFetchSink = {
   lastFailure: OpenRouterFetchFailure | null;
   options: OpenWikiRunOptions;
+  retryAttempts: number;
+  sleep: (ms: number) => Promise<void>;
 };
 
 const activeOpenRouterSinks = new Set<OpenRouterFetchSink>();
 let openRouterOriginalFetch: typeof fetch | null = null;
+const OPENROUTER_PROVIDER_ERROR_RETRY_BASE_DELAY_MS = 1_000;
+const OPENROUTER_PROVIDER_ERROR_RETRY_MAX_DELAY_MS = 30_000;
 
 function openRouterDebugFetch(
   input: Parameters<typeof fetch>[0],
@@ -2024,31 +2035,55 @@ function openRouterDebugFetch(
   };
 
   return (async () => {
+    let attempt = 0;
+
     try {
-      const response = await baseFetch(input, init);
+      while (true) {
+        const response = await baseFetch(input, init);
 
-      if (!response.ok) {
-        const failure: OpenRouterFetchFailure = {
-          request,
-          response: {
-            bodyPreview: await readResponseBodyPreview(response),
-            headers: getSafeResponseHeaders(response.headers),
-            status: response.status,
-            statusText: response.statusText,
-          },
-        };
-        recordFailure(failure);
-        for (const sink of activeOpenRouterSinks) {
-          emitDebug(
-            sink.options,
-            `openrouter.http status=${response.status} statusText=${JSON.stringify(
-              response.statusText,
-            )}`,
-          );
+        if (!response.ok) {
+          const body = await readResponseBody(response);
+          const failure: OpenRouterFetchFailure = {
+            request,
+            response: {
+              bodyPreview: body.preview,
+              headers: getSafeResponseHeaders(response.headers),
+              status: response.status,
+              statusText: response.statusText,
+            },
+          };
+          recordFailure(failure);
+          for (const sink of activeOpenRouterSinks) {
+            emitDebug(
+              sink.options,
+              `openrouter.http status=${response.status} statusText=${JSON.stringify(
+                response.statusText,
+              )}`,
+            );
+          }
+
+          const retry = getOpenRouterProviderErrorRetry();
+          if (
+            attempt < retry.maxRetries &&
+            isOpenRouterRequestResendable(input, init) &&
+            isTransientOpenRouterProvider404(response, body.raw)
+          ) {
+            attempt += 1;
+            const delayMs = getOpenRouterProviderErrorRetryDelayMs(attempt);
+            for (const sink of activeOpenRouterSinks) {
+              emitDebug(
+                sink.options,
+                `openrouter.retry status=404 attempt=${attempt}/${retry.maxRetries} delayMs=${delayMs}`,
+              );
+            }
+            await response.body?.cancel().catch(() => undefined);
+            await retry.sleep(delayMs);
+            continue;
+          }
         }
-      }
 
-      return response;
+        return response;
+      }
     } catch (error) {
       recordFailure({
         fetchError: error instanceof Error ? error.message : String(error),
@@ -2067,8 +2102,15 @@ function openRouterDebugFetch(
  */
 export function installOpenRouterDebugFetch(
   options: OpenWikiRunOptions,
+  retryAttempts = 0,
+  fetchOptions: OpenRouterFetchOptions = {},
 ): OpenRouterFetchCapture {
-  const sink: OpenRouterFetchSink = { lastFailure: null, options };
+  const sink: OpenRouterFetchSink = {
+    lastFailure: null,
+    options,
+    retryAttempts,
+    sleep: fetchOptions.sleep ?? sleep,
+  };
 
   // Install the wrapper once, capturing the genuine original fetch. Concurrent
   // runs share the single wrapper and each detach their own sink; the global
@@ -2095,7 +2137,76 @@ export function installOpenRouterDebugFetch(
         openRouterOriginalFetch = null;
       }
     },
+    setRetryAttempts: (updatedRetryAttempts) => {
+      sink.retryAttempts = updatedRetryAttempts;
+    },
   };
+}
+
+function getOpenRouterProviderErrorRetry(): {
+  maxRetries: number;
+  sleep: (ms: number) => Promise<void>;
+} {
+  let maxRetries = 0;
+  let retrySleep = sleep;
+
+  // The OpenRouter wrapper is process-global, so retry follows the same
+  // best-effort active-run fan-out contract used for debug capture.
+  for (const sink of activeOpenRouterSinks) {
+    if (sink.retryAttempts > maxRetries) {
+      maxRetries = sink.retryAttempts;
+      retrySleep = sink.sleep;
+    }
+  }
+
+  return { maxRetries, sleep: retrySleep };
+}
+
+function getOpenRouterProviderErrorRetryDelayMs(attempt: number): number {
+  return Math.min(
+    OPENROUTER_PROVIDER_ERROR_RETRY_BASE_DELAY_MS * 2 ** (attempt - 1),
+    OPENROUTER_PROVIDER_ERROR_RETRY_MAX_DELAY_MS,
+  );
+}
+
+function isOpenRouterRequestResendable(
+  input: Parameters<typeof fetch>[0],
+  init: Parameters<typeof fetch>[1],
+): boolean {
+  if (input instanceof Request && input.body !== null) {
+    return false;
+  }
+
+  return (
+    init?.body === undefined ||
+    init.body === null ||
+    typeof init.body === "string"
+  );
+}
+
+function isTransientOpenRouterProvider404(
+  response: Response,
+  rawBody: string | null,
+): boolean {
+  if (response.status !== 404 || rawBody === null) {
+    return false;
+  }
+
+  const parsedBody = parseJsonRecord(rawBody);
+  if (parsedBody === null) {
+    return false;
+  }
+
+  const error = isRecord(parsedBody?.error) ? parsedBody.error : parsedBody;
+  const message = getStringRecordValue(error, "message");
+  const metadata = isRecord(error?.metadata) ? error.metadata : null;
+
+  return (
+    metadata !== null &&
+    message === "Provider returned error" &&
+    metadata.raw === "" &&
+    typeof metadata.provider_name === "string"
+  );
 }
 
 function attachOpenRouterDebugInfo(
@@ -2224,19 +2335,32 @@ function countMessageContentChars(content: unknown): number {
   }, 0);
 }
 
-async function readResponseBodyPreview(response: Response): Promise<string> {
+async function readResponseBody(
+  response: Response,
+): Promise<{ preview: string; raw: string | null }> {
   try {
     const body = await response.clone().text();
     const sanitizedBody = sanitizeOpenRouterResponseBody(body);
 
-    return sanitizedBody.length <= OPENROUTER_DEBUG_BODY_LIMIT
-      ? sanitizedBody
-      : `${sanitizedBody.slice(0, OPENROUTER_DEBUG_BODY_LIMIT - 3)}...`;
+    return {
+      preview:
+        sanitizedBody.length <= OPENROUTER_DEBUG_BODY_LIMIT
+          ? sanitizedBody
+          : `${sanitizedBody.slice(0, OPENROUTER_DEBUG_BODY_LIMIT - 3)}...`,
+      raw: body,
+    };
   } catch (error) {
-    return `Unable to read response body: ${
-      error instanceof Error ? error.message : String(error)
-    }`;
+    return {
+      preview: `Unable to read response body: ${
+        error instanceof Error ? error.message : String(error)
+      }`,
+      raw: null,
+    };
   }
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
 export function sanitizeOpenRouterResponseBody(body: string): string {

--- a/test/openrouter-debug-fetch.test.ts
+++ b/test/openrouter-debug-fetch.test.ts
@@ -43,6 +43,33 @@ function stubFetch(): typeof globalThis.fetch {
   return stub;
 }
 
+function stubFetchSequence(responses: Response[]): ReturnType<typeof vi.fn> {
+  let call = 0;
+  const stub = vi.fn(() => {
+    const response = responses[Math.min(call, responses.length - 1)];
+    call += 1;
+    return Promise.resolve(response);
+  });
+  globalThis.fetch = stub;
+  return stub;
+}
+
+function openRouterProvider404(): Response {
+  return new Response(
+    JSON.stringify({
+      error: {
+        message: "Provider returned error",
+        metadata: {
+          is_byok: false,
+          provider_name: "Nvidia",
+          raw: "",
+        },
+      },
+    }),
+    { status: 404, statusText: "Not Found" },
+  );
+}
+
 describe("installOpenRouterDebugFetch concurrency", () => {
   test("restores the exact original fetch after a single run", () => {
     const original = stubFetch();
@@ -126,5 +153,101 @@ describe("installOpenRouterDebugFetch concurrency", () => {
 
     runB.restore();
     expect(globalThis.fetch).toBe(original);
+  });
+
+  test("retries transient OpenRouter provider 404 responses", async () => {
+    const original = stubFetchSequence([
+      openRouterProvider404(),
+      new Response("ok", { status: 200 }),
+    ]);
+    const delays: number[] = [];
+    const events: string[] = [];
+    const capture = installOpenRouterDebugFetch(
+      {
+        debug: true,
+        onEvent: (event) => {
+          if (event.type === "debug") {
+            events.push(event.message);
+          }
+        },
+      },
+      0,
+      {
+        sleep: (ms) => {
+          delays.push(ms);
+          return Promise.resolve();
+        },
+      },
+    );
+    capture.setRetryAttempts(2);
+
+    try {
+      const response = await globalThis.fetch(OPENROUTER_CHAT_URL, {
+        body: JSON.stringify({ messages: [], model: "nvidia/test-model" }),
+        method: "POST",
+      });
+
+      expect(response.status).toBe(200);
+      expect(original).toHaveBeenCalledTimes(2);
+      expect(delays).toEqual([1000]);
+      expect(capture.getLastFailure()?.response?.status).toBe(404);
+      expect(
+        events.some((message) =>
+          message.includes("openrouter.retry status=404"),
+        ),
+      ).toBe(true);
+    } finally {
+      capture.restore();
+    }
+  });
+
+  test("does not retry ordinary OpenRouter 404 responses", async () => {
+    const original = stubFetchSequence([
+      new Response(JSON.stringify({ error: "missing model" }), {
+        status: 404,
+        statusText: "Not Found",
+      }),
+      new Response("ok", { status: 200 }),
+    ]);
+    const capture = installOpenRouterDebugFetch({}, 2, {
+      sleep: () => Promise.resolve(),
+    });
+
+    try {
+      const response = await globalThis.fetch(OPENROUTER_CHAT_URL, {
+        body: JSON.stringify({ messages: [], model: "missing/model" }),
+        method: "POST",
+      });
+
+      expect(response.status).toBe(404);
+      expect(original).toHaveBeenCalledTimes(1);
+      expect(capture.getLastFailure()?.response?.status).toBe(404);
+    } finally {
+      capture.restore();
+    }
+  });
+
+  test("does not retry OpenRouter request bodies that cannot be resent", async () => {
+    const original = stubFetchSequence([
+      openRouterProvider404(),
+      new Response("ok", { status: 200 }),
+    ]);
+    const capture = installOpenRouterDebugFetch({}, 2, {
+      sleep: () => Promise.resolve(),
+    });
+
+    try {
+      const request = new Request(OPENROUTER_CHAT_URL, {
+        body: JSON.stringify({ messages: [], model: "nvidia/test-model" }),
+        method: "POST",
+      });
+      const response = await globalThis.fetch(request);
+
+      expect(response.status).toBe(404);
+      expect(original).toHaveBeenCalledTimes(1);
+      expect(capture.getLastFailure()?.response?.status).toBe(404);
+    } finally {
+      capture.restore();
+    }
   });
 });


### PR DESCRIPTION
## Summary

- Retry OpenRouter 404 responses that match the transient upstream provider failure shape reported in #831.
- Keep ordinary 404s and non-replayable request bodies single-shot so missing models or consumed request bodies are not retried.
- Add focused regression coverage plus a patch changeset.

## Why

`OPENWIKI_PROVIDER_RETRY_ATTEMPTS` is already passed to LangChain, but LangChain treats 404 as non-retryable. OpenRouter can return a transient upstream provider failure as 404 with `error.message: "Provider returned error"`, an empty `metadata.raw`, and a `metadata.provider_name`. This adds a narrow OpenWiki-layer retry for that specific failure shape while preserving the existing OpenRouter debug capture behavior.

Fixes #831.
Related #667.

## Tests

Windows:
- `corepack pnpm exec vitest run test/openrouter-debug-fetch.test.ts --reporter=dot` (7 tests passed)
- `corepack pnpm run typecheck`
- `corepack pnpm run lint:check`
- `corepack pnpm run format:check`
- build-equivalent: `corepack pnpm run clean`, `corepack pnpm exec tsc -p tsconfig.json`, `corepack pnpm exec tsc -p tsconfig.client.json`, `node scripts/copy-visualize-assets.cjs`

DGX Spark Ubuntu fresh clone from `HwangJohn:fix/openrouter-provider-404-retry` at `44205e7`:
- Node `v22.23.1`, pnpm `11.25.0`
- `pnpm install --frozen-lockfile`
- `pnpm exec vitest run test/openrouter-debug-fetch.test.ts --reporter=dot` (7 tests passed)
- `pnpm run format:check`
- `pnpm run lint:check`
- `pnpm run typecheck`
- `pnpm test` (225 files passed, 2 skipped; 3069 tests passed, 3 skipped)
