### PR TITLE
fix: add claude opus 5 to the anthropic and vertex model lists

### DIFF
--- a/.changeset/add-claude-opus-5-model-options.md
+++ b/.changeset/add-claude-opus-5-model-options.md
@@ -1,0 +1,5 @@
+---
+"openwiki": patch
+---
+
+fix: add Claude Opus 5 to the Anthropic and Gemini Enterprise model lists

--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -369,7 +369,8 @@ export const PROVIDER_CONFIGS: Record<OpenWikiProvider, ProviderConfig> = {
     modelOptions: [
       { id: "claude-haiku-4-5", label: "Haiku" },
       { id: "claude-sonnet-5", label: "Sonnet" },
-      { id: "claude-opus-4-8", label: "Opus" },
+      { id: "claude-opus-5", label: "Opus" },
+      { id: "claude-opus-4-8", label: "Opus 4.8" },
     ],
   },
   gemini: {
@@ -392,7 +393,8 @@ export const PROVIDER_CONFIGS: Record<OpenWikiProvider, ProviderConfig> = {
       ...GEMINI_MODELS,
       { id: "claude-haiku-4-5@20251001", label: "Claude Haiku" },
       { id: "claude-sonnet-5", label: "Claude Sonnet" },
-      { id: "claude-opus-4-8", label: "Claude Opus" },
+      { id: "claude-opus-5", label: "Claude Opus" },
+      { id: "claude-opus-4-8", label: "Claude Opus 4.8" },
     ],
   },
   openrouter: {

--- a/test/config/constants.test.ts
+++ b/test/config/constants.test.ts
@@ -1129,6 +1129,15 @@ describe("isModelIdForOtherProvider", () => {
     );
   });
 
+  test("does not flag Claude Opus 5 on the providers that serve Claude", () => {
+    // Opus 5 was listed only under copilot, so both providers that serve Claude
+    // directly warned that it "belongs to GitHub Copilot" on every run.
+    expect(isModelIdForOtherProvider("claude-opus-5", "anthropic")).toBe(false);
+    expect(
+      isModelIdForOtherProvider("claude-opus-5", "gemini-enterprise"),
+    ).toBe(false);
+  });
+
   test("does not flag shared OpenAI models across openai / openai-chatgpt", () => {
     const [firstOpenAiModel] = getProviderModelOptions("openai");
     if (firstOpenAiModel) {


### PR DESCRIPTION
Fixes #868.

`claude-opus-5` was only listed under `copilot`, so running it on `anthropic` or `gemini-enterprise` printed "it belongs to GitHub Copilot" on every single run. The ID is correct for both — Vertex serves current-generation Claude models under the bare first-party ID — and routing already worked, so the warning was pure noise on a working config. It also meant Opus 5 never showed up in the setup picker for either provider.

Added it to both lists and kept `claude-opus-4-8` as an explicitly versioned entry rather than dropping it, since it's still served and the existing tests use it as their fixture for "known to more than one provider". `openrouter` needs nothing — its IDs are namespaced, so it never collided in the first place.

Tested with a new case in `test/config/constants.test.ts` asserting `isModelIdForOtherProvider("claude-opus-5", ...)` is false for both providers; it fails on main and passes here. The other 107 assertions in that file are untouched and still pass, and `pnpm run typecheck`, `lint:check` and `format:check` are clean.