### PR TITLE
feat(anthropic): enable prompt caching on stable request prefix

### DIFF
--- a/.changeset/anthropic-prompt-caching.md
+++ b/.changeset/anthropic-prompt-caching.md
@@ -1,0 +1,5 @@
+---
+"openwiki": patch
+---
+
+feat: enable Anthropic prompt caching on the stable request prefix

--- a/src/agent/anthropic-prompt-caching.ts
+++ b/src/agent/anthropic-prompt-caching.ts
@@ -1,0 +1,49 @@
+import { ChatAnthropic } from "@langchain/anthropic";
+import { createMiddleware } from "langchain";
+import { resolveAnthropicPromptCachingEnabled } from "../config/constants.js";
+
+// A single top-level cache_control breakpoint. @langchain/anthropic forwards
+// this as Anthropic's top-level `cache_control` request parameter, which
+// automatically applies a cache breakpoint to the last cacheable block in the
+// request (system prompt + tool definitions on turn one) and advances it as
+// the conversation grows on later turns. This is the mechanism the library
+// itself recommends for multi-turn agent loops in preference to placing
+// cache_control on individual content blocks by hand.
+const ANTHROPIC_TOP_LEVEL_CACHE_CONTROL = { type: "ephemeral" } as const;
+
+/**
+ * Middleware that opts Anthropic requests into prompt caching.
+ *
+ * OpenWiki's agent loops (chat turns, and the repository planner/page
+ * workers) resend an unchanging system prompt and tool schema set on every
+ * turn. Without a cache breakpoint, Anthropic bills that stable prefix at
+ * full input price on every turn instead of the ~10% cache-read rate
+ * (issue #696). This middleware is safe to add to every agent's middleware
+ * list unconditionally: it only touches the request when the resolved model
+ * for that step is a `ChatAnthropic` instance, so chat/OpenAI/Gemini/etc.
+ * provider runs are untouched, and it can be disabled entirely with
+ * `OPENWIKI_ANTHROPIC_PROMPT_CACHING=false`.
+ *
+ * @returns Provider-scoped `wrapModelCall` middleware.
+ */
+export function createAnthropicPromptCachingMiddleware() {
+  return createMiddleware({
+    name: "OpenWikiAnthropicPromptCaching",
+    wrapModelCall: (request, handler) => {
+      if (
+        !(request.model instanceof ChatAnthropic) ||
+        !resolveAnthropicPromptCachingEnabled()
+      ) {
+        return handler(request);
+      }
+
+      return handler({
+        ...request,
+        modelSettings: {
+          ...request.modelSettings,
+          cache_control: ANTHROPIC_TOP_LEVEL_CACHE_CONTROL,
+        },
+      });
+    },
+  });
+}

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -34,6 +34,7 @@ import {
   resolveIndexLabels,
 } from "../okf/index-labels.js";
 import { OpenWikiLocalShellBackend } from "./docs-only-backend.js";
