### PR TITLE
fix: normalize malformed OpenRouter success responses

### DIFF
--- a/.changeset/openrouter-malformed-success.md
+++ b/.changeset/openrouter-malformed-success.md
@@ -1,0 +1,5 @@
+---
+"openwiki": patch
+---
+
+Convert malformed successful OpenRouter chat responses into retryable provider errors.

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -1980,8 +1980,11 @@ type OpenRouterRequestSummary = {
 type OpenRouterResponseSummary = {
   bodyPreview: string;
   headers: Record<string, string>;
+  malformedReason?: string;
   status: number;
   statusText: string;
+  upstreamStatus?: number;
+  upstreamStatusText?: string;
 };
 
 const OPENROUTER_DEBUG_PROPERTY = "openRouterDebug";
@@ -2027,6 +2030,39 @@ function openRouterDebugFetch(
     try {
       const response = await baseFetch(input, init);
 
+      if (response.ok && request.stream === false) {
+        const malformedResponse =
+          await createMalformedOpenRouterResponse(response);
+
+        if (malformedResponse) {
+          const failure: OpenRouterFetchFailure = {
+            request,
+            response: {
+              bodyPreview: await readResponseBodyPreview(response),
+              headers: getSafeResponseHeaders(response.headers),
+              malformedReason: malformedResponse.reason,
+              status: malformedResponse.response.status,
+              statusText: malformedResponse.response.statusText,
+              upstreamStatus: response.status,
+              upstreamStatusText: response.statusText,
+            },
+          };
+          recordFailure(failure);
+          for (const sink of activeOpenRouterSinks) {
+            emitDebug(
+              sink.options,
+              `openrouter.http status=${malformedResponse.response.status} statusText=${JSON.stringify(
+                malformedResponse.response.statusText,
+              )} upstreamStatus=${response.status} malformed=${JSON.stringify(
+                malformedResponse.reason,
+              )}`,
+            );
+          }
+
+          return malformedResponse.response;
+        }
+      }
+
       if (!response.ok) {
         const failure: OpenRouterFetchFailure = {
           request,
@@ -2057,6 +2093,109 @@ function openRouterDebugFetch(
       throw error;
     }
   })();
+}
+
+async function createMalformedOpenRouterResponse(
+  response: Response,
+): Promise<{ reason: string; response: Response } | null> {
+  let body: unknown;
+
+  try {
+    body = await response.clone().json();
+  } catch {
+    return {
+      reason: "invalid_json",
+      response: createOpenRouterMalformedSuccessResponse(
+        response,
+        "the response body was not valid JSON",
+      ),
+    };
+  }
+
+  const reason = getMalformedOpenRouterChatCompletionReason(body);
+
+  if (reason === null) {
+    return null;
+  }
+
+  return {
+    reason,
+    response: createOpenRouterMalformedSuccessResponse(
+      response,
+      describeMalformedOpenRouterReason(reason),
+    ),
+  };
+}
+
+function getMalformedOpenRouterChatCompletionReason(
+  body: unknown,
+): string | null {
+  if (!isRecord(body)) {
+    return "root_not_object";
+  }
+
+  if (!Array.isArray(body.choices) || body.choices.length === 0) {
+    return "missing_choices";
+  }
+
+  const firstChoice: unknown = body.choices[0];
+
+  if (!isRecord(firstChoice)) {
+    return "first_choice_not_object";
+  }
+
+  if (!isRecord(firstChoice.message)) {
+    return "missing_choices_0_message";
+  }
+
+  return null;
+}
+
+function describeMalformedOpenRouterReason(reason: string): string {
+  switch (reason) {
+    case "root_not_object":
+      return "the JSON root was not an object";
+    case "missing_choices":
+      return "choices was missing or empty";
+    case "first_choice_not_object":
+      return "choices[0] was not an object";
+    case "missing_choices_0_message":
+      return "choices[0].message was missing or not an object";
+    default:
+      return reason;
+  }
+}
+
+function createOpenRouterMalformedSuccessResponse(
+  upstreamResponse: Response,
+  detail: string,
+): Response {
+  const headers = new Headers({ "content-type": "application/json" });
+
+  for (const [key, value] of Object.entries(
+    getSafeResponseHeaders(upstreamResponse.headers),
+  )) {
+    headers.set(key, value);
+  }
+
+  return new Response(
+    JSON.stringify({
+      error: {
+        code: 502,
+        message: `OpenRouter returned a malformed successful non-streaming chat completion response: ${detail}.`,
+        metadata: {
+          openwiki_reason: "malformed_success_response",
+          upstream_status: upstreamResponse.status,
+          upstream_status_text: upstreamResponse.statusText,
+        },
+      },
+    }),
+    {
+      headers,
+      status: 502,
+      statusText: "Bad Gateway",
+    },
+  );
 }
 
 /**

--- a/test/openrouter-debug-fetch.test.ts
+++ b/test/openrouter-debug-fetch.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import { ChatOpenRouter, OpenRouterError } from "@langchain/openrouter";
 import { installOpenRouterDebugFetch } from "../src/agent/index.ts";
 import { OPENROUTER_BASE_URL } from "../src/config/constants.ts";
 
@@ -10,6 +11,7 @@ import { OPENROUTER_BASE_URL } from "../src/config/constants.ts";
 
 const OPENROUTER_CHAT_URL = `${OPENROUTER_BASE_URL}/chat/completions`;
 const OTHER_URL = "https://api.example.com/v1/chat/completions";
+const MODEL = "openai/gpt-4o-mini";
 
 let realFetch: typeof globalThis.fetch;
 
@@ -42,6 +44,133 @@ function stubFetch(): typeof globalThis.fetch {
   globalThis.fetch = stub;
   return stub;
 }
+
+function stubFetchHandler(
+  handler: (
+    input: Parameters<typeof fetch>[0],
+    init: Parameters<typeof fetch>[1],
+    call: number,
+  ) => Response,
+): typeof globalThis.fetch {
+  let call = 0;
+  const stub = vi.fn(
+    (
+      input: Parameters<typeof fetch>[0],
+      init?: Parameters<typeof fetch>[1],
+    ): Promise<Response> => {
+      call += 1;
+
+      return Promise.resolve(handler(input, init, call));
+    },
+  ) as unknown as typeof globalThis.fetch;
+  globalThis.fetch = stub;
+  return stub;
+}
+
+function openRouterFetchInit(stream: boolean): RequestInit {
+  return {
+    body: JSON.stringify({
+      messages: [{ role: "user", content: "hello" }],
+      model: MODEL,
+      stream,
+    }),
+    method: "POST",
+  };
+}
+
+function jsonResponse(body: unknown, init: ResponseInit = {}): Response {
+  return new Response(JSON.stringify(body), {
+    headers: { "content-type": "application/json", ...init.headers },
+    status: 200,
+    statusText: "OK",
+    ...init,
+  });
+}
+
+function validChatCompletion(content = "ok"): Record<string, unknown> {
+  return {
+    choices: [
+      {
+        finish_reason: "stop",
+        index: 0,
+        message: { content, role: "assistant" },
+      },
+    ],
+    created: 0,
+    id: "chatcmpl_test",
+    model: MODEL,
+    object: "chat.completion",
+    usage: {
+      completion_tokens: 1,
+      prompt_tokens: 1,
+      total_tokens: 2,
+    },
+  };
+}
+
+function createChatOpenRouter(maxRetries = 0): ChatOpenRouter {
+  return new ChatOpenRouter({
+    apiKey: "sk-or-v1-test",
+    maxRetries,
+    model: MODEL,
+  });
+}
+
+async function expectOpenRouterMalformedError(
+  promise: Promise<unknown>,
+  expectedMessage: string,
+): Promise<void> {
+  let error: unknown;
+
+  try {
+    await promise;
+  } catch (caught) {
+    error = caught;
+  }
+
+  expect(error).toBeDefined();
+  expect(OpenRouterError.isInstance(error)).toBe(true);
+
+  if (!OpenRouterError.isInstance(error)) {
+    return;
+  }
+
+  expect(error.name).toBe("OpenRouterError");
+  expect(error.statusCode).toBe(502);
+  expect(error.message).toContain(
+    "malformed successful non-streaming chat completion response",
+  );
+  expect(error.message).toContain(expectedMessage);
+}
+
+const malformedSuccessCases = [
+  {
+    bodyPreview: "",
+    expectedMessage: "not valid JSON",
+    name: "empty body",
+    reason: "invalid_json",
+    response: () =>
+      new Response("", {
+        headers: { "content-type": "application/json" },
+        status: 200,
+        statusText: "OK",
+      }),
+  },
+  {
+    bodyPreview: "{}",
+    expectedMessage: "choices was missing or empty",
+    name: "empty object",
+    reason: "missing_choices",
+    response: () => jsonResponse({}),
+  },
+  {
+    bodyPreview: '{"choices":[{}]}',
+    expectedMessage: "choices[0].message",
+    name: "choice without message",
+    reason: "missing_choices_0_message",
+    response: () => jsonResponse({ choices: [{}] }),
+  },
+];
 
 describe("installOpenRouterDebugFetch concurrency", () => {
   test("restores the exact original fetch after a single run", () => {
@@ -125,6 +254,186 @@ describe("installOpenRouterDebugFetch concurrency", () => {
     expect(globalThis.fetch).toBe(patched);
 
     runB.restore();
+    expect(globalThis.fetch).toBe(original);
+  });
+});
+
+describe("installOpenRouterDebugFetch malformed non-streaming responses", () => {
+  test.each(malformedSuccessCases)(
+    "converts $name to a retryable OpenRouter error response through fetch",
+    async ({
+      bodyPreview,
+      expectedMessage,
+      reason,
+      response: createResponse,
+    }) => {
+      const original = stubFetchHandler(() => createResponse());
+      const capture = installOpenRouterDebugFetch({});
+
+      try {
+        const response = await globalThis.fetch(
+          OPENROUTER_CHAT_URL,
+          openRouterFetchInit(false),
+        );
+
+        expect(response.status).toBe(502);
+        expect(response.statusText).toBe("Bad Gateway");
+
+        const body = (await response.clone().json()) as {
+          error?: { message?: string };
+        };
+        expect(body.error?.message).toContain(
+          "malformed successful non-streaming chat completion response",
+        );
+        expect(body.error?.message).toContain(expectedMessage);
+
+        const error = await OpenRouterError.fromResponse(response);
+        expect(error.statusCode).toBe(502);
+        expect(error.code).toBe(502);
+        expect(error.metadata).toMatchObject({
+          openwiki_reason: "malformed_success_response",
+          upstream_status: 200,
+        });
+        expect(error.message).toContain(expectedMessage);
+
+        expect(capture.getLastFailure()).toMatchObject({
+          request: { stream: false },
+          response: {
+            bodyPreview,
+            malformedReason: reason,
+            status: 502,
+            upstreamStatus: 200,
+          },
+        });
+      } finally {
+        capture.restore();
+      }
+
+      expect(globalThis.fetch).toBe(original);
+    },
+  );
+
+  test.each(malformedSuccessCases)(
+    "converts $name to OpenRouterError through ChatOpenRouter",
+    async ({ expectedMessage, reason, response: createResponse }) => {
+      const original = stubFetchHandler(() => createResponse());
+      const capture = installOpenRouterDebugFetch({});
+
+      try {
+        await expectOpenRouterMalformedError(
+          createChatOpenRouter().invoke("hello"),
+          expectedMessage,
+        );
+
+        expect(capture.getLastFailure()).toMatchObject({
+          request: { stream: false },
+          response: {
+            malformedReason: reason,
+            status: 502,
+            upstreamStatus: 200,
+          },
+        });
+      } finally {
+        capture.restore();
+      }
+
+      expect(globalThis.fetch).toBe(original);
+    },
+  );
+
+  test("lets ChatOpenRouter recover when a retry returns a valid response", async () => {
+    const original = stubFetchHandler((_input, _init, call) =>
+      call === 1
+        ? jsonResponse({})
+        : jsonResponse(validChatCompletion("recovered")),
+    );
+    const capture = installOpenRouterDebugFetch({});
+
+    try {
+      const message = await createChatOpenRouter(1).invoke("hello");
+
+      expect(message.content).toBe("recovered");
+      expect(capture.getLastFailure()).toMatchObject({
+        response: {
+          malformedReason: "missing_choices",
+          status: 502,
+          upstreamStatus: 200,
+        },
+      });
+    } finally {
+      capture.restore();
+    }
+
+    expect(globalThis.fetch).toBe(original);
+  });
+
+  test("leaves a valid non-streaming 200 response readable", async () => {
+    const body = validChatCompletion("still readable");
+    const original = stubFetchHandler(() => jsonResponse(body));
+    const capture = installOpenRouterDebugFetch({});
+
+    try {
+      const response = await globalThis.fetch(
+        OPENROUTER_CHAT_URL,
+        openRouterFetchInit(false),
+      );
+
+      expect(response.status).toBe(200);
+      expect(await response.json()).toEqual(body);
+      expect(capture.getLastFailure()).toBeNull();
+    } finally {
+      capture.restore();
+    }
+
+    expect(globalThis.fetch).toBe(original);
+  });
+
+  test("does not parse or convert streaming OpenRouter responses", async () => {
+    const original = stubFetchHandler(
+      () =>
+        new Response("", {
+          headers: { "content-type": "text/event-stream" },
+          status: 200,
+          statusText: "OK",
+        }),
+    );
+    const capture = installOpenRouterDebugFetch({});
+
+    try {
+      const response = await globalThis.fetch(
+        OPENROUTER_CHAT_URL,
+        openRouterFetchInit(true),
+      );
+
+      expect(response.status).toBe(200);
+      expect(await response.text()).toBe("");
+      expect(capture.getLastFailure()).toBeNull();
+    } finally {
+      capture.restore();
+    }
+
+    expect(globalThis.fetch).toBe(original);
+  });
+
+  test("does not convert malformed non-OpenRouter responses", async () => {
+    const original = stubFetchHandler(
+      () => new Response("", { status: 200, statusText: "OK" }),
+    );
+    const capture = installOpenRouterDebugFetch({});
+
+    try {
+      const response = await globalThis.fetch(
+        OTHER_URL,
+        openRouterFetchInit(false),
+      );
+
+      expect(response.status).toBe(200);
+      expect(await response.text()).toBe("");
+      expect(capture.getLastFailure()).toBeNull();
+    } finally {
+      capture.restore();
+    }
+
     expect(globalThis.fetch).toBe(original);
   });
 });


### PR DESCRIPTION
## Summary

- Convert malformed successful OpenRouter non-streaming chat completion responses into a synthetic 502 provider error before `@langchain/openrouter` indexes into the payload.
- Cover empty/invalid JSON, missing or empty `choices`, non-object first choices, and missing `choices[0].message`.
- Leave valid non-streaming responses, streaming responses, and non-OpenRouter requests untouched.
- Add focused no-key regression coverage and a patch changeset.

## Why

Fixes #830. On current `main`, a stubbed OpenRouter `200 {}` non-streaming response reproduces the reported raw `TypeError: Cannot read properties of undefined (reading '0')` inside `ChatOpenRouter._generate`. Empty bodies similarly surface as raw `SyntaxError`, and malformed choices can fail later in the OpenAI converter.

The new boundary turns these unusable successful responses into typed `OpenRouterError` failures with `statusCode: 502`, preserving the upstream `200` details in debug metadata. That makes the failure actionable and lets LangChain's existing retry path recover when a subsequent response is valid.

## Relationship to nearby PRs

- #864 handles transient OpenRouter HTTP 404 provider errors. This PR handles malformed HTTP 200 chat-completion bodies before they reach LangChain's response indexing.
- #862 handles repository worker stream message coercion after a model call returns. This PR handles a failure before the model call can return a valid message.

## Tests

Windows:

- Stubbed current-main reproduction: `ChatOpenRouter` + HTTP `200 {}` produces `TypeError: Cannot read properties of undefined (reading '0')`
- `corepack pnpm exec vitest run test/openrouter-debug-fetch.test.ts --reporter=dot` (14 tests passed)
- `corepack pnpm run typecheck`
- `corepack pnpm run lint:check`
- `corepack pnpm run format:check`
- build-equivalent: `corepack pnpm run clean`, `corepack pnpm exec tsc -p tsconfig.json`, `corepack pnpm exec tsc -p tsconfig.client.json`, `node scripts/copy-visualize-assets.cjs`
- `git diff --check`

DGX Spark Ubuntu fresh clone from `HwangJohn:fix/openrouter-malformed-response` at `81f7f2d`:

- Node `v22.23.1`, pnpm `11.25.0`
- `pnpm install --frozen-lockfile`
- `pnpm exec vitest run test/openrouter-debug-fetch.test.ts --reporter=dot` (14 tests passed)
- `pnpm run format:check`
- `pnpm run lint:check`
- `pnpm run typecheck`
- `pnpm test` (225 test files passed, 2 skipped; 3076 tests passed, 3 skipped)
