### PR TITLE
fix: instruct repository planner to invoke submit_plan directly without conversational text

### DIFF
--- a/.changeset/planner-prompt-direct-submit.md
+++ b/.changeset/planner-prompt-direct-submit.md
@@ -1,0 +1,5 @@
+---
+"openwiki": patch
+---
+
+instruct repository planner to invoke submit_plan directly without conversational text

--- a/src/agent/repository-prompts.ts
+++ b/src/agent/repository-prompts.ts
@@ -42,8 +42,9 @@ ${formatIssues(view.claimIssues)}`
 
   return `You are planning an OpenWiki code wiki for this repository.
 
-Your only output action is submit_plan. Do not write documentation and do not
-delegate work.
+Your only output action is submit_plan. Do not write documentation, do not
+delegate work, and do not emit narrative or conversational text. Invoke
+submit_plan directly.
 
 Design the smallest complete repository-specific information architecture that
 helps a coding agent understand and safely change the system. Organize around

--- a/test/agent/repository-prompts.test.ts
+++ b/test/agent/repository-prompts.test.ts
@@ -105,6 +105,7 @@ describe("repository worker prompts", () => {
     expect(prompt).toContain("Populate relatedPages");
     expect(prompt).toContain("trace representative end-to-end control");
     expect(prompt).toContain("focused tests and neighboring");
+    expect(prompt).toContain("submit_plan directly.");
     expect(prompt).not.toContain("force flag");
   });
 


### PR DESCRIPTION
## Summary

Instructs the repository planner prompt to invoke `submit_plan` directly without emitting narrative or conversational text.

## Context

When planning a repository wiki, some models output conversational preamble, explanations, or markdown summaries before emitting completion tool calls. In large repositories or deep exploration sessions with extensive message history, emitting conversational notes can consume output token budgets or cause premature turn endings before `submit_plan` is invoked, resulting in `Error: Repository planning worker exited without submit_plan.`

Explicitly instructing the worker to avoid conversational text and invoke `submit_plan` directly ensures the tool call is emitted cleanly.