### PR TITLE
fix: classify symlinked claim evidence as unresolved instead of aborting update

### DIFF
--- a/.changeset/symlinked-evidence-unresolved.md
+++ b/.changeset/symlinked-evidence-unresolved.md
@@ -1,0 +1,5 @@
+---
+"openwiki": patch
+---
+
+fix: report a claim whose evidence now traverses a symbolic link as unresolved instead of aborting the update

--- a/src/claims/brains/code/preflight.ts
+++ b/src/claims/brains/code/preflight.ts
@@ -1,5 +1,6 @@
+import { EvidenceSecurityError } from "../../core/errors.js";
 import { cacheEvidenceResolver } from "../../core/resolver-cache.js";
-import type { EvidenceResolver } from "../../core/types.js";
+import type { EvidenceResolver, ResolvedEvidence } from "../../core/types.js";
 import type { GroundingIssue, PageClaims } from "./types.js";
 import { ClaimsStore } from "./store.js";
 
@@ -28,6 +29,9 @@ export interface ClaimsPreflightResult {
  *
  * Each evidence resource and prior version resolves once per preflight.
  * Resolution errors propagate so they cannot be mistaken for deleted evidence.
+ * A containment refusal (`EvidenceSecurityError`) is the one exception: it is
+ * permanent for the cited resource rather than operational, so the claim is
+ * reported as unresolved for reconciliation instead of aborting the run.
  *
  * @param store - Repository claim persistence.
  * @param resolver - Repository evidence resolver.
@@ -57,10 +61,18 @@ export async function runClaimsPreflight(
       const unresolvedResources: string[] = [];
 
       for (const evidence of claim.evidence) {
-        const current = await cachedResolver.resolve(
-          evidence.resource,
-          evidence.version,
-        );
+        let current: ResolvedEvidence | null;
+        try {
+          current = await cachedResolver.resolve(
+            evidence.resource,
+            evidence.version,
+          );
+        } catch (error) {
+          if (!(error instanceof EvidenceSecurityError)) {
+            throw error;
+          }
+          current = null;
+        }
         if (!current) {
           unresolvedResources.push(evidence.resource);
         } else if (current.evidence.version !== evidence.version) {

--- a/test/claims/brains/code/preflight.test.ts
+++ b/test/claims/brains/code/preflight.test.ts
@@ -1,9 +1,14 @@
-import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, rm, symlink, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, test } from "vitest";
 import { runClaimsPreflight } from "../../../../src/claims/brains/code/preflight.ts";
 import { ClaimsStore } from "../../../../src/claims/brains/code/store.ts";
+import {
+  EvidenceResolutionError,
+  EvidenceSecurityError,
+} from "../../../../src/claims/core/errors.ts";
+import { RepositoryEvidenceResolver } from "../../../../src/claims/evidence/repository/resolver.ts";
 import { CODE_CLAIMS_SCHEMA_VERSION } from "../../../../src/claims/brains/code/types.ts";
 import type { PageClaims } from "../../../../src/claims/brains/code/types.ts";
 import type {
@@ -246,6 +251,135 @@ describe("runClaimsPreflight", () => {
     await expect(
       runClaimsPreflight(store, createResolver(new Map([[resource, failure]]))),
     ).rejects.toBe(failure);
+  });
+
+  test("classifies a containment refusal as unresolved instead of aborting", async () => {
+    const page = "/openwiki/page.md";
+    const refusedResource = "repo://lib/greeter.ts#L1-L3";
+    const healthyResource = "repo://src/healthy.ts";
+    await writePage(page, "# Page\n");
+    const store = new ClaimsStore(rootDir);
+    await store.writePage(
+      page,
+      await pageClaims(store, page, [
+        {
+          id: "claim_refused",
+          statement: "A fact cited through a symbolic link.",
+          evidence: [
+            { resource: healthyResource, version: "current" },
+            { resource: refusedResource, version: "old" },
+          ],
+        },
+        {
+          id: "claim_healthy",
+          statement: "A fact that still resolves.",
+          evidence: [{ resource: healthyResource, version: "current" }],
+        },
+      ]),
+    );
+    const resolver = createResolver(
+      new Map([
+        [healthyResource, resolvedEvidence(healthyResource, "current")],
+        [
+          refusedResource,
+          new EvidenceSecurityError(
+            "Evidence path traverses a symbolic link or filesystem alias: lib/greeter.ts",
+          ),
+        ],
+      ]),
+    );
+
+    const result = await runClaimsPreflight(store, resolver);
+
+    expect(result.issues).toEqual([
+      {
+        page,
+        kind: "unresolved",
+        claimId: "claim_refused",
+        resources: [refusedResource],
+      },
+    ]);
+  });
+
+  test("still propagates operational resolution failures", async () => {
+    const page = "/openwiki/page.md";
+    const resource = "repo://src/unreadable.ts";
+    await writePage(page, "# Page\n");
+    const store = new ClaimsStore(rootDir);
+    await store.writePage(
+      page,
+      await pageClaims(store, page, [
+        {
+          id: "claim_unreadable",
+          statement: "A fact.",
+          evidence: [{ resource, version: "old" }],
+        },
+      ]),
+    );
+    const failure = new EvidenceResolutionError(
+      "Unable to read evidence src/unreadable.ts: EACCES",
+    );
+
+    await expect(
+      runClaimsPreflight(store, createResolver(new Map([[resource, failure]]))),
+    ).rejects.toBe(failure);
+  });
+
+  test("reports a claim whose evidence now traverses a symbolic link as unresolved", async () => {
+    const page = "/openwiki/page.md";
+    const resource = "repo://lib/greeter.txt";
+    const content = 'def greet(name):\n    return f"Hello, {name}!"\n';
+    const outsideDir = await mkdtemp(path.join(tmpdir(), "openwiki-outside-"));
+    try {
+      await mkdir(path.join(rootDir, "lib"));
+      await writeFile(
+        path.join(rootDir, "lib", "greeter.txt"),
+        content,
+        "utf8",
+      );
+      await writePage(page, "# Page\n");
+      const established = await new RepositoryEvidenceResolver({
+        rootDir,
+      }).resolve(resource);
+      if (!established) {
+        throw new Error("fixture evidence did not resolve");
+      }
+      const store = new ClaimsStore(rootDir);
+      await store.writePage(
+        page,
+        await pageClaims(store, page, [
+          {
+            id: "claim_greeter",
+            statement: "greet returns a greeting.",
+            evidence: [established.evidence],
+          },
+        ]),
+      );
+      const healthy = await runClaimsPreflight(
+        store,
+        new RepositoryEvidenceResolver({ rootDir }),
+      );
+
+      await writeFile(path.join(outsideDir, "greeter.txt"), content, "utf8");
+      await rm(path.join(rootDir, "lib"), { force: true, recursive: true });
+      await symlink(outsideDir, path.join(rootDir, "lib"), "dir");
+      const linked = await runClaimsPreflight(
+        store,
+        new RepositoryEvidenceResolver({ rootDir }),
+      );
+
+      expect(healthy.issues).toEqual([]);
+      expect(linked.issues).toEqual([
+        {
+          page,
+          kind: "unresolved",
+          claimId: "claim_greeter",
+          resources: [resource],
+        },
+      ]);
+    } finally {
+      await rm(outsideDir, { force: true, recursive: true });
+    }
   });
 
   test("inventories orphan sidecars without deleting them", async () => {


### PR DESCRIPTION
## What this fixes

If a repository has a claim whose evidence file is now reached through a symlinked directory, `openwiki --update` (and `openwiki_begin` with `mode: "update"` in host-driven mode) stops before doing anything, with only:

```
OpenWiki MCP operation failed.
```

One claim, one symlink, and the whole update is dead. That is #867, and the reporter's reproduction is exact: a repository where `lib/` is a real directory updates fine; replace `lib/` with a symlink to byte-identical content and the same update aborts.

After this change, that claim is reported as **unresolved**, the same way OpenWiki already reports a claim whose file was deleted. The update runs, every other page and claim is untouched, and the page that owns the claim is asked to re-cite it or retract it.

## Why it was happening

OpenWiki refuses to read evidence through a symlink. That is deliberate and correct: `repo://lib/greeter.py` has to mean the file physically inside the repository at that path, otherwise a claim could quietly cite something outside the repo. The resolver enforces this by throwing `EvidenceSecurityError`.

The problem is what preflight did with that error. Before an update, preflight re-checks every persisted claim's evidence, and it has a sensible rule: if resolving evidence *errors* (as opposed to returning "not found"), let the error propagate, because a permissions or I/O hiccup must never be mistaken for "the file was deleted". `EvidenceSecurityError` is a subclass of `EvidenceResolutionError`, so it fell under that rule. A permanent "this path is not allowed" was being handled as a transient "could not read it right now", and it took the whole run down instead of flagging one claim. The MCP layer then hides everything except `HostIntegrationError`, which is why the reporter saw no detail.

## What the change is

In `runClaimsPreflight`, when resolving one evidence resource throws `EvidenceSecurityError`, that resource is recorded as unresolved. Any other error is rethrown exactly as before. That is the entire code change, plus a comment on the function explaining the exception:

```ts
try {
  current = await cachedResolver.resolve(evidence.resource, evidence.version);
} catch (error) {
  if (!(error instanceof EvidenceSecurityError)) {
    throw error;
  }
  current = null;
}
```

Things I deliberately did not do:

- **Did not make the resolver follow symlinks.** That would let a claim cite a file outside the repository, which the containment check exists to prevent. The resolver is unchanged and still throws before it reads anything.
- **Did not add a new issue kind.** `unresolved` already means "this evidence does not resolve under the current rules, recheck it". A symlinked path is exactly that. No schema, prompt, or tool-output change.
- **Did not loosen anything on the write side.** If a page worker tries to re-cite the symlinked path when submitting, the same resolver refuses it (`src/claims/core/mutations.ts` resolves through it with no catch). If a security error reaches finalization, `isRecoverableFinalizationError` still treats it as fatal. Both boundaries are as they were.

## How I tested it

Three tests added to `test/claims/brains/code/preflight.test.ts`:

1. **The fix itself.** With a fixture resolver, a security error on one resource marks that claim unresolved. A healthy resource on the same claim, and a second healthy claim, are unaffected.
2. **The fence.** A plain `EvidenceResolutionError` (the parent class, an operational failure) still aborts preflight. This is what proves the catch is narrow.
3. **The issue's scenario, for real.** Using the actual `RepositoryEvidenceResolver`: a real `lib/` directory resolves cleanly, then `lib/` is replaced with a symlink to byte-identical content outside the root, and preflight reports the claim unresolved instead of throwing.

Without the source change, tests 1 and 3 fail and test 2 passes. With it, `pnpm test` (typecheck, build, Vitest with coverage) passes: 3069 tests, 0 failures, 3 pre-existing skips. `pnpm run format` and `pnpm run lint:check` are clean.

Not tested: a live host-driven run on a large repository like the reporter's 35-tree case. The change is confined to the deterministic preflight, so I would not expect a difference, but I have not measured it.

## Not in this PR

Two things from the issue that I left alone so this stays one change:

- **The masked error message.** `executeTool` still reduces every non-`HostIntegrationError` to `OpenWiki MCP operation failed.` The reporter is right that surfacing the cause would have made this a one-line diagnosis. Worth its own PR.
- **`.openwikiignore` exclusions.** An evidence path excluded by `.openwikiignore` still aborts preflight, through `EvidenceResourceError`. The reporter flagged it as a possible second bug. It is a different error class with different semantics (an ignore rule is something the user can edit), so it deserves a separate decision.

Changeset included (`patch`). Closes #867.
