### PR TITLE
fix: scope update planning to explicit requests

### DIFF
--- a/.changeset/scoped-update-planner-prompt.md
+++ b/.changeset/scoped-update-planner-prompt.md
@@ -1,0 +1,5 @@
+---
+"openwiki": patch
+---
+
+Tighten update-mode repository planning prompts for explicitly scoped documentation requests.

--- a/src/agent/repository-prompts.ts
+++ b/src/agent/repository-prompts.ts
@@ -40,6 +40,19 @@ ${formatIssues(view.claimIssues)}`
     ? `\nUser and connector planning context:\n${planningContext}\n`
     : "";
 
+  const scopedUpdateContext =
+    view.mode === "update" && planningContext?.trim()
+      ? `
+When the user planning context names files or OpenWiki pages, says to document
+only specific files, or otherwise limits the requested documentation scope,
+treat that as a hard scoped update mandate. Preserve unrelated page
+framing/theme and the existing information architecture; do not use a narrow
+request as permission for a broad wiki refresh. Schedule only directly requested
+pages/files and genuinely affected cross-references or navigation. Refresh
+/openwiki/quickstart.md only when the page map, navigation, or task-routing
+links actually change.`
+      : "";
+
   return `You are planning an OpenWiki code wiki for this repository.
 
 Your only output action is submit_plan. Do not write documentation and do not
@@ -77,7 +90,7 @@ An update with no required page edits and no deletions may submit pages: [].
 For every page provide a concise purpose and useful seedPaths. seedPaths are
 starting points, not research boundaries. Copy only relevant global constraints
 from the user/connector context into that page's instructions array; do not copy
-unrelated context into every job.${semanticContext}${updateContext}
+unrelated context into every job.${semanticContext}${scopedUpdateContext}${updateContext}
 
 ${view.wikiGoal ? `Repository OpenWiki instructions:\n${view.wikiGoal}\n` : ""}`;
 }

--- a/test/agent/repository-prompts.test.ts
+++ b/test/agent/repository-prompts.test.ts
@@ -108,6 +108,41 @@ describe("repository worker prompts", () => {
     expect(prompt).not.toContain("force flag");
   });
 
+  test("adds a scoped update mandate for update planning context", () => {
+    const prompt = createRepositoryPlannerPrompt(
+      planningView(),
+      "User: document only src/auth.ts and /openwiki/auth.md.",
+    );
+
+    expect(prompt).toContain("hard scoped update mandate");
+    expect(prompt).toMatch(/Preserve unrelated page\s+framing\/theme/u);
+    expect(prompt).toMatch(
+      /Schedule only directly requested\s+pages\/files and genuinely affected cross-references or navigation/u,
+    );
+    expect(prompt).toMatch(
+      /Refresh\s+\/openwiki\/quickstart\.md only when the page map, navigation, or task-routing\s+links actually change/u,
+    );
+  });
+
+  test("does not add scoped update mandate for init or missing planning context", () => {
+    const initPrompt = createRepositoryPlannerPrompt(
+      planningView({
+        mode: "init",
+        pageUpdateWindows: [],
+        claimIssues: [],
+      }),
+      "User: document only src/auth.ts.",
+    );
+    const updateWithoutContextPrompt =
+      createRepositoryPlannerPrompt(planningView());
+
+    expect(initPrompt).toContain("User and connector planning context");
+    expect(initPrompt).not.toContain("hard scoped update mandate");
+    expect(updateWithoutContextPrompt).not.toContain(
+      "hard scoped update mandate",
+    );
+  });
+
   test("renders unknown baselines as explicit full-review windows", () => {
     const prompt = createRepositoryPlannerPrompt(
       planningView({


### PR DESCRIPTION
## Summary

- Treat explicit file/page-scoped update instructions as a scoped update mandate in the repository planner prompt.
- Tell the planner to preserve unrelated page framing/theme and existing information architecture.
- Refresh `/openwiki/quickstart.md` only when the page map, navigation, or task-routing links actually change.
- Add focused prompt-contract coverage and a patch changeset.

## Why

Fixes #797. The report shows a `code --update -p` request naming only two files re-themed unrelated top-level pages. This change keeps the fix to the planner prompt contract; it does not add new deterministic page-selection enforcement.

## Tests

Windows:

- `corepack pnpm install --frozen-lockfile`
- `corepack pnpm exec vitest run test/agent/repository-prompts.test.ts --reporter=dot` (6 tests passed)
- `corepack pnpm run typecheck`
- `corepack pnpm run lint:check`
- `corepack pnpm run format:check`
- build-equivalent: `corepack pnpm run clean`, `corepack pnpm exec tsc -p tsconfig.json`, `corepack pnpm exec tsc -p tsconfig.client.json`, `node scripts/copy-visualize-assets.cjs`
- `git diff --check`

DGX Spark Ubuntu fresh clone from `HwangJohn:fix/scoped-update-planner-prompt` at `4c732e5`:

- Node `v22.23.1`, pnpm `11.25.0`
- `pnpm install --frozen-lockfile`
- `pnpm exec vitest run test/agent/repository-prompts.test.ts --reporter=dot` (6 tests passed)
- `pnpm run format:check`
- `pnpm run lint:check`
- `pnpm run typecheck`
- `pnpm test` (225 test files passed, 2 skipped; 3068 tests passed, 3 skipped)