+import { createAnthropicPromptCachingMiddleware } from "./anthropic-prompt-caching.js";
 import { getSelectedModelAvailability } from "../model-availability.js";
 import { createOpenWikiIndexMiddleware } from "./okf-middleware.js";
 import {
@@ -485,8 +486,9 @@ function createOpenWikiAgentGraph(
     backend,
     middleware:
       options.command === "chat"
-        ? []
+        ? [createAnthropicPromptCachingMiddleware()]
         : [
+            createAnthropicPromptCachingMiddleware(),
             ...(translation
               ? [
                   createWikiTranslationMiddleware(

--- a/src/agent/repository-runner.ts
+++ b/src/agent/repository-runner.ts
@@ -28,6 +28,7 @@ import {
   createAgentBackend,
 } from "./agent-backend.js";
 import { OpenWikiLocalShellBackend } from "./docs-only-backend.js";
+import { createAnthropicPromptCachingMiddleware } from "./anthropic-prompt-caching.js";
 import { OpenWikiIgnore } from "./openwiki-ignore.js";
 import {
   createRepositoryPagePrompt,
@@ -343,6 +344,7 @@ async function runPlanningAgent(
         permissions: AGENT_FILESYSTEM_PERMISSIONS,
         tools: PLANNER_FILESYSTEM_TOOLS,
       }),
+      createAnthropicPromptCachingMiddleware(),
       NO_DELEGATION_MIDDLEWARE,
     ],
     skills: ["/skills/"],
@@ -479,6 +481,7 @@ async function runPageAgent(
         permissions: AGENT_FILESYSTEM_PERMISSIONS,
         tools: PAGE_FILESYSTEM_TOOLS,
       }),
+      createAnthropicPromptCachingMiddleware(),
       NO_DELEGATION_MIDDLEWARE,
     ],
     skills: ["/skills/"],

--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -71,9 +71,12 @@ export const NEBIUS_BASE_URL = "https://api.tokenfactory.nebius.com/v1/";
 export const OPENWIKI_PROVIDER_RETRY_ATTEMPTS_ENV_KEY =
   "OPENWIKI_PROVIDER_RETRY_ATTEMPTS";
 export const OPENWIKI_REASONING_EFFORT_ENV_KEY = "OPENWIKI_REASONING_EFFORT";
+export const OPENWIKI_ANTHROPIC_PROMPT_CACHING_ENV_KEY =
+  "OPENWIKI_ANTHROPIC_PROMPT_CACHING";
 export const DEFAULT_PROVIDER_RETRY_ATTEMPTS = 3;
 export const DEFAULT_ANTHROPIC_MAX_OUTPUT_TOKENS = 16_384;
 const TRUE_ENV_VALUE = "true";
+const FALSE_ENV_VALUE = "false";
 export const OPENWIKI_GOOGLE_ACCESS_TOKEN_ENV_KEY =
   "OPENWIKI_GOOGLE_ACCESS_TOKEN";
 export const OPENWIKI_GOOGLE_CLIENT_ID_ENV_KEY = "OPENWIKI_GOOGLE_CLIENT_ID";
@@ -1080,6 +1083,25 @@ export function resolveOpenAiCompatibleStreaming(
   return (
     env[OPENAI_COMPATIBLE_STREAMING_ENV_KEY]?.trim().toLowerCase() ===
     TRUE_ENV_VALUE
+  );
+}
+
+// Anthropic prompt caching is on by default: it sets a single top-level
+// `cache_control: { type: "ephemeral" }` breakpoint on every Anthropic
+// request, which @langchain/anthropic applies to the last cacheable block
+// (system prompt + tool definitions on the first turn, growing to cover the
+// conversation history as an agent loop continues) and advances
+// automatically as later turns are appended. This is a pure billing/latency
+// optimization — cached tokens round-trip through the API unchanged — so
+// unlike the openai-compatible toggles above it defaults on rather than off.
+// The escape hatch exists for anyone routing OPENWIKI_ANTHROPIC_BASE_URL at a
+// proxy that does not support Anthropic's prompt-caching headers.
+export function resolveAnthropicPromptCachingEnabled(
+  env: NodeJS.ProcessEnv = process.env,
+): boolean {
+  return (
+    env[OPENWIKI_ANTHROPIC_PROMPT_CACHING_ENV_KEY]?.trim().toLowerCase() !==
+    FALSE_ENV_VALUE
   );
 }
 

--- a/test/agent/anthropic-prompt-caching.test.ts
+++ b/test/agent/anthropic-prompt-caching.test.ts
@@ -1,0 +1,93 @@
+import { afterEach, beforeEach, describe, expect, test } from "vitest";
+import { ChatAnthropic } from "@langchain/anthropic";
+import { ChatOpenAI } from "@langchain/openai";
+import { createAnthropicPromptCachingMiddleware } from "../../src/agent/anthropic-prompt-caching.ts";
+
+// Constructing these chat models makes no network calls (auth/clients
+// resolve lazily on first request), matching the pattern used throughout
+// test/agent/create-model.test.ts.
+
+const TOGGLE_KEY = "OPENWIKI_ANTHROPIC_PROMPT_CACHING";
+
+function fakeRequest(model: unknown) {
+  return {
+    model,
+    messages: [],
+    systemPrompt: "",
+    tools: [],
+  } as never;
+}
+
+describe("createAnthropicPromptCachingMiddleware", () => {
+  let saved: string | undefined;
+
+  beforeEach(() => {
+    saved = process.env[TOGGLE_KEY];
+    delete process.env[TOGGLE_KEY];
+  });
+
+  afterEach(() => {
+    if (saved === undefined) {
+      delete process.env[TOGGLE_KEY];
+    } else {
+      process.env[TOGGLE_KEY] = saved;
+    }
+  });
+
+  test("adds a top-level ephemeral cache_control breakpoint for a ChatAnthropic model", async () => {
+    const middleware = createAnthropicPromptCachingMiddleware();
+    const model = new ChatAnthropic({
+      model: "claude-sonnet-5",
+      apiKey: "test-key",
+    });
+    const request = fakeRequest(model);
+
+    let seenRequest: unknown;
+    await middleware.wrapModelCall?.(request, async (nextRequest) => {
+      seenRequest = nextRequest;
+      return { role: "ai", content: "" } as never;
+    });
+
+    expect(
+      (seenRequest as { modelSettings?: Record<string, unknown> })
+        .modelSettings,
+    ).toMatchObject({
+      cache_control: { type: "ephemeral" },
+    });
+  });
+
+  test("leaves the request untouched for a non-Anthropic model", async () => {
+    const middleware = createAnthropicPromptCachingMiddleware();
+    const model = new ChatOpenAI({
+      model: "gpt-5.6",
+      apiKey: "test-key",
+    });
+    const request = fakeRequest(model);
+
+    let seenRequest: unknown;
+    await middleware.wrapModelCall?.(request, async (nextRequest) => {
+      seenRequest = nextRequest;
+      return { role: "ai", content: "" } as never;
+    });
+
+    expect(seenRequest).toBe(request);
+  });
+
+  test("honors OPENWIKI_ANTHROPIC_PROMPT_CACHING=false", async () => {
+    process.env[TOGGLE_KEY] = "false";
+    const middleware = createAnthropicPromptCachingMiddleware();
+    const model = new ChatAnthropic({
+      model: "claude-sonnet-5",
+      apiKey: "test-key",
+    });
+    const request = fakeRequest(model);
+
+    let seenRequest: unknown;
+    await middleware.wrapModelCall?.(request, async (nextRequest) => {
+      seenRequest = nextRequest;
+      return { role: "ai", content: "" } as never;
+    });
+
+    expect(seenRequest).toBe(request);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #696. OpenWiki never set `cache_control` on Anthropic requests, so the stable prefix of every request (system prompt, tool definitions) was re-billed at full input price on every turn of a multi-turn agent loop instead of being cached.

- Adds `createAnthropicPromptCachingMiddleware()` (`src/agent/anthropic-prompt-caching.ts`), a `wrapModelCall` middleware that sets the top-level `cache_control: { type: "ephemeral" }` call option on `ChatAnthropicCallOptions`. Per the currently installed `@langchain/anthropic@1.5.8`'s own type docs, this single breakpoint is applied by the library to the last cacheable block in the request (system prompt + tool definitions on turn one) and advances automatically as later turns are appended — the mechanism the library itself recommends for multi-turn loops over hand-placing `cache_control` on individual content blocks.
- The middleware only mutates the request when the resolved model for that step is a `ChatAnthropic` instance (checked via `instanceof`), so OpenAI/Gemini/Bedrock/OpenRouter/etc. provider paths are completely untouched.
- Wired into every OpenWiki agent/worker middleware list that resends a stable prefix across turns: the chat loop and translation/index middleware graph in `src/agent/index.ts`, and both the repository planner and repository page workers in `src/agent/repository-runner.ts` (the `openwiki code --init --print` path the issue's cost example ran).
- Defaults on — prompt caching only affects billing/latency, not behavior — with an opt-out via `OPENWIKI_ANTHROPIC_PROMPT_CACHING=false` (`resolveAnthropicPromptCachingEnabled` in `src/config/constants.ts`) for anyone routing `OPENWIKI_ANTHROPIC_BASE_URL` at a proxy without prompt-caching support.

## What I verified

- Confirmed the issue's `dist/chat_models.js:802` line no longer matches current `@langchain/anthropic@1.5.8`; the currently-shipped API exposes `cache_control` as a top-level `ChatAnthropicCallOptions` field (not per-content-block metadata), documented in `chat_models.d.ts` and demonstrated directly in `langchain`'s own `ModelRequest.systemMessage` JSDoc example for `wrapModelCall`.
- `npx tsc -p tsconfig.json --noEmit` — clean.
- `npm run build` — clean.
- Added `test/agent/anthropic-prompt-caching.test.ts`, asserting: the breakpoint is added for a `ChatAnthropic` model, the request is left untouched for a non-Anthropic model (`ChatOpenAI`), and the `OPENWIKI_ANTHROPIC_PROMPT_CACHING=false` opt-out works. All pass.
- Ran the existing `test/agent` and `test/config` suites; no new failures introduced by this change (a handful of pre-existing unrelated failures on this Windows dev environment — Unix file-mode assertions and sqlite file-lock flakiness — are unaffected by this diff).
- Added a changeset (`.changeset/anthropic-prompt-caching.md`, patch bump) matching the repo's existing format.

## Test plan

- [x] `npx tsc -p tsconfig.json --noEmit`
- [x] `npm run build`
- [x] `npx vitest run test/agent/anthropic-prompt-caching.test.ts`
- [x] `npx vitest run test/agent/repository-runner.test.ts test/agent/create-openwiki-agent.test.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)